### PR TITLE
docs(codesign): document provisioning a stable signing identity on additional Macs

### DIFF
--- a/defaults/docs/macos-tcc-codesign.md
+++ b/defaults/docs/macos-tcc-codesign.md
@@ -86,6 +86,111 @@ machine-local, ungitted override):
 }
 ```
 
+## Provisioning additional Macs
+
+The certificate lives in **one** Mac's login keychain — nothing about it is
+committed, so a second fleet Mac invoked with the *same*
+`LOOM_CODESIGN_IDENTITY` finds no matching identity and falls back to ad-hoc
+signing. `provision-daemon.sh` says so explicitly on stderr before the
+ad-hoc line:
+
+```
+  [loom-daemon] WARNING: LOOM_CODESIGN_IDENTITY 'Loom Local Signing' not found via 'security find-identity -v -p codesigning'; falling back to ad-hoc signing (see defaults/docs/macos-tcc-codesign.md)
+  [loom-daemon] ad-hoc signed /Users/you/.local/bin/loom-daemon (identifier=com.rjwalters.loom-daemon)
+```
+
+That host still runs fine — the only consequence is the deferred one this
+doc exists for: its TCC grants reset on every rebuild. To fix it, give the
+new Mac its own stable identity, either by copying the existing certificate
+(Option 1) or by minting a fresh one there (Option 2).
+
+**Prefer Option 2, and reuse the same Common Name on every host.** A TCC
+grant is per-host, so nothing requires the *certificate* to be shared —
+only that the identity *name* matches what `codesign.identity` /
+`LOOM_CODESIGN_IDENTITY` asks for. Minting a same-named cert per host gets
+you one committed config value with no private key ever leaving the first
+machine. Option 1 exists for when you specifically want one certificate
+across the fleet (e.g. so `codesign -dvv` reports an identical
+`Authority=` leaf everywhere).
+
+### Option 1 — export the cert + key and import it on the second Mac
+
+On the Mac that already has the identity, export both halves. Keychain
+Access is the reliable single-identity path: select the **certificate and
+its private key** together → **File → Export Items…** → `Personal
+Information Exchange (.p12)`. The CLI equivalent exports *every* identity
+in the keychain, so only reach for it on a keychain you know is clean:
+
+```bash
+# Exports ALL codesigning identities in the keychain, not just this one.
+security export -k ~/Library/Keychains/login.keychain-db \
+  -t identities -f pkcs12 -P changeit -o loom-signing.p12
+
+# The public certificate alone, needed for add-trusted-cert on the far side.
+security find-certificate -c "Loom Local Signing" -p \
+  ~/Library/Keychains/login.keychain-db > loom-signing.crt
+```
+
+The `.p12` contains the **private key** — move it over a channel you trust
+(`scp`, AirDrop), use a real passphrase rather than `changeit`, and delete
+it from both hosts once imported.
+
+On the new Mac, import with the same flags the one-time setup above uses
+(`-T /usr/bin/codesign` so later signing is non-interactive; the trust step
+is what keeps the self-signed root from prompting on first use):
+
+```bash
+security import loom-signing.p12 -k ~/Library/Keychains/login.keychain-db \
+  -P changeit -T /usr/bin/codesign
+
+security add-trusted-cert -p codeSign -k ~/Library/Keychains/login.keychain-db \
+  loom-signing.crt
+
+rm -f loom-signing.p12          # the private key does not need to persist on disk
+security find-identity -v -p codesigning   # should now list "Loom Local Signing"
+```
+
+If the import fails with "MAC verification failed", the `.p12` was written
+in OpenSSL 3's default format — re-export it with `-legacy` (same quirk as
+step 2 of Option B above).
+
+### Option 2 — mint an independent cert per host
+
+Just run the one-time setup (Option A or B) again on the new Mac. No key
+material is transferred, and each host's certificate is independent.
+
+- **Same CN on every host** (recommended): use `/CN=Loom Local Signing`
+  again, and the committed `codesign.identity` keeps working unchanged.
+  The certificates differ per host, but each host only ever validates its
+  own signature, so the shared name is all the config needs.
+- **Different CN per host** (e.g. `Loom Local Signing (studio)`): then a
+  single committed value can't cover the fleet. Set the identity per host
+  in `.loom-local/local.json` — the highest-precedence config tier, meant to
+  stay untracked (`install-loom.sh --local` gitignores `/.loom-local/` for
+  you):
+
+  ```json
+  {
+    "codesign": { "identity": "Loom Local Signing (studio)" }
+  }
+  ```
+
+  Exporting `LOOM_CODESIGN_IDENTITY` from the host's shell profile works
+  too and takes precedence over both config tiers.
+
+### Verifying the new host
+
+```bash
+security find-identity -v -p codesigning        # the identity is listed
+./.loom/scripts/cli/loom-daemon-update.sh       # re-provision + re-sign
+codesign -dvv ~/.local/bin/loom-daemon 2>&1 | grep -E 'Authority|adhoc'
+# want: Authority=Loom Local Signing   (and NO 'adhoc' in the flags line)
+```
+
+If `adhoc` is still reported, re-read the provisioning output: the
+`WARNING:` line above pinpoints whether the identity was requested but
+missing from *this* keychain, versus `codesign` itself failing.
+
 ## Grant the daemon identity, not Terminal
 
 Work spawned from an interactive terminal shell — in-session


### PR DESCRIPTION
## Summary

`defaults/docs/macos-tcc-codesign.md` documented creating the self-signed
signing certificate on **one** Mac but said nothing about a second one. The
cert lives only in that first host's login keychain and nothing about it is
committed, so every other fleet Mac invoked with the same
`LOOM_CODESIGN_IDENTITY` silently falls back to ad-hoc signing — and loses its
TCC grants on every self-update rebuild. This PR adds the missing
"Provisioning additional Macs" section (AC2, the only genuinely unimplemented
acceptance criterion — see verification below).

## Changes

- `defaults/docs/macos-tcc-codesign.md` — new **"Provisioning additional Macs"**
  section, placed between "Using it" and "Grant the daemon identity, not
  Terminal":
  - Shows the exact stderr `WARNING:` + `ad-hoc signed` pair
    `provision-daemon.sh` already prints on this path, and names the deferred
    consequence (TCC grants reset on every rebuild).
  - **Option 1 — export/import the existing cert**: Keychain Access as the
    reliable single-identity `.p12` export path, with the `security export`
    CLI equivalent plus its "exports *all* identities" caveat;
    `security find-certificate -c … -p` for the public cert needed by
    `add-trusted-cert`; import on the far side with the same
    `-T /usr/bin/codesign` / trust flags the one-time setup already documents,
    and the `-legacy` pointer for the "MAC verification failed" case.
    Private-key handling is called out (trusted channel, real passphrase,
    delete after import).
  - **Option 2 — mint an independent cert per host** (recommended, and the
    doc says why): TCC grants are per-host, so nothing requires a *shared
    certificate* — only a matching identity *name*. Reusing the same CN keeps
    one committed `codesign.identity` value with no private key transfer. For
    the different-CN case it documents the per-host `.loom-local/local.json`
    override (highest-precedence config tier, gitignored by
    `install-loom.sh --local`) and the `LOOM_CODESIGN_IDENTITY` env alternative.
  - A short "Verifying the new host" snippet (`find-identity` →
    `loom-daemon-update.sh` → `codesign -dvv | grep Authority|adhoc`).

No code changes — see AC1 below.

## Acceptance Criteria Verification

- [x] **AC1 — warn when the requested identity is absent: already implemented
  on `main`, no change needed.** Verified by fresh read of
  `scripts/install/provision-daemon.sh` at `6f4cbc34`. `sign_daemon_binary()`
  line 143-145:

  ```bash
  elif [[ -n "$identity" ]]; then
    _pmd_warn "LOOM_CODESIGN_IDENTITY '$identity' not found via 'security find-identity -v -p codesigning'; falling back to ad-hoc signing (see defaults/docs/macos-tcc-codesign.md)"
  fi
  ```

  `_pmd_warn()` (line 29) is `echo "  [loom-daemon] WARNING: $*" >&2` — no
  verbosity gate can swallow it. The `elif` covers both resolution sources
  (env and `codesign.identity` config) because `_pmd_resolve_codesign_identity`
  unifies them before the keychain lookup. This matches the Curator's finding
  that PR #4284 (`d51fe444`) landed it before the issue was filed; per the
  curated scope, `provision-daemon.sh` is left untouched.

  *Observation, deliberately not changed (out of the curated scope):* the
  message text hardcodes `LOOM_CODESIGN_IDENTITY` even when the identity came
  from the `codesign.identity` config key, and defers the "TCC grants will not
  survive rebuilds" consequence to the doc pointer rather than stating it
  inline. Both are cosmetic; happy to file a follow-up if the Judge wants the
  wording tightened.

- [x] **AC2 — `macos-tcc-codesign.md` gains a "second Mac" section**: done, as
  described above; covers both the export/import route and the per-host mint
  route.

- [n/a] **AC3 — `fleet add-worker` mentions the cert step**: ruled out of scope
  by the Curator and confirmed here — `fleet add-worker` is Linux/Ubuntu-only
  by design (its machine-layout step explicitly skips codesign), so there is no
  macOS fleet-provisioning command for this AC to extend.

## Test Plan

Per the issue, this is doc content with no automated test harness covering
`provision-daemon.sh`'s Darwin-only codesign path; verification is
manual/read-based.

- [x] `bash scripts/check-docs-defaults-parity.sh` → OK (no unshipped orphans,
      sibling links resolve, no escaping links).
- [x] `git diff --check` → clean (no whitespace errors).
- [x] AC1 warning line confirmed present and reachable by reading
      `sign_daemon_binary()` / `_pmd_resolve_codesign_identity()` on current
      `main` (quoted above).
- [x] Doc reviewed for accuracy against the flags/quirks already documented in
      the one-time-setup section (`-legacy`, `-T /usr/bin/codesign`,
      `add-trusted-cert -p codeSign`) and against
      `.loom/scripts/lib/config-resolver.sh` for the `.loom-local/local.json`
      precedence claim (tier 4, highest below env).
- [ ] Operator follow-up (needs a real second Mac): follow the new section on a
      fresh keychain and confirm `codesign -dvv ~/.local/bin/loom-daemon`
      reports `Authority=…` instead of `adhoc`.
- Automated tests: N/A (doc-only change).

Closes #4953
