### PR TITLE
fix(hooks): gate the user-scope wrapper's transition-dedup deferral on a real project entry

### DIFF
--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -168,13 +168,13 @@ so anything that hides the string from the scan defeats it — most notably the
 Pattern-Blocked" below) and interpreter one-liners. And it only fires if the hook
 is actually wired, which is the next section.
 
-### Hook-wiring integrity (#4791 assessment)
+### Hook-wiring integrity (#4791 assessment, fixed by #4806)
 
 The floor's guarantee is conditional on `guard-destructive.sh` *running*. That is
 governed by hook **registration**, which is a different surface from `guards.*`
 policy — so it deserves its own assessment. Verdict: **the machine-level wiring
-is well protected; the transition (copies-present) layout has a real gap, and the
-fix belongs in the installer, not in a new mechanism.**
+is well protected; the transition (copies-present) layout's former gap is now
+closed at the installer level.**
 
 - **Machine-level wiring is out of reach of a repository change.** Since Phase 5
   (#4262) the entries live in the operator's user-scope `~/.claude/settings.json`
@@ -183,32 +183,37 @@ fix belongs in the installer, not in a new mechanism.**
   Daemon-spawned workers inherit it because `loom-daemon` copies it into each
   worker's isolated `CLAUDE_CONFIG_DIR`. This is strictly stronger than the old
   per-repo wiring and needs no additional protection.
-- **The transition layout has a wiring gap.** While a repo still carries per-repo
-  `.loom/hooks/<name>` copies, the user-scope wrapper's transition-dedup step is
-  an unconditional `[ -x "$ROOT/.loom/hooks/<name>" ] && exit 0` — it defers
-  **without checking that a project-level entry exists to defer to.** So the
-  state "copies present, `hooks` block absent from the repo's
-  `.claude/settings.json`" yields **zero guards**: the wrapper steps aside and
-  nothing takes its place. That is the #4401 failure mode, and #4401 fixed only
-  the *installer* half of it (`ensure_project_hook_wiring` re-asserts the project
-  entries on every install); a commit that later deletes the `hooks` block —
-  careless or hostile — re-creates it silently, and Loom itself dogfoods the
-  copies-present layout.
-- **Proposed fix (not implemented here; deliberately deferred).** Make the
-  deferral conditional: defer only when the copy exists **and** the project
-  `.claude/settings.json` actually references `.loom/hooks/<name>`; otherwise
-  exec the machine hook. It is fork-free in the wrapper — `[ -f "$ROOT/.claude/settings.json" ] && case "$(<"$ROOT/.claude/settings.json")" in *".loom/hooks/<name>"*) exit 0;; esac`
+- **The transition layout's wiring gap is fixed (#4806).** While a repo still
+  carries per-repo `.loom/hooks/<name>` copies, the user-scope wrapper's
+  transition-dedup step used to be an unconditional `[ -x "$ROOT/.loom/hooks/
+  <name>" ] && exit 0` — it deferred **without checking that a project-level
+  entry exists to defer to.** So the state "copies present, `hooks` block absent
+  from the repo's `.claude/settings.json`" yielded **zero guards**: the wrapper
+  stepped aside and nothing took its place. That was the #4401 failure mode, and
+  #4401 fixed only the *installer* half of it (`ensure_project_hook_wiring`
+  re-asserts the project entries on every install); a commit that later deleted
+  the `hooks` block — careless or hostile — re-created the gap silently, and
+  Loom itself dogfoods the copies-present layout.
+- **The fix (#4806): the deferral is now conditional.** `_phook_cmd()`
+  (`scripts/install/provision-hooks.sh`) defers only when the copy exists **and**
+  the project `.claude/settings.json` actually references `.loom/hooks/<name>`;
+  otherwise it falls through and execs the machine hook. It is fork-free in the
+  wrapper — `[ -x "$ROOT/.loom/hooks/<name>" ] && [ -f "$ROOT/.claude/settings.json" ] && case "$(<"$ROOT/.claude/settings.json")" in *".loom/hooks/<name>"*) exit 0 ;; esac`
   (the `[ -f ]` guard matters: `$(<missing)` writes to stderr) — and it cannot
   double-fire, because it defers exactly when the project entry will run the
-  copy. It is *not* landed in this change for one concrete reason: the
-  wrapper string is embedded in every operator's `~/.claude/settings.json`, and
-  `_phook_merge_one` deduplicates on the `defaults/hooks/<name>` marker — which
-  the new wrapper also contains — so re-provisioning would **skip** the entry and
-  leave the old wrapper in place. Landing the fix therefore requires a companion
-  change: a versioned "replace a stale Loom-owned entry" upgrade path in
-  `scripts/install/provision-hooks.sh`. That is installer surgery on live,
-  machine-level state, so it is tracked as its own issue (**#4806**) rather than
-  smuggled into a documentation change.
+  copy. Landing the wrapper change alone would have been inert on already-
+  installed machines: the wrapper string is embedded in every operator's
+  `~/.claude/settings.json`, and `_phook_merge_one` deduplicates on the
+  `defaults/hooks/<name>` marker — which the new wrapper also contains — so a
+  naive re-provision would **skip** the entry and leave the old wrapper in
+  place forever. #4806 therefore also added a versioned "replace a stale
+  Loom-owned entry" upgrade path: `_phook_merge_one` accepts an optional
+  `upgrade_marker` (`_PHOOK_WRAPPER_MARKER`, the `ROOT=$(cd "$(git rev-parse
+  --git-common-dir` prefix unique to a Loom-authored wrapper) and, when a
+  duplicate-by-marker entry is found whose command differs from the current
+  `_phook_cmd()` output *and* carries that upgrade marker, rewrites it in place
+  — a hand-written / non-Loom entry that happens to reference the same hook name
+  never matches the upgrade marker and is never touched.
 - **Verify wiring on demand** (an operator or Auditor can run this in any repo):
 
   ```bash

--- a/defaults/scripts/tests/test-provision-hooks.sh
+++ b/defaults/scripts/tests/test-provision-hooks.sh
@@ -179,15 +179,32 @@ LOOMREPO=$(mktemp -d); git -C "$LOOMREPO" init -q; mkdir -p "$LOOMREPO/.loom"; e
 run_wrapper "$LOOMREPO"
 assert_contains "$WOUT" "MACHINE-RAN:$LOOMREPO" "AC1: Loom workspace with no copy -> execs the machine hook, LOOM_PROJECT_ROOT set"
 
-# 8c: Loom workspace WITH a per-repo .loom/hooks/ copy -> defers (transition dedup)
+# 8c: Loom workspace WITH a per-repo .loom/hooks/ copy but NO project-level
+# entry referencing it -> the deferral is now CONDITIONAL (#4806): with
+# nothing to defer TO, the wrapper falls through and execs the machine hook
+# rather than silently no-op'ing (the zero-guard-hooks bug this issue closes).
 mkdir -p "$LOOMREPO/.loom/hooks"
 printf '#!/usr/bin/env bash\necho SHOULD-NOT-RUN\n' > "$LOOMREPO/.loom/hooks/guard-destructive.sh"
 chmod +x "$LOOMREPO/.loom/hooks/guard-destructive.sh"
 run_wrapper "$LOOMREPO"
-[[ -z "$WOUT" && "$WRC" == "0" ]] && pass "transition: defers to a present per-repo copy (machine hook does not run)" || fail "transition: expected silent defer, got out='$WOUT' rc=$WRC"
+assert_contains "$WOUT" "MACHINE-RAN:$LOOMREPO" "#4806 AC(a): copies present + no project entry -> machine hook runs (was a zero-guard silent no-op)"
 
-# 8d: Loom workspace but machine checkout absent -> no-op (fail-open)
-out=$(cd "$LOOMREPO" && rm -rf "$LOOMREPO/.loom/hooks" && LOOM_HOME="/nonexistent/checkout" bash -c "$CMD" </dev/null 2>/dev/null); wrc=$?
+# 8c2: same repo, but NOW the project .claude/settings.json actually
+# references the per-repo copy -> the wrapper defers (exactly one fire, no
+# double-fire; #4806 AC(b)).
+mkdir -p "$LOOMREPO/.claude"
+printf '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"}]}]}}\n' > "$LOOMREPO/.claude/settings.json"
+run_wrapper "$LOOMREPO"
+[[ -z "$WOUT" && "$WRC" == "0" ]] && pass "#4806 AC(b): copies present + project entry -> defers to it (machine hook does not double-fire)" || fail "#4806 AC(b): expected silent defer, got out='$WOUT' rc=$WRC"
+
+# 8d: Loom workspace, copies ABSENT -> machine exec runs (#4806 AC(c); also
+# covered by 8b above, restated explicitly per the issue's AC wording).
+rm -rf "$LOOMREPO/.loom/hooks" "$LOOMREPO/.claude/settings.json"
+run_wrapper "$LOOMREPO"
+assert_contains "$WOUT" "MACHINE-RAN:$LOOMREPO" "#4806 AC(c): copies absent -> machine hook runs"
+
+# 8e: Loom workspace but machine checkout absent -> no-op (fail-open)
+out=$(cd "$LOOMREPO" && LOOM_HOME="/nonexistent/checkout" bash -c "$CMD" </dev/null 2>/dev/null); wrc=$?
 [[ -z "$out" && "$wrc" == "0" ]] && pass "machine checkout absent -> silent no-op (exit 0)" || fail "expected silent exit 0 when checkout absent, got out='$out' rc=$wrc"
 
 # ── Test 9: deprovision removes only Loom-owned entries ──────────────────────
@@ -368,6 +385,53 @@ OUT18=$(cd "$R18" && LOOM_HOME="$CHK18" bash -c "$CMD18" </dev/null 2>/dev/null)
 rm -rf "$R18/.loom/hooks"
 OUT18b=$(cd "$R18" && LOOM_HOME="$CHK18" bash -c "$CMD18" </dev/null 2>/dev/null)
 assert_contains "$OUT18b" "MACHINE-RAN" "once the copies are gone, the machine-checkout hook runs (coverage never zero)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stale-Loom-wrapper UPGRADE path (#4806) — re-provisioning an install that
+# carries an OLDER Loom-authored wrapper (predating a `_phook_cmd()` edit)
+# must REWRITE it in place, since the dedup marker (`defaults/hooks/<name>`)
+# matches regardless of wrapper version and would otherwise cause a naive
+# re-provision to skip it forever.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# An "older" wrapper: same overall shape (the recognizable
+# `ROOT=$(cd "$(git rev-parse --git-common-dir` prefix + the
+# `defaults/hooks/<name>` marker) but with the UNCONDITIONAL transition-dedup
+# step this issue replaces (no `.claude/settings.json` check before deferring).
+OLD_WRAPPER_CMD='bash -c '"'"'ROOT=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd); [ -n "$ROOT" ] || exit 0; { [ -f "$ROOT/.loom-project/project.json" ] || [ -f "$ROOT/.loom/config.json" ]; } || exit 0; [ -x "$ROOT/.loom/hooks/guard-destructive.sh" ] && exit 0; H="${LOOM_HOME:-$HOME/.local/share/loom}/defaults/hooks/guard-destructive.sh"; [ -x "$H" ] && LOOM_PROJECT_ROOT="$ROOT" exec "$H" || exit 0'"'"''
+
+# ── Test 19: re-provisioning REPLACES a stale Loom-authored wrapper ──────────
+echo "Test 19: re-provisioning an install with an OLDER Loom wrapper replaces it in place (#4806)"
+HOME19=$(mktemp -d); mkdir -p "$HOME19/.claude"
+jq -n --arg cmd "$OLD_WRAPPER_CMD" \
+    '{hooks:{PreToolUse:[{matcher:"Bash",hooks:[{type:"command",command:$cmd}]}]}}' \
+    > "$HOME19/.claude/settings.json"
+BEFORE_CMD19=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$HOME19/.claude/settings.json")
+assert_eq "$BEFORE_CMD19" "$OLD_WRAPPER_CMD" "precondition: the stale wrapper is seeded verbatim"
+provision_loom_hooks "$HOME19/.claude" >/dev/null 2>&1
+assert_eq "$(count_marker "$HOME19/.claude/settings.json" guard-destructive.sh)" "1" "still exactly one guard-destructive.sh entry after upgrade (no duplicate)"
+AFTER_CMD19=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$HOME19/.claude/settings.json")
+CURRENT_CMD19="$(_phook_cmd guard-destructive.sh)"
+assert_eq "$AFTER_CMD19" "$CURRENT_CMD19" "the stale entry was rewritten to the CURRENT _phook_cmd() output"
+[[ "$AFTER_CMD19" != "$OLD_WRAPPER_CMD" ]] && pass "the old unconditional-defer text is gone" || fail "the old wrapper text is still present — upgrade did not fire"
+# Idempotent: a second re-provision must not touch it again (it now matches).
+provision_loom_hooks "$HOME19/.claude" >/dev/null 2>&1
+assert_eq "$(count_marker "$HOME19/.claude/settings.json" guard-destructive.sh)" "1" "still exactly one entry after a second re-provision"
+assert_eq "$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$HOME19/.claude/settings.json")" "$CURRENT_CMD19" "already-current entry left unchanged by a second re-provision"
+
+# ── Test 20: a hand-written entry sharing the marker is NEVER rewritten ──────
+echo "Test 20: a non-Loom / hand-written entry is never rewritten or removed by the upgrade path (#4806)"
+HOME20=$(mktemp -d); mkdir -p "$HOME20/.claude"
+HANDWRITTEN_CMD='.claude/hooks/my-custom-wrapper.sh --marker defaults/hooks/guard-destructive.sh'
+jq -n --arg cmd "$HANDWRITTEN_CMD" \
+    '{hooks:{PreToolUse:[{matcher:"Bash",hooks:[{type:"command",command:$cmd}]}]}}' \
+    > "$HOME20/.claude/settings.json"
+provision_loom_hooks "$HOME20/.claude" >/dev/null 2>&1
+assert_eq "$(jq -r '[.hooks.PreToolUse[0].hooks[] | select(.command == $h)] | length' --arg h "$HANDWRITTEN_CMD" "$HOME20/.claude/settings.json")" "1" "hand-written entry is byte-identical after provisioning (never rewritten)"
+# Its shape does not match the known Loom wrapper prefix, so the dedup test
+# treats the marker match as satisfied and does NOT append a second (Loom)
+# entry either — same no-duplicate contract as before this issue.
+assert_eq "$(count_marker "$HOME20/.claude/settings.json" guard-destructive.sh)" "1" "no second (Loom) entry appended alongside the hand-written one"
 
 echo ""
 echo "======================================"

--- a/scripts/install/provision-hooks.sh
+++ b/scripts/install/provision-hooks.sh
@@ -126,10 +126,22 @@ _PHOOK_NAMES=(
 # single hook script <name>. A single-quoted `bash -c '...'` body with NO
 # embedded single quotes (all internal quoting is double quotes) so it survives
 # JSON round-tripping cleanly. See the header for the four steps this encodes.
+#
+# TRANSITION DEDUP (#4806): the deferral to a present per-repo `.loom/hooks/
+# <name>` copy is CONDITIONAL, not unconditional — it only steps aside when the
+# project's `.claude/settings.json` actually references that copy (i.e. there is
+# something for it to defer TO). Without this guard, a repo that carries stale
+# `.loom/hooks/` copies but has had its project-level `hooks` block deleted
+# (accident or #4401-style installer gap) would silently run ZERO guard hooks:
+# the user-scope wrapper steps aside for an entry that was never wired. The
+# `[ -f ... ]` check matters — `$(<missing-file)` writes an error to stderr,
+# which would leak into hook output.
+# shellcheck disable=SC2016  # literal $-expansion is intentional (a fixed marker string, not evaluated here)
+_PHOOK_WRAPPER_MARKER='ROOT=$(cd "$(git rev-parse --git-common-dir'
 _phook_cmd() {
     local name="$1"
     # shellcheck disable=SC2016  # literal $-expansions are intentional (per-user, at hook time)
-    printf '%s' "bash -c 'ROOT=\$(cd \"\$(git rev-parse --git-common-dir 2>/dev/null)/..\" 2>/dev/null && pwd); [ -n \"\$ROOT\" ] || exit 0; { [ -f \"\$ROOT/.loom-project/project.json\" ] || [ -f \"\$ROOT/.loom/config.json\" ]; } || exit 0; [ -x \"\$ROOT/.loom/hooks/${name}\" ] && exit 0; H=\"\${LOOM_HOME:-\$HOME/.local/share/loom}/defaults/hooks/${name}\"; [ -x \"\$H\" ] && LOOM_PROJECT_ROOT=\"\$ROOT\" exec \"\$H\" || exit 0'"
+    printf '%s' "bash -c 'ROOT=\$(cd \"\$(git rev-parse --git-common-dir 2>/dev/null)/..\" 2>/dev/null && pwd); [ -n \"\$ROOT\" ] || exit 0; { [ -f \"\$ROOT/.loom-project/project.json\" ] || [ -f \"\$ROOT/.loom/config.json\" ]; } || exit 0; [ -x \"\$ROOT/.loom/hooks/${name}\" ] && [ -f \"\$ROOT/.claude/settings.json\" ] && case \"\$(<\"\$ROOT/.claude/settings.json\")\" in *\".loom/hooks/${name}\"*) exit 0 ;; esac; H=\"\${LOOM_HOME:-\$HOME/.local/share/loom}/defaults/hooks/${name}\"; [ -x \"\$H\" ] && LOOM_PROJECT_ROOT=\"\$ROOT\" exec \"\$H\" || exit 0'"
 }
 
 # provision_loom_hooks [claude_dir]
@@ -199,7 +211,7 @@ provision_loom_hooks() {
         local name="${_PHOOK_NAMES[$i]}"
         local cmd
         cmd="$(_phook_cmd "$name")"
-        if _phook_merge_one "$settings" "$htype" "$matcher" "defaults/hooks/$name" "$cmd"; then
+        if _phook_merge_one "$settings" "$htype" "$matcher" "defaults/hooks/$name" "$cmd" "" "$_PHOOK_WRAPPER_MARKER"; then
             _phook_ok "wired $htype/${matcher:-<all>} -> $name"
         else
             _phook_warn "failed to wire $name into $settings"
@@ -222,10 +234,21 @@ provision_loom_hooks() {
 # — so a bare `.loom/hooks/<name>` substring test would mistake a stray
 # machine-level entry for the project-level entry that entry defers TO, and skip
 # writing the only command that actually executes anything.
+#
+# <$7 upgrade_marker> (optional, #4806): enables the stale-Loom-wrapper UPGRADE
+# path. When a duplicate is found (by <dedup_marker>) that is NOT byte-identical
+# to <command>, it is normally left alone (a `_phook_cmd()` edit would otherwise
+# never reach already-provisioned installs, because the dedup marker matches
+# regardless of which version of the wrapper generated it — the exact trap
+# described in #4806). Passing <upgrade_marker> narrows that: a duplicate is
+# REWRITTEN in place only when it ALSO contains <upgrade_marker> — a substring
+# recognizable ONLY in a Loom-authored wrapper (see `_PHOOK_WRAPPER_MARKER`) —
+# so a hand-written / non-Loom entry that happens to reference the same hook
+# name is never touched, only ever left as-is.
 #   $1 settings_file  $2 hook_type  $3 matcher  $4 dedup_marker  $5 command
-#   $6 exclude_marker (optional)
+#   $6 exclude_marker (optional)  $7 upgrade_marker (optional)
 _phook_merge_one() {
-    local f="$1" htype="$2" matcher="$3" marker="$4" cmd="$5" exclude="${6:-}"
+    local f="$1" htype="$2" matcher="$3" marker="$4" cmd="$5" exclude="${6:-}" upgrade="${7:-}"
     local tmp
     tmp="$(mktemp 2>/dev/null)" || return 1
     if jq \
@@ -233,9 +256,13 @@ _phook_merge_one() {
         --arg m "$matcher" \
         --arg marker "$marker" \
         --arg exclude "$exclude" \
+        --arg upgrade "$upgrade" \
         --arg cmd "$cmd" '
         def is_dup($c): ($c | contains($marker))
             and (($exclude | length) == 0 or ($c | contains($exclude) | not));
+        def is_stale_loom_wrapper($c): ($upgrade | length) > 0
+            and ($c != $cmd)
+            and ($c | contains($upgrade));
         .hooks = (.hooks // {})
         | .hooks[$ht] = (.hooks[$ht] // [])
         | (.hooks[$ht] | map(.matcher // "") | index($m)) as $idx
@@ -244,7 +271,17 @@ _phook_merge_one() {
           else
             .hooks[$ht][$idx].hooks = (.hooks[$ht][$idx].hooks // [])
             | if (.hooks[$ht][$idx].hooks | map(.command // "") | any(is_dup(.)))
-              then .
+              then
+                # A duplicate (by dedup_marker) already exists. Rewrite it IN
+                # PLACE only if it is a stale Loom-authored wrapper (recognized
+                # by upgrade_marker) that differs from the current command —
+                # never touch anything else (already-current, or hand-written).
+                .hooks[$ht][$idx].hooks |= map(
+                    if is_dup(.command // "") and is_stale_loom_wrapper(.command // "")
+                    then .command = $cmd
+                    else .
+                    end
+                )
               else .hooks[$ht][$idx].hooks += [{type: "command", command: $cmd}]
               end
           end


### PR DESCRIPTION
## Summary

The user-scope guard-hook wrapper's transition-dedup step deferred to a present per-repo `.loom/hooks/<name>` copy **unconditionally**, without checking that `.claude/settings.json` actually wires that copy in. A repo that carries stale `.loom/hooks/` copies but has no matching project-level `hooks` block (accidental deletion, or the #4401-style installer gap) ran **zero guard hooks**: the wrapper stepped aside for an entry that was never registered. This Loom repo itself dogfoods the copies-present layout, so the gap was live here.

## Changes

- `scripts/install/provision-hooks.sh`
  - `_phook_cmd()`: the transition-dedup deferral is now conditional — `[ -x "$ROOT/.loom/hooks/<name>" ] && [ -f "$ROOT/.claude/settings.json" ] && case "$(<"$ROOT/.claude/settings.json")" in *".loom/hooks/<name>"*) exit 0 ;; esac` — it only steps aside when there is actually something to defer to; otherwise it falls through and execs the machine-level hook.
  - `_phook_merge_one()`: added an optional 7th `upgrade_marker` parameter. When a duplicate-by-marker entry is found whose command differs from the freshly-generated one *and* carries the known Loom-wrapper shape (`_PHOOK_WRAPPER_MARKER`, the `ROOT=$(cd "$(git rev-parse --git-common-dir` prefix), it is **rewritten in place** instead of skipped — this is the companion upgrade path required so re-provisioning an install with an OLDER Loom-authored wrapper actually replaces it (the plain marker-based dedup would otherwise skip it forever, since the marker matches both old and new wrapper text). A hand-written / non-Loom entry that happens to reference the same hook name never matches the upgrade marker and is never touched.
  - `provision_loom_hooks()` now passes `_PHOOK_WRAPPER_MARKER` through as the upgrade marker; `ensure_project_hook_wiring()` (the project-level fallback) is unchanged — it doesn't pass an upgrade marker, so its existing skip-on-dup behavior is preserved.
- `defaults/scripts/tests/test-provision-hooks.sh`
  - Reworked Test 8's transition-dedup coverage into the three scenarios from the issue's AC: (a) copies present + no project entry ⇒ machine hook runs, (b) copies present + project entry ⇒ defers (no double-fire), (c) copies absent ⇒ machine hook runs.
  - Added Test 19: re-provisioning an install carrying an OLDER Loom-authored wrapper rewrites it in place (idempotent on a second run).
  - Added Test 20: a hand-written entry that happens to contain the `defaults/hooks/<name>` marker substring is never rewritten by the upgrade path.
- `defaults/docs/guard-hooks.md`
  - "Hook-wiring integrity" section flipped from "proposed" to "implemented" — describes the fix and the upgrade-path mechanism in place of the deferred-fix note.

## Acceptance Criteria Verification

- [x] The user-scope wrapper defers ONLY when a project-level entry referencing `.loom/hooks/<name>` actually exists in `.claude/settings.json` — verified by manual wrapper execution (three scenarios) and Test 8 (a/b/c) in the automated suite.
- [x] Re-provisioning an install that carries an OLDER Loom-authored wrapper REPLACES it in place — verified by Test 19 (including idempotence on a second re-provision).
- [x] A non-Loom / hand-written entry is never rewritten or removed by the upgrade path — verified by Test 20.
- [x] Test coverage for (a) copies-present + no project entry, (b) copies-present + project entry, (c) copies-absent — Test 8 a/b/c.
- [x] `defaults/docs/guard-hooks.md` → "Hook-wiring integrity" section updated from "proposed" to "implemented".

## Test Plan

- `bash defaults/scripts/tests/test-provision-hooks.sh` — 73/73 passed (was 63 before this PR; added Tests 19-20 and reworked Test 8).
- `bash -n scripts/install/provision-hooks.sh` and `shellcheck scripts/install/provision-hooks.sh` — clean.
- Manual runtime verification of the wrapper's new conditional deferral against a fake machine checkout for all three deferral scenarios plus the machine-checkout-absent fail-open case.
- `./.loom/scripts/check-main-clean.sh` — main worktree clean, no contamination.

Closes #4806