### PR TITLE
fix(daemon): bound the auto-update build-stampede gate with a defer deadline

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2597,6 +2597,7 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.autoUpdate.enabled` | `LOOM_AUTO_UPDATE` | `false` | Autonomous self-update loop on/off (#4055). **Opt-in** (it rebuilds + restarts the daemon process). Exactly one loop per daemon, not a per-workspace fan-out. See [Autonomous self-update loop](#autonomous-self-update-loop-4055) below |
 | `autonomous.autoUpdate.intervalSecs` | `LOOM_AUTO_UPDATE_INTERVAL_SECS` | `900` | Cadence between staleness checks. Zero/invalid → default |
 | `autonomous.autoUpdate.settleSecs` | `LOOM_AUTO_UPDATE_SETTLE_SECS` | `600` | Settle window: wait this long after first observing a stale commit — resetting on every further commit — before rolling, so a burst of merges collapses into one roll. Zero/invalid → default |
+| `autonomous.autoUpdate.deferDeadlineSecs` | `LOOM_AUTO_UPDATE_DEFER_DEADLINE_SECS` | `21600` (6h) | Bound on the build-stampede gate (#4929): after this much **continuous** deferral for in-flight sweeps, the rebuild runs anyway at reduced CPU priority (`nice 19`) instead of deferring forever. Any check that sees zero in-flight sweeps — or a new source commit, or a completed rebuild — re-arms the clock, so short busy bursts never reach it. Zero/invalid → default; there is deliberately no "defer forever" value (set a very large one instead) |
 
 ### Idle exit for remote hosts (#4467)
 
@@ -4832,10 +4833,11 @@ It is the *deciding + sequencing* layer — it reuses `loom-daemon-update.sh`
 primitive for the restart, reimplementing neither.
 
 **Opt-in, default OFF** (it has side effects on the running process). Enable via
-`autonomous.autoUpdate.enabled` / `LOOM_AUTO_UPDATE=1`; tune the cadence and
-settle window with `intervalSecs` (default 900) / `settleSecs` (default 600).
-All three knobs resolve **env > config > default** through `config_resolver`, so
-the `.loom-project/` tier is honored like every other `autonomous.*` block.
+`autonomous.autoUpdate.enabled` / `LOOM_AUTO_UPDATE=1`; tune the cadence, settle
+window, and stampede-gate deadline with `intervalSecs` (default 900) /
+`settleSecs` (default 600) / `deferDeadlineSecs` (default 21600). All four knobs
+resolve **env > config > default** through `config_resolver`, so the
+`.loom-project/` tier is honored like every other `autonomous.*` block.
 
 **Exactly one loop per daemon process** — not a `spawn_multi_*` per-workspace
 fan-out. Its subject is the daemon process itself (one binary, one source
@@ -4858,9 +4860,19 @@ Each tick (surfaced in `loom-daemon status` — human and `--json` — as
 3. **Settle window** — waits `settleSecs` after first observing a stale commit,
    resetting on every further commit, so a burst of daemon merges collapses into
    a single roll.
-4. **Build-stampede gate** — defers the rebuild while `ipc::count_in_flight_sweeps`
-   reports any non-terminal sweep across every managed root (a `cargo build
-   --release` competes with in-flight sweep builds for CPU).
+4. **Build-stampede gate (bounded, #4929)** — defers the rebuild while
+   `ipc::count_in_flight_sweeps` reports any non-terminal sweep across every
+   managed root (a `cargo build --release` competes with in-flight sweep builds
+   for CPU). The deferral is **not** open-ended: a host that runs at its
+   dispatch cap around the clock never reaches zero in-flight sweeps, and an
+   unconditional gate there starved the roll indefinitely (`last_roll: null`
+   with `update_available: true` for a day+). After `deferDeadlineSecs` of
+   *continuous* deferral the loop rebuilds anyway, niced to 19 so the forced
+   build yields CPU to the running sweeps; the roll then proceeds through the
+   same drain path below (and if that drain is refused or times out, the fresh
+   binary is still provisioned for the next supervised restart). The clock
+   re-arms on any zero-in-flight check, a new source commit, or a completed
+   rebuild, so short busy bursts never reach the deadline.
 5. **Roll via drain, not a bare restart** — on a clean rebuild it triggers
    `ipc::handle_drain_request` (#4090), so in-flight sweeps finish first and
    survive in the registry rather than being orphaned as bare processes. The

--- a/loom-daemon/src/auto_update.rs
+++ b/loom-daemon/src/auto_update.rs
@@ -32,7 +32,13 @@
 //! 4. **No build stampede** — a `cargo build --release` competes with every
 //!    in-flight sweep's own build for CPU, so the loop defers the rebuild while
 //!    [`crate::ipc::count_in_flight_sweeps`] reports any non-terminal sweep
-//!    across every managed root (the "gated" policy).
+//!    across every managed root (the "gated" policy). **Bounded** (#4929): the
+//!    deferral is not open-ended — a host that runs at its dispatch cap around
+//!    the clock never reaches zero in-flight sweeps, and an unconditional gate
+//!    there starves the rebuild forever (observed: `last_roll: null` with
+//!    `update_available: true` for a day+). After `deferDeadlineSecs` of
+//!    continuous deferral the loop rebuilds anyway, at **reduced CPU priority**
+//!    (`nice(19)`), so the stampede is mitigated rather than merely postponed.
 //! 5. **In-flight sweeps survive** — the roll goes through #4090's **drain**
 //!    path, not a bare restart, so dispatched sweeps finish first and stay in
 //!    the registry rather than being orphaned as bare processes.
@@ -88,6 +94,9 @@ pub const AUTO_UPDATE_INTERVAL_ENV: &str = "LOOM_AUTO_UPDATE_INTERVAL_SECS";
 /// Env override for the settle window (seconds).
 pub const AUTO_UPDATE_SETTLE_ENV: &str = "LOOM_AUTO_UPDATE_SETTLE_SECS";
 
+/// Env override for gate 4's deferral deadline (seconds).
+pub const AUTO_UPDATE_DEFER_DEADLINE_ENV: &str = "LOOM_AUTO_UPDATE_DEFER_DEADLINE_SECS";
+
 /// Default cadence between staleness checks (15 minutes). A rebuild is far from
 /// free, so this is deliberately coarse.
 pub const DEFAULT_AUTO_UPDATE_INTERVAL_SECS: u64 = 900;
@@ -96,6 +105,24 @@ pub const DEFAULT_AUTO_UPDATE_INTERVAL_SECS: u64 = 900;
 /// the loop waits this long — resetting on every further commit — before it
 /// rolls, so a burst of merges collapses into a single roll.
 pub const DEFAULT_AUTO_UPDATE_SETTLE_SECS: u64 = 600;
+
+/// Default gate-4 deferral deadline (6 hours, #4929): once gate 4 has deferred
+/// the rebuild continuously for this long — i.e. the host has had at least one
+/// in-flight sweep at *every* check across that window — the loop stops
+/// deferring and rebuilds at reduced CPU priority.
+///
+/// Chosen to be far longer than any healthy busy burst (a sweep is minutes to
+/// low hours, and the gate re-arms the moment the host goes idle and the roll
+/// happens normally), so the escape hatch only ever fires on a genuinely
+/// *continuously* saturated host — never trading "never rebuilds" for
+/// "stampedes on every busy period".
+pub const DEFAULT_AUTO_UPDATE_DEFER_DEADLINE_SECS: u64 = 21_600;
+
+/// `nice` value applied to the rebuild subprocess when it runs under the gate-4
+/// deadline override, so a build forced onto a saturated host yields CPU to the
+/// in-flight sweeps instead of competing with them. `19` is the maximum (lowest
+/// priority) niceness on Linux and macOS.
+const LOW_PRIORITY_NICE: i32 = 19;
 
 /// First backoff delay after a retryable build failure. Subsequent failures
 /// double it, capped at [`BACKOFF_CEILING`].
@@ -137,6 +164,11 @@ pub struct AutoUpdateConfig {
     /// zero/invalid value is dropped to `None`; `0` is intentionally *not* a
     /// meaningful "no settle" here — use a small positive value).
     pub settle_secs: Option<u64>,
+    /// `autonomous.autoUpdate.deferDeadlineSecs` — how long gate 4 may defer
+    /// the rebuild for in-flight sweeps before rebuilding anyway at reduced
+    /// priority (#4929). A zero/invalid value is dropped to `None`; `0` is
+    /// intentionally *not* "never defer" — use a small positive value.
+    pub defer_deadline_secs: Option<u64>,
 }
 
 /// Read `.loom/config.json → autonomous.autoUpdate` through
@@ -160,6 +192,10 @@ pub fn read_auto_update_config(repo_root: &Path) -> AutoUpdateConfig {
             .filter(|&s| s > 0),
         settle_secs: block
             .get("settleSecs")
+            .and_then(serde_json::Value::as_u64)
+            .filter(|&s| s > 0),
+        defer_deadline_secs: block
+            .get("deferDeadlineSecs")
             .and_then(serde_json::Value::as_u64)
             .filter(|&s| s > 0),
     }
@@ -198,6 +234,24 @@ pub fn resolve_settle(config: &AutoUpdateConfig) -> Duration {
         .filter(|&s| s > 0)
         .or(config.settle_secs)
         .map_or_else(|| Duration::from_secs(DEFAULT_AUTO_UPDATE_SETTLE_SECS), Duration::from_secs)
+}
+
+/// Resolve gate 4's deferral deadline with precedence **env > config >
+/// default** (#4929). There is deliberately no "defer forever" setting: an
+/// unbounded gate 4 is exactly the starvation bug this knob fixes. To make the
+/// escape hatch effectively unreachable on a host that must never build under
+/// load, set a very large value.
+#[must_use]
+pub fn resolve_defer_deadline(config: &AutoUpdateConfig) -> Duration {
+    std::env::var(AUTO_UPDATE_DEFER_DEADLINE_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .or(config.defer_deadline_secs)
+        .map_or_else(
+            || Duration::from_secs(DEFAULT_AUTO_UPDATE_DEFER_DEADLINE_SECS),
+            Duration::from_secs,
+        )
 }
 
 // ============================================================================
@@ -327,7 +381,11 @@ pub trait AutoUpdateProbe: Send {
     fn in_flight_sweeps(&self) -> usize;
     /// Run the rebuild + provision step (`loom-daemon-update.sh --no-restart`)
     /// and map its exit code to a [`RebuildOutcome`]. Never panics.
-    fn rebuild(&mut self) -> RebuildOutcome;
+    ///
+    /// `low_priority` requests that the build run niced (#4929) — set when the
+    /// gate-4 deadline forced the rebuild while sweeps are still in flight, so
+    /// the build yields CPU to them instead of competing for it.
+    fn rebuild(&mut self, low_priority: bool) -> RebuildOutcome;
 }
 
 /// Triggers the roll through #4090's drain path — separated from
@@ -395,7 +453,7 @@ impl AutoUpdateProbe for ScriptAutoUpdateProbe {
         crate::ipc::count_in_flight_sweeps(&self.workspace_pool, &self.fallback_root)
     }
 
-    fn rebuild(&mut self) -> RebuildOutcome {
+    fn rebuild(&mut self, low_priority: bool) -> RebuildOutcome {
         let Some(root) = self.source_root.clone() else {
             return RebuildOutcome::Retryable(
                 "no source checkout resolved — cannot rebuild".to_string(),
@@ -407,7 +465,7 @@ impl AutoUpdateProbe for ScriptAutoUpdateProbe {
                 root.display()
             ));
         };
-        run_update_script(&script, &root, self.timeout)
+        run_update_script(&script, &root, self.timeout, low_priority)
     }
 }
 
@@ -492,7 +550,17 @@ impl DrainTrigger for IpcDrainTrigger {
 /// Maps the script's documented exit codes to a [`RebuildOutcome`]:
 /// `0`→Success, `4`/`5`→Terminal, everything else (incl. spawn/timeout)
 /// →Retryable.
-fn run_update_script(script: &Path, cwd: &Path, timeout: Duration) -> RebuildOutcome {
+///
+/// `low_priority` (#4929) niced the whole build subtree to
+/// [`LOW_PRIORITY_NICE`] via a `pre_exec` `setpriority(2)` — inherited by
+/// `cargo`/`rustc`, so a rebuild forced past gate 4's deadline yields CPU to
+/// the in-flight sweeps rather than stampeding them.
+fn run_update_script(
+    script: &Path,
+    cwd: &Path,
+    timeout: Duration,
+    low_priority: bool,
+) -> RebuildOutcome {
     let log_path =
         std::env::temp_dir().join(format!("loom-auto-update-{}.log", uuid::Uuid::new_v4()));
     let out_file = match std::fs::File::create(&log_path) {
@@ -507,14 +575,18 @@ fn run_update_script(script: &Path, cwd: &Path, timeout: Duration) -> RebuildOut
         }
     };
 
-    let mut child = match Command::new(script)
+    let mut command = Command::new(script);
+    command
         .arg("--no-restart")
         .current_dir(cwd)
         .stdin(Stdio::null())
         .stdout(Stdio::from(out_file))
-        .stderr(Stdio::from(stderr_file))
-        .spawn()
-    {
+        .stderr(Stdio::from(stderr_file));
+    if low_priority {
+        nice_child(&mut command);
+    }
+
+    let mut child = match command.spawn() {
         Ok(c) => c,
         Err(e) => {
             let _ = std::fs::remove_file(&log_path);
@@ -552,6 +624,31 @@ fn run_update_script(script: &Path, cwd: &Path, timeout: Duration) -> RebuildOut
     let _ = std::fs::remove_file(&log_path);
     outcome
 }
+
+/// Nice the child (and, by inheritance, the `cargo`/`rustc` processes it
+/// spawns) down to [`LOW_PRIORITY_NICE`] before `exec`. Best-effort: a failing
+/// `setpriority` is deliberately ignored — a build at normal priority is far
+/// better than no build at all, which is the starvation this whole path exists
+/// to end (#4929).
+#[cfg(unix)]
+fn nice_child(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    // SAFETY: `pre_exec` runs between fork and exec, where only
+    // async-signal-safe work is permitted. `setpriority(2)` is a bare syscall
+    // wrapper — it allocates nothing, takes no locks, and touches no libc
+    // global state — so it is safe in that window.
+    unsafe {
+        command.pre_exec(|| {
+            libc::setpriority(libc::PRIO_PROCESS, 0, LOW_PRIORITY_NICE);
+            Ok(())
+        });
+    }
+}
+
+/// Non-unix hosts have no `setpriority`; the build simply runs at normal
+/// priority (the daemon's supervised install targets are macOS/Linux).
+#[cfg(not(unix))]
+fn nice_child(_command: &mut Command) {}
 
 /// Map a `loom-daemon-update.sh` exit code to a [`RebuildOutcome`], attaching a
 /// tail of the captured output on any non-success.
@@ -598,7 +695,12 @@ pub enum TickDecision {
     /// `loom-daemon status`.
     Skip(String),
     /// All gates passed — run the rebuild.
-    Rebuild,
+    Rebuild {
+        /// `true` when gate 4's deferral deadline forced this rebuild while
+        /// sweeps are still in flight (#4929), so the build must run niced.
+        /// `false` on the normal quiescent-host path.
+        low_priority: bool,
+    },
 }
 
 /// The loop's mutable bookkeeping: settle-window tracking, backoff, and the
@@ -617,6 +719,11 @@ pub struct AutoUpdateState {
     backoff_until: Option<Instant>,
     /// The current backoff delay (for status), or `None` when not backing off.
     backoff: Option<Duration>,
+    /// When gate 4 first deferred the rebuild for the currently-tracked commit
+    /// (monotonic). Cleared whenever the host is observed idle, the tracked
+    /// commit advances, or a rebuild succeeds — so only a *continuous* run of
+    /// deferrals accumulates toward the deadline (#4929).
+    deferred_since: Option<Instant>,
     /// A terminal give-up reason for the tracked commit (sticky until the
     /// source commit advances).
     terminal_reason: Option<String>,
@@ -630,9 +737,9 @@ impl AutoUpdateState {
         Self::default()
     }
 
-    /// Decide this tick from the probe readings. Mutates settle-window and
-    /// commit-identity bookkeeping (resetting backoff/terminal when the source
-    /// commit advances) but performs no I/O.
+    /// Decide this tick from the probe readings. Mutates settle-window,
+    /// gate-4-deferral, and commit-identity bookkeeping (resetting
+    /// backoff/terminal when the source commit advances) but performs no I/O.
     pub fn decide(
         &mut self,
         now: Instant,
@@ -640,6 +747,7 @@ impl AutoUpdateState {
         tree_clean: bool,
         in_flight: usize,
         settle: Duration,
+        defer_deadline: Duration,
     ) -> TickDecision {
         // Only `Some(true)` is actionable. `Some(false)` (current) and `None`
         // (undecidable — tarball / unknown built commit) both clear any pending
@@ -647,6 +755,7 @@ impl AutoUpdateState {
         if check.update_available != Some(true) {
             self.tracked_commit = None;
             self.stale_since = None;
+            self.deferred_since = None;
             return TickDecision::Skip(match check.update_available {
                 Some(false) => "up to date with source HEAD".to_string(),
                 _ => "no source checkout / staleness undecidable — nothing to do".to_string(),
@@ -663,6 +772,15 @@ impl AutoUpdateState {
             self.backoff_until = None;
             self.backoff = None;
             self.terminal_reason = None;
+            self.deferred_since = None;
+        }
+
+        // Gate 4's deadline only accumulates while the host is genuinely busy:
+        // any idle observation re-arms it from scratch, so a healthy host that
+        // dips to zero in-flight sweeps rolls the normal way and never
+        // approaches the override.
+        if in_flight == 0 {
+            self.deferred_since = None;
         }
 
         if let Some(reason) = &self.terminal_reason {
@@ -698,14 +816,34 @@ impl AutoUpdateState {
             );
         }
 
-        // Gate 4 — do not stampede in-flight sweep builds.
+        // Gate 4 — do not stampede in-flight sweep builds. Bounded (#4929): a
+        // host that runs at its dispatch cap around the clock never reaches
+        // zero in-flight sweeps, and an open-ended defer there starves the
+        // rebuild forever. After `defer_deadline` of *continuous* deferral the
+        // loop builds anyway, niced, so the update still converges.
         if in_flight > 0 {
-            return TickDecision::Skip(format!(
-                "{in_flight} in-flight sweep(s) — deferring rebuild to avoid a build stampede"
-            ));
+            let since = *self.deferred_since.get_or_insert(now);
+            let waited = now.saturating_duration_since(since);
+            if waited < defer_deadline {
+                let left = defer_deadline.saturating_sub(waited).as_secs();
+                return TickDecision::Skip(format!(
+                    "{in_flight} in-flight sweep(s) — deferring rebuild to avoid a build stampede \
+                     (forcing a low-priority rebuild in ~{left}s if the host stays busy)"
+                ));
+            }
+            log::warn!(
+                "auto_update: gate 4 has deferred the rebuild for {}s with {in_flight} in-flight \
+                 sweep(s) — exceeding the {}s deadline; rebuilding at reduced priority so the \
+                 update is not starved by a permanently saturated host",
+                waited.as_secs(),
+                defer_deadline.as_secs()
+            );
+            return TickDecision::Rebuild { low_priority: true };
         }
 
-        TickDecision::Rebuild
+        TickDecision::Rebuild {
+            low_priority: false,
+        }
     }
 
     /// Record the outcome of a rebuild attempt (and, for a success, whether the
@@ -721,6 +859,11 @@ impl AutoUpdateState {
     ) -> String {
         match outcome {
             RebuildOutcome::Success => {
+                // A completed build re-arms gate 4's deadline (#4929): if this
+                // roll did not restart the process (refused drain), the next
+                // forced-under-load rebuild waits a full deadline again rather
+                // than repeating every tick on a saturated host.
+                self.deferred_since = None;
                 if drain_accepted {
                     self.consecutive_failures = 0;
                     self.backoff_until = None;
@@ -805,6 +948,7 @@ fn run_tick<P: AutoUpdateProbe, T: DrainTrigger>(
     probe: &mut P,
     trigger: &T,
     settle: Duration,
+    defer_deadline: Duration,
 ) {
     let now = Instant::now();
     let last_check = Utc::now();
@@ -819,15 +963,28 @@ fn run_tick<P: AutoUpdateProbe, T: DrainTrigger>(
         0
     };
 
-    let note = match state.decide(now, &check, tree_clean, in_flight, settle) {
+    let note = match state.decide(now, &check, tree_clean, in_flight, settle, defer_deadline) {
         TickDecision::Skip(reason) => reason,
-        TickDecision::Rebuild => {
-            log::info!(
-                "auto_update: source is stale and settled with 0 in-flight sweeps — rebuilding"
-            );
-            let outcome = probe.rebuild();
+        TickDecision::Rebuild { low_priority } => {
+            if low_priority {
+                log::info!(
+                    "auto_update: source is stale and settled but the host has stayed busy past \
+                     the gate-4 deadline ({in_flight} in-flight) — rebuilding at reduced priority"
+                );
+            } else {
+                log::info!(
+                    "auto_update: source is stale and settled with 0 in-flight sweeps — rebuilding"
+                );
+            }
+            let outcome = probe.rebuild(low_priority);
             let drain_accepted = matches!(outcome, RebuildOutcome::Success) && trigger.trigger();
-            let note = state.record_rebuild(now, &outcome, drain_accepted);
+            let mut note = state.record_rebuild(now, &outcome, drain_accepted);
+            if low_priority {
+                note = format!(
+                    "{note} [forced past the in-flight gate after the defer deadline; built at \
+                     reduced priority]"
+                );
+            }
             match &outcome {
                 RebuildOutcome::Success => log::warn!("auto_update: {note}"),
                 RebuildOutcome::Retryable(_) => log::warn!("auto_update: {note}"),
@@ -855,6 +1012,7 @@ pub fn spawn_auto_update_task<P, T>(
     status: Arc<AutoUpdateStatus>,
     interval: Duration,
     settle: Duration,
+    defer_deadline: Duration,
 ) -> tokio::task::JoinHandle<()>
 where
     P: AutoUpdateProbe + Send + 'static,
@@ -862,9 +1020,10 @@ where
 {
     register_global_status(status.clone());
     log::info!(
-        "auto_update: starting loop (interval={}s, settle={}s)",
+        "auto_update: starting loop (interval={}s, settle={}s, deferDeadline={}s)",
         interval.as_secs(),
-        settle.as_secs()
+        settle.as_secs(),
+        defer_deadline.as_secs()
     );
     tokio::spawn(async move {
         let mut state = AutoUpdateState::new();
@@ -874,7 +1033,7 @@ where
             ticker.tick().await;
             let status_task = status.clone();
             let joined = tokio::task::spawn_blocking(move || {
-                run_tick(&mut state, &status_task, &mut probe, &trigger, settle);
+                run_tick(&mut state, &status_task, &mut probe, &trigger, settle, defer_deadline);
                 (state, probe, trigger)
             })
             .await;
@@ -951,7 +1110,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write_config(
             tmp.path(),
-            r#"{"autonomous": {"autoUpdate": {"enabled": true, "intervalSecs": 120, "settleSecs": 30}}}"#,
+            r#"{"autonomous": {"autoUpdate": {"enabled": true, "intervalSecs": 120, "settleSecs": 30, "deferDeadlineSecs": 7200}}}"#,
         );
         assert_eq!(
             read_auto_update_config(tmp.path()),
@@ -959,6 +1118,7 @@ mod tests {
                 enabled: Some(true),
                 interval_secs: Some(120),
                 settle_secs: Some(30),
+                defer_deadline_secs: Some(7200),
             }
         );
     }
@@ -968,11 +1128,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         write_config(
             tmp.path(),
-            r#"{"autonomous": {"autoUpdate": {"intervalSecs": 0, "settleSecs": 0}}}"#,
+            r#"{"autonomous": {"autoUpdate": {"intervalSecs": 0, "settleSecs": 0, "deferDeadlineSecs": 0}}}"#,
         );
         let cfg = read_auto_update_config(tmp.path());
         assert_eq!(cfg.interval_secs, None);
         assert_eq!(cfg.settle_secs, None);
+        assert_eq!(cfg.defer_deadline_secs, None);
     }
 
     // ===================================================================
@@ -1070,6 +1231,7 @@ mod tests {
             enabled: None,
             interval_secs: Some(300),
             settle_secs: Some(45),
+            defer_deadline_secs: None,
         };
         assert_eq!(resolve_interval(&cfg), Duration::from_secs(300));
         assert_eq!(resolve_settle(&cfg), Duration::from_secs(45));
@@ -1088,6 +1250,35 @@ mod tests {
 
         std::env::remove_var(AUTO_UPDATE_INTERVAL_ENV);
         std::env::remove_var(AUTO_UPDATE_SETTLE_ENV);
+    }
+
+    /// Gate 4's deferral deadline (#4929) resolves **env > config > default**
+    /// like every other knob on this block.
+    #[test]
+    #[serial]
+    fn test_resolve_defer_deadline_precedence() {
+        std::env::remove_var(AUTO_UPDATE_DEFER_DEADLINE_ENV);
+        assert_eq!(
+            resolve_defer_deadline(&AutoUpdateConfig::default()),
+            Duration::from_secs(DEFAULT_AUTO_UPDATE_DEFER_DEADLINE_SECS)
+        );
+
+        let cfg = AutoUpdateConfig {
+            defer_deadline_secs: Some(1800),
+            ..AutoUpdateConfig::default()
+        };
+        assert_eq!(resolve_defer_deadline(&cfg), Duration::from_secs(1800));
+
+        std::env::set_var(AUTO_UPDATE_DEFER_DEADLINE_ENV, "60");
+        assert_eq!(resolve_defer_deadline(&cfg), Duration::from_secs(60));
+
+        // Zero/garbage env falls through to config, never to "defer forever".
+        std::env::set_var(AUTO_UPDATE_DEFER_DEADLINE_ENV, "0");
+        assert_eq!(resolve_defer_deadline(&cfg), Duration::from_secs(1800));
+        std::env::set_var(AUTO_UPDATE_DEFER_DEADLINE_ENV, "garbage");
+        assert_eq!(resolve_defer_deadline(&cfg), Duration::from_secs(1800));
+
+        std::env::remove_var(AUTO_UPDATE_DEFER_DEADLINE_ENV);
     }
 
     // ===================================================================
@@ -1109,6 +1300,9 @@ mod tests {
     // ===================================================================
 
     const SETTLE: Duration = Duration::from_secs(60);
+    /// Gate 4's deferral deadline for the decision tests: long enough that the
+    /// existing gate-4 cases still exercise the *deferring* branch.
+    const DEFER: Duration = Duration::from_secs(3600);
 
     #[test]
     fn test_decide_up_to_date_is_skip() {
@@ -1118,7 +1312,7 @@ mod tests {
             update_available: Some(false),
             source_commit: Some("abc".into()),
         };
-        assert!(matches!(st.decide(now, &check, true, 0, SETTLE), TickDecision::Skip(_)));
+        assert!(matches!(st.decide(now, &check, true, 0, SETTLE, DEFER), TickDecision::Skip(_)));
     }
 
     #[test]
@@ -1129,7 +1323,7 @@ mod tests {
             update_available: None,
             source_commit: None,
         };
-        assert!(matches!(st.decide(now, &check, true, 0, SETTLE), TickDecision::Skip(_)));
+        assert!(matches!(st.decide(now, &check, true, 0, SETTLE, DEFER), TickDecision::Skip(_)));
     }
 
     #[test]
@@ -1137,9 +1331,9 @@ mod tests {
         let mut st = AutoUpdateState::new();
         let base = Instant::now();
         // First observe (starts settle timer), then advance past settle.
-        st.decide(base, &stale("c1"), false, 0, SETTLE);
+        st.decide(base, &stale("c1"), false, 0, SETTLE, DEFER);
         let later = base + SETTLE + Duration::from_secs(1);
-        let d = st.decide(later, &stale("c1"), false, 0, SETTLE);
+        let d = st.decide(later, &stale("c1"), false, 0, SETTLE, DEFER);
         assert!(matches!(d, TickDecision::Skip(reason) if reason.contains("dirty")));
     }
 
@@ -1147,7 +1341,7 @@ mod tests {
     fn test_decide_stale_clean_within_settle_is_skip() {
         let mut st = AutoUpdateState::new();
         let base = Instant::now();
-        let d = st.decide(base, &stale("c1"), true, 0, SETTLE);
+        let d = st.decide(base, &stale("c1"), true, 0, SETTLE, DEFER);
         assert!(matches!(d, TickDecision::Skip(reason) if reason.contains("settle")));
     }
 
@@ -1155,31 +1349,172 @@ mod tests {
     fn test_decide_stale_clean_settled_zero_inflight_is_rebuild() {
         let mut st = AutoUpdateState::new();
         let base = Instant::now();
-        st.decide(base, &stale("c1"), true, 0, SETTLE);
+        st.decide(base, &stale("c1"), true, 0, SETTLE, DEFER);
         let later = base + SETTLE + Duration::from_secs(1);
-        assert_eq!(st.decide(later, &stale("c1"), true, 0, SETTLE), TickDecision::Rebuild);
+        assert_eq!(
+            st.decide(later, &stale("c1"), true, 0, SETTLE, DEFER),
+            TickDecision::Rebuild {
+                low_priority: false
+            }
+        );
     }
 
     #[test]
     fn test_decide_gate4_inflight_sweeps_blocks_rebuild() {
         let mut st = AutoUpdateState::new();
         let base = Instant::now();
-        st.decide(base, &stale("c1"), true, 3, SETTLE);
+        st.decide(base, &stale("c1"), true, 3, SETTLE, DEFER);
         let later = base + SETTLE + Duration::from_secs(1);
-        let d = st.decide(later, &stale("c1"), true, 3, SETTLE);
+        let d = st.decide(later, &stale("c1"), true, 3, SETTLE, DEFER);
         assert!(matches!(d, TickDecision::Skip(reason) if reason.contains("in-flight")));
+    }
+
+    // ===================================================================
+    // Gate 4's deferral deadline (#4929) — a permanently saturated host must
+    // still converge instead of deferring the rebuild forever.
+    // ===================================================================
+
+    /// The starvation case from #4929: the host never reaches zero in-flight
+    /// sweeps, so gate 4 defers at every check. Before the deadline it keeps
+    /// deferring (unchanged behavior); once the deadline elapses it rebuilds
+    /// anyway, at low priority — so `last_roll` can finally become non-null.
+    #[test]
+    fn test_decide_gate4_deadline_forces_low_priority_rebuild() {
+        let mut st = AutoUpdateState::new();
+        let base = Instant::now();
+        // First observation starts both the settle timer and (once settled) the
+        // gate-4 deferral clock.
+        st.decide(base, &stale("c1"), true, 13, SETTLE, DEFER);
+
+        // Settled, but still busy: deferral begins here.
+        let settled = base + SETTLE + Duration::from_secs(1);
+        let d = st.decide(settled, &stale("c1"), true, 13, SETTLE, DEFER);
+        assert!(
+            matches!(&d, TickDecision::Skip(reason) if reason.contains("in-flight")),
+            "still within the deadline ⇒ defer, got {d:?}"
+        );
+
+        // Just short of the deadline: still deferring, and the note counts down.
+        let almost = settled + DEFER - Duration::from_secs(1);
+        let d = st.decide(almost, &stale("c1"), true, 13, SETTLE, DEFER);
+        assert!(
+            matches!(&d, TickDecision::Skip(reason) if reason.contains("low-priority rebuild in")),
+            "one second short of the deadline must still defer, got {d:?}"
+        );
+
+        // Past the deadline with the host STILL saturated: rebuild anyway.
+        let past = settled + DEFER + Duration::from_secs(1);
+        assert_eq!(
+            st.decide(past, &stale("c1"), true, 13, SETTLE, DEFER),
+            TickDecision::Rebuild { low_priority: true },
+            "a continuously saturated host must eventually rebuild (#4929)"
+        );
+    }
+
+    /// The deadline measures *continuous* deferral: a host that dips to zero
+    /// in-flight sweeps re-arms it, so a long series of short busy bursts never
+    /// accumulates into a forced build-under-load (the "do not trade
+    /// never-rebuilds for stampede-on-every-busy-period" edge case).
+    #[test]
+    fn test_decide_gate4_deadline_resets_when_host_goes_idle() {
+        let mut st = AutoUpdateState::new();
+        let base = Instant::now();
+        st.decide(base, &stale("c1"), true, 2, SETTLE, DEFER);
+
+        // Busy for most of the deadline...
+        let busy = base + SETTLE + DEFER - Duration::from_secs(1);
+        assert!(matches!(
+            st.decide(busy, &stale("c1"), true, 2, SETTLE, DEFER),
+            TickDecision::Skip(_)
+        ));
+
+        // ...then one idle observation: that tick rolls normally, at NORMAL
+        // priority, because the host is quiescent.
+        let idle = busy + Duration::from_secs(1);
+        assert_eq!(
+            st.decide(idle, &stale("c1"), true, 0, SETTLE, DEFER),
+            TickDecision::Rebuild {
+                low_priority: false
+            }
+        );
+
+        // And the deferral clock restarted, so a later busy tick defers again
+        // rather than immediately forcing a build.
+        let busy_again = idle + Duration::from_secs(1);
+        assert!(
+            matches!(
+                st.decide(busy_again, &stale("c1"), true, 2, SETTLE, DEFER),
+                TickDecision::Skip(reason) if reason.contains("in-flight")
+            ),
+            "an idle observation must re-arm the gate-4 deadline"
+        );
+    }
+
+    /// A new source commit restarts the deferral clock too — the deadline is
+    /// per-tracked-commit, like the settle window and backoff state.
+    #[test]
+    fn test_decide_gate4_deadline_resets_on_new_commit() {
+        let mut st = AutoUpdateState::new();
+        let base = Instant::now();
+        st.decide(base, &stale("c1"), true, 4, SETTLE, DEFER);
+        // The deferral clock only starts once a tick actually reaches gate 4
+        // (i.e. past the settle window), so take one settled-but-busy tick.
+        let settled = base + SETTLE + Duration::from_secs(1);
+        st.decide(settled, &stale("c1"), true, 4, SETTLE, DEFER);
+        let deep = settled + DEFER + Duration::from_secs(1);
+        // c1 would force a rebuild now...
+        assert_eq!(
+            st.decide(deep, &stale("c1"), true, 4, SETTLE, DEFER),
+            TickDecision::Rebuild { low_priority: true }
+        );
+        // ...but a new commit resets settle + deferral together.
+        let d = st.decide(deep, &stale("c2"), true, 4, SETTLE, DEFER);
+        assert!(matches!(d, TickDecision::Skip(reason) if reason.contains("settle")));
+        let settled2 = deep + SETTLE + Duration::from_secs(1);
+        let d = st.decide(settled2, &stale("c2"), true, 4, SETTLE, DEFER);
+        assert!(
+            matches!(d, TickDecision::Skip(reason) if reason.contains("in-flight")),
+            "the new commit's deferral clock starts fresh"
+        );
+    }
+
+    /// A successful rebuild re-arms the deadline, so a roll whose drain was
+    /// refused does not re-force a build-under-load on every subsequent tick.
+    #[test]
+    fn test_successful_rebuild_rearms_gate4_deadline() {
+        let mut st = AutoUpdateState::new();
+        let base = Instant::now();
+        st.decide(base, &stale("c1"), true, 5, SETTLE, DEFER);
+        // One settled-but-busy tick starts gate 4's deferral clock.
+        let settled = base + SETTLE + Duration::from_secs(1);
+        st.decide(settled, &stale("c1"), true, 5, SETTLE, DEFER);
+        let past = settled + DEFER + Duration::from_secs(1);
+        assert_eq!(
+            st.decide(past, &stale("c1"), true, 5, SETTLE, DEFER),
+            TickDecision::Rebuild { low_priority: true }
+        );
+        // Provisioned, but the drain was refused ⇒ still reported stale.
+        st.record_rebuild(past, &RebuildOutcome::Success, false);
+        assert!(st.last_roll.is_some(), "#4929: last_roll must go non-null under saturation");
+
+        let next = past + Duration::from_secs(900);
+        let d = st.decide(next, &stale("c1"), true, 5, SETTLE, DEFER);
+        assert!(
+            matches!(&d, TickDecision::Skip(reason) if reason.contains("in-flight")),
+            "the next forced rebuild must wait another full deadline, got {d:?}"
+        );
     }
 
     #[test]
     fn test_new_commit_resets_settle_window() {
         let mut st = AutoUpdateState::new();
         let base = Instant::now();
-        st.decide(base, &stale("c1"), true, 0, SETTLE);
+        st.decide(base, &stale("c1"), true, 0, SETTLE, DEFER);
         // Settled for c1...
         let later = base + SETTLE + Duration::from_secs(1);
         // ...but a NEW commit lands: the settle timer restarts, so this tick is
         // within-settle again (not a rebuild).
-        let d = st.decide(later, &stale("c2"), true, 0, SETTLE);
+        let d = st.decide(later, &stale("c2"), true, 0, SETTLE, DEFER);
         assert!(matches!(d, TickDecision::Skip(reason) if reason.contains("settle")));
     }
 
@@ -1192,7 +1527,7 @@ mod tests {
         let mut st = AutoUpdateState::new();
         let t0 = Instant::now();
         // Establish a tracked commit + settle so backoff_until is meaningful.
-        st.decide(t0, &stale("c1"), true, 0, SETTLE);
+        st.decide(t0, &stale("c1"), true, 0, SETTLE, DEFER);
 
         st.record_rebuild(t0, &RebuildOutcome::Retryable("boom".into()), false);
         assert_eq!(st.consecutive_failures, 1);
@@ -1213,34 +1548,39 @@ mod tests {
     fn test_backing_off_blocks_rebuild_until_delay_elapses() {
         let mut st = AutoUpdateState::new();
         let t0 = Instant::now();
-        st.decide(t0, &stale("c1"), true, 0, SETTLE);
+        st.decide(t0, &stale("c1"), true, 0, SETTLE, DEFER);
         // A settled rebuild fails at t1; backoff_until = t1 + backoff_delay(1) (60s).
         let t1 = t0 + SETTLE;
         st.record_rebuild(t1, &RebuildOutcome::Retryable("boom".into()), false);
         // t2 is settled (past t0+SETTLE) but still inside the 60s backoff window.
         let t2 = t1 + Duration::from_secs(30);
-        let d = st.decide(t2, &stale("c1"), true, 0, SETTLE);
+        let d = st.decide(t2, &stale("c1"), true, 0, SETTLE, DEFER);
         assert!(matches!(d, TickDecision::Skip(reason) if reason.contains("backing off")));
         // Once the backoff elapses, the same settled/clean/idle state rebuilds.
         let t3 = t1 + backoff_delay(1) + Duration::from_secs(1);
-        assert_eq!(st.decide(t3, &stale("c1"), true, 0, SETTLE), TickDecision::Rebuild);
+        assert_eq!(
+            st.decide(t3, &stale("c1"), true, 0, SETTLE, DEFER),
+            TickDecision::Rebuild {
+                low_priority: false
+            }
+        );
     }
 
     #[test]
     fn test_terminal_is_sticky_until_commit_changes() {
         let mut st = AutoUpdateState::new();
         let t0 = Instant::now();
-        st.decide(t0, &stale("c1"), true, 0, SETTLE);
+        st.decide(t0, &stale("c1"), true, 0, SETTLE, DEFER);
         st.record_rebuild(t0, &RebuildOutcome::Terminal("commit mismatch (exit 4)".into()), false);
         assert!(st.terminal_reason.is_some());
 
         // Same commit, fully settled + clean + idle: still skipped (terminal).
         let later = t0 + SETTLE + Duration::from_secs(1);
-        let d = st.decide(later, &stale("c1"), true, 0, SETTLE);
+        let d = st.decide(later, &stale("c1"), true, 0, SETTLE, DEFER);
         assert!(matches!(d, TickDecision::Skip(reason) if reason.contains("terminal")));
 
         // A NEW commit clears the terminal state (fresh attempt).
-        st.decide(later, &stale("c2"), true, 0, SETTLE);
+        st.decide(later, &stale("c2"), true, 0, SETTLE, DEFER);
         assert!(st.terminal_reason.is_none());
         assert_eq!(st.consecutive_failures, 0);
     }
@@ -1268,7 +1608,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let s = write_fake_script(tmp.path(), "echo built; exit 0");
         assert_eq!(
-            run_update_script(&s, tmp.path(), Duration::from_secs(10)),
+            run_update_script(&s, tmp.path(), Duration::from_secs(10), false),
             RebuildOutcome::Success
         );
     }
@@ -1277,7 +1617,7 @@ mod tests {
     fn test_run_update_script_exit_1_is_retryable() {
         let tmp = tempfile::tempdir().unwrap();
         let s = write_fake_script(tmp.path(), "echo compile error; exit 1");
-        let o = run_update_script(&s, tmp.path(), Duration::from_secs(10));
+        let o = run_update_script(&s, tmp.path(), Duration::from_secs(10), false);
         assert!(matches!(o, RebuildOutcome::Retryable(m) if m.contains("compile error")));
     }
 
@@ -1285,7 +1625,7 @@ mod tests {
     fn test_run_update_script_exit_4_is_terminal() {
         let tmp = tempfile::tempdir().unwrap();
         let s = write_fake_script(tmp.path(), "echo commit mismatch; exit 4");
-        let o = run_update_script(&s, tmp.path(), Duration::from_secs(10));
+        let o = run_update_script(&s, tmp.path(), Duration::from_secs(10), false);
         assert!(matches!(o, RebuildOutcome::Terminal(m) if m.contains("commit mismatch")));
     }
 
@@ -1294,7 +1634,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let s = write_fake_script(tmp.path(), "exit 5");
         assert!(matches!(
-            run_update_script(&s, tmp.path(), Duration::from_secs(10)),
+            run_update_script(&s, tmp.path(), Duration::from_secs(10), false),
             RebuildOutcome::Terminal(_)
         ));
     }
@@ -1303,7 +1643,7 @@ mod tests {
     fn test_run_update_script_timeout_is_retryable() {
         let tmp = tempfile::tempdir().unwrap();
         let s = write_fake_script(tmp.path(), "sleep 30");
-        let o = run_update_script(&s, tmp.path(), Duration::from_millis(300));
+        let o = run_update_script(&s, tmp.path(), Duration::from_millis(300), false);
         assert!(matches!(o, RebuildOutcome::Retryable(m) if m.contains("timed out")));
     }
 
@@ -1312,7 +1652,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let bogus = tmp.path().join("does-not-exist.sh");
         assert!(matches!(
-            run_update_script(&bogus, tmp.path(), Duration::from_secs(10)),
+            run_update_script(&bogus, tmp.path(), Duration::from_secs(10), false),
             RebuildOutcome::Retryable(_)
         ));
     }
@@ -1327,6 +1667,9 @@ mod tests {
         in_flight: usize,
         rebuild_outcome: RebuildOutcome,
         rebuild_calls: Arc<AtomicUsize>,
+        /// How many of those rebuilds asked for the niced/low-priority build
+        /// (the gate-4 deadline override, #4929).
+        low_priority_calls: Arc<AtomicUsize>,
     }
 
     impl AutoUpdateProbe for FakeProbe {
@@ -1339,8 +1682,11 @@ mod tests {
         fn in_flight_sweeps(&self) -> usize {
             self.in_flight
         }
-        fn rebuild(&mut self) -> RebuildOutcome {
+        fn rebuild(&mut self, low_priority: bool) -> RebuildOutcome {
             self.rebuild_calls.fetch_add(1, Ordering::SeqCst);
+            if low_priority {
+                self.low_priority_calls.fetch_add(1, Ordering::SeqCst);
+            }
             self.rebuild_outcome.clone()
         }
     }
@@ -1369,6 +1715,7 @@ mod tests {
             in_flight: 0,
             rebuild_outcome: RebuildOutcome::Success,
             rebuild_calls: rebuild_calls.clone(),
+            low_priority_calls: Arc::new(AtomicUsize::new(0)),
         };
         let trigger = FakeTrigger {
             accepted: true,
@@ -1379,7 +1726,7 @@ mod tests {
         // A zero settle window makes the very first observed-stale tick settled.
         let settle = Duration::from_secs(0);
 
-        run_tick(&mut state, &status, &mut probe, &trigger, settle);
+        run_tick(&mut state, &status, &mut probe, &trigger, settle, DEFER);
         assert_eq!(rebuild_calls.load(Ordering::SeqCst), 1);
         assert_eq!(trigger_calls.load(Ordering::SeqCst), 1);
         let snap = status.snapshot();
@@ -1400,6 +1747,7 @@ mod tests {
             in_flight: 0,
             rebuild_outcome: RebuildOutcome::Success,
             rebuild_calls: rebuild_calls.clone(),
+            low_priority_calls: Arc::new(AtomicUsize::new(0)),
         };
         let trigger = FakeTrigger {
             accepted: true,
@@ -1407,7 +1755,7 @@ mod tests {
         };
         let status = AutoUpdateStatus::new(true);
         let mut state = AutoUpdateState::new();
-        run_tick(&mut state, &status, &mut probe, &trigger, Duration::from_secs(0));
+        run_tick(&mut state, &status, &mut probe, &trigger, Duration::from_secs(0), DEFER);
         assert_eq!(rebuild_calls.load(Ordering::SeqCst), 0, "None must never rebuild");
         assert_eq!(trigger_calls.load(Ordering::SeqCst), 0);
     }
@@ -1421,6 +1769,7 @@ mod tests {
             in_flight: 0,
             rebuild_outcome: RebuildOutcome::Success,
             rebuild_calls: rebuild_calls.clone(),
+            low_priority_calls: Arc::new(AtomicUsize::new(0)),
         };
         let trigger = FakeTrigger {
             accepted: true,
@@ -1428,7 +1777,7 @@ mod tests {
         };
         let status = AutoUpdateStatus::new(true);
         let mut state = AutoUpdateState::new();
-        run_tick(&mut state, &status, &mut probe, &trigger, Duration::from_secs(0));
+        run_tick(&mut state, &status, &mut probe, &trigger, Duration::from_secs(0), DEFER);
         assert_eq!(rebuild_calls.load(Ordering::SeqCst), 0, "dirty tree must never rebuild");
     }
 
@@ -1441,6 +1790,7 @@ mod tests {
             in_flight: 0,
             rebuild_outcome: RebuildOutcome::Terminal("commit mismatch (exit 4)".into()),
             rebuild_calls: rebuild_calls.clone(),
+            low_priority_calls: Arc::new(AtomicUsize::new(0)),
         };
         let trigger = FakeTrigger {
             accepted: true,
@@ -1450,11 +1800,11 @@ mod tests {
         let mut state = AutoUpdateState::new();
         let settle = Duration::from_secs(0);
         // Tick 1: rebuilds, hits terminal.
-        run_tick(&mut state, &status, &mut probe, &trigger, settle);
+        run_tick(&mut state, &status, &mut probe, &trigger, settle, DEFER);
         assert_eq!(rebuild_calls.load(Ordering::SeqCst), 1);
         assert!(status.snapshot().terminal_reason.is_some());
         // Tick 2 (same commit): must NOT rebuild again.
-        run_tick(&mut state, &status, &mut probe, &trigger, settle);
+        run_tick(&mut state, &status, &mut probe, &trigger, settle, DEFER);
         assert_eq!(rebuild_calls.load(Ordering::SeqCst), 1, "terminal must not retry same commit");
     }
 
@@ -1467,6 +1817,7 @@ mod tests {
             in_flight: 2,
             rebuild_outcome: RebuildOutcome::Success,
             rebuild_calls: rebuild_calls.clone(),
+            low_priority_calls: Arc::new(AtomicUsize::new(0)),
         };
         let trigger = FakeTrigger {
             accepted: true,
@@ -1474,8 +1825,70 @@ mod tests {
         };
         let status = AutoUpdateStatus::new(true);
         let mut state = AutoUpdateState::new();
-        run_tick(&mut state, &status, &mut probe, &trigger, Duration::from_secs(0));
+        run_tick(&mut state, &status, &mut probe, &trigger, Duration::from_secs(0), DEFER);
         assert_eq!(rebuild_calls.load(Ordering::SeqCst), 0, "in-flight sweeps must gate the build");
+    }
+
+    /// End-to-end #4929: a host whose in-flight count NEVER drops to zero still
+    /// converges. The first check defers (gate 4 intact); once the deferral
+    /// deadline elapses the loop rebuilds anyway — niced — the drain-and-restart
+    /// is triggered, and `last_roll` finally goes non-null.
+    #[test]
+    fn test_run_tick_saturated_host_eventually_rolls_after_defer_deadline() {
+        let rebuild_calls = Arc::new(AtomicUsize::new(0));
+        let low_priority_calls = Arc::new(AtomicUsize::new(0));
+        let trigger_calls = Arc::new(AtomicUsize::new(0));
+        let mut probe = FakeProbe {
+            check: stale("c1"),
+            tree_clean: Some(true),
+            // Permanently saturated — the sweep count never reaches 0, which is
+            // exactly what starved the updater on robb-STUDIO.
+            in_flight: 13,
+            rebuild_outcome: RebuildOutcome::Success,
+            rebuild_calls: rebuild_calls.clone(),
+            low_priority_calls: low_priority_calls.clone(),
+        };
+        let trigger = FakeTrigger {
+            accepted: true,
+            calls: trigger_calls.clone(),
+        };
+        let status = AutoUpdateStatus::new(true);
+        let mut state = AutoUpdateState::new();
+        // `run_tick` reads the real monotonic clock, so use a short deadline and
+        // sleep past it. The FIRST tick can never fire the override (it starts
+        // the deferral clock at its own `now`), so this is robust in both
+        // directions regardless of machine speed.
+        let settle = Duration::from_secs(0);
+        let deadline = Duration::from_millis(50);
+
+        run_tick(&mut state, &status, &mut probe, &trigger, settle, deadline);
+        assert_eq!(
+            rebuild_calls.load(Ordering::SeqCst),
+            0,
+            "first busy check must still defer (gate 4 intact)"
+        );
+        assert!(status.snapshot().last_roll.is_none());
+
+        std::thread::sleep(Duration::from_millis(120));
+
+        run_tick(&mut state, &status, &mut probe, &trigger, settle, deadline);
+        assert_eq!(
+            rebuild_calls.load(Ordering::SeqCst),
+            1,
+            "a permanently saturated host must rebuild once the deadline elapses (#4929)"
+        );
+        assert_eq!(
+            low_priority_calls.load(Ordering::SeqCst),
+            1,
+            "the forced build must run at reduced priority, not compete head-on"
+        );
+        assert_eq!(trigger_calls.load(Ordering::SeqCst), 1, "the roll still goes through drain");
+        let snap = status.snapshot();
+        assert!(snap.last_roll.is_some(), "#4929 acceptance: last_roll must become non-null");
+        assert!(
+            snap.note.unwrap_or_default().contains("reduced priority"),
+            "the forced build must be visible in `loom-daemon status`"
+        );
     }
 
     // ===================================================================

--- a/loom-daemon/src/daemon_service.rs
+++ b/loom-daemon/src/daemon_service.rs
@@ -1256,10 +1256,12 @@ pub(crate) async fn run_daemon() -> Result<()> {
     let _auto_update_handle = if auto_update::resolve_enabled(&auto_update_config) {
         let interval = auto_update::resolve_interval(&auto_update_config);
         let settle = auto_update::resolve_settle(&auto_update_config);
+        let defer_deadline = auto_update::resolve_defer_deadline(&auto_update_config);
         log::info!(
-            "auto_update: enabled (interval={}s, settle={}s)",
+            "auto_update: enabled (interval={}s, settle={}s, deferDeadline={}s)",
             interval.as_secs(),
-            settle.as_secs()
+            settle.as_secs(),
+            defer_deadline.as_secs()
         );
         let probe = auto_update::ScriptAutoUpdateProbe::new(
             workspace_pool.clone(),
@@ -1273,7 +1275,14 @@ pub(crate) async fn run_daemon() -> Result<()> {
             tokio::runtime::Handle::current(),
         );
         let status = std::sync::Arc::new(auto_update::AutoUpdateStatus::new(true));
-        Some(auto_update::spawn_auto_update_task(probe, trigger, status, interval, settle))
+        Some(auto_update::spawn_auto_update_task(
+            probe,
+            trigger,
+            status,
+            interval,
+            settle,
+            defer_deadline,
+        ))
     } else {
         log::debug!(
             "auto_update: disabled (set LOOM_AUTO_UPDATE=1 or autonomous.autoUpdate.enabled=true to opt in)"


### PR DESCRIPTION
## Summary

Gate 4 of `AutoUpdateState::decide` (`loom-daemon/src/auto_update.rs`) deferred the
auto-update rebuild **unconditionally** while any sweep was in flight. On a host that
runs at its dispatch cap around the clock the in-flight count never reaches zero, so
the gate deferred forever — `auto_update.last_roll` stayed `null` with
`self_update.update_available: true` for a day+, silently pinning the host to an old
binary (observed on robb-STUDIO, 13 in-flight sweeps at every check).

This PR bounds the deferral with a deadline plus a low-priority escape hatch, so a
permanently saturated host still converges on the current source commit.

## Changes

- **`loom-daemon/src/auto_update.rs`**
  - `AutoUpdateState` gains a `deferred_since: Option<Instant>` clock alongside
    `stale_since`/`backoff_until`. It starts the first time a settled + clean tick is
    turned away by gate 4, and **re-arms** on any zero-in-flight observation, a new
    tracked source commit, or a completed rebuild — so only *continuous* deferral
    accumulates toward the deadline.
  - Gate 4 keeps deferring while `waited < defer_deadline` (unchanged behavior, now
    with a countdown in the status note); past the deadline it returns
    `TickDecision::Rebuild` instead of skipping, and logs a warning.
  - `TickDecision::Rebuild` now carries `low_priority: bool`. When the deadline forced
    the build, `AutoUpdateProbe::rebuild(low_priority)` runs the update script under a
    `pre_exec` `setpriority(PRIO_PROCESS, 0, 19)` — inherited by `cargo`/`rustc` — so
    the forced build yields CPU to the running sweeps rather than stampeding them.
    Best-effort: a failing `setpriority` is ignored (a normal-priority build beats no
    build). Non-unix hosts get a no-op stub.
  - New knob `autonomous.autoUpdate.deferDeadlineSecs` /
    `LOOM_AUTO_UPDATE_DEFER_DEADLINE_SECS`, resolving **env > config > default** via
    `resolve_defer_deadline` like the block's other knobs. Default 6h — far longer
    than any healthy busy burst. Zero/invalid falls through; there is deliberately no
    "defer forever" value.
  - The roll still goes through the existing drain path; the forced-build fact is
    appended to the status note so it is visible in `loom-daemon status`.
- **`loom-daemon/src/daemon_service.rs`** — resolve and thread `defer_deadline` into
  `spawn_auto_update_task`, and log it at startup.
- **`defaults/docs/daemon-reference.md`** — document the new knob in the
  `autonomous.autoUpdate` table and rewrite the "Build-stampede gate" bullet to
  describe the bounded behavior.

## Acceptance Criteria Verification

- [x] **Gate 4 gains a bounded escape hatch** — `deferred_since` + `defer_deadline`
      check in `decide()`; once the deadline elapses gate 4 returns
      `Rebuild { low_priority: true }` instead of `Skip`.
- [x] **A continuously-saturated host converges within a bounded window** — new
      `test_run_tick_saturated_host_eventually_rolls_after_defer_deadline` drives
      `run_tick` with a probe whose `in_flight` is permanently 13: the first tick
      defers (0 rebuilds, `last_roll` none), and after the deadline elapses it
      rebuilds once, at low priority, triggers the drain, and sets `last_roll`.
- [x] **Existing gate 4 behavior unchanged** —
      `test_decide_gate4_inflight_sweeps_blocks_rebuild` and
      `test_run_tick_gate4_defers_rebuild_with_inflight_sweeps` still assert a defer
      and still pass; only the new `defer_deadline` argument was threaded through
      (both use a deadline long enough that they exercise the deferring branch, so
      their behavior is identical).
- [x] **`last_roll` becomes non-null within the bounded window** — asserted both in
      the `run_tick` test above and in
      `test_successful_rebuild_rearms_gate4_deadline` (`st.last_roll.is_some()` after
      a forced-under-saturation rebuild).

## Test Plan

New tests (all in `loom-daemon/src/auto_update.rs`):

- `test_decide_gate4_deadline_forces_low_priority_rebuild` — defers at the settled
  tick, still defers one second short of the deadline, rebuilds at low priority past it.
- `test_decide_gate4_deadline_resets_when_host_goes_idle` — **the edge case from the
  issue's test plan**: a single zero-in-flight observation re-arms the clock, so a
  series of short busy bursts never accumulates into a forced build-under-load.
- `test_decide_gate4_deadline_resets_on_new_commit` — the deadline is
  per-tracked-commit, like settle/backoff.
- `test_successful_rebuild_rearms_gate4_deadline` — a roll whose drain was refused
  does not re-force a build on every subsequent tick.
- `test_run_tick_saturated_host_eventually_rolls_after_defer_deadline` — end-to-end.
- `test_resolve_defer_deadline_precedence` — env > config > default; zero/garbage env
  never means "defer forever".

Results:

- `cargo test -p loom-daemon --lib auto_update` → **40 passed, 0 failed**
- `cargo test -p loom-daemon --lib` → **3085 passed, 7 failed**
- `cargo fmt --all -- --check` → clean
- `cargo clippy --package loom-daemon --package loom-api -- -D warnings …` (CI flags) → clean
- `cargo clippy --package loom-daemon --features otlp --all-targets -- -D warnings …` → clean
- `cargo check --workspace --all-targets` → clean

### Note on the 7 `--lib` failures (pre-existing, host-specific, not from this PR)

The 7 failures are all in `work_finder::tests::test_config_*` and reproduce
**identically on an unmodified `main` checkout**. Root cause: this host has a
machine-level config tier at `~/.local/share/loom/config/defaults.json` setting
`autonomous.workFinder.enabled: true` / `perTokenConcurrency` / `maxConcurrent`, which
`config_resolver::resolve_effective_config` merges into the tmpdir-based "expect all
`None`" config tests. The same leakage initially made three
`auto_update::tests::test_config_*` cases fail; neutralizing the tier with
`LOOM_CONFIG_DEFAULTS_FILE=` makes all 40 `auto_update` tests pass. CI runners have no
such file, so this does not affect CI.

Closes #4929