### PR TITLE
feat(install): serialize concurrent installs with a per-target PID lock

### DIFF
--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -309,6 +309,36 @@ cat .loom/config.json.bak
 `loom-daemon init` against a workspace that already has a `.loom/config.json`, so
 repeat provisioning passes cannot re-enter this path on a tuned host.
 
+### `install.sh` refuses to run: "Another Loom install is already running" (#4928)
+
+`install.sh`'s `--quick` / `--clean` paths take a per-target lock at
+`<target>/.loom/.install.lock` before any destructive phase, because two
+installers racing over one target interleave one run's uninstall (which stages
+Loom file deletions and strips the Loom sections out of `CLAUDE.md` /
+`.gitignore` **in place**) with the other's copy phase. The message names the
+owning PID, host, and phase:
+
+```bash
+cat <target>/.loom/.install.lock   # pid / host / started / phase
+```
+
+- **The PID is alive** — a real install is in flight (a `cargo build --release`
+  can run for minutes; it emits a progress line every 15s). Wait for it.
+- **The PID is gone** — the next installer reclaims the lock automatically; you
+  should never need to delete it. If you do (e.g. a lock written by another
+  host, which cannot be liveness-probed and is only reclaimed after
+  `LOOM_INSTALL_LOCK_MAX_AGE`, default 6h), `rm -f <target>/.loom/.install.lock`.
+
+If the lock's `phase` is `uninstalling` / `installing` / `restoring`, that run
+died **inside the destructive window** and the target may be partially
+uninstalled. The next installer prints the recovery commands; the short form is:
+
+```bash
+git -C <target> status --short
+git -C <target> restore --staged --worktree -- .loom .claude CLAUDE.md .gitignore
+git -C <target> stash list | grep loom-install   # changes the installer stashed, if any
+```
+
 ### Daemon won't start
 
 ```bash

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -60,6 +60,7 @@ test-guard-codex-bridge.sh
 test-guard-hook-schema.sh
 test-install-active-session.sh
 test-install-full-reinstall-no-target-mutation.sh
+test-install-lock.sh
 test-install-pr-markers.sh
 test-install-source-guard.sh
 test-install-stash-scope.sh

--- a/defaults/scripts/tests/test-install-lock.sh
+++ b/defaults/scripts/tests/test-install-lock.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+# test-install-lock.sh — per-target install lock regression tests (issue #4928).
+#
+# Before the fix, nothing in install.sh detected or prevented a SECOND
+# installer running against the same target while a first one was mid-flight.
+# In the reported incident (2026-08-01) a caller concluded a silent
+# `--quick --yes --confirm-reinstall` run had died, restored the target from
+# git, and started a second installer — which ran concurrently with the
+# still-alive first one. The only thing that serialized them was cargo's
+# build-directory lock, by luck; the uninstall-phase deletions of one run and
+# the copy phase of the other could just as easily have corrupted the target.
+#
+# The fix (scripts/install/install-lock.sh) takes a PID-bearing lock file at
+# <target>/.loom/.install.lock before any destructive phase of the --quick /
+# --clean paths, releases it from an EXIT trap, and reclaims it automatically
+# when the recorded PID is no longer alive.
+#
+# Strategy — two layers:
+#   1. Unit tests that source the real helper directly (mirroring
+#      test-install-stash-scope.sh) and pin acquire/reclaim/phase/release
+#      semantics deterministically, including the cross-host and
+#      malformed-lock edge cases.
+#   2. End-to-end tests that run the REAL install.sh from a throwaway "fake
+#      LOOM_ROOT" (mirroring test-install-full-reinstall-no-target-mutation.sh)
+#      and assert that a held lock stops the second installer before it
+#      touches the target, that a stale lock does not block, and that the lock
+#      is released on both a successful run and an `error()`-triggered exit.
+#
+# Usage:
+#   bash defaults/scripts/tests/test-install-lock.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# In the source checkout this file lives at defaults/scripts/tests/; the repo
+# root is three levels up. This suite is a source-checkout artifact and expects
+# the real scripts/install/ and install.sh.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+LOCK_LIB="$REPO_ROOT/scripts/install/install-lock.sh"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_PASSED=$((TESTS_PASSED + 1)); TESTS_RUN=$((TESTS_RUN + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() {
+  TESTS_FAILED=$((TESTS_FAILED + 1)); TESTS_RUN=$((TESTS_RUN + 1))
+  echo -e "  ${RED}FAIL${NC}: $1"
+  [[ -n "${2:-}" ]] && echo "$2" | sed 's/^/      /'
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg" "expected to find: [$needle]
+in:
+$haystack"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" msg="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg" "did NOT expect to find: [$needle]
+in:
+$haystack"
+  fi
+}
+
+for f in "$LOCK_LIB" "$INSTALL_SH"; do
+  if [[ ! -f "$f" ]]; then
+    echo "ERROR: $f not found" >&2
+    exit 1
+  fi
+done
+
+if ! command -v git &> /dev/null; then
+  echo -e "${YELLOW}SKIP${NC}: missing required dependency 'git'"
+  exit 0
+fi
+
+echo "================================================================"
+echo "Per-target install lock (issue #4928)"
+echo "================================================================"
+echo ""
+
+WORKDIR="$(mktemp -d /tmp/loom-install-lock.XXXXXX)"
+
+# NOTE: deliberately no EXIT trap for cleanup. Background jobs inherit a shell's
+# EXIT trap, so the sleeper below would run it when killed — deleting $WORKDIR
+# out from under the still-running suite. Cleanup happens at the end instead
+# (matching the sibling install suites).
+
+# A definitely-live PID: a sleeper we own for the duration of the suite.
+sleep 600 &
+LIVE_PID=$!
+
+# A definitely-dead PID: a short-lived child, confirmed reaped. Retry a few
+# times in the (vanishingly unlikely) event the PID is immediately recycled.
+DEAD_PID=""
+for _ in 1 2 3 4 5; do
+  _candidate="$(bash -c 'echo $$')"
+  if ! kill -0 "$_candidate" 2>/dev/null && ! ps -p "$_candidate" >/dev/null 2>&1; then
+    DEAD_PID="$_candidate"
+    break
+  fi
+done
+if [[ -z "$DEAD_PID" ]]; then
+  echo -e "${YELLOW}SKIP${NC}: could not obtain a reliably-dead PID on this host"
+  rm -rf "$WORKDIR"
+  kill "$LIVE_PID" 2>/dev/null
+  exit 0
+fi
+
+THIS_HOST="$(hostname 2>/dev/null || uname -n 2>/dev/null || echo unknown-host)"
+
+# Write a lock file by hand, standing in for another installer's lock.
+write_lock() {
+  local file="$1" pid="$2" host="$3" phase="$4" epoch="${5:-$(date +%s)}"
+  mkdir -p "$(dirname "$file")"
+  {
+    echo "# Loom install lock (issue #4928)."
+    echo "pid=$pid"
+    echo "host=$host"
+    echo "started=2026-08-01T00:00:00Z"
+    echo "started_epoch=$epoch"
+    echo "phase=$phase"
+    echo "target=$(dirname "$(dirname "$file")")"
+  } > "$file"
+}
+
+# Fresh scratch target directory for one scenario.
+new_target() {
+  local d
+  d="$(mktemp -d "$WORKDIR/target.XXXXXX")"
+  echo "$d"
+}
+
+# ===============================================================
+# Part 1 — unit tests against the real helper
+# ===============================================================
+echo "--- Unit: acquire / reclaim / phase / release ---"
+
+# 1. A fresh acquire creates the lock, records this PID, and creates .loom/.
+T="$(new_target)"
+OUT="$(
+  source "$LOCK_LIB"
+  acquire_install_lock "$T" "preparing" && echo "ACQUIRED"
+)"
+assert_contains "$OUT" "ACQUIRED" "fresh acquire succeeds"
+if [[ -f "$T/.loom/.install.lock" ]]; then
+  pass "lock file created at <target>/.loom/.install.lock"
+else
+  fail "lock file was not created at $T/.loom/.install.lock"
+fi
+assert_contains "$(cat "$T/.loom/.install.lock")" "phase=preparing" "lock records the phase"
+assert_contains "$(cat "$T/.loom/.install.lock")" "host=$THIS_HOST" "lock records the host"
+
+# 2. A lock held by a LIVE pid blocks a second acquire, and is not stolen.
+T="$(new_target)"
+write_lock "$T/.loom/.install.lock" "$LIVE_PID" "$THIS_HOST" "uninstalling"
+OUT="$(
+  source "$LOCK_LIB"
+  acquire_install_lock "$T" "preparing" 2>&1 && echo "ACQUIRED"
+)"
+assert_not_contains "$OUT" "ACQUIRED" "acquire fails while a live installer holds the lock"
+assert_contains "$OUT" "Another Loom install is already running" "failure names the conflict"
+assert_contains "$OUT" "Held by pid $LIVE_PID" "failure names the live owning pid"
+assert_contains "$OUT" "$T/.loom/.install.lock" "failure names the lock path"
+if [[ -f "$T/.loom/.install.lock" ]]; then
+  pass "the live installer's lock is left intact"
+else
+  fail "the live installer's lock was stolen/removed"
+fi
+
+# 3. A lock whose pid is dead is reclaimed rather than blocking forever.
+T="$(new_target)"
+write_lock "$T/.loom/.install.lock" "$DEAD_PID" "$THIS_HOST" "preparing"
+OUT="$(
+  source "$LOCK_LIB"
+  acquire_install_lock "$T" "preparing" 2>&1 && echo "ACQUIRED"
+)"
+assert_contains "$OUT" "ACQUIRED" "stale (dead pid) lock is reclaimed"
+assert_contains "$OUT" "Reclaiming stale Loom install lock" "reclaim is announced"
+assert_contains "$OUT" "no longer running" "reclaim names the dead-pid reason"
+
+# 4. Reclaiming a lock interrupted mid-uninstall surfaces recovery guidance
+#    (the AC #3 "half-uninstalled window is explicit in state" contract).
+T="$(new_target)"
+write_lock "$T/.loom/.install.lock" "$DEAD_PID" "$THIS_HOST" "uninstalling"
+OUT="$(
+  source "$LOCK_LIB"
+  acquire_install_lock "$T" "preparing" 2>&1 && echo "ACQUIRED"
+)"
+assert_contains "$OUT" "ACQUIRED" "interrupted-run lock does not block the retry"
+assert_contains "$OUT" "interrupted during the 'uninstalling' phase" "names the interrupted phase"
+assert_contains "$OUT" "PARTIALLY UNINSTALLED" "warns the target may be half-uninstalled"
+assert_contains "$OUT" "git -C \"$T\" status --short" "prints a concrete recovery command"
+
+# 5. A lock with no parseable pid is treated as malformed and reclaimed.
+T="$(new_target)"
+mkdir -p "$T/.loom"
+echo "# garbage" > "$T/.loom/.install.lock"
+OUT="$(
+  source "$LOCK_LIB"
+  acquire_install_lock "$T" "preparing" 2>&1 && echo "ACQUIRED"
+)"
+assert_contains "$OUT" "ACQUIRED" "malformed lock is reclaimed"
+assert_contains "$OUT" "no owning pid" "malformed reclaim names the reason"
+
+# 6. A recent lock owned by ANOTHER host is respected (pid liveness is not
+#    probeable across hosts), but an old one is reclaimed rather than wedging
+#    the target forever.
+T="$(new_target)"
+write_lock "$T/.loom/.install.lock" "999999" "some-other-host" "installing"
+OUT="$(
+  source "$LOCK_LIB"
+  acquire_install_lock "$T" "preparing" 2>&1 && echo "ACQUIRED"
+)"
+assert_not_contains "$OUT" "ACQUIRED" "recent foreign-host lock is respected"
+assert_contains "$OUT" "some-other-host" "foreign-host failure names the host"
+
+T="$(new_target)"
+write_lock "$T/.loom/.install.lock" "999999" "some-other-host" "installing" "$(( $(date +%s) - 999999 ))"
+OUT="$(
+  source "$LOCK_LIB"
+  acquire_install_lock "$T" "preparing" 2>&1 && echo "ACQUIRED"
+)"
+assert_contains "$OUT" "ACQUIRED" "long-abandoned foreign-host lock is reclaimed"
+
+# 7. set_install_lock_phase rewrites the phase in place; release removes the
+#    lock; release also drops a .loom/ the lock itself created.
+T="$(new_target)"
+OUT="$(
+  source "$LOCK_LIB"
+  acquire_install_lock "$T" "preparing" >/dev/null 2>&1 || exit 1
+  set_install_lock_phase "uninstalling"
+  cat "$T/.loom/.install.lock"
+  release_install_lock
+  [[ -e "$T/.loom/.install.lock" ]] && echo "LOCK-STILL-PRESENT"
+  [[ -d "$T/.loom" ]] && echo "LOOM-DIR-STILL-PRESENT"
+  echo "DONE"
+)"
+assert_contains "$OUT" "phase=uninstalling" "set_install_lock_phase updates the recorded phase"
+assert_not_contains "$OUT" "LOCK-STILL-PRESENT" "release removes the lock file"
+assert_not_contains "$OUT" "LOOM-DIR-STILL-PRESENT" "release drops a .loom/ it created itself"
+
+# 8. release never removes a lock that now belongs to a DIFFERENT process
+#    (e.g. this run was stopped long enough to be reclaimed).
+T="$(new_target)"
+OUT="$(
+  source "$LOCK_LIB"
+  acquire_install_lock "$T" "preparing" >/dev/null 2>&1 || exit 1
+  # Another installer reclaimed and re-took the lock.
+  printf 'pid=%s\nhost=%s\nphase=installing\n' "$LIVE_PID" "$THIS_HOST" > "$T/.loom/.install.lock"
+  release_install_lock
+  [[ -f "$T/.loom/.install.lock" ]] && echo "FOREIGN-LOCK-PRESERVED"
+  echo "DONE"
+)"
+assert_contains "$OUT" "FOREIGN-LOCK-PRESERVED" "release leaves another process's lock alone"
+
+# 9. A second acquire from the same process is idempotent (phase update only).
+T="$(new_target)"
+OUT="$(
+  source "$LOCK_LIB"
+  acquire_install_lock "$T" "preparing" >/dev/null 2>&1 || exit 1
+  acquire_install_lock "$T" "installing" >/dev/null 2>&1 && echo "RE-ACQUIRED"
+  cat "$T/.loom/.install.lock"
+)"
+assert_contains "$OUT" "RE-ACQUIRED" "re-acquiring an already-held lock succeeds"
+assert_contains "$OUT" "phase=installing" "re-acquire updates the phase"
+
+# ===============================================================
+# Part 2 — end-to-end through the real install.sh
+# ===============================================================
+echo ""
+echo "--- End-to-end: install.sh --quick ---"
+
+# Build a fake LOOM_ROOT: the REAL install.sh + real helper scripts, with only
+# the pieces that need network/toolchain replaced by stubs. Same construction
+# as test-install-full-reinstall-no-target-mutation.sh.
+FAKE_ROOT="$WORKDIR/fakeroot"
+mkdir -p "$FAKE_ROOT/scripts" "$FAKE_ROOT/target/release"
+ln -s "$REPO_ROOT/scripts/install" "$FAKE_ROOT/scripts/install"
+ln -s "$REPO_ROOT/scripts/uninstall-loom.sh" "$FAKE_ROOT/scripts/uninstall-loom.sh"
+ln -s "$REPO_ROOT/install.sh" "$FAKE_ROOT/install.sh"
+ln -s "$REPO_ROOT/defaults" "$FAKE_ROOT/defaults"
+cat > "$FAKE_ROOT/scripts/install-loom.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "STUB install-loom.sh (should not be reached by these tests)" >&2
+exit 1
+EOF
+chmod +x "$FAKE_ROOT/scripts/install-loom.sh"
+
+# install.sh gates on node/pnpm/cargo before any of the logic under test, so
+# stub them (version printers) to keep the suite host-independent. `git` is
+# used for real and keeps its hard skip-guard above.
+STUB_BIN="$FAKE_ROOT/stub-bin"
+mkdir -p "$STUB_BIN"
+for _tool in node pnpm cargo; do
+  cat > "$STUB_BIN/$_tool" <<EOF
+#!/usr/bin/env bash
+echo "$_tool (loom test stub) 0.0.0"
+EOF
+  chmod +x "$STUB_BIN/$_tool"
+done
+
+# Stub loom-daemon. \`init\` writes just enough for install.sh's post-init
+# steps (finalize_quick_install / verify_install) to run; LOOM_DAEMON_FAIL=1
+# makes it fail instead, standing in for a downstream install failure.
+cat > "$FAKE_ROOT/target/release/loom-daemon" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${LOOM_DAEMON_FAIL:-0}" == "1" ]]; then
+  echo "STUB loom-daemon: simulated init failure" >&2
+  exit 1
+fi
+[[ "${1:-}" == "init" ]] || exit 0
+target=""
+for arg in "$@"; do target="$arg"; done
+mkdir -p "$target/.loom/scripts/lib" "$target/.loom/roles"
+echo '{"terminals": []}' > "$target/.loom/config.json"
+echo '#!/usr/bin/env bash' > "$target/.loom/scripts/worktree.sh"
+echo '#!/usr/bin/env bash' > "$target/.loom/scripts/lib/loom-tools.sh"
+printf '# Loom\n\n**Loom Version**: %s\n' "${LOOM_VERSION:-unknown}" > "$target/.loom/CLAUDE.md"
+echo "STUB loom-daemon: init wrote $target/.loom"
+EOF
+chmod +x "$FAKE_ROOT/target/release/loom-daemon"
+
+# Seed a scratch target repo carrying an existing ("older") Loom install.
+seed_target() {
+  local t="$1"
+  git -C "$t" init --quiet
+  git -C "$t" config user.email "test@test.com"
+  git -C "$t" config user.name "Test"
+  mkdir -p "$t/.loom/roles" "$t/.claude"
+  echo '{"loom_version": "0.1.0"}' > "$t/.loom/install-metadata.json"
+  echo '{}' > "$t/.loom/config.json"
+  echo '{}' > "$t/.claude/settings.json"
+  cat > "$t/CLAUDE.md" <<'CMD'
+<!-- BEGIN LOOM ORCHESTRATION -->
+This repository uses Loom.
+<!-- END LOOM ORCHESTRATION -->
+
+# My Project
+CMD
+  printf 'node_modules/\n' > "$t/.gitignore"
+  git -C "$t" add -A
+  git -C "$t" commit -m "Initial commit with an older Loom install" --quiet
+}
+
+# Run install.sh from the fake root with a scratch HOME (so user-scope hook
+# provisioning and machine-daemon provisioning cannot touch the real one).
+run_installer() {
+  local target="$1"; shift
+  local fake_home="$WORKDIR/home"
+  mkdir -p "$fake_home"
+  env PATH="$STUB_BIN:$PATH" HOME="$fake_home" \
+    LOOM_DAEMON_BIN_DIR="$fake_home/.local/bin" \
+    LOOM_DAEMON_FAIL="${LOOM_DAEMON_FAIL:-0}" \
+    "$FAKE_ROOT/install.sh" "$@" "$target" < /dev/null 2>&1
+}
+
+# --- E2E 1: a held lock stops the second installer before it mutates anything.
+T="$(new_target)"
+seed_target "$T"
+PRE_SHA="$(git -C "$T" rev-parse HEAD)"
+write_lock "$T/.loom/.install.lock" "$LIVE_PID" "$THIS_HOST" "uninstalling"
+
+OUT="$(run_installer "$T" --quick --confirm-reinstall -y)"
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+  pass "second installer exits non-zero while the lock is held"
+else
+  fail "second installer exited 0 (expected a fast failure)" "$OUT"
+fi
+assert_contains "$OUT" "Another Loom install is already running" "e2e: names the concurrent run"
+assert_contains "$OUT" "Held by pid $LIVE_PID" "e2e: names the live pid"
+assert_contains "$OUT" "$T/.loom/.install.lock" "e2e: names the lock path"
+
+if [[ -f "$T/.loom/.install.lock" ]]; then
+  pass "e2e: the held lock is left intact"
+else
+  fail "e2e: the held lock was removed by the blocked installer"
+fi
+# The lock file this test planted is itself untracked in the scratch repo (a
+# real install ships a .gitignore entry for it), so filter it out.
+STATUS_AFTER="$(git -C "$T" status --porcelain | grep -v '\.loom/\.install\.lock$')"
+if [[ "$(git -C "$T" rev-parse HEAD)" == "$PRE_SHA" ]] && [[ -z "$STATUS_AFTER" ]]; then
+  pass "e2e: target tree untouched — the uninstall phase never started"
+else
+  fail "e2e: target was mutated despite the held lock" "$STATUS_AFTER"
+fi
+assert_not_contains "$OUT" "Uninstalling existing Loom installation" "e2e: uninstall never ran"
+
+# --- E2E 2: a stale lock does not block, and an error() exit releases the lock.
+T="$(new_target)"
+seed_target "$T"
+write_lock "$T/.loom/.install.lock" "$DEAD_PID" "$THIS_HOST" "uninstalling"
+
+export LOOM_DAEMON_FAIL=1
+OUT="$(run_installer "$T" --quick --confirm-reinstall -y)"
+EXIT_CODE=$?
+unset LOOM_DAEMON_FAIL
+
+assert_contains "$OUT" "Reclaiming stale Loom install lock" "e2e: stale lock reclaimed, not blocking"
+assert_contains "$OUT" "Entering the destructive uninstall" "e2e: the destructive window is announced"
+if [[ $EXIT_CODE -ne 0 ]]; then
+  pass "e2e: the simulated init failure propagates (non-zero exit)"
+else
+  fail "e2e: expected the simulated init failure to propagate" "$OUT"
+fi
+assert_contains "$OUT" "PARTIALLY UNINSTALLED" "e2e: failure inside the destructive window prints recovery guidance"
+if [[ ! -e "$T/.loom/.install.lock" ]]; then
+  pass "e2e: lock released on an error()-triggered early exit"
+else
+  fail "e2e: lock survived an error() exit (would wedge the next install)"
+fi
+
+# --- E2E 3: a successful run releases the lock and leaves no lock artifacts.
+T="$(new_target)"
+git -C "$T" init --quiet
+git -C "$T" config user.email "test@test.com"
+git -C "$T" config user.name "Test"
+printf 'node_modules/\n' > "$T/.gitignore"
+git -C "$T" add -A
+git -C "$T" commit -m "Empty project, no Loom install" --quiet
+
+OUT="$(run_installer "$T" --quick -y)"
+EXIT_CODE=$?
+
+if [[ $EXIT_CODE -eq 0 ]]; then
+  pass "e2e: fresh quick install succeeds"
+else
+  fail "e2e: fresh quick install failed" "$OUT"
+fi
+if [[ ! -e "$T/.loom/.install.lock" ]]; then
+  pass "e2e: lock released on normal successful completion"
+else
+  fail "e2e: lock left behind after a successful install"
+fi
+if [[ -z "$(find "$T/.loom" -name '.install.lock*' 2>/dev/null)" ]]; then
+  pass "e2e: no lock tmp sidecar left behind"
+else
+  fail "e2e: a .install.lock* sidecar was left behind" "$(find "$T/.loom" -name '.install.lock*')"
+fi
+
+kill "$LIVE_PID" 2>/dev/null
+wait "$LIVE_PID" 2>/dev/null
+rm -rf "$WORKDIR"
+
+echo ""
+echo "================================================================"
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+  echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+  exit 1
+fi
+echo "================================================================"
+echo "All tests passed."

--- a/install.sh
+++ b/install.sh
@@ -261,6 +261,20 @@ regenerate_manifest_after_hook_wiring() {
 prepare_loom_metadata_env() {
   local loom_root="$1"
 
+  # Issue #4928 (AC #4): clear both before sampling. LOOM_VERSION / LOOM_COMMIT
+  # are ordinary environment variables, so a value inherited from the caller
+  # (another installer run, a resync, an exported shell var) would otherwise
+  # survive every early return below and be written verbatim into
+  # install-metadata.json / CLAUDE.md -- recording a commit that is NOT the
+  # source HEAD being installed, while the warnings claim it will be "unknown".
+  # Sampling itself is correct: `git -C "$loom_root" rev-parse --short HEAD`
+  # reads the Loom source checkout being installed FROM (not the target), and
+  # finalize_quick_install writes the result in the same run.
+  LOOM_VERSION=""
+  LOOM_COMMIT=""
+  export LOOM_VERSION
+  export LOOM_COMMIT
+
   if [[ ! -f "$loom_root/package.json" ]]; then
     warning "Cannot find package.json in $loom_root — LOOM_VERSION will be 'unknown'"
     return 0
@@ -659,6 +673,37 @@ source "$LOOM_ROOT/scripts/install/provision-daemon.sh"
 # project-level fallback for a repo that still carries `.loom/hooks/` copies).
 # shellcheck source=scripts/install/provision-hooks.sh
 source "$LOOM_ROOT/scripts/install/provision-hooks.sh"
+
+# Per-target install lock (issue #4928). Provides acquire_install_lock /
+# release_install_lock / set_install_lock_phase, which serialize the
+# destructive uninstall→reinstall sequence so two installers can never
+# interleave their uninstall and copy phases against the same target.
+# shellcheck source=scripts/install/install-lock.sh
+source "$LOOM_ROOT/scripts/install/install-lock.sh"
+
+# Release the lock on EVERY exit path -- normal completion, `error()`, a
+# `set -e` abort, and the SIGINT/SIGTERM handlers above (both of which `exit`,
+# which runs this trap). A run killed with SIGKILL cannot run it, which is
+# exactly why the lock records a PID: the next installer reclaims it (see
+# _install_lock_reclaim_if_stale).
+#
+# When the run dies inside a destructive phase, print the recovery banner
+# BEFORE dropping the lock, so the operator sees which phase was interrupted
+# and how to restore the target instead of discovering a half-uninstalled tree
+# later (issue #4928, AC #3).
+_install_lock_on_exit() {
+  local status=$?
+  if [[ -n "$INSTALL_LOCK_FILE" ]]; then
+    if [[ $status -ne 0 ]] && install_lock_is_destructive_phase "$INSTALL_LOCK_PHASE"; then
+      echo ""
+      warning "Install exited with status $status during the '$INSTALL_LOCK_PHASE' phase."
+      install_lock_recovery_banner "$INSTALL_LOCK_PHASE" "$INSTALL_LOCK_TARGET"
+    fi
+    release_install_lock
+  fi
+  return $status
+}
+trap '_install_lock_on_exit' EXIT
 
 # Show banner
 echo ""
@@ -1089,6 +1134,15 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
   # install-loom.sh's own idempotency check detects the older installed
   # version and proceeds with a normal upgrade (see the delegation site below).
   if [[ "$INSTALL_TYPE" == "1" ]]; then
+    # Issue #4928: take the per-target install lock BEFORE anything in this
+    # branch touches $TARGET_PATH. Everything below -- the stash, the chained
+    # uninstall, `loom-daemon init --force`, the index reconcile, the stash pop
+    # -- mutates the target's main checkout in place, so a second installer
+    # running concurrently against the same target can land its copy phase
+    # inside this one's uninstall window. Fail fast instead.
+    acquire_install_lock "$TARGET_PATH" "preparing" || \
+      error "Refusing to start a concurrent reinstall of $TARGET_PATH (see above)."
+
     # Issue #3545: for a --quick reinstall, guard uncommitted user changes across
     # the uninstall→reinstall cycle (mirrors the stash guard in the sibling
     # scripts/install-loom.sh --clean path). The uninstall runs `git add` in the
@@ -1143,6 +1197,16 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
       fi
     fi
 
+    # Issue #4928 (AC #3): make the half-uninstalled window explicit in output
+    # AND in state. The uninstall below mutates the target's main checkout in
+    # place and the fresh install only restores it several steps later, so the
+    # phase is recorded in the lock file first -- an interrupted run is then
+    # recognizable (by the next installer and by the operator) instead of
+    # surfacing as an unexplained half-uninstalled tree requiring a blind
+    # `git reset --hard`.
+    set_install_lock_phase "uninstalling"
+    announce_destructive_window "$TARGET_PATH"
+
     # Uninstall existing installation (local mode, no separate PR)
     info "Uninstalling existing Loom installation..."
     "$LOOM_ROOT/scripts/uninstall-loom.sh" --yes --local "$TARGET_PATH" || \
@@ -1150,6 +1214,9 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     echo ""
     success "Existing installation removed"
     echo ""
+
+    # The target is now stripped; everything from here re-stages the payload.
+    set_install_lock_phase "installing"
 
     info "Running fresh Quick Install..."
     echo ""
@@ -1233,6 +1300,10 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     # non-Loom changes (sibling installers, unrelated work) stay staged. The
     # uninstall only stages Loom-managed paths (#3450), so the dirty ∩
     # ownership intersection is exactly the set of staged deletions to undo.
+    # The payload is back on disk; what remains is index/stash reconciliation
+    # (issue #4928 phase tracking -- still destructive if interrupted).
+    set_install_lock_phase "restoring"
+
     info "Reconciling git index after reinstall..."
     RECONCILE_PATHS=()
     while IFS= read -r _owned_path; do
@@ -1437,6 +1508,12 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
       done
     fi
 
+    # Issue #4928: the destructive window is closed -- record that, then drop
+    # the lock explicitly (the EXIT trap would do it too, but an explicit
+    # release keeps the "released on normal completion" contract obvious).
+    set_install_lock_phase "complete"
+    release_install_lock
+
     echo ""
     success "Quick reinstallation complete!"
     exit 0
@@ -1461,6 +1538,12 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
   if [[ "$NON_INTERACTIVE" == true ]]; then
     INSTALL_FLAGS+=(--yes)
   fi
+  # `exec` replaces this process, so the EXIT trap never fires -- drop any held
+  # lock first or it would be stranded (issue #4928). No-op on this path today
+  # (the Full Install delegation never takes the lock: it mutates nothing in
+  # the target's main checkout, see #4888), but the release must sit next to
+  # the `exec` so it stays correct if that ever changes.
+  release_install_lock
   exec "$LOOM_ROOT/scripts/install-loom.sh" ${INSTALL_FLAGS[@]+"${INSTALL_FLAGS[@]}"} ${SOURCE_OVERRIDE_FLAGS[@]+"${SOURCE_OVERRIDE_FLAGS[@]}"} "$TARGET_PATH"
 else
   FORCE_FLAG=""
@@ -1563,6 +1646,14 @@ case "$METHOD" in
     info "Running Quick Install..."
     echo ""
 
+    # Issue #4928: take the per-target install lock before ANY mutation of the
+    # target -- the `--clean` uninstall below, and `loom-daemon init` itself.
+    # Two concurrent Quick Installs into the same target interleave their file
+    # copies (and, under --clean, one run's uninstall with the other's copy
+    # phase), which is exactly the reported corruption window.
+    acquire_install_lock "$TARGET_PATH" "preparing" || \
+      error "Refusing to start a concurrent install of $TARGET_PATH (see above)."
+
     # Check if loom-daemon is built AND up to date with the current source
     # tree (issue #4188 -- a bare existence check reuses a binary built from
     # an older commit after `git pull` landed a newer one).
@@ -1592,14 +1683,22 @@ case "$METHOD" in
 
     # Handle --clean: run local uninstall first, then fresh install
     if [[ "$FORCE_FLAG" == "--clean" ]]; then
+      # Issue #4928 (AC #3): same explicit destructive window as the
+      # --confirm-reinstall branch above -- the uninstall strips the target in
+      # place and only the init below puts it back.
+      set_install_lock_phase "uninstalling"
+      announce_destructive_window "$TARGET_PATH"
+
       info "Running local uninstall before fresh install..."
       "$LOOM_ROOT/scripts/uninstall-loom.sh" --yes --local "$TARGET_PATH" || \
         error "Uninstall failed - aborting clean install"
       echo ""
+      set_install_lock_phase "installing"
       info "Uninstall complete, proceeding with fresh install..."
       "$LOOM_ROOT/target/release/loom-daemon" init --force --defaults "$LOOM_ROOT/defaults" "$TARGET_PATH" || \
         error "Installation failed"
     else
+      set_install_lock_phase "installing"
       # Run loom-daemon init
       "$LOOM_ROOT/target/release/loom-daemon" init $FORCE_FLAG --defaults "$LOOM_ROOT/defaults" "$TARGET_PATH" || \
         error "Installation failed"
@@ -1629,6 +1728,10 @@ case "$METHOD" in
     # this install path are complete (issue #5279 — see the function's own
     # comment for why this must run after wire_quick_install_guard_hooks).
     regenerate_manifest_after_hook_wiring "$TARGET_PATH"
+
+    # Issue #4928: destructive window closed -- drop the per-target lock.
+    set_install_lock_phase "complete"
+    release_install_lock
 
     echo ""
     success "Quick installation complete!"
@@ -1695,7 +1798,10 @@ case "$METHOD" in
     fi
     echo ""
 
-    # Run the full installation workflow
+    # Run the full installation workflow. Release first: `exec` replaces this
+    # process, so the EXIT trap never runs and any held lock would be stranded
+    # (issue #4928).
+    release_install_lock
     exec "$LOOM_ROOT/scripts/install-loom.sh" $FORCE_FLAG ${SOURCE_OVERRIDE_FLAGS[@]+"${SOURCE_OVERRIDE_FLAGS[@]}"} "$TARGET_PATH"
     ;;
 esac

--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -214,6 +214,11 @@ pub const EPHEMERAL_PATTERNS: &[&str] = &[
     // exists so an operator can recover hand-tuned keys after a torn write, but
     // it is machine-local salvage — never something to commit.
     ".loom/*.bak",
+    // Per-target install lock written by install.sh (#4928). It is removed by
+    // the installer's EXIT trap, but a SIGKILLed run leaves it behind for the
+    // next installer to reclaim — machine-local coordination state that a
+    // consumer's `git add -A` must never sweep into a commit.
+    ".loom/.install.lock",
     ".loom/logs/",
 ];
 

--- a/scripts/install/install-lock.sh
+++ b/scripts/install/install-lock.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# scripts/install/install-lock.sh — per-target install lock (issue #4928).
+#
+# Two installers running against the SAME target repository interleave
+# destructively. The `--quick` reinstall path stages Loom file deletions and
+# strips the Loom sections out of CLAUDE.md / .gitignore *in place* before
+# writing the new payload; a second installer's copy phase landing inside that
+# window can corrupt the target. In the reported incident (2026-08-01) the only
+# thing that serialized two concurrent `--quick --confirm-reinstall` runs was
+# cargo's build-directory lock — by luck, and only for the window in which both
+# runs happened to be building. Nothing serialized the install phases on either
+# side of the build.
+#
+# This helper adds the missing mutual exclusion: a single lock file at
+#   <target>/.loom/.install.lock
+# carrying the owning PID, the host, the start time, and the run's current
+# PHASE. It is
+#   - created with O_EXCL (`set -o noclobber`) so two racing installers cannot
+#     both believe they hold it,
+#   - released by install.sh's EXIT trap, so `error()`, a `set -e` abort,
+#     Ctrl-C and SIGTERM all release it,
+#   - reclaimed automatically when the recorded PID is no longer alive, so an
+#     installer killed with SIGKILL never wedges the target permanently.
+#
+# The recorded phase does double duty as the "half-uninstalled window is
+# explicit in state" marker: a lock left behind by a hard-killed run tells the
+# next installer — and the operator — exactly which phase was interrupted, so
+# the target is recoverable from the printed commands instead of a blind
+# `git reset --hard`.
+#
+# Source with:
+#     source "$LOOM_ROOT/scripts/install/install-lock.sh"
+#
+# Public functions:
+#   acquire_install_lock <target> [phase]
+#       Take the lock for <target>. Returns 0 on success (or when this process
+#       already holds it — the call is idempotent and just updates the phase).
+#       Returns 1 when another LIVE installer holds it, after printing who
+#       holds it and how to recover. Callers turn that into a fatal error.
+#
+#   set_install_lock_phase <phase>
+#       Record the current phase in the held lock. No-op without a lock.
+#       Known phases: preparing | uninstalling | installing | restoring |
+#       complete. The middle three are "destructive" — an interruption during
+#       one of them can leave the target partially uninstalled.
+#
+#   release_install_lock
+#       Remove the lock this process holds (never another process's). No-op
+#       when no lock is held, so it is safe to call unconditionally — e.g.
+#       immediately before an `exec`, which would otherwise strand the lock
+#       (the EXIT trap does not survive `exec`).
+#
+#   install_lock_recovery_banner <phase> [target]
+#       Print the "target may be partially uninstalled" recovery instructions
+#       for a destructive phase. No-op for a non-destructive phase.
+#
+#   announce_destructive_window <target>
+#       Print the explicit "entering the destructive uninstall→reinstall
+#       window" notice before the uninstall runs.
+#
+#   install_lock_is_destructive_phase <phase>
+#       Predicate: does an interruption in <phase> risk a half-uninstalled
+#       target?
+
+# Logging helpers. install.sh defines these; provide plain fallbacks so the
+# library can also be sourced standalone (e.g. by its test suite).
+if ! declare -f info >/dev/null 2>&1; then
+  info() { echo "ℹ $*"; }
+fi
+if ! declare -f warning >/dev/null 2>&1; then
+  warning() { echo "⚠ $*" >&2; }
+fi
+
+# Path of the lock this process currently holds ("" ⇒ none held).
+INSTALL_LOCK_FILE=""
+# Target the held lock belongs to.
+INSTALL_LOCK_TARGET=""
+# Phase recorded in the held lock.
+INSTALL_LOCK_PHASE=""
+# Whether acquire_install_lock created <target>/.loom itself (a fresh install
+# into a target with no .loom/ yet). If so, release removes the directory again
+# when it is empty — install.sh's reinstall gate keys off `-d "$TARGET/.loom"`,
+# so a bare .loom/ left behind by a failed fresh install would make the next
+# run demand --confirm-reinstall for an install that never happened.
+INSTALL_LOCK_DIR_CREATED=false
+
+# Age (in seconds) after which a lock owned by a DIFFERENT host is treated as
+# abandoned. PID liveness is not probeable across hosts (a target on a shared
+# filesystem), so age is the only available signal — deliberately generous, and
+# overridable with LOOM_INSTALL_LOCK_MAX_AGE.
+INSTALL_LOCK_FOREIGN_MAX_AGE="${LOOM_INSTALL_LOCK_MAX_AGE:-21600}"
+
+_install_lock_host() {
+  hostname 2>/dev/null || uname -n 2>/dev/null || echo "unknown-host"
+}
+
+# Read one `key=value` field out of a lock file. Empty output ⇒ absent.
+_install_lock_field() {
+  local field="$1" file="$2"
+  [[ -r "$file" ]] || return 0
+  sed -n "s/^${field}=//p" "$file" 2>/dev/null | head -n1
+}
+
+# Is <pid> a live process?
+#
+# `kill -0` also fails (EPERM) for a LIVE process owned by another user, so a
+# negative result is confirmed with `ps` before the lock is declared stale —
+# otherwise a second user's in-flight install would be silently stolen.
+_install_lock_pid_alive() {
+  local pid="${1:-}"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  [[ "$pid" -gt 0 ]] || return 1
+  kill -0 "$pid" 2>/dev/null && return 0
+  ps -p "$pid" >/dev/null 2>&1
+}
+
+install_lock_is_destructive_phase() {
+  case "${1:-}" in
+    uninstalling|installing|restoring) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Render the lock payload on stdout.
+_install_lock_render() {
+  local phase="$1"
+  echo "# Loom install lock (issue #4928)."
+  echo "# Written by install.sh; removed automatically when the run exits."
+  echo "# Safe to delete by hand ONLY if the pid below is no longer running."
+  echo "pid=$$"
+  echo "host=${INSTALL_LOCK_HOST:-unknown-host}"
+  echo "started=${INSTALL_LOCK_STARTED:-unknown}"
+  echo "started_epoch=${INSTALL_LOCK_STARTED_EPOCH:-0}"
+  echo "phase=${phase}"
+  echo "target=${INSTALL_LOCK_TARGET:-unknown}"
+  echo "source=${LOOM_ROOT:-unknown}"
+}
+
+# Create the lock file atomically, or fail because it already exists.
+#
+# `set -o noclobber` makes the `>` redirection open with O_CREAT|O_EXCL, so
+# exactly one of two racing installers can win. It runs in a subshell so the
+# option never leaks into the caller's shell.
+_install_lock_create() {
+  local file="$1" phase="$2"
+  ( set -o noclobber; _install_lock_render "$phase" > "$file" ) 2>/dev/null
+}
+
+# Print who holds the lock and how to proceed.
+_install_lock_report_held() {
+  local file="$1" target="$2" pid="$3" host="$4" phase="$5" started="$6"
+  {
+    echo ""
+    echo "  Another Loom install is already running against this target."
+    echo "    Target: $target"
+    echo "    Lock:   $file"
+    echo "    Held by pid ${pid:-unknown} on host ${host:-unknown}${started:+ (started $started)}"
+    [[ -n "$phase" ]] && echo "    Phase:  $phase"
+    echo ""
+    echo "  Refusing to run two installers against the same target — their"
+    echo "  uninstall and copy phases interleave destructively."
+    echo ""
+    echo "  Wait for that run to finish and retry. If you are certain the"
+    echo "  process above is gone, remove the lock and retry:"
+    echo "    rm -f \"$file\""
+  } >&2
+}
+
+# Print recovery guidance for an interrupted destructive phase.
+install_lock_recovery_banner() {
+  local phase="${1:-}"
+  local target="${2:-$INSTALL_LOCK_TARGET}"
+  install_lock_is_destructive_phase "$phase" || return 0
+  echo ""
+  warning "The target may be left PARTIALLY UNINSTALLED (staged Loom file"
+  warning "deletions, a stripped CLAUDE.md / .gitignore, or a partly written"
+  warning ".loom/) — the '$phase' phase did not finish."
+  echo ""
+  echo "  Inspect and recover before retrying:"
+  echo "    git -C \"$target\" status --short"
+  echo "    git -C \"$target\" restore --staged --worktree -- .loom .claude CLAUDE.md .gitignore"
+  echo "      # older git: git -C \"$target\" reset -q HEAD -- <paths> && git -C \"$target\" checkout -- <paths>"
+  echo "    git -C \"$target\" stash list | grep loom-install   # changes this installer stashed, if any"
+  echo ""
+  echo "  Re-running the installer is also safe once the tree is restored."
+  echo ""
+}
+
+# Print the explicit "destructive window opening" notice (issue #4928): the
+# uninstall→reinstall sequence mutates the target's main checkout in place, so
+# say so BEFORE it starts rather than leaving an interrupted run to be
+# discovered as an unexplained half-uninstalled tree.
+announce_destructive_window() {
+  local target="$1"
+  echo ""
+  warning "Entering the destructive uninstall→reinstall window for $target"
+  info "  The uninstall stages Loom file deletions and strips the Loom sections"
+  info "  from CLAUDE.md / .gitignore in place; the target is only partially"
+  info "  installed until this run completes."
+  info "  Progress state: ${INSTALL_LOCK_FILE:-<no lock>}"
+  info "  If this run is interrupted, the next installer reports the interrupted"
+  info "  phase and the exact recovery commands (no blind 'git reset --hard')."
+  echo ""
+}
+
+# Remove the lock if its owner is demonstrably gone. Returns 0 when the lock
+# was reclaimed (caller may retry the create), 1 when it is genuinely held.
+_install_lock_reclaim_if_stale() {
+  local file="$1"
+
+  # A racing installer creates the file and writes its payload in one
+  # redirection, but a reader can still observe the (briefly) empty file
+  # between the O_EXCL create and the write. Re-read a few times before
+  # concluding the lock is malformed, so a live installer is never stolen from
+  # in that microsecond window.
+  local pid tries=0
+  pid="$(_install_lock_field pid "$file")"
+  while [[ -z "$pid" && $tries -lt 5 ]]; do
+    sleep 0.2 2>/dev/null || sleep 1
+    pid="$(_install_lock_field pid "$file")"
+    tries=$((tries + 1))
+  done
+
+  local host phase started reason=""
+  host="$(_install_lock_field host "$file")"
+  phase="$(_install_lock_field phase "$file")"
+  started="$(_install_lock_field started "$file")"
+
+  if [[ -z "$pid" ]]; then
+    reason="the lock file carries no owning pid"
+  elif [[ -n "$host" && "$host" != "$(_install_lock_host)" ]]; then
+    # Foreign host: PID liveness is unknowable, so fall back to age. Below the
+    # cutoff the lock is respected (report it as held); above it, reclaimed.
+    local started_epoch now age
+    started_epoch="$(_install_lock_field started_epoch "$file")"
+    [[ "$started_epoch" =~ ^[0-9]+$ ]] || started_epoch=0
+    now="$(date +%s 2>/dev/null || echo 0)"
+    age=$((now - started_epoch))
+    if [[ $started_epoch -gt 0 && $age -gt $INSTALL_LOCK_FOREIGN_MAX_AGE ]]; then
+      reason="it is owned by host '$host' and is ${age}s old (> ${INSTALL_LOCK_FOREIGN_MAX_AGE}s)"
+    else
+      return 1
+    fi
+  elif _install_lock_pid_alive "$pid"; then
+    return 1
+  else
+    reason="owning pid $pid is no longer running"
+  fi
+
+  warning "Reclaiming stale Loom install lock — $reason"
+  info "  Lock: $file"
+  if install_lock_is_destructive_phase "$phase"; then
+    warning "That run was interrupted during the '$phase' phase."
+    install_lock_recovery_banner "$phase" "$INSTALL_LOCK_TARGET"
+  fi
+  rm -f "$file" 2>/dev/null || return 1
+  return 0
+}
+
+# Take the per-target install lock. See the header for the contract.
+acquire_install_lock() {
+  local target="$1"
+  local phase="${2:-preparing}"
+
+  # Idempotent: an already-held lock just moves to the requested phase.
+  if [[ -n "$INSTALL_LOCK_FILE" ]]; then
+    set_install_lock_phase "$phase"
+    return 0
+  fi
+
+  local lock_dir="$target/.loom"
+  local file="$lock_dir/.install.lock"
+
+  if [[ ! -d "$lock_dir" ]]; then
+    mkdir -p "$lock_dir" 2>/dev/null || {
+      warning "Cannot create $lock_dir — install lock unavailable"
+      return 1
+    }
+    INSTALL_LOCK_DIR_CREATED=true
+  fi
+
+  INSTALL_LOCK_TARGET="$target"
+  INSTALL_LOCK_HOST="$(_install_lock_host)"
+  INSTALL_LOCK_STARTED="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
+  INSTALL_LOCK_STARTED_EPOCH="$(date +%s 2>/dev/null || echo 0)"
+
+  local attempt
+  for attempt in 1 2; do
+    if _install_lock_create "$file" "$phase"; then
+      INSTALL_LOCK_FILE="$file"
+      INSTALL_LOCK_PHASE="$phase"
+      return 0
+    fi
+    # Lost the create: the lock exists. Reclaim it if its owner is gone, then
+    # retry exactly once (a third installer may have won the reclaimed slot).
+    if [[ $attempt -eq 1 ]] && _install_lock_reclaim_if_stale "$file"; then
+      continue
+    fi
+    break
+  done
+
+  _install_lock_report_held "$file" "$target" \
+    "$(_install_lock_field pid "$file")" \
+    "$(_install_lock_field host "$file")" \
+    "$(_install_lock_field phase "$file")" \
+    "$(_install_lock_field started "$file")"
+
+  # Never clean up a directory we may have created for a lock we do not own —
+  # a concurrent installer is using it.
+  INSTALL_LOCK_DIR_CREATED=false
+  return 1
+}
+
+# Record the current phase in the held lock (tmp+rename so a concurrent reader
+# never observes a torn file, and the path never briefly disappears).
+set_install_lock_phase() {
+  local phase="$1"
+  INSTALL_LOCK_PHASE="$phase"
+  [[ -n "$INSTALL_LOCK_FILE" ]] || return 0
+  local tmp="${INSTALL_LOCK_FILE}.tmp"
+  if _install_lock_render "$phase" > "$tmp" 2>/dev/null; then
+    mv -f "$tmp" "$INSTALL_LOCK_FILE" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+  else
+    rm -f "$tmp" 2>/dev/null || true
+  fi
+  return 0
+}
+
+# Release the lock held by THIS process. Safe to call unconditionally.
+release_install_lock() {
+  local file="$INSTALL_LOCK_FILE"
+  [[ -n "$file" ]] || return 0
+  INSTALL_LOCK_FILE=""
+  # shellcheck disable=SC2034  # read by install.sh's EXIT trap, not here
+  INSTALL_LOCK_PHASE=""
+
+  # Only remove a lock we still own: if the file was reclaimed by another
+  # installer (e.g. this process was stopped long enough to look dead), that
+  # installer's lock must survive.
+  local owner
+  owner="$(_install_lock_field pid "$file")"
+  if [[ -n "$owner" && "$owner" != "$$" ]]; then
+    return 0
+  fi
+
+  rm -f "$file" 2>/dev/null || true
+  if [[ "$INSTALL_LOCK_DIR_CREATED" == true ]]; then
+    rmdir "$(dirname "$file")" 2>/dev/null || true
+    INSTALL_LOCK_DIR_CREATED=false
+  fi
+  return 0
+}


### PR DESCRIPTION
## Summary

`install.sh` had no mutual exclusion per target. The `--quick` / `--clean`
reinstall paths run `uninstall-loom.sh --yes --local` against the target's
**main checkout** — staging Loom file deletions and stripping the Loom sections
out of `CLAUDE.md` / `.gitignore` in place — and only restore the payload
several steps later. A second installer starting inside that window interleaves
its copy phase with the first run's uninstall. In the reported incident
(censusapi, 2026-08-01) the only thing that serialized two concurrent
`--quick --yes --confirm-reinstall` runs was cargo's build-directory lock, by
luck; nothing serialized the install phases on either side of the build.

This adds a per-target PID lock, makes the destructive window explicit in both
output and state, and fixes one real (narrow) metadata-sampling defect found
during the AC #4 verification.

## Changes

**`scripts/install/install-lock.sh` (new)** — a sourceable helper (same shape
as the existing `scripts/install/stash-scope.sh`) providing
`acquire_install_lock` / `set_install_lock_phase` / `release_install_lock` /
`install_lock_recovery_banner` / `announce_destructive_window`. The lock is a
single file at `<target>/.loom/.install.lock` created with O_EXCL
(`set -o noclobber`), carrying `pid`, `host`, `started`, `started_epoch`,
`phase`, `target`, `source`.

- **Live owner → fail fast.** The message names the owning PID, host, phase and
  the lock path, and tells the operator how to proceed.
- **Dead owner → reclaimed automatically.** `kill -0` with a `ps` confirmation
  (so a live process owned by *another user*, where `kill -0` fails with
  EPERM, is never mistaken for stale).
- **Foreign-host owner** (target on a shared filesystem — PID liveness is not
  probeable) is respected until `LOOM_INSTALL_LOCK_MAX_AGE` (default 6h), then
  reclaimed, so it can never wedge the target permanently.
- **Malformed lock** is reclaimed, but only after a short bounded re-read, so a
  racing installer caught between its O_EXCL create and its write is not stolen
  from.
- `release_install_lock` only removes a lock **this** process still owns, and
  drops a `.loom/` directory it created itself (a failed fresh install must not
  leave a bare `.loom/` behind — `install.sh`'s reinstall gate keys off
  `-d "$TARGET/.loom"`).

**`install.sh`**

- Sources the helper and registers an `EXIT` trap, so `error()`, a `set -e`
  abort, Ctrl-C (SIGINT → `exit 130`) and SIGTERM all release the lock. Both
  `exec` sites release explicitly first — `exec` replaces the process and the
  trap never fires.
- Takes the lock **before** the destructive phase in both reinstall entry
  points: the `--confirm-reinstall` / `INSTALL_TYPE == "1"` branch (before the
  stash, which is the first mutation, not just before the uninstall call) and
  the `METHOD 1` Quick Install branch (covering the interactive `--clean`
  uninstall and `loom-daemon init` itself).
- **AC #3, lighter-weight option**: the run's phase (`preparing` →
  `uninstalling` → `installing` → `restoring` → `complete`) is recorded in the
  lock as it advances. `announce_destructive_window()` prints an explicit notice
  before the uninstall runs; a failure inside a destructive phase prints the
  concrete recovery commands (`git status --short`, `git restore --staged
  --worktree -- …`, `git stash list | grep loom-install`); and a lock left
  behind by a SIGKILLed run makes the interrupted phase **recognizable to the
  next installer**, which prints the same guidance while reclaiming it. Chose
  this over deferring the uninstall until the payload is staged: PR #4920's
  `--full` fix worked by removing the pre-mutation entirely (that path `exec`s
  into an isolated worktree and never needed it), which does not transfer to
  `--quick`, where the uninstall→init sequence is synchronous in the same tree
  by design.
- **AC #4 fix**: `prepare_loom_metadata_env()` now clears `LOOM_VERSION` /
  `LOOM_COMMIT` before sampling.

**`loom-daemon/src/init/post_init.rs`** — adds `.loom/.install.lock` to the
managed `.gitignore` patterns, so a lock stranded by a SIGKILLed run is never
swept into a consumer's `git add -A` (same rationale as the existing
`.loom/*.tmp` entry). The `.install.lock.tmp` sidecar used by the phase rewrite
is already covered by `.loom/*.tmp`.

**Docs** — a troubleshooting entry for "Another Loom install is already
running" (how to read the lock, when it self-reclaims, and the recovery
commands for an interrupted destructive phase).

## Acceptance Criteria Verification

- [x] **Per-target lockfile.** `<target>/.loom/.install.lock` with the
  installer's PID, taken before the uninstall phase of both `--quick`
  entry points. A second attempt against a live PID exits non-zero naming the
  PID and the lock path; stale (dead-PID) locks are reclaimed automatically.
  Verified end-to-end through the real `install.sh` (tests below) — the blocked
  run exits non-zero, the target tree is byte-identical, and the uninstall never
  starts.
- [x] ~~Progress output during the daemon cargo build~~ — already delivered by
  PR #4922; untouched here.
- [x] **Uninstall→install ordering hardened for `--quick`** via the explicit
  destructive-window announcement + phase-in-state + recovery banner (the
  "make the window explicit and recoverable" option the issue offers).
- [x] **`install-metadata.json` commit/date sampling verified.** See below.

### AC #4 finding: sampling is correct; one real latent bug fixed

**Confirmed correct as-is:**

- `install.sh:~234` samples `git -C "$loom_root" rev-parse --short HEAD` where
  `$loom_root` is `$LOOM_ROOT`, the Loom **source** checkout being installed
  *from* (never the target), in the same run and before
  `finalize_quick_install` writes the file. On the reinstall path the order is
  `prepare_loom_metadata_env` → `loom-daemon init` → `finalize_quick_install`,
  so the value written is this run's source HEAD.
- `scripts/install-loom.sh:889` does `cd "$LOOM_ROOT"` before its own
  `git rev-parse` — also correct (worth stating: a `cd`-less `git rev-parse`
  there would have sampled the *target's* HEAD).
- `install_date` is `date +%Y-%m-%d` at write time in `install.sh`, and
  `Local::now()` in the daemon's writer. **Neither can produce a day-old date**,
  which is what makes the reported artifact a stale/restored file (the reporter
  did restore the target from git mid-incident) rather than a writer bug —
  matching the Curator's stale-checkout hypothesis.

**One real bug found and fixed:** `prepare_loom_metadata_env()` had two early
returns (`package.json` missing; `node -pe` failing) that ran **before**
`LOOM_COMMIT` was ever assigned. Since `LOOM_VERSION`/`LOOM_COMMIT` are
ordinary environment variables, a value inherited from the calling environment
survived those returns and was written verbatim into `install-metadata.json`
and substituted into `CLAUDE.md` — while the warning on that very line promised
the value would be `"unknown"`. Both are now cleared and exported at function
entry.

**Related observation (no change, flagged for future triage):** when
`LOOM_COMMIT` is *not* exported, `loom-daemon init` falls back to the daemon
binary's compiled-in `BUILT_COMMIT`
(`loom-daemon/src/init/templates.rs:34`, `env_or_compiled`). That fallback
produces a *real but wrong* commit rather than `"unknown"` — exactly the shape
of the reported `bf0bfb1e` mismatch — so a stale machine-level daemon binary is
the most likely alternative explanation if this recurs. Left as-is: it is
deliberate (#4050) and outside this issue's scope.

## Test Plan

New suite `defaults/scripts/tests/test-install-lock.sh` (wired into
`ci-wired.txt`), **42 assertions, all passing**. Two layers, mirroring the
existing install suites:

*Unit (sources the real helper, like `test-install-stash-scope.sh`)*: fresh
acquire; live-PID lock blocks and is **not** stolen; dead-PID lock reclaimed;
interrupted-phase lock surfaces the recovery banner; malformed lock reclaimed;
foreign-host lock respected when recent / reclaimed when long-abandoned; phase
rewrite; release removes the lock and a self-created `.loom/`; release leaves
another process's lock alone; re-acquire is idempotent.

*End-to-end through the real `install.sh`* (throwaway fake `LOOM_ROOT` +
stubbed `node`/`pnpm`/`cargo`/`loom-daemon`, scratch `HOME` so user-scope hook
and machine-daemon provisioning cannot touch the real one — same construction as
`test-install-full-reinstall-no-target-mutation.sh`):

1. **Held lock** → second installer exits non-zero, names the live PID and lock
   path, leaves the lock intact, and the target's HEAD + `git status` are
   unchanged (the uninstall never ran).
2. **Stale lock + simulated init failure** → reclaimed (not blocking), the
   destructive window is announced, the failure propagates, the recovery banner
   prints, and the lock **is released on the `error()` path** (edge case b).
3. **Successful fresh quick install** → exit 0, lock released, no
   `.install.lock*` sidecar left behind (edge cases a and c).

Also run:

- `bash defaults/scripts/tests/check-ci-suite-manifest.sh` → OK (99 suites).
- Sibling install suites all green: `test-install-reinstall-safety.sh` (8/8),
  `test-install-full-reinstall-no-target-mutation.sh` (8/8),
  `test-install-stash-scope.sh` (7/7), `test-install-active-session.sh` (37/37),
  `test-install-source-guard.sh` (14/14), `test-verify-install-scope.sh` (16/16),
  `test-gitignore-guard.sh` (18/18).
- `cargo test -p loom-daemon --lib init::post_init` → 26/26.
- `cargo fmt --check`, `cargo clippy -p loom-daemon --lib` → clean.
- `shellcheck --severity=warning` on both new scripts → clean.
- `bash -n` on `install.sh` → clean.

**Pre-existing failure, unrelated to this PR:** `test-resync-installed.sh`
fails 1/114 on this host (`(#4280) missing binary did not produce the expected
warning`). Reproduced identically against a pristine `git archive` of
`origin/main`, so it predates this branch and touches none of the files here.

Closes #4928
