### PR TITLE
fix(daemon): systemd restart primitive verifies relaunch + self-heals a stop-timeout failed unit

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -4544,6 +4544,7 @@ disable-on-stop. The contract mirrors launchd point-for-point:
 | `RunAtLoad=true` + `launchctl enable` (#3972) | `[Install] WantedBy=default.target` + `systemctl --user enable` |
 | `KeepAlive:{SuccessfulExit:true}` — relaunch only on a clean exit `0` (#4054) | `Restart=on-success` — relaunch only on a clean exit `0` (exact analog; a crash / operator SIGTERM/SIGINT exits non-zero and stays down) |
 | (no cgroup-timeout reclassification of a clean exit — not applicable) | `KillMode=mixed` (#4862) — without it, a clean exit(0) with lingering cgroup children (in-flight `claude`/`tee`/`sleep` sweep workers) gets reclassified `Result=timeout` by the default `control-group` mode once `TimeoutStopSec` elapses, and `Restart=on-success` does not match `timeout` — so the relaunch silently never fires. `mixed` escalates the leftover-process SIGKILL sweep on the *main process's own exit*, not after `TimeoutStopSec`, so the unit's `Result` tracks the main process's exit status |
+| (no `TimeoutStopSec` analog — launchd's `KeepAlive` has no stop-timeout escalation) | `TimeoutStopSec=20` (#4950) — the daemon's own stop paths (`RestartDaemon`'s `exit(0)`, the SIGTERM handler's `exit(143)`) are near-instant with no blocking drain, so 20s is a generous multiple, not a tight fit; it exists purely as a fast-failure backstop against a regression or a stale, not-yet-re-rendered unit, well below systemd's 90s default |
 | `launchctl bootout` on operator stop | `systemctl --user disable --now <unit>` |
 | plist `EnvironmentVariables` (`LOOM_DAEMON_SUPERVISOR=launchd`, forwarded `LOOM_*`/tokens, deterministic PATH #4172) | `Environment=` lines (`LOOM_DAEMON_SUPERVISOR=systemd`, same forwarded env + PATH) |
 | `WorkingDirectory` = checkout in machine mode (#4229), else repo root | `WorkingDirectory=` — same resolution |
@@ -4591,6 +4592,22 @@ disable-on-stop. The contract mirrors launchd point-for-point:
   `ExecMainStatus=0`, mirroring `launchctl kickstart`), which run `systemctl
   --user reset-failed <unit> && systemctl --user start <unit>` — never for a
   crash or an operator stop.
+- **The `restart` primitive itself also verifies, synchronously (#4950).** The
+  watchdog gate above is a periodic (timer-driven) safety net; it can be
+  minutes away from the moment a roll actually breaks the relaunch. So
+  `loom-daemon-update.sh`'s systemd branch (mirroring #4232's launchd
+  verification) polls for a NEW, live `MainPID` within a bounded window
+  (`LOOM_DAEMON_RESTART_POLL_SECS`, default 30s) right after the `restart` IPC
+  ack, *before* reporting success — the 2026-08-02 incident this closes was a
+  `restart` that ack'd cleanly (exit 0) but whose unit landed in `failed
+  (Result: timeout)` because `TimeoutStopSec` (now bounded to 20s, see
+  "systemd unit rendering" below) had not yet been applied to the live,
+  already-installed unit. When the poll times out AND the unit's `ActiveState`
+  is confirmed `failed` — `Restart=on-success` never auto-relaunches a `failed`
+  unit — it self-heals with the identical `systemctl --user reset-failed
+  <unit> && systemctl --user start <unit>` recovery, re-polls
+  (`LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS`, default 15s), and only then gives
+  up (exit 7) with a `systemctl --user status` diagnostic snapshot.
 
 ### macOS TCC hygiene under launchd (#3980)
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -649,6 +649,15 @@ render_launchd_plist() {
 #     status. This does not change genuine-crash semantics (still Result=
 #     exit-code / signal, still refused by on-success) -- verified with both
 #     shapes in test-loom-daemon-start.sh.
+#   * TimeoutStopSec=20 (#4950): a fast-failure backstop well below systemd's
+#     90s default -- see the printf site below for the full sizing rationale
+#     (both the RestartDaemon primitive and the operator-stop SIGTERM handler
+#     exit near-instantly, so a healthy daemon never approaches 20s). Without
+#     this, a stop-transition that DOES stall (e.g. a stale unit predating
+#     KillMode=mixed above, still lingering on an already-provisioned host)
+#     drags out the default 90s before landing the unit in `failed (Result:
+#     timeout)` -- the exact 2026-08-02 incident `loom-daemon-update.sh`'s
+#     #4950 restart-verification poll now detects and self-heals.
 #   * [Install] WantedBy=default.target + `systemctl --user enable` is the
 #     RunAtLoad=true analog: the service comes up on login (and, with
 #     `loginctl enable-linger`, after a reboot).
@@ -706,6 +715,21 @@ render_systemd_unit() {
     # reclassified as Result=timeout (control-group's default forced-SIGKILL-
     # after-TimeoutStopSec path) and Restart=on-success never fires.
     printf 'KillMode=mixed\n'
+    # TimeoutStopSec=20 (#4950): bounds the unit's own stop-transition wait
+    # well below systemd's 90s default. Both the RestartDaemon primitive
+    # (#4054, exit(0) synchronously after the IPC ack) and the operator-stop
+    # SIGTERM handler (#3813, exit(143) right after removing the socket) exit
+    # near-instantly with no blocking drain -- 20s is a generous multiple of
+    # that worst case, not a tight fit -- so a HEALTHY daemon never brushes
+    # this ceiling. It exists purely as a fast-failure backstop: if a future
+    # regression reintroduces a slow/blocking shutdown path (or a stale,
+    # not-yet-re-rendered unit predating KillMode=mixed above leaves lingering
+    # cgroup children), the unit fails fast at 20s instead of dragging out the
+    # full 90s default before `loom-daemon-update.sh`'s #4950 verification
+    # poll (LOOM_DAEMON_RESTART_POLL_SECS, default 30s) even has a chance to
+    # observe the failure and self-heal via `systemctl --user reset-failed &&
+    # start`.
+    printf 'TimeoutStopSec=20\n'
     printf '%b' "$env_lines"
     printf 'StandardOutput=append:%s\n' "$log_path"
     printf 'StandardError=append:%s\n' "$log_path"

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -95,7 +95,13 @@
 # by the identical `loom-daemon restart` IPC primitive (recognized daemon-side by
 # `detect_supervisor()` since #4267/PR #4298 when `LOOM_DAEMON_SUPERVISOR=systemd`
 # is present — baked into the rendered unit by loom-daemon-start.sh); a clean
-# exit 0 lets systemd's `Restart=on-success` relaunch onto the fresh binary. On a
+# exit 0 lets systemd's `Restart=on-success` relaunch onto the fresh binary.
+# That ack is verified, not trusted (#4950, mirroring #4232's launchd
+# verification): the script polls for a NEW, live MainPID within a bounded
+# window before reporting success, and — if the unit instead lands in `failed`
+# (e.g. a stop-timeout escalation, which `Restart=on-success` never matches) —
+# self-heals via `systemctl --user reset-failed <unit> && systemctl --user
+# start <unit>` before giving up (exit 7). On a
 # refused restart (a pre-#4267 binary with no RestartDaemon handler, or a dead
 # socket), the script refuses loudly (exit 6) exactly like launchd, and
 # --relaunch (or LOOM_DAEMON_UPDATE_RELAUNCH=1) re-renders the unit and forces
@@ -168,15 +174,19 @@
 #                          checkout. Direct invocation of this script (no
 #                          dispatcher -- the existing dev workflow) never sets
 #                          it and is unaffected.
-#   LOOM_DAEMON_RESTART_POLL_SECS  macOS/launchd only: seconds to poll for a
-#                          NEW, live pid after a `restart` ack before falling
-#                          back to `launchctl kickstart` (default 30, #4232).
+#   LOOM_DAEMON_RESTART_POLL_SECS  macOS/launchd (#4232) AND Linux/systemd
+#                          (#4950): seconds to poll for a NEW, live pid after a
+#                          `restart` ack before falling back to the
+#                          supervisor's self-heal (`launchctl kickstart` on
+#                          launchd; `systemctl --user reset-failed && start` on
+#                          systemd, and only when the unit is `failed`)
+#                          (default 30).
 #   LOOM_DAEMON_RESTART_POLL_INTERVAL  Poll interval in seconds between pid
 #                          checks (default 1; may be fractional, e.g. 0.5).
-#   LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS  macOS/launchd only: seconds to
-#                          re-poll for a new, live pid after the `launchctl
-#                          kickstart` fallback before giving up (default 15,
-#                          #4232).
+#   LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS  macOS/launchd (#4232) AND
+#                          Linux/systemd (#4950): seconds to re-poll for a new,
+#                          live pid after the self-heal fallback before giving
+#                          up (default 15).
 #
 # Exit codes:
 #   0  up to date (no-op) OR rebuild+provision+restart succeeded
@@ -205,14 +215,20 @@
 #      with --relaunch (or LOOM_DAEMON_UPDATE_RELAUNCH=1) it performs that
 #      re-render+relaunch itself, propagating loom-daemon-start.sh's exit code
 #      (#4042, #4118, #4260 sub-issue C).
-#   7  launchd restart ACK'd but never took effect (#4232): the running (old)
-#      binary accepted the `restart` IPC request (exit 0), but launchd never
-#      relaunched the job onto a NEW, live pid within the poll window, AND the
-#      `launchctl kickstart` fallback (plain, never -k) also failed to bring it
-#      up within its own poll window. The fresh binary IS provisioned, but the
-#      daemon's live status is NOT confirmed — this is the "restart scheduled
-#      but launchd silently never relaunched" outage this issue closes; the
-#      script refuses to report success on the ack alone.
+#   7  restart ACK'd but never took effect: the running (old) binary accepted
+#      the `restart` IPC request (exit 0), but the supervisor never relaunched
+#      the job/unit onto a NEW, live pid within the poll window, AND the
+#      self-heal fallback also failed to bring it up within its own poll
+#      window. On launchd (#4232) the fallback is a plain `launchctl
+#      kickstart` (never -k). On systemd (#4950) the fallback is `systemctl
+#      --user reset-failed <unit> && systemctl --user start <unit>`, tried ONLY
+#      when the unit's ActiveState is confirmed `failed` (systemd never
+#      auto-relaunches a `failed` unit even under `Restart=on-success` — a
+#      `Result=timeout` stop escalation is the exact incident shape #4950
+#      closes). The fresh binary IS provisioned, but the daemon's live status
+#      is NOT confirmed — this is the "restart scheduled but the supervisor
+#      silently never relaunched" outage class these issues close; the script
+#      refuses to report success on the ack alone.
 #
 # See also: loom-daemon-start.sh (writes .loom/.daemon.flags), loom-daemon-stop.sh
 # (SIGTERM -> grace -> SIGKILL; in-flight sweeps survive by design — this
@@ -863,6 +879,16 @@ systemd_unit_loaded() {
 systemd_unit_pid() {
     systemctl --user show -p MainPID --value "$SYSTEMD_UNIT" 2>/dev/null
 }
+# systemd_unit_active_state / systemd_unit_result — the two `systemctl --user
+# show` properties the #4950 verification/recovery logic below keys off of:
+# ActiveState (e.g. active/inactive/failed) and Result (success/timeout/...).
+# Mirror systemd_unit_pid's plain --value query shape.
+systemd_unit_active_state() {
+    systemctl --user show -p ActiveState --value "$SYSTEMD_UNIT" 2>/dev/null
+}
+systemd_unit_result() {
+    systemctl --user show -p Result --value "$SYSTEMD_UNIT" 2>/dev/null
+}
 
 # ---------- verify a launchd restart actually relaunched the job (#4232) ----------
 # THE PROBLEM: the launchd branch below used to treat a successful `restart`
@@ -910,6 +936,67 @@ log_launchd_diagnostics() {
     while IFS= read -r line; do
         warn "  $line"
     done < <(launchctl print "$LAUNCHD_SERVICE" 2>&1)
+}
+
+# ---------- verify a systemd restart actually relaunched the unit (#4950) ----------
+# THE PROBLEM (the systemd mirror of #4232's launchd gap): the systemd branch
+# below used to treat a successful `restart` ack (the RUNNING binary accepting
+# the IPC request and exiting 0, per #4054) as success and exit 0 immediately —
+# fire-and-forget, with NO verification that `Restart=on-success` actually
+# relaunched the unit. On 2026-08-02 that ack was honest (the daemon exited 0),
+# but the unit's own STOP transition (systemd sends SIGTERM to the main process
+# as part of processing the exit, then waits up to `TimeoutStopSec` for the
+# unit to fully settle) exceeded the default 90s `TimeoutStopSec` — likely
+# because the LIVE, already-installed unit predated #4862's `KillMode=mixed`
+# fix (a plain `restart` IPC request never re-renders the unit; only
+# `--relaunch` does — see perform_systemd_relaunch below) and lingering
+# `claude`/`tee`/`sleep` sweep-worker children in the same cgroup were reaped
+# only after the full timeout. systemd then marked the unit `failed (Result:
+# timeout)`, and `Restart=on-success` does NOT match `Result=timeout` (only
+# `Result=success` triggers it — see the `Restart=` table in
+# systemd.service(5)), so the relaunch silently never fired and the host was
+# daemonless until an operator ran `systemctl --user reset-failed <unit> &&
+# systemctl --user start <unit>` by hand. This closes that gap: verify a NEW,
+# live MainPID before reporting success, and self-heal via the exact
+# reset-failed+start recovery when the unit lands in `failed`.
+#
+# wait_for_new_systemd_pid <pre_pid> <timeout_secs> <interval_secs> — poll
+# `systemd_unit_pid` (the unit's MainPID) until it reports a pid that is BOTH
+# different from <pre_pid> AND alive (`kill -0`), for up to <timeout_secs>. A
+# reported "0" (not running) never counts, and neither does a pid that merely
+# differs but is already dead (a race artifact) or still equals <pre_pid> (the
+# old process lingering mid-teardown during the poll window). On success,
+# echoes the new pid on stdout and returns 0; on timeout, returns 1 with no
+# output. <interval_secs> may be fractional (e.g. 0.2), matching `sleep`'s own
+# support. Mirrors wait_for_new_launchd_pid above byte-for-byte in contract.
+wait_for_new_systemd_pid() {
+    local pre_pid="$1" timeout_secs="$2" interval_secs="$3"
+    local deadline cur_pid
+    deadline=$(( $(date +%s) + timeout_secs ))
+    while true; do
+        cur_pid="$(systemd_unit_pid)"
+        if [[ -n "$cur_pid" && "$cur_pid" != "0" && "$cur_pid" != "$pre_pid" ]] \
+            && kill -0 "$cur_pid" 2>/dev/null; then
+            echo "$cur_pid"
+            return 0
+        fi
+        if (( $(date +%s) >= deadline )); then
+            return 1
+        fi
+        sleep "$interval_secs"
+    done
+}
+
+# log_systemd_diagnostics — dump `systemctl --user status`'s current state
+# (including the `Active:`/`Result:` line the incident's journal excerpt was
+# read off of) as a diagnostic breadcrumb when a relaunch cannot be verified,
+# mirroring log_launchd_diagnostics above.
+log_systemd_diagnostics() {
+    warn "systemctl --user status $SYSTEMD_UNIT diagnostic snapshot:"
+    local line
+    while IFS= read -r line; do
+        warn "  $line"
+    done < <(systemctl --user status "$SYSTEMD_UNIT" --no-pager --full 2>&1)
 }
 
 # ---------- re-render + relaunch on a refused restart (#4118) ----------
@@ -1415,10 +1502,58 @@ if [[ "$DAEMON_MANAGER" == "systemd" ]]; then
     echo "loom-daemon is systemd-managed (unit ${SYSTEMD_UNIT})."
     echo "Restarting via the supervised restart primitive: $PROVISION_TARGET restart"
     echo "(.daemon.flags is NOT consulted — the unit's Environment= lines carry the equivalent config.)"
+
+    # Capture the pre-restart pid BEFORE the request so the poll below can tell
+    # "systemd relaunched onto a new pid" apart from "the same unit never moved".
+    PRE_RESTART_PID="$(systemd_unit_pid)"
+
     if "$PROVISION_TARGET" restart; then
-        ok "loom-daemon restart scheduled — systemd will relaunch it onto the freshly-provisioned binary."
-        print_final_installed_line "$BUILT_COMMIT"
-        exit 0
+        # The RUNNING (old) binary accepted the request — but that ack is the
+        # daemon's promise, not proof systemd actually honored it (#4950: the
+        # daemon can exit 0 and the unit can still land in `failed (Result:
+        # timeout)` before `Restart=on-success` ever fires). Verify a NEW,
+        # live MainPID before reporting success; the success message below is
+        # intentionally the ONLY "restart scheduled"-style success line in
+        # this branch, and it is unreachable until verification passes.
+        RESTART_POLL_SECS="${LOOM_DAEMON_RESTART_POLL_SECS:-30}"
+        RESTART_POLL_INTERVAL="${LOOM_DAEMON_RESTART_POLL_INTERVAL:-1}"
+        KICKSTART_POLL_SECS="${LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS:-15}"
+        echo "Restart request accepted (pre-restart pid: ${PRE_RESTART_PID:-<none>}). Verifying systemd relaunches onto a NEW, live MainPID within ${RESTART_POLL_SECS}s before reporting success (#4950)..."
+
+        if NEW_PID="$(wait_for_new_systemd_pid "$PRE_RESTART_PID" "$RESTART_POLL_SECS" "$RESTART_POLL_INTERVAL")"; then
+            ok "loom-daemon restart scheduled — systemd relaunched it onto the freshly-provisioned binary (new pid ${NEW_PID}, verified within ${RESTART_POLL_SECS}s)."
+            print_final_installed_line "$BUILT_COMMIT"
+            exit 0
+        fi
+
+        warn "systemd did NOT relaunch within ${RESTART_POLL_SECS}s of the restart ack — no new, live MainPID observed (pre-restart pid was ${PRE_RESTART_PID:-<none>})."
+        log_systemd_diagnostics
+        UNIT_ACTIVE_STATE="$(systemd_unit_active_state)"
+        UNIT_RESULT="$(systemd_unit_result)"
+
+        if [[ "$UNIT_ACTIVE_STATE" == "failed" ]]; then
+            # The exact incident shape (#4950): a stop-timeout escalation left
+            # the unit `failed`, so `Restart=on-success` will NEVER fire on its
+            # own — systemd refuses to auto-restart a unit already in `failed`.
+            # Self-heal via the documented recovery.
+            warn "Unit is in a 'failed' state (Result=${UNIT_RESULT:-unknown}) — systemd will NOT auto-relaunch a failed unit even under Restart=on-success. Self-healing via 'systemctl --user reset-failed $SYSTEMD_UNIT && systemctl --user start $SYSTEMD_UNIT'."
+            systemctl --user reset-failed "$SYSTEMD_UNIT" >/dev/null 2>&1
+            systemctl --user start "$SYSTEMD_UNIT" >/dev/null 2>&1
+
+            if NEW_PID="$(wait_for_new_systemd_pid "$PRE_RESTART_PID" "$KICKSTART_POLL_SECS" "$RESTART_POLL_INTERVAL")"; then
+                ok "loom-daemon restart scheduled — systemd's own relaunch did not occur within ${RESTART_POLL_SECS}s (unit landed in 'failed', Result=${UNIT_RESULT:-unknown}), but 'systemctl --user reset-failed && start' recovered it (new pid ${NEW_PID}, verified within ${KICKSTART_POLL_SECS}s). Remediation note: the reset-failed+start fallback was required (#4950) — investigate why the unit's stop sequence exceeded TimeoutStopSec (a live unit that predates #4862's KillMode=mixed fix — never re-rendered by a plain restart — is the most likely cause; re-render it with 'loom-daemon-update.sh --relaunch')."
+                print_final_installed_line "$BUILT_COMMIT"
+                exit 0
+            fi
+
+            err "loom-daemon restart FAILED: no new, live MainPID was observed even after 'systemctl --user reset-failed && start'."
+        else
+            err "loom-daemon restart FAILED: the unit is not confirmed relaunched, and its ActiveState (${UNIT_ACTIVE_STATE:-unknown}) is not 'failed' — refusing to guess at a recovery action."
+        fi
+        log_systemd_diagnostics
+        err "The freshly-built binary IS provisioned, but the daemon's live status is NOT confirmed (pre-restart pid was ${PRE_RESTART_PID:-<none>})."
+        err "Investigate manually: systemctl --user status $SYSTEMD_UNIT"
+        exit 7
     fi
     # The restart request is served by the RUNNING (old) binary. A pre-#4267
     # daemon has no RestartDaemon handler recognizing LOOM_DAEMON_SUPERVISOR=systemd

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -294,19 +294,21 @@ rm -rf "$MACHINE_HOME" "$MACHINE_CHECKOUT" "$NON_REPO_DIR"
 SD_UNIT="loom-daemon-test-$$.service"
 
 # S1. --print-unit renders the unit with NO side effects (no systemctl, no file
-#     write). Assert the five load-bearing fields from the issue's test plan:
-#     Restart=on-success, KillMode=mixed (#4862), WantedBy=default.target, the
-#     baked Environment=LOOM_DAEMON_SUPERVISOR=systemd, and WorkingDirectory=<repo>.
+#     write). Assert the six load-bearing fields from the issue's test plan:
+#     Restart=on-success, KillMode=mixed (#4862), TimeoutStopSec=20 (#4950),
+#     WantedBy=default.target, the baked Environment=LOOM_DAEMON_SUPERVISOR=systemd,
+#     and WorkingDirectory=<repo>.
 unit_out=$( ( cd "$WORKDIR" && env -u LOOM_WORK_FINDER -u LOOM_MAIN_HEALTH_GATE \
     LOOM_DAEMON_BIN="$FAKE_BIN" bash "$START_SCRIPT" --print-unit 2>/dev/null ) )
 TESTS_RUN=$((TESTS_RUN + 1))
 if echo "$unit_out" | grep -qx 'Restart=on-success' \
     && echo "$unit_out" | grep -qx 'KillMode=mixed' \
+    && echo "$unit_out" | grep -qx 'TimeoutStopSec=20' \
     && echo "$unit_out" | grep -qx 'WantedBy=default.target' \
     && echo "$unit_out" | grep -qx 'Environment=LOOM_DAEMON_SUPERVISOR=systemd' \
     && echo "$unit_out" | grep -qx "WorkingDirectory=$WORKDIR"; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "${GREEN}✓${NC} --print-unit renders Restart=on-success, KillMode=mixed, WantedBy=default.target, LOOM_DAEMON_SUPERVISOR=systemd, WorkingDirectory=<repo>"
+    echo -e "${GREEN}✓${NC} --print-unit renders Restart=on-success, KillMode=mixed, TimeoutStopSec=20, WantedBy=default.target, LOOM_DAEMON_SUPERVISOR=systemd, WorkingDirectory=<repo>"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} --print-unit renders the expected unit fields"
@@ -373,12 +375,13 @@ rm -f "$WORKDIR/.loom/.daemon.pid"
 TESTS_RUN=$((TESTS_RUN + 1))
 if [[ -f "$SD_HOME/.config/systemd/user/$SD_UNIT" ]] \
     && grep -qx 'Restart=on-success' "$SD_HOME/.config/systemd/user/$SD_UNIT" \
-    && grep -qx 'KillMode=mixed' "$SD_HOME/.config/systemd/user/$SD_UNIT"; then
+    && grep -qx 'KillMode=mixed' "$SD_HOME/.config/systemd/user/$SD_UNIT" \
+    && grep -qx 'TimeoutStopSec=20' "$SD_HOME/.config/systemd/user/$SD_UNIT"; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "${GREEN}✓${NC} systemd path: renders the unit file under ~/.config/systemd/user with Restart=on-success + KillMode=mixed (#4862)"
+    echo -e "${GREEN}✓${NC} systemd path: renders the unit file under ~/.config/systemd/user with Restart=on-success + KillMode=mixed (#4862) + TimeoutStopSec=20 (#4950)"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "${RED}✗${NC} systemd path: renders the unit file under ~/.config/systemd/user with Restart=on-success + KillMode=mixed"
+    echo -e "${RED}✗${NC} systemd path: renders the unit file under ~/.config/systemd/user with Restart=on-success + KillMode=mixed + TimeoutStopSec=20"
 fi
 TESTS_RUN=$((TESTS_RUN + 1))
 if echo "$sd_out" | grep -qi 'enable-linger'; then

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -478,6 +478,99 @@ EOF
     chmod +x "$bin_dir/systemctl"
 }
 
+# Writes a stub `systemctl` at $1/systemctl for the #4950 restart-VERIFICATION
+# tests: `MainPID`/`ActiveState`/`Result` all live in a single state file ($3,
+# colon-delimited "pid:activestate:result") rather than being hardcoded, so a
+# test can drive the exact transitions the update script's #4950 poll +
+# self-heal logic reacts to. Structurally unable to touch a real systemd
+# --user manager — this suite runs on Darwin runners (LOOM_SYSTEMD_FORCE=1).
+#
+# Args: <bin_dir> <log> <state_file> <pre_state> [post_restart_marker]
+#       [post_state] [recovery_state]
+#
+#   <pre_state>            the initial "pid:activestate:result" written to
+#                           <state_file> on first invocation if it does not
+#                           already exist (e.g. "4242:active:success").
+#   <post_restart_marker>  (optional) when this file EXISTS, the state auto-
+#                           advances from <pre_state> to <post_state> exactly
+#                           once — simulating "the instant the restart request
+#                           was accepted, systemd's own transition took
+#                           effect" (paired with write_fake_daemon_restart,
+#                           which creates the marker as a side effect of its
+#                           `restart` subcommand).
+#   <post_state>            the state to advance to once the marker exists
+#                           (e.g. "<new-live-pid>:active:success" to simulate
+#                           an immediate spontaneous relaunch, or
+#                           "0:failed:timeout" to simulate the #4950 incident
+#                           shape — a stop-timeout escalation that
+#                           Restart=on-success never fires for).
+#   <recovery_state>        (optional) the state `start` (as invoked by the
+#                           update script's `systemctl --user reset-failed
+#                           <unit> && systemctl --user start <unit>` self-heal)
+#                           advances to. Omit to simulate a self-heal attempt
+#                           that ALSO fails to bring the unit up (the state
+#                           stays whatever `reset-failed` left it at:
+#                           "<pid>:inactive:success").
+write_fake_systemd_pid_bin() {
+    local bin_dir="$1" log="$2" state_file="$3" pre_state="$4"
+    local post_restart_marker="${5:-}" post_state="${6:-}" recovery_state="${7:-}"
+    mkdir -p "$bin_dir"
+    : > "$log"
+    echo "${pre_state}" > "${state_file}"
+    cat > "$bin_dir/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "${log}"
+if [[ "\${1:-}" == "--user" ]]; then shift; fi
+
+state_file="${state_file}"
+cur="\$(cat "\$state_file" 2>/dev/null)"
+if [[ -n "${post_restart_marker}" && -e "${post_restart_marker}" && "\$cur" == "${pre_state}" ]]; then
+    echo "${post_state}" > "\$state_file"
+    cur="${post_state}"
+fi
+IFS=: read -r cur_pid cur_active cur_result <<< "\$cur"
+
+case "\${1:-}" in
+  is-active)
+    [[ "\$cur_active" == "active" ]] && exit 0 || exit 1 ;;
+  is-enabled)
+    exit 0 ;;
+  show)
+    prop=""
+    for a in "\$@"; do
+      case "\$a" in
+        MainPID) prop=MainPID ;;
+        ActiveState) prop=ActiveState ;;
+        Result) prop=Result ;;
+      esac
+    done
+    case "\$prop" in
+      MainPID)     echo "\$cur_pid" ;;
+      ActiveState) echo "\$cur_active" ;;
+      Result)      echo "\$cur_result" ;;
+      *)           echo "" ;;
+    esac
+    ;;
+  status)
+    echo "● loom-daemon.service - Loom autonomous daemon (loom-daemon)"
+    echo "   Loaded: loaded"
+    echo "   Active: \$cur_active (Result: \$cur_result) since Mon 2026-08-02 03:17:36 UTC"
+    echo "Main PID: \$cur_pid"
+    ;;
+  reset-failed)
+    echo "\$cur_pid:inactive:success" > "\$state_file"
+    ;;
+  start)
+    if [[ -n "${recovery_state}" ]]; then
+      echo "${recovery_state}" > "\$state_file"
+    fi
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+    chmod +x "$bin_dir/systemctl"
+}
+
 # Writes a stale, PRE-#4267 systemd --user unit at $1 (the exact state that
 # causes the refused-restart exit-6 fallback): NO Restart=on-success, NO
 # LOOM_DAEMON_SUPERVISOR key, four autonomy Environment= lines, and a SENTINEL
@@ -1713,9 +1806,12 @@ fi
 #     with NO .loom/.daemon.pid file -> the updater plans/executes a RESTART
 #     (not "was not running"), drives it through the `restart` subcommand
 #     (stub records the invocation), does NOT consult .daemon.flags, and exits
-#     0. Forced via the LOOM_SYSTEMD_FORCE=1 test seam (lib/systemd-user.sh)
-#     since this suite runs on Darwin; LOOM_DAEMON_LAUNCHD=0 is already the
-#     suite-wide default so launchd never competes for this tier.
+#     0. The stub relaunches onto a NEW, real, live pid the instant the restart
+#     is accepted (#4950 case (a): relaunch observed -> success, no
+#     reset-failed+start self-heal ever invoked). Forced via the
+#     LOOM_SYSTEMD_FORCE=1 test seam (lib/systemd-user.sh) since this suite
+#     runs on Darwin; LOOM_DAEMON_LAUNCHD=0 is already the suite-wide default
+#     so launchd never competes for this tier.
 # ============================================================
 W26="$BASE_WORKDIR/w26"
 new_fixture "$W26"
@@ -1729,15 +1825,23 @@ write_fake_daemon_restart "$NEW_FAKE26" "$HEAD26" "$RESTART_MARKER26" 0
 # A .daemon.flags that MUST NOT be consulted in systemd mode (would otherwise
 # add --work-finder to a stop+start path).
 echo "--work-finder" > "$W26/.loom/.daemon.flags"
+# A real, live process standing in for "the relaunched unit's new MainPID" —
+# the #4950 poll requires a live pid (kill -0), not just a differing number.
+sleep 60 >/dev/null 2>&1 &
+RELAUNCHED_PID26=$!
+bg_proc_track "$RELAUNCHED_PID26"
 SD_BIN26="$W26/systemd-bin"
 SD_LOG26="$W26/systemctl.log"
-write_fake_systemd_active_bin "$SD_BIN26" "$SD_LOG26" "4242"
+SD_STATE26="$W26/systemd-pid-state"
+write_fake_systemd_pid_bin "$SD_BIN26" "$SD_LOG26" "$SD_STATE26" "4242:active:success" \
+    "$RESTART_MARKER26" "${RELAUNCHED_PID26}:active:success"
 
 out26=$( cd "$W26" && PATH="$SD_BIN26:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
     LOOM_SYSTEMD_UNIT="loom-daemon-test-sd26.service" \
     LOOM_DAEMON_BIN="$INSTALLED26" NEW_FAKE_BIN_SRC="$NEW_FAKE26" \
     bash "$UPDATE_SCRIPT" 2>&1 )
 rc26=$?
+kill "$RELAUNCHED_PID26" 2>/dev/null || true
 assert_eq "0" "$rc26" "systemd-managed update (no pid file) exits 0"
 TESTS_RUN=$((TESTS_RUN + 1))
 if [[ -s "$RESTART_MARKER26" ]]; then
@@ -1765,6 +1869,24 @@ if echo "$out26" | grep -qi 'FLAGS-OFF'; then
 else
     TESTS_PASSED=$((TESTS_PASSED + 1))
     echo -e "${GREEN}✓${NC} no 'restarting FLAGS-OFF' warning fires for a systemd restart"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q "new pid ${RELAUNCHED_PID26}" <<< "$out26"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} success message reports the VERIFIED new MainPID (#4950)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} success message reports the VERIFIED new MainPID (#4950)"
+    echo "  output: $out26"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q 'reset-failed' "$SD_LOG26" 2>/dev/null; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} relaunch observed immediately -> reset-failed+start self-heal is NEVER invoked (#4950 case a)"
+    echo "  systemctl.log: $(cat "$SD_LOG26" 2>/dev/null)"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} relaunch observed immediately -> reset-failed+start self-heal is NEVER invoked (#4950 case a)"
 fi
 
 # ============================================================
@@ -2643,6 +2765,188 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} unreadable guard script -> notice still fires with an honest unknown window (#4697)"
     echo "  output: $out53"
+fi
+
+# ============================================================
+# 54. Systemd restart ack'd but the unit never relaunches on its own AND lands
+#     in 'failed (Result: timeout)' -> the #4950 self-heal ('systemctl --user
+#     reset-failed <unit> && systemctl --user start <unit>') DOES recover it:
+#     the restart request is accepted (exit 0) but the reported MainPID never
+#     moves off the pre-restart pid until AFTER reset-failed+start are invoked
+#     -- success, with a remediation note in the output. This is the exact
+#     2026-08-02 incident shape this issue closes. Poll windows are shrunk via
+#     env so the test runs fast without changing the production defaults.
+# ============================================================
+W54="$BASE_WORKDIR/w54"
+new_fixture "$W54"
+INSTALLED54="$W54/installed/loom-daemon"
+mkdir -p "$W54/installed"
+RESTART_MARKER54="$W54/restart-invoked"
+write_fake_daemon_restart "$INSTALLED54" "deadbee" "$RESTART_MARKER54" 0
+NEW_FAKE54="$W54/new-fake-daemon"
+HEAD54="$(cd "$W54" && git rev-parse --short HEAD)"
+write_fake_daemon_restart "$NEW_FAKE54" "$HEAD54" "$RESTART_MARKER54" 0
+
+sleep 60 >/dev/null 2>&1 &
+RECOVERED_PID54=$!
+bg_proc_track "$RECOVERED_PID54"
+SD_BIN54="$W54/systemd-bin"
+SD_LOG54="$W54/systemctl.log"
+SD_STATE54="$W54/systemd-pid-state"
+# pre_state: OLD pid, active/success. post_state (once restart is requested):
+# 0:failed:timeout -- Restart=on-success never fires for a failed unit.
+# recovery_state: only reached via reset-failed + start -- a NEW, live pid.
+write_fake_systemd_pid_bin "$SD_BIN54" "$SD_LOG54" "$SD_STATE54" "9999:active:success" \
+    "$RESTART_MARKER54" "0:failed:timeout" "${RECOVERED_PID54}:active:success"
+
+out54=$( cd "$W54" && PATH="$SD_BIN54:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+    LOOM_SYSTEMD_UNIT="loom-daemon-test-sd54.service" \
+    LOOM_DAEMON_BIN="$INSTALLED54" NEW_FAKE_BIN_SRC="$NEW_FAKE54" \
+    LOOM_DAEMON_RESTART_POLL_SECS=1 LOOM_DAEMON_RESTART_POLL_INTERVAL=0.2 \
+    LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS=3 \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc54=$?
+kill "$RECOVERED_PID54" 2>/dev/null || true
+assert_eq "0" "$rc54" "no spontaneous relaunch, unit failed -> reset-failed+start recovers it -> exit 0 (#4950)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out54" | grep -qi 'reset-failed' && echo "$out54" | grep -qi 'remediation'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} success output names the reset-failed+start self-heal + a remediation note"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} success output names the reset-failed+start self-heal + a remediation note"
+    echo "  output: $out54"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- 'reset-failed' "$SD_LOG54" 2>/dev/null \
+    && grep -qE -- '(^|[[:space:]])start([[:space:]]|$)' "$SD_LOG54" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} self-heal invokes the EXACT documented recovery: reset-failed then start"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} self-heal invokes the EXACT documented recovery: reset-failed then start"
+    echo "  systemctl.log: $(cat "$SD_LOG54" 2>/dev/null)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q "new pid ${RECOVERED_PID54}" <<< "$out54"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} success message reports the pid recovered by the self-heal"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} success message reports the pid recovered by the self-heal"
+    echo "  output: $out54"
+fi
+
+# ============================================================
+# 55. Systemd restart ack'd, unit never relaunches, lands in 'failed
+#     (Result: timeout)', AND the reset-failed+start self-heal ALSO fails to
+#     bring it up -> exit NON-ZERO (7), loudly, rather than a silent
+#     half-update success (#4950 case (c), mirrors test 36).
+# ============================================================
+W55="$BASE_WORKDIR/w55"
+new_fixture "$W55"
+INSTALLED55="$W55/installed/loom-daemon"
+mkdir -p "$W55/installed"
+RESTART_MARKER55="$W55/restart-invoked"
+write_fake_daemon_restart "$INSTALLED55" "deadbee" "$RESTART_MARKER55" 0
+NEW_FAKE55="$W55/new-fake-daemon"
+HEAD55="$(cd "$W55" && git rev-parse --short HEAD)"
+write_fake_daemon_restart "$NEW_FAKE55" "$HEAD55" "$RESTART_MARKER55" 0
+
+SD_BIN55="$W55/systemd-bin"
+SD_LOG55="$W55/systemctl.log"
+SD_STATE55="$W55/systemd-pid-state"
+# No recovery_state given -> reset-failed+start leaves the unit inactive; the
+# pid never moves.
+write_fake_systemd_pid_bin "$SD_BIN55" "$SD_LOG55" "$SD_STATE55" "9999:active:success" \
+    "$RESTART_MARKER55" "0:failed:timeout"
+
+out55=$( cd "$W55" && PATH="$SD_BIN55:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+    LOOM_SYSTEMD_UNIT="loom-daemon-test-sd55.service" \
+    LOOM_DAEMON_BIN="$INSTALLED55" NEW_FAKE_BIN_SRC="$NEW_FAKE55" \
+    LOOM_DAEMON_RESTART_POLL_SECS=1 LOOM_DAEMON_RESTART_POLL_INTERVAL=0.2 \
+    LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS=1 \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc55=$?
+assert_eq "7" "$rc55" "no relaunch even after reset-failed+start -> exit 7 (never a silent half-update, #4950 case c)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out55" | grep -qi 'FAILED' && echo "$out55" | grep -qi 'reset-failed'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} failure output loudly reports the exhausted self-heal fallback"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} failure output loudly reports the exhausted self-heal fallback"
+    echo "  output: $out55"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out55" | grep -qi 'Active:' && echo "$out55" | grep -qi 'Result:'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} failure output includes systemctl status diagnostics (Active:/Result:)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} failure output includes systemctl status diagnostics (Active:/Result:)"
+    echo "  output: $out55"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- 'reset-failed' "$SD_LOG55" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} exhausted self-heal still attempted the documented reset-failed recovery"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} exhausted self-heal still attempted the documented reset-failed recovery"
+    echo "  systemctl.log: $(cat "$SD_LOG55" 2>/dev/null)"
+fi
+
+# ============================================================
+# 56. Systemd restart ack'd but never relaunches, and the unit is NOT in a
+#     'failed' state (some other stall, e.g. still 'activating') -> the
+#     updater refuses to guess at a recovery action (no reset-failed/start
+#     invoked) and exits non-zero (7) with diagnostics (#4950 AC2 scope: the
+#     self-heal is gated on a CONFIRMED 'failed' ActiveState).
+# ============================================================
+W56="$BASE_WORKDIR/w56"
+new_fixture "$W56"
+INSTALLED56="$W56/installed/loom-daemon"
+mkdir -p "$W56/installed"
+RESTART_MARKER56="$W56/restart-invoked"
+write_fake_daemon_restart "$INSTALLED56" "deadbee" "$RESTART_MARKER56" 0
+NEW_FAKE56="$W56/new-fake-daemon"
+HEAD56="$(cd "$W56" && git rev-parse --short HEAD)"
+write_fake_daemon_restart "$NEW_FAKE56" "$HEAD56" "$RESTART_MARKER56" 0
+
+SD_BIN56="$W56/systemd-bin"
+SD_LOG56="$W56/systemctl.log"
+SD_STATE56="$W56/systemd-pid-state"
+# post_state is 'activating', not 'failed' -- the pid never moves, but the
+# self-heal gate must NOT fire since the unit was never confirmed failed.
+write_fake_systemd_pid_bin "$SD_BIN56" "$SD_LOG56" "$SD_STATE56" "9999:active:success" \
+    "$RESTART_MARKER56" "0:activating:success"
+
+out56=$( cd "$W56" && PATH="$SD_BIN56:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+    LOOM_SYSTEMD_UNIT="loom-daemon-test-sd56.service" \
+    LOOM_DAEMON_BIN="$INSTALLED56" NEW_FAKE_BIN_SRC="$NEW_FAKE56" \
+    LOOM_DAEMON_RESTART_POLL_SECS=1 LOOM_DAEMON_RESTART_POLL_INTERVAL=0.2 \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc56=$?
+assert_eq "7" "$rc56" "unit stalled but never confirmed failed -> exit 7, no guessed recovery"
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- 'reset-failed' "$SD_LOG56" 2>/dev/null \
+    || grep -qE -- '(^|[[:space:]])start([[:space:]]|$)' "$SD_LOG56" 2>/dev/null; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} self-heal is NEVER invoked when ActiveState is not confirmed 'failed'"
+    echo "  systemctl.log: $(cat "$SD_LOG56" 2>/dev/null)"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} self-heal is NEVER invoked when ActiveState is not confirmed 'failed'"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out56" | grep -qi 'FAILED'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} failure output loudly reports the unconfirmed relaunch"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} failure output loudly reports the unconfirmed relaunch"
+    echo "  output: $out56"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary

Closes #4950.

The launchd path of the supervised `restart` primitive got explicit
relaunch verification in #4232 ("verify a NEW, live pid within 30s"), but
the systemd path just printed `restart scheduled` and exited 0 without
verifying anything. On 2026-08-02, `loom-daemon-update.sh` invoked
`loom-daemon restart` on a systemd-managed host; the daemon's own stop
transition exceeded the default 90s `TimeoutStopSec`, systemd escalated and
marked the unit `failed (Result: timeout)`, and `Restart=on-success` never
fired -- the host was silently daemonless until an operator manually ran
`systemctl --user reset-failed loom-daemon.service && systemctl --user start
loom-daemon.service`.

This mirrors #4232's launchd verification onto the systemd branch of
`loom-daemon-update.sh`:

- **Bounded verification poll.** After the `restart` IPC ack, poll
  `systemctl --user show -p MainPID` for a NEW, live pid within
  `LOOM_DAEMON_RESTART_POLL_SECS` (default 30s) before reporting success.
  On timeout, print a `systemctl --user status` diagnostic snapshot
  (the `Active:`/`Result:` lines).
- **Self-heal on a confirmed `failed` unit.** When the unit's `ActiveState`
  is `failed` (the exact incident shape -- `Restart=on-success` never
  auto-relaunches a `failed` unit), perform the documented recovery:
  `systemctl --user reset-failed <unit> && systemctl --user start <unit>`,
  then re-poll (`LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS`, default 15s)
  before giving up. If the unit isn't confirmed `failed`, the script refuses
  to guess at a recovery action and just reports the failure (exit 7).
- **`TimeoutStopSec=20`** added to the rendered systemd unit
  (`render_systemd_unit` in `loom-daemon-start.sh`). Both the
  `RestartDaemon` IPC handler (`exit(0)` synchronously after the ack) and
  the operator-stop SIGTERM handler (`exit(143)` right after removing the
  socket) exit near-instantly with no blocking drain, so 20s is a generous
  multiple of the worst case, not a tight fit -- it exists purely as a
  fast-failure backstop well below systemd's 90s default, so a future
  regression (or a stale, not-yet-re-rendered unit predating #4862's
  `KillMode=mixed`) fails fast instead of dragging out 90s before the new
  verification poll even gets a chance to observe and self-heal it.

Exit code 7's meaning is generalized in the header doc comment to cover
both the launchd (#4232) and systemd (#4950) "ack'd but never took effect"
outage class.

## Test plan

- [x] `bash defaults/scripts/tests/test-loom-daemon-update.sh` -- 131/131
      passed (adds 3 new systemd scenarios: spontaneous-relaunch success,
      failed-unit self-heal success, failed-unit self-heal exhausted; updates
      scenario 26 to exercise the new pid-verification poll).
- [x] `bash defaults/scripts/tests/test-loom-daemon-start.sh` -- 74/74 passed
      (asserts `TimeoutStopSec=20` in the rendered unit, both via
      `--print-unit` and the on-disk unit file; includes the pre-existing
      real-systemd `KillMode=mixed` regression test).
- [x] `shellcheck --severity=warning` clean on all four touched scripts.
- [x] `bash scripts/check-docs-defaults-parity.sh` -- OK.

Generated with Claude Code
