### PR TITLE
docs(roles): rewrite daemon-reference.md link to absolute GitHub URL in doctor.md/judge.md

### DIFF
--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -657,7 +657,7 @@ stand-down comment self-refreshes `updatedAt` but not the label event). That
 pass runs on an interval (up to ~10 minutes of lag) and cannot see an
 *in-flight* Doctor, so it never substitutes for this check or the pre-push
 recheck below. See [`daemon-reference.md`'s "Stale-claim reconciliation"
-section](../../../.loom/docs/daemon-reference.md#stale-claim-reconciliation--the-sweep-journal-3953-fixed-3975-extended-to-pr-side-claims-4367).
+section](https://github.com/rjwalters/loom/blob/main/defaults/docs/daemon-reference.md#stale-claim-reconciliation--the-sweep-journal-3953-fixed-3975-extended-to-pr-side-claims-4367).
 
 ### Pre-Push Head-SHA Recheck (Step 9)
 

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -578,7 +578,7 @@ label's own `labeled` timeline-event timestamp rather than the PR's
 aggregate `updatedAt`, for the identical reason the marker convention above
 exists (a stand-down comment self-refreshes `updatedAt` but not the label
 event). See [`daemon-reference.md`'s "Stale-claim reconciliation"
-section](../../../.loom/docs/daemon-reference.md#stale-claim-reconciliation--the-sweep-journal-3953-fixed-3975-extended-to-pr-side-claims-4367).
+section](https://github.com/rjwalters/loom/blob/main/defaults/docs/daemon-reference.md#stale-claim-reconciliation--the-sweep-journal-3953-fixed-3975-extended-to-pr-side-claims-4367).
 
 **Applies everywhere a Judge claims a PR from a multi-PR pass** — not just
 this single-PR narrative. This same check-then-claim rule governs the batch


### PR DESCRIPTION
## Summary

Fixes the one remaining live bug from #4936: `doctor.md`/`judge.md` linked to
`daemon-reference.md` with a `../../../`-relative path that is correct only
from the file's source location (`.claude/commands/loom/`, 3 levels below repo
root) but 404s from the same content's other install location
(`.loom/roles/`, 2 levels below repo root, populated via a symlink dereferenced
to a real file copy at install time).

## Changes

- `defaults/.claude/commands/loom/doctor.md:660` — rewrote the
  `daemon-reference.md#stale-claim-reconciliation...` link from a relative
  path to an absolute GitHub blob URL
  (`https://github.com/rjwalters/loom/blob/main/defaults/docs/daemon-reference.md#...`),
  matching the pattern already used to fix the other three link issues in
  #4936.
- `defaults/.claude/commands/loom/judge.md:581` — same fix, identical link
  text.
- `defaults/roles/doctor.md` and `defaults/roles/judge.md` are symlinks to the
  two files above, so the fix propagates automatically — no separate edit.

## Acceptance Criteria Verification

- [x] `defaults/.claude/commands/loom/doctor.md:660` and `judge.md:581` no
      longer use a `../`-relative path to `daemon-reference.md` — rewritten to
      an absolute GitHub URL, depth-independent regardless of which installed
      copy is opened.
- [x] Verified the anchor fragment (`#stale-claim-reconciliation--the-sweep-journal-3953-fixed-3975-extended-to-pr-side-claims-4367`)
      matches the actual heading in `defaults/docs/daemon-reference.md:1345`.
- [x] Grepped the full repo for the same broken relative-link pattern
      (`../../../.loom/docs/daemon-reference`) — two other occurrences exist
      (`watch.md`, `sweep.md`), but neither of those files is symlinked into
      `defaults/roles/`, so they are only ever read from the 3-level-deep
      source location where the relative depth is correct. No fix needed
      there; confirmed via `ls defaults/roles/` (no `watch.md`/`sweep.md`
      symlinks present).
- [x] Grepped for any test/fixture asserting on the old relative-link string
      (`../../../.loom/docs/daemon-reference`) across `*.py`/`*.rs`/`*.sh`/`*.json`
      — none found, no test updates needed.

## Test Plan

- Manual verification (doc-content-only change, no automated test suite
  entry applicable per the curator's test plan):
  - Confirmed the symlink chain `defaults/roles/doctor.md` → `../.claude/commands/loom/doctor.md`
    and `.loom/roles/doctor.md` → `../defaults/roles` → same target, so this
    repo's own dogfooded `.loom/roles/doctor.md`/`judge.md` already reflect
    the fixed absolute URL.
  - `./.loom/scripts/check-main-clean.sh` — clean, no contamination of the
    main checkout.
  - `git diff --stat` — only the two intended lines changed (2 files, 2
    insertions, 2 deletions).

Closes #4936