### PR TITLE
fix(dashboard): render host staleness (LIVE/STALE/OFFLINE) instead of last-known state as current forever

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -37,7 +37,11 @@ covers and its fail-closed contract.
   by the retention sweep (age + size caps — see `src/retention.ts`).
 - **Durable Object** (`FleetState`, singleton) — live per-host health/token
   snapshots plus currently in-flight sweeps. Independent of D1; a
-  best-effort cache, not a source of truth (see `src/fleetState.ts`).
+  best-effort cache, not a source of truth (see `src/fleetState.ts`). Every
+  health/tokens entry is tagged `live`/`stale`/`offline` from its
+  `updatedAt` age (issue #4957) and entries older than 7 days are pruned on
+  the next snapshot build, so a host that stops reporting eventually
+  disappears rather than rendering its last-known state as current forever.
 - **`hosts` table** — per-host ingest key auth. Only a SHA-256 hash of each
   key is stored; a key is only ever shown once, at creation time.
 
@@ -140,7 +144,7 @@ asserts the `ADMIN_TOKEN` secret exists on the deployed Worker.
 | `GET /` + `/assets/*` | none in-Worker — put behind Cloudflare Access | The dashboard UI (static assets built from `web/`). Served by the asset router before any Worker code runs; the plain-text banner in `src/index.ts` is only the fallback when no assets are uploaded. |
 | `POST /ingest` | `Authorization: Bearer <ingest_key>` | Accept a batch (bare JSON array of `TelemetryEnvelope`s). |
 | `POST /admin/hosts` | `Authorization: Bearer <ADMIN_TOKEN>` | Provision a host + ingest key (`{"host_id": "..."}`, optional `"key"` to bring your own). |
-| `POST /admin/hosts/:hostId/revoke` | `Authorization: Bearer <ADMIN_TOKEN>` | Revoke a host's key. |
+| `POST /admin/hosts/:hostId/revoke` | `Authorization: Bearer <ADMIN_TOKEN>` | Revoke a host's key and clear its `FleetState` Durable Object entries (issue #4957) — no more rendering the last-known health/tokens sample as current. |
 | `POST /admin/retention/run` | `Authorization: Bearer <ADMIN_TOKEN>` | Run the retention sweep on demand (also runs hourly via `[triggers] crons`). |
 | `GET /admin/fleet-state` | `Authorization: Bearer <ADMIN_TOKEN>` | Read the Durable Object's live snapshot (operator introspection/manual verification). |
 | `GET /api/fleet-state` | none in-Worker — put behind Cloudflare Access (see below) | Authenticated query API: current state of every known host/sweep, full detail. |

--- a/dashboard/docs/query-api.md
+++ b/dashboard/docs/query-api.md
@@ -75,8 +75,16 @@ always returns full detail.
 {
   "hosts": {
     "host-abc": {
-      "health": { "record": { "kind": "host.health", "...": "..." }, "updatedAt": "2026-07-30T12:00:00Z" },
-      "tokens": { "record": { "kind": "tokens.snapshot", "...": "..." }, "updatedAt": "2026-07-30T12:00:00Z" }
+      "health": {
+        "record": { "kind": "host.health", "...": "..." },
+        "updatedAt": "2026-07-30T12:00:00Z",
+        "freshness": { "status": "live", "ageSeconds": 42 }
+      },
+      "tokens": {
+        "record": { "kind": "tokens.snapshot", "...": "..." },
+        "updatedAt": "2026-07-30T12:00:00Z",
+        "freshness": { "status": "live", "ageSeconds": 42 }
+      }
     }
   },
   "activeSweeps": [
@@ -96,6 +104,19 @@ always returns full detail.
   ]
 }
 ```
+
+**`freshness`** (issue #4957): derived from `updatedAt` alone (never the
+daemon-supplied `captured_at`, which a clock-skewed host could spoof) —
+`status` is one of `"live"` (reported within the last ~15 minutes, roughly
+2x the daemon's `host.health`/`tokens.snapshot` sampling cadence),
+`"stale"` (up to ~4 hours), or `"offline"` (beyond that — the daemon has
+very likely stopped, the host is asleep, or it lost its tailnet).
+`ageSeconds` is seconds since `updatedAt`. An entry older than 7 days is
+pruned from the Durable Object entirely on the next snapshot build rather
+than ever appearing here — see `src/fleetState.ts`'s `classifyFreshness`/
+`PRUNE_AFTER_MS`. Both the SSR `/` fallback page (`src/publicPage.ts`) and
+any consumer of this route should treat a `stale`/`offline` sample's
+numbers as historical, never as current.
 
 A completed sweep is not present in `activeSweeps` (removed on
 `sweep.completed` — see `src/fleetState.ts`'s module doc); its full record

--- a/dashboard/src/fleetState.ts
+++ b/dashboard/src/fleetState.ts
@@ -40,12 +40,126 @@ export interface ActiveSweepState {
   updatedAt: string;
 }
 
+/**
+ * Staleness classification for a `health:`/`tokens:` entry, derived purely
+ * from how long ago the Durable Object applied it (`updatedAt` — the
+ * backend's own ingest clock, not the daemon's `captured_at`, so a
+ * skewed host clock can never fake liveness).
+ *
+ * Boundaries (issue #4957 — "dashboard renders last-known host state as
+ * current forever"):
+ *
+ *   - `live`    — within [`LIVE_AFTER_SEC`], roughly 2x the daemon's
+ *     ~5-minute `host.health`/`tokens.snapshot` sampling cadence
+ *     (`SNAPSHOT_INTERVAL` in `loom-daemon/src/observability/mod.rs`,
+ *     documented at `dashboard/docs/deploy-runbook.md` §10) — long enough
+ *     that ordinary batching/flush jitter never flickers a healthy host to
+ *     STALE, short enough to notice a genuinely stalled daemon quickly.
+ *     Matches the "3 missed samples" reasoning `dashboard/web/src/fleet.ts`'s
+ *     own (finer-grained) `STALE_AFTER_SEC` badge already uses.
+ *   - `stale`   — up to [`OFFLINE_AFTER_SEC`]: no longer "current", but a
+ *     single dropped push, a host asleep overnight, or a brief network blip
+ *     is not yet "gone".
+ *   - `offline` — beyond that: the daemon has very likely stopped, the host
+ *     is asleep/powered off, or it lost its tailnet — its last-known
+ *     numbers must never be presented as current (see `publicPage.ts`).
+ */
+export type HostFreshness = "live" | "stale" | "offline";
+
+/** How old an entry may be and still read as `live`. */
+export const LIVE_AFTER_SEC = 15 * 60;
+/** Beyond this, an entry reads as `offline` rather than merely `stale`. */
+export const OFFLINE_AFTER_SEC = 4 * 60 * 60;
+/** Entries older than this are pruned from the Durable Object entirely on
+ * the next [`FleetState.buildSnapshot`] — long enough that a host asleep
+ * over a long weekend does not vanish, short enough that a decommissioned
+ * host does not linger forever (issue #4957 AC: "long-gone hosts age out of
+ * the DO entirely"). */
+export const PRUNE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface FreshnessInfo {
+  status: HostFreshness;
+  /** Seconds since `updatedAt`, floored at `0`. `Number.POSITIVE_INFINITY`
+   * for an unparseable `updatedAt` (never treated as fresh). */
+  ageSeconds: number;
+}
+
+/** Classify one `updatedAt` timestamp's freshness as of `now`. Exported so
+ * both this module's `buildSnapshot` and `publicPage.ts`'s rendering share
+ * exactly one cadence/boundary policy — see the module doc above. */
+export function classifyFreshness(updatedAt: string, now: Date = new Date()): FreshnessInfo {
+  const ageMs = now.getTime() - Date.parse(updatedAt);
+  if (!Number.isFinite(ageMs)) {
+    return { status: "offline", ageSeconds: Number.POSITIVE_INFINITY };
+  }
+  const ageSeconds = Math.max(0, Math.round(ageMs / 1000));
+  const status: HostFreshness =
+    ageSeconds <= LIVE_AFTER_SEC ? "live" : ageSeconds <= OFFLINE_AFTER_SEC ? "stale" : "offline";
+  return { status, ageSeconds };
+}
+
+/** `true` once an entry is old enough to be pruned from the Durable Object
+ * entirely — see [`PRUNE_AFTER_MS`]. An unparseable `updatedAt` is never
+ * pruned by this check (a `NaN` age fails every numeric comparison), which
+ * is the fail-safe direction: a malformed timestamp should surface as
+ * `offline` via [`classifyFreshness`], not silently vanish. */
+function isPruneable(updatedAt: string, now: Date): boolean {
+  return now.getTime() - Date.parse(updatedAt) > PRUNE_AFTER_MS;
+}
+
+type TimestampedEntry = { record: Record<string, unknown>; updatedAt: string };
+
+/** Pure core of [`FleetState.buildSnapshot`]'s host-classification/pruning
+ * step, split out so it is unit-testable without spinning up a Durable
+ * Object (issue #4957's test plan: "unit test buildSnapshot() classifies a
+ * health/tokens entry as LIVE/STALE/OFFLINE correctly at boundary ages").
+ * Takes the raw `storage.list()` results for both prefixes and returns the
+ * classified `hosts` map plus the full storage keys (`health:<hostId>` /
+ * `tokens:<hostId>`) that are old enough to prune — the instance method
+ * below is the only thing that actually touches `this.state.storage`.
+ */
+export function classifyAndPruneHosts(
+  healthEntries: ReadonlyMap<string, TimestampedEntry>,
+  tokenEntries: ReadonlyMap<string, TimestampedEntry>,
+  now: Date = new Date(),
+): { hosts: FleetSnapshot["hosts"]; pruneKeys: string[] } {
+  const hosts: FleetSnapshot["hosts"] = {};
+  const pruneKeys: string[] = [];
+
+  for (const [key, value] of healthEntries) {
+    if (isPruneable(value.updatedAt, now)) {
+      pruneKeys.push(key);
+      continue;
+    }
+    const hostId = key.slice("health:".length);
+    hosts[hostId] ??= {};
+    hosts[hostId].health = { ...value, freshness: classifyFreshness(value.updatedAt, now) };
+  }
+  for (const [key, value] of tokenEntries) {
+    if (isPruneable(value.updatedAt, now)) {
+      pruneKeys.push(key);
+      continue;
+    }
+    const hostId = key.slice("tokens:".length);
+    hosts[hostId] ??= {};
+    hosts[hostId].tokens = { ...value, freshness: classifyFreshness(value.updatedAt, now) };
+  }
+
+  return { hosts, pruneKeys };
+}
+
 export interface FleetSnapshot {
   hosts: Record<
     string,
     {
-      health?: { record: Record<string, unknown>; updatedAt: string };
-      tokens?: { record: Record<string, unknown>; updatedAt: string };
+      // `freshness` is optional on the *type* (older callers/fixtures that
+      // predate issue #4957 construct a bare `{ record, updatedAt }`) even
+      // though `FleetState.buildSnapshot` always populates it today —
+      // `publicPage.ts` recomputes it from `updatedAt` at render time via
+      // `classifyFreshness` regardless, rather than trusting this field, so
+      // its absence never silently hides a stale sample's age.
+      health?: { record: Record<string, unknown>; updatedAt: string; freshness?: FreshnessInfo };
+      tokens?: { record: Record<string, unknown>; updatedAt: string; freshness?: FreshnessInfo };
     }
   >;
   activeSweeps: ActiveSweepState[];
@@ -82,7 +196,32 @@ export class FleetState implements DurableObject {
       });
     }
 
+    if (request.method === "POST" && url.pathname === "/remove-host") {
+      const body = (await request.json()) as { hostId?: unknown };
+      const hostId = typeof body.hostId === "string" ? body.hostId : undefined;
+      if (!hostId) {
+        return new Response("hostId is required", { status: 400 });
+      }
+      await this.removeHost(hostId);
+      return new Response(null, { status: 204 });
+    }
+
     return new Response("not found", { status: 404 });
+  }
+
+  /**
+   * Remove a host's live-state entries (`health:<hostId>` / `tokens:<hostId>`)
+   * outright — the DO-side half of retiring a host (issue #4957 AC: "fleet
+   * drain removes the host's live-state entries"). Wired from
+   * `src/index.ts`'s `POST /admin/hosts/:hostId/revoke`, the dashboard's
+   * existing "this host is gone" signal — there is no separate "drain"
+   * concept at this layer. Does **not** touch that host's `sweep:<sweepId>`
+   * entries: an in-flight sweep on a host being revoked mid-run is a real
+   * anomaly worth surfacing (via its own staleness), not something this
+   * best-effort cleanup should paper over.
+   */
+  private async removeHost(hostId: string): Promise<void> {
+    await this.state.storage.delete([`health:${hostId}`, `tokens:${hostId}`]);
   }
 
   private async applyUpdate({ hostId, record }: FleetStateUpdate): Promise<void> {
@@ -153,23 +292,27 @@ export class FleetState implements DurableObject {
     }
   }
 
-  private async buildSnapshot(): Promise<FleetSnapshot> {
-    const hosts: FleetSnapshot["hosts"] = {};
+  /**
+   * Build the current fleet snapshot, classifying every `health:`/`tokens:`
+   * entry's freshness (issue #4957) and pruning any entry older than
+   * [`PRUNE_AFTER_MS`] as a side effect — the "DO hygiene" half of the AC
+   * ("long-gone hosts age out of the DO entirely"). Pruning piggybacks on
+   * this read rather than needing its own cron/route: every consumer
+   * (`/snapshot`, `/admin/fleet-state`, `/api/fleet-state`,
+   * `/public/fleet-state`) already calls this on every request, so a
+   * decommissioned host's entries are deleted the next time anyone looks —
+   * `now` is threaded through for deterministic tests.
+   */
+  private async buildSnapshot(now: Date = new Date()): Promise<FleetSnapshot> {
     const healthEntries = await this.state.storage.list<{ record: Record<string, unknown>; updatedAt: string }>({
       prefix: "health:",
     });
-    for (const [key, value] of healthEntries) {
-      const hostId = key.slice("health:".length);
-      hosts[hostId] ??= {};
-      hosts[hostId].health = value;
-    }
     const tokenEntries = await this.state.storage.list<{ record: Record<string, unknown>; updatedAt: string }>({
       prefix: "tokens:",
     });
-    for (const [key, value] of tokenEntries) {
-      const hostId = key.slice("tokens:".length);
-      hosts[hostId] ??= {};
-      hosts[hostId].tokens = value;
+    const { hosts, pruneKeys } = classifyAndPruneHosts(healthEntries, tokenEntries, now);
+    if (pruneKeys.length > 0) {
+      await this.state.storage.delete(pruneKeys);
     }
 
     const sweepEntries = await this.state.storage.list<ActiveSweepState>({ prefix: "sweep:" });

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -20,7 +20,11 @@
  *     <ingest_key>`. See `handleIngest` below for the full contract.
  *
  *   POST /admin/hosts               — provision a new host + ingest key.
- *   POST /admin/hosts/:hostId/revoke — revoke a host's key.
+ *   POST /admin/hosts/:hostId/revoke — revoke a host's ingest key AND clear
+ *                                      its `FleetState` Durable Object
+ *                                      entries (issue #4957) — the
+ *                                      dashboard's "this host is gone"
+ *                                      signal.
  *   POST /admin/retention/run       — run the retention sweep on demand
  *                                      (the cron `scheduled()` handler runs
  *                                      the same sweep hourly).
@@ -324,6 +328,24 @@ async function handleRevokeHost(env: Env, hostId: string): Promise<Response> {
     .run();
   if ((result.meta.changes ?? 0) === 0) {
     return jsonError(404, `host_id "${hostId}" not found or already revoked`);
+  }
+  // Issue #4957 AC: "fleet drain removes the host's live-state entries" —
+  // this is the dashboard's own "this host is gone" signal (there is no
+  // separate drain concept at this layer), so it also clears the Durable
+  // Object's `health:`/`tokens:` entries for it, rather than leaving a
+  // revoked host's last-known numbers rendering as current until the
+  // 7-day prune horizon (`fleetState.ts`'s `PRUNE_AFTER_MS`) catches up.
+  // Best-effort: a DO hiccup here must not fail the revoke itself — the
+  // D1 key revocation (above) is the security-relevant half of this route,
+  // already committed by the time this runs.
+  try {
+    await fleetStateStub(env).fetch("https://fleet-state/remove-host", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ hostId }),
+    });
+  } catch (err) {
+    console.error(`fleet-state remove-host failed for "${hostId}":`, err);
   }
   return new Response(JSON.stringify({ host_id: hostId, revoked: true }), {
     status: 200,

--- a/dashboard/src/publicPage.ts
+++ b/dashboard/src/publicPage.ts
@@ -57,6 +57,7 @@
  * reads `/public/*`; the authenticated variant only ever reads `/api/*`.
  */
 
+import { classifyFreshness, type FreshnessInfo, type HostFreshness } from "./fleetState";
 import type { HistoryQueryResult, HistoryRecord } from "./query";
 import type { PublicActiveSweep, RedactedFleetSnapshot } from "./redaction";
 
@@ -133,28 +134,98 @@ function renderActiveSweepRow(sweep: PublicActiveSweep): string {
   </tr>`;
 }
 
-function renderHostHealthRow(hostId: string, health?: { record: Record<string, unknown>; updatedAt: string }): string {
+// ---------------------------------------------------------------------------
+// Host staleness (issue #4957): LIVE/STALE/OFFLINE, not a raw timestamp
+// forever presented as current — see `fleetState.ts`'s `classifyFreshness`
+// for the shared cadence/boundary policy this page renders faithfully
+// rather than reimplements.
+// ---------------------------------------------------------------------------
+
+const FRESHNESS_LABEL: Readonly<Record<HostFreshness, string>> = {
+  live: "LIVE",
+  stale: "STALE",
+  offline: "OFFLINE",
+};
+
+/** "just now" / "5m ago" / "3h ago" / "2d ago" — coarse enough to read at a
+ * glance, exact enough to distinguish "missed one sample" from "gone for
+ * days"; the full ISO timestamp is always still available in the cell's
+ * `title` attribute for anyone who wants precision. */
+function formatAge(ageSeconds: number): string {
+  if (!Number.isFinite(ageSeconds)) return "unknown";
+  if (ageSeconds < 60) return "just now";
+  const minutes = Math.floor(ageSeconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/** The freshness badge + "last seen …" qualifier — rendered directly beside
+ * every cell of host detail so a stale sample's numbers are never shown
+ * without it (issue #4957's AC: "its stale metrics are never displayed as
+ * current"). */
+function renderFreshnessBadge(freshness: FreshnessInfo, updatedAt: string): string {
+  return (
+    `<span class="freshness-badge freshness-badge--${freshness.status}">${FRESHNESS_LABEL[freshness.status]}</span> ` +
+    `<span class="muted" title="${escapeHtml(updatedAt)}">last seen ${escapeHtml(formatAge(freshness.ageSeconds))}</span>`
+  );
+}
+
+function renderHostHealthRow(
+  hostId: string,
+  health: { record: Record<string, unknown>; updatedAt: string } | undefined,
+  now: Date,
+): string {
   if (!health) return "";
-  return `<tr>
+  const freshness = classifyFreshness(health.updatedAt, now);
+  return `<tr class="freshness-${freshness.status}">
     <td>${escapeHtml(hostId)}</td>
-    <td>${escapeHtml(health.updatedAt)}</td>
+    <td>${renderFreshnessBadge(freshness, health.updatedAt)}</td>
     <td>${formatDetails("host.health", health.record)}</td>
   </tr>`;
 }
 
-export function renderFleetOverview(snapshot: RedactedFleetSnapshot): string {
+/** "3 hosts: 2 live, 1 offline (robb-pro, last seen 5h ago)" — the overview
+ * heading's explicit totals (issue #4957's AC). Hosts with no `health` entry
+ * at all (known only from `activeSweeps`) are counted in `hostIds.length`
+ * but contribute no freshness bucket — nothing to classify. */
+function renderFreshnessSummary(hostIds: readonly string[], hosts: RedactedFleetSnapshot["hosts"], now: Date): string {
+  const counts: Record<HostFreshness, number> = { live: 0, stale: 0, offline: 0 };
+  const offlineDescriptions: string[] = [];
+  for (const hostId of hostIds) {
+    const health = hosts[hostId]?.health;
+    if (!health) continue;
+    const freshness = classifyFreshness(health.updatedAt, now);
+    counts[freshness.status] += 1;
+    if (freshness.status === "offline") {
+      offlineDescriptions.push(`${hostId}, last seen ${formatAge(freshness.ageSeconds)}`);
+    }
+  }
+  const reporting = counts.live + counts.stale + counts.offline;
+  if (reporting === 0) return "";
+
+  const parts = [`${counts.live} live`];
+  if (counts.stale > 0) parts.push(`${counts.stale} stale`);
+  if (counts.offline > 0) parts.push(`${counts.offline} offline (${offlineDescriptions.join("; ")})`);
+  return `: ${parts.join(", ")}`;
+}
+
+export function renderFleetOverview(snapshot: RedactedFleetSnapshot, now: Date = new Date()): string {
   const hostIds = Object.keys(snapshot.hosts).sort();
   const healthRows = hostIds
-    .map((id) => renderHostHealthRow(id, snapshot.hosts[id]?.health))
+    .map((id) => renderHostHealthRow(id, snapshot.hosts[id]?.health, now))
     .filter((row) => row.length > 0)
     .join("\n");
   const sweepRows = snapshot.activeSweeps.map(renderActiveSweepRow).join("\n");
+  const freshnessSummary = renderFreshnessSummary(hostIds, snapshot.hosts, now);
 
   return `<section id="fleet-overview">
     <h2>Fleet overview</h2>
-    <h3>Hosts (${hostIds.length})</h3>
+    <h3>Hosts (${hostIds.length})${escapeHtml(freshnessSummary)}</h3>
     <table>
-      <thead><tr><th>Host</th><th>Last health update</th><th>Detail</th></tr></thead>
+      <thead><tr><th>Host</th><th>Status</th><th>Detail</th></tr></thead>
       <tbody>${healthRows || `<tr><td colspan="3" class="muted">No host health reported yet.</td></tr>`}</tbody>
     </table>
     <h3>Active sweeps (${snapshot.activeSweeps.length})</h3>
@@ -291,6 +362,11 @@ const PAGE_STYLE = `
   th { background: #f0f0f0; }
   .muted { color: #999; font-style: italic; }
   section { margin-bottom: 2.5rem; }
+  .freshness-badge { display: inline-block; padding: 0.1rem 0.4rem; border-radius: 0.25rem; font-size: 0.75rem; font-weight: 600; }
+  .freshness-badge--live { background: #d7f5dd; color: #1a7431; }
+  .freshness-badge--stale { background: #fff1cc; color: #8a6100; }
+  .freshness-badge--offline { background: #f3d4d4; color: #8a1f1f; }
+  tr.freshness-stale td, tr.freshness-offline td { color: #888; }
 `;
 
 /** Options for {@link renderPublicPage} distinguishing the two callers that

--- a/dashboard/src/redaction.ts
+++ b/dashboard/src/redaction.ts
@@ -343,12 +343,20 @@ export function redactFleetSnapshot(snapshot: FleetSnapshot, isAuthenticated: bo
       ? entry
       : {
           ...(entry.health && {
-            health: { record: redactPayload("host.health", entry.health.record), updatedAt: entry.health.updatedAt },
+            health: {
+              record: redactPayload("host.health", entry.health.record),
+              updatedAt: entry.health.updatedAt,
+              // Staleness (issue #4957) is derived, non-identifying timing
+              // metadata — same footing as `updatedAt` itself, so it passes
+              // through the redaction boundary unchanged for both viewers.
+              freshness: entry.health.freshness,
+            },
           }),
           ...(entry.tokens && {
             tokens: {
               record: redactPayload("tokens.snapshot", entry.tokens.record),
               updatedAt: entry.tokens.updatedAt,
+              freshness: entry.tokens.freshness,
             },
           }),
         };

--- a/dashboard/test/fleetState.test.ts
+++ b/dashboard/test/fleetState.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the pure staleness-classification/pruning core the
+ * `FleetState` Durable Object's `buildSnapshot` delegates to (issue #4957).
+ *
+ * These test the exported pure functions directly — `classifyFreshness` and
+ * `classifyAndPruneHosts` — rather than spinning up the Durable Object,
+ * because there is no way to control workerd's own wall clock from a
+ * vitest-pool-workers test (`vi.useFakeTimers()` patches Node's `Date`, not
+ * the separate workerd isolate the DO actually runs in). `now` is threaded
+ * through both functions as an explicit parameter for exactly this reason.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  classifyAndPruneHosts,
+  classifyFreshness,
+  LIVE_AFTER_SEC,
+  OFFLINE_AFTER_SEC,
+  PRUNE_AFTER_MS,
+} from "../src/fleetState";
+
+const NOW = new Date("2026-08-02T12:00:00Z");
+
+function secondsAgo(seconds: number): string {
+  return new Date(NOW.getTime() - seconds * 1000).toISOString();
+}
+
+describe("classifyFreshness", () => {
+  it("classifies an entry updated just now as live", () => {
+    expect(classifyFreshness(secondsAgo(0), NOW)).toEqual({ status: "live", ageSeconds: 0 });
+  });
+
+  it("classifies an entry at the LIVE boundary as live", () => {
+    expect(classifyFreshness(secondsAgo(LIVE_AFTER_SEC), NOW).status).toBe("live");
+  });
+
+  it("classifies an entry one second past the LIVE boundary as stale", () => {
+    expect(classifyFreshness(secondsAgo(LIVE_AFTER_SEC + 1), NOW).status).toBe("stale");
+  });
+
+  it("classifies an entry at the OFFLINE boundary as stale", () => {
+    expect(classifyFreshness(secondsAgo(OFFLINE_AFTER_SEC), NOW).status).toBe("stale");
+  });
+
+  it("classifies an entry one second past the OFFLINE boundary as offline", () => {
+    expect(classifyFreshness(secondsAgo(OFFLINE_AFTER_SEC + 1), NOW).status).toBe("offline");
+  });
+
+  it("classifies a very old entry as offline, with the correct age", () => {
+    const result = classifyFreshness(secondsAgo(30 * 24 * 60 * 60), NOW);
+    expect(result.status).toBe("offline");
+    expect(result.ageSeconds).toBe(30 * 24 * 60 * 60);
+  });
+
+  it("treats an unparseable updatedAt as offline rather than throwing or reading as fresh", () => {
+    expect(classifyFreshness("not-a-timestamp", NOW)).toEqual({
+      status: "offline",
+      ageSeconds: Number.POSITIVE_INFINITY,
+    });
+  });
+});
+
+describe("classifyAndPruneHosts", () => {
+  function entryMap(entries: Record<string, { record: Record<string, unknown>; updatedAt: string }>): Map<
+    string,
+    { record: Record<string, unknown>; updatedAt: string }
+  > {
+    return new Map(Object.entries(entries));
+  }
+
+  it("classifies a live host.health entry and attaches its freshness", () => {
+    const { hosts, pruneKeys } = classifyAndPruneHosts(
+      entryMap({ "health:host-a": { record: { kind: "host.health" }, updatedAt: secondsAgo(60) } }),
+      entryMap({}),
+      NOW,
+    );
+    expect(pruneKeys).toEqual([]);
+    expect(hosts["host-a"]?.health?.freshness).toEqual({ status: "live", ageSeconds: 60 });
+    expect(hosts["host-a"]?.health?.record).toEqual({ kind: "host.health" });
+  });
+
+  it("classifies a stale tokens.snapshot entry independently of a live health entry for the same host", () => {
+    const { hosts } = classifyAndPruneHosts(
+      entryMap({ "health:host-a": { record: { kind: "host.health" }, updatedAt: secondsAgo(30) } }),
+      entryMap({
+        "tokens:host-a": { record: { kind: "tokens.snapshot" }, updatedAt: secondsAgo(OFFLINE_AFTER_SEC - 1) },
+      }),
+      NOW,
+    );
+    expect(hosts["host-a"]?.health?.freshness?.status).toBe("live");
+    expect(hosts["host-a"]?.tokens?.freshness?.status).toBe("stale");
+  });
+
+  it("classifies an offline entry but still returns it (offline != pruned)", () => {
+    const { hosts, pruneKeys } = classifyAndPruneHosts(
+      entryMap({ "health:host-a": { record: {}, updatedAt: secondsAgo(OFFLINE_AFTER_SEC + 60) } }),
+      entryMap({}),
+      NOW,
+    );
+    expect(pruneKeys).toEqual([]);
+    expect(hosts["host-a"]?.health?.freshness?.status).toBe("offline");
+  });
+
+  it("prunes an entry older than PRUNE_AFTER_MS and excludes it from hosts", () => {
+    const ancientUpdatedAt = new Date(NOW.getTime() - PRUNE_AFTER_MS - 1000).toISOString();
+    const { hosts, pruneKeys } = classifyAndPruneHosts(
+      entryMap({ "health:host-old": { record: {}, updatedAt: ancientUpdatedAt } }),
+      entryMap({}),
+      NOW,
+    );
+    expect(hosts["host-old"]).toBeUndefined();
+    expect(pruneKeys).toEqual(["health:host-old"]);
+  });
+
+  it("does not prune an entry exactly at the prune horizon", () => {
+    const boundaryUpdatedAt = new Date(NOW.getTime() - PRUNE_AFTER_MS).toISOString();
+    const { hosts, pruneKeys } = classifyAndPruneHosts(
+      entryMap({ "health:host-a": { record: {}, updatedAt: boundaryUpdatedAt } }),
+      entryMap({}),
+      NOW,
+    );
+    expect(pruneKeys).toEqual([]);
+    expect(hosts["host-a"]?.health).toBeDefined();
+  });
+
+  it("prunes health and tokens entries independently for a host that is old in one and fresh in the other", () => {
+    const ancientUpdatedAt = new Date(NOW.getTime() - PRUNE_AFTER_MS - 1000).toISOString();
+    const { hosts, pruneKeys } = classifyAndPruneHosts(
+      entryMap({ "health:host-a": { record: {}, updatedAt: ancientUpdatedAt } }),
+      entryMap({ "tokens:host-a": { record: {}, updatedAt: secondsAgo(60) } }),
+      NOW,
+    );
+    expect(pruneKeys).toEqual(["health:host-a"]);
+    expect(hosts["host-a"]?.health).toBeUndefined();
+    expect(hosts["host-a"]?.tokens?.freshness?.status).toBe("live");
+  });
+});

--- a/dashboard/test/ingest.test.ts
+++ b/dashboard/test/ingest.test.ts
@@ -308,4 +308,36 @@ describe("POST /admin/hosts/:hostId/revoke", () => {
     const ingestResponse = await callWorker(ingestRequest([sweepStartedEnvelope()], "Bearer abc-ingest-key"));
     expect(ingestResponse.status).toBe(401);
   });
+
+  // Issue #4957 AC: "fleet drain removes the host's live-state entries" —
+  // revoking a host is the dashboard's own retirement signal, so it must
+  // also clear that host's `FleetState` Durable Object entries rather than
+  // leaving its last-known health/tokens rendering as current indefinitely.
+  it("clears the host's FleetState Durable Object entries (health/tokens)", async () => {
+    await callWorker(ingestRequest([hostHealthEnvelope()], "Bearer abc-ingest-key"));
+
+    const beforeSnapshot = await callWorker(
+      new Request("https://ingest.example/admin/fleet-state", {
+        headers: { authorization: "Bearer test-admin-token" },
+      }),
+    );
+    const before = (await beforeSnapshot.json()) as { hosts: Record<string, unknown> };
+    expect(before.hosts).toHaveProperty("host-abc");
+
+    const revokeResponse = await callWorker(
+      new Request("https://ingest.example/admin/hosts/host-abc/revoke", {
+        method: "POST",
+        headers: { authorization: "Bearer test-admin-token" },
+      }),
+    );
+    expect(revokeResponse.status).toBe(200);
+
+    const afterSnapshot = await callWorker(
+      new Request("https://ingest.example/admin/fleet-state", {
+        headers: { authorization: "Bearer test-admin-token" },
+      }),
+    );
+    const after = (await afterSnapshot.json()) as { hosts: Record<string, unknown> };
+    expect(after.hosts).not.toHaveProperty("host-abc");
+  });
 });

--- a/dashboard/test/publicPage.test.ts
+++ b/dashboard/test/publicPage.test.ts
@@ -199,6 +199,80 @@ describe("renderFleetOverview — redaction", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Host staleness (issue #4957): LIVE/STALE/OFFLINE, not a raw timestamp
+// rendered as current forever.
+// ---------------------------------------------------------------------------
+
+function snapshotWithHealthUpdatedAt(updatedAt: string): RedactedFleetSnapshot {
+  return {
+    hosts: {
+      "host-abc": {
+        health: {
+          record: { kind: "host.health", captured_at: updatedAt, uptime_sec: 100, logical_cpus: 8 },
+          updatedAt,
+        },
+      },
+    },
+    activeSweeps: [],
+  };
+}
+
+describe("renderFleetOverview — host staleness (issue #4957)", () => {
+  const NOW = new Date("2026-08-02T12:00:00Z");
+
+  it("a host that reported 1 minute ago renders LIVE", () => {
+    const html = renderFleetOverview(snapshotWithHealthUpdatedAt("2026-08-02T11:59:00Z"), NOW);
+    expect(html).toContain("freshness-badge--live");
+    expect(html).toContain("LIVE");
+    expect(html).not.toContain("freshness-badge--stale");
+    expect(html).not.toContain("freshness-badge--offline");
+  });
+
+  it("a host that reported 1 hour ago renders STALE with a last-seen age", () => {
+    const html = renderFleetOverview(snapshotWithHealthUpdatedAt("2026-08-02T11:00:00Z"), NOW);
+    expect(html).toContain("freshness-badge--stale");
+    expect(html).toContain("STALE");
+    expect(html).toContain("last seen 1h ago");
+  });
+
+  it("a host that reported 2 days ago renders OFFLINE with a last-seen age", () => {
+    const html = renderFleetOverview(snapshotWithHealthUpdatedAt("2026-07-31T12:00:00Z"), NOW);
+    expect(html).toContain("freshness-badge--offline");
+    expect(html).toContain("OFFLINE");
+    expect(html).toContain("last seen 2d ago");
+  });
+
+  it("never renders a health row's numeric detail fields without an adjacent freshness badge + age qualifier", () => {
+    for (const updatedAt of ["2026-08-02T11:59:30Z", "2026-08-02T11:00:00Z", "2026-07-31T12:00:00Z"]) {
+      const html = renderFleetOverview(snapshotWithHealthUpdatedAt(updatedAt), NOW);
+      // Every row that carries `uptime_sec=100` (the numeric metric) must
+      // also carry a freshness badge and a "last seen" qualifier — i.e. the
+      // metric is never presented bare, regardless of how stale it is.
+      const row = html.slice(html.indexOf("<tbody>"), html.indexOf("</tbody>"));
+      expect(row).toContain("uptime_sec=100");
+      expect(row).toMatch(/freshness-badge--(live|stale|offline)/);
+      expect(row).toContain("last seen");
+    }
+  });
+
+  it("the Hosts heading reports explicit live/stale/offline totals with offline hosts named", () => {
+    const snapshot: RedactedFleetSnapshot = {
+      hosts: {
+        "host-live": {
+          health: { record: { kind: "host.health" }, updatedAt: "2026-08-02T11:59:30Z" },
+        },
+        "host-offline": {
+          health: { record: { kind: "host.health" }, updatedAt: "2026-07-31T12:00:00Z" },
+        },
+      },
+      activeSweeps: [],
+    };
+    const html = renderFleetOverview(snapshot, NOW);
+    expect(html).toContain("Hosts (2): 1 live, 1 offline (host-offline, last seen 2d ago)");
+  });
+});
+
 describe("renderHistoryTable — redaction", () => {
   it("a private-repo record renders zero occurrences of the repo name, issue title, branch name, or PR link", () => {
     const html = renderHistoryTable(historyFixture());


### PR DESCRIPTION
## Summary

The dashboard rendered a host's last-known `health`/`tokens` sample as if
it were current, forever — a daemon that died, slept, or lost its tailnet
kept showing its final numbers as though live.

- `dashboard/src/fleetState.ts`: `FleetState.buildSnapshot` now classifies
  every `health:`/`tokens:` entry's freshness from `updatedAt` age via a new
  `classifyFreshness` (`live` <15m, `stale` <4h, `offline` beyond — roughly
  2x/many-x the daemon's ~5-minute sampling cadence) and prunes any entry
  older than 7 days as a side effect of the read (`classifyAndPruneHosts` is
  the pure, unit-tested core of this). `freshness` is attached to each
  entry in the snapshot (optional on the type, backward compatible).
- `dashboard/src/publicPage.ts`: `renderHostHealthRow`/`renderFleetOverview`
  now render an explicit `LIVE`/`STALE`/`OFFLINE` badge + "last seen Xm/h/d
  ago" qualifier next to every host's metrics (never a bare timestamp), and
  the `Hosts (N)` heading reports explicit totals, e.g. `Hosts (3): 2 live,
  1 offline (robb-pro, last seen 5h ago)`.
- `dashboard/src/redaction.ts`: `freshness` passes through the redaction
  boundary unchanged for both viewers (derived timing metadata, not
  identifying).
- `dashboard/src/index.ts`: `POST /admin/hosts/:hostId/revoke` (the
  dashboard's own "this host is gone" signal — there is no separate `fleet
  drain`-to-dashboard wiring today, see Scope note below) now also clears
  the host's Durable Object entries via a new internal `POST /remove-host`
  DO route, best-effort, so a retired host stops rendering immediately
  instead of waiting out the 7-day prune horizon.

## Scope note

The Rust `loom-daemon fleet drain` CLI (`loom-daemon/src/fleet/drain.rs`)
retires a *compute worker* (the SSH fleet that spawns Claude workers) and
has no existing wiring to this dashboard's observability backend (a
completely separate Cloudflare Worker + `ADMIN_TOKEN`-gated admin API,
provisioned independently). I did not invent that cross-system wiring here
— it would need new daemon config (dashboard URL + admin token) and is a
bigger, separate integration decision. Instead, this PR satisfies the AC's
DO-hygiene intent through the dashboard's own existing host-retirement
primitive (`POST /admin/hosts/:hostId/revoke`) plus the 7-day prune
horizon, which together mean no host's DO entries linger indefinitely
either way.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` (180 tests, `@cloudflare/vitest-pool-workers`/Miniflare) — all pass, including:
  - `test/fleetState.test.ts` (new): `classifyFreshness` boundary tests (live/stale/offline transitions, unparseable timestamp) and `classifyAndPruneHosts` (classification + pruning, including per-host independent health/tokens pruning).
  - `test/publicPage.test.ts`: LIVE/STALE/OFFLINE badge rendering, "never shown without an age qualifier" assertion, and the `Hosts (N): ...` summary heading.
  - `test/ingest.test.ts`: `POST /admin/hosts/:hostId/revoke` now clears the host's DO entries end to end.
- [x] Manual verification note: a host's dashboard entry transitions LIVE → STALE → OFFLINE purely as a function of `updatedAt` age (verified via the boundary unit tests above, since Miniflare's DO runs in a separate workerd clock unreachable from vitest's fake timers).

Closes #4957