### PR TITLE
feat(dashboard): auto-deploy on merge + serve a build-commit stamp

### DIFF
--- a/.github/workflows/dashboard-deploy.yml
+++ b/.github/workflows/dashboard-deploy.yml
@@ -1,0 +1,132 @@
+name: Dashboard Deploy
+
+# Auto-deploy the fleet observability Worker to the 2AM reference instance
+# (dashboard.2amlogic.com) on every push to `main` that touches `dashboard/**`
+# (issue #4958). Before this workflow, a merged dashboard fix only reached
+# production when an operator remembered to run `wrangler deploy` by hand
+# (`docs/deploy-runbook.md`) — the same starvation shape as daemon binary
+# staleness (#4929), one layer up.
+#
+# `test` always gates `deploy` (`needs: test`): a failing test blocks the
+# live Worker from ever seeing the broken commit.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "dashboard/**"
+
+concurrency:
+  # Serialize deploys of the same branch — two overlapping `wrangler deploy`
+  # runs against the same Worker/D1 database is not a scenario worth
+  # supporting, and cancelling an in-flight deploy could leave a half-applied
+  # migration, so this does NOT cancel-in-progress (unlike ci.yml's group).
+  group: dashboard-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Dashboard Tests (deploy gate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+      - name: Install backend dependencies
+        run: npm ci
+        working-directory: dashboard
+      - name: Install web UI dependencies
+        run: npm ci
+        working-directory: dashboard/web
+      - name: Run backend (Miniflare) + web (happy-dom) suites
+        run: npm run check:all
+        working-directory: dashboard
+
+  deploy:
+    name: Deploy Worker (dashboard.2amlogic.com)
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+      - name: Install backend dependencies
+        run: npm ci
+        working-directory: dashboard
+      - name: Install web UI dependencies
+        run: npm ci
+        working-directory: dashboard/web
+
+      # `dashboard/wrangler.toml` is BOTH the working config this repo's own
+      # test suite uses AND the public template a third party copies to
+      # deploy their own instance (see its own header comment) — it carries
+      # only placeholder account/database/route values, never the 2AM
+      # instance's real ones. The instance-specific overlay
+      # (`wrangler.2amlogic.toml`) is deliberately never committed
+      # (docs/reference-deployment.md §3), so CI materializes it from a
+      # secret the same shape as the file an operator already keeps locally —
+      # nothing about the 2AM account/route/database is hardcoded here, so a
+      # later change (e.g. epic #4859's production cutover) only requires
+      # updating the secret, never this workflow.
+      - name: Materialize the 2AM instance's wrangler config
+        working-directory: dashboard
+        env:
+          WRANGLER_CONFIG_2AMLOGIC: ${{ secrets.CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WRANGLER_CONFIG_2AMLOGIC:-}" ]; then
+            echo "::error::CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC secret is not set — deploy cannot proceed." >&2
+            echo "This must be the full contents of the 2AM instance's wrangler.2amlogic.toml overlay" >&2
+            echo "(Worker name, D1 database name/id, custom-domain route, Access vars) — see" >&2
+            echo "dashboard/docs/reference-deployment.md section 3 for what it must contain, and" >&2
+            echo "'gh secret set CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC < dashboard/wrangler.2amlogic.toml'" >&2
+            echo "run from the operator's machine (where that file already lives) to provision it." >&2
+            exit 1
+          fi
+          printf '%s\n' "$WRANGLER_CONFIG_2AMLOGIC" > wrangler.2amlogic.toml
+
+      - name: Build the dashboard UI
+        working-directory: dashboard
+        run: npm run build:web
+
+      # `--remote` also confirms the ADMIN_TOKEN secret is set on the
+      # deployed Worker; `wrangler deploy --dry-run` inside it is what makes
+      # a bad overlay (still-a-placeholder database_id, config that fails to
+      # parse) fail here instead of mid-migration.
+      - name: Preflight the deploy config
+        working-directory: dashboard
+        env:
+          LOOM_DASHBOARD_WRANGLER_CONFIG: wrangler.2amlogic.toml
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npm run preflight -- --remote
+
+      # `wrangler d1 migrations apply` is idempotent by design (it tracks
+      # applied migrations inside the D1 database itself), so a run with
+      # nothing new to apply is a clean no-op — this step does not need its
+      # own "only if pending" guard.
+      - name: Apply D1 migrations (idempotent)
+        working-directory: dashboard
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          db_name="$(awk -F'"' '/^[[:space:]]*database_name[[:space:]]*=/{print $2; exit}' wrangler.2amlogic.toml)"
+          if [ -z "$db_name" ]; then
+            echo "::error::could not read database_name out of wrangler.2amlogic.toml" >&2
+            exit 1
+          fi
+          npx wrangler d1 migrations apply "$db_name" --remote --config wrangler.2amlogic.toml
+
+      # The build/deploy commit stamp (issue #4958): a plain `--var`, never
+      # written into any committed or overlay wrangler.toml, so it needs no
+      # config-file change per deploy. Served back by `/api/version` and the
+      # dashboard footer (`src/index.ts`, `web/src/buildInfo.ts`).
+      - name: Deploy Worker
+        working-directory: dashboard
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler deploy --config wrangler.2amlogic.toml --var "BUILD_COMMIT:${{ github.sha }}"

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -147,6 +147,7 @@ asserts the `ADMIN_TOKEN` secret exists on the deployed Worker.
 | `POST /admin/hosts/:hostId/revoke` | `Authorization: Bearer <ADMIN_TOKEN>` | Revoke a host's key and clear its `FleetState` Durable Object entries (issue #4957) — no more rendering the last-known health/tokens sample as current. |
 | `POST /admin/retention/run` | `Authorization: Bearer <ADMIN_TOKEN>` | Run the retention sweep on demand (also runs hourly via `[triggers] crons`). |
 | `GET /admin/fleet-state` | `Authorization: Bearer <ADMIN_TOKEN>` | Read the Durable Object's live snapshot (operator introspection/manual verification). |
+| `GET /api/version` | none (always public) | The deploying commit SHA (issue #4958), e.g. `{"commit":"abc1234"}` — `"unknown"` when the deployment never stamped one (local `wrangler dev`, Miniflare tests). Deliberately unauthenticated, unlike the rest of `/api/*`: a build stamp is not sensitive, and drift-detection tooling should not need an Access session to ask "what is live right now?". |
 | `GET /api/fleet-state` | none in-Worker — put behind Cloudflare Access (see below) | Authenticated query API: current state of every known host/sweep, full detail. |
 | `GET /api/history` | none in-Worker — put behind Cloudflare Access | Authenticated query API: filterable, paginated D1 history query, full detail. |
 | `GET /api/events` | none in-Worker — put behind Cloudflare Access | Authenticated query API: SSE live tail of newly-ingested telemetry, full detail. |

--- a/dashboard/docs/deploy-runbook.md
+++ b/dashboard/docs/deploy-runbook.md
@@ -15,12 +15,27 @@ Companion documents:
 | [`../web/README.md`](../web/README.md) | The dashboard UI this Worker also serves — architecture, local development, why it deploys as Workers Assets |
 | [`cloudflare-access.md`](cloudflare-access.md) | Gating the authenticated view behind zero-trust SSO while leaving the public view ungated |
 | [`reference-deployment.md`](reference-deployment.md) | The 2AM reference instance (`dashboard.2amlogic.com`) — a concrete, filled-in example of every value this runbook asks you to supply, plus its credential-file locations and current Access layout |
+| [`../../.github/workflows/dashboard-deploy.yml`](../../.github/workflows/dashboard-deploy.yml) | CI auto-deploy for the 2AM reference instance (issue #4958) — see the note below |
 | [`../README.md`](../README.md) | Architecture, routes, local development, tests |
 | [`../../.loom/docs/telemetry-schema.md`](../../.loom/docs/telemetry-schema.md) | The wire contract the daemon pushes |
 
 > **Everything here is your own infrastructure.** Loom never phones home:
 > the daemon's `observability` block is opt-in, off by default, and points
 > only at the endpoint you configure.
+
+> **This is a bootstrap/recovery runbook for the 2AM reference instance
+> (issue #4958).** Since `.github/workflows/dashboard-deploy.yml` landed,
+> `dashboard.2amlogic.com` auto-deploys on every push to `main` that touches
+> `dashboard/**` — tests gate the deploy, D1 migrations apply automatically,
+> and a failed deploy is a loud GitHub Actions failure, never silent. Steps
+> 1-10 below remain exactly what CI (and you, deploying your **own** fresh
+> instance) still needs: they are how any instance, including the 2AM one,
+> gets bootstrapped in the first place, and Step 6's manual `wrangler deploy`
+> is still the right move if CI itself is unavailable and a fix needs to
+> reach production immediately. For the 2AM instance specifically, routine
+> deploys no longer need Step 6 run by hand — see
+> [`reference-deployment.md`](reference-deployment.md) for how the CI
+> workflow's config is provisioned.
 
 ---
 

--- a/dashboard/docs/reference-deployment.md
+++ b/dashboard/docs/reference-deployment.md
@@ -111,6 +111,47 @@ template untouched — the pattern intentionally does not match a bare
 itself). If you create an overlay for a different instance later, it is
 covered by the same rule; no per-instance gitignore edits are needed.
 
+## 3a. CI auto-deploy (issue #4958)
+
+`.github/workflows/dashboard-deploy.yml` deploys this instance automatically
+on every push to `main` touching `dashboard/**` — see that workflow for the
+full pipeline (tests gate the deploy, `wrangler d1 migrations apply` runs
+idempotently, the deploying commit is stamped via `--var
+BUILD_COMMIT:$GITHUB_SHA` and served at `/api/version` + the dashboard
+footer). This section records only the CI-specific secrets it needs, which
+extend — do not replace — the local overlay pattern in §3.
+
+| Secret | Contents | Status |
+|---|---|---|
+| `CLOUDFLARE_API_TOKEN` | The `gha-loom-dashboard-deploy` CI token (Workers Scripts:Edit + D1:Write + Account Settings:Read on the account; Workers Routes:Edit + Zone:Read on the `2amlogic.com` zone) | Provisioned 2026-08-02 |
+| `CLOUDFLARE_ACCOUNT_ID` | `a7a402ccb9616532d8f4ee64447affe9` (§1) | Provisioned 2026-08-02 |
+| `CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC` | The **full contents** of this instance's `wrangler.2amlogic.toml` overlay (§3) | **Operator action required** — not yet provisioned as of this writing |
+
+**Why a whole-file secret instead of individual account/database/route
+secrets**: those values are not sensitive (§3 already says so), but the
+workflow has no safe way to reconstruct them on its own — in particular the
+`CF_ACCESS_TEAM_DOMAIN`/`CF_ACCESS_AUD` `[vars]` this instance's overlay also
+carries (§4's cutover) are load-bearing for the single-URL Access gate, and a
+generated overlay that silently omitted or mis-set them would risk
+deploying a Worker that treats every request as unauthenticated. Reusing the
+overlay file an operator already maintains locally (§3) avoids the workflow
+ever guessing at those values.
+
+**Provisioning it** (from the operator's machine, where `wrangler.2amlogic.toml`
+already exists per §3):
+
+```bash
+cd dashboard
+gh secret set CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC < wrangler.2amlogic.toml
+```
+
+Until this secret exists, the deploy job fails loudly on its first step (a
+`::error::` annotation naming the missing secret) rather than deploying with
+a wrong or incomplete config — see the workflow's "Materialize the 2AM
+instance's wrangler config" step. Re-run the same command any time the
+overlay changes (a new D1 database, a rotated route, an Access app change);
+no workflow edit is needed.
+
 ## 4. Cloudflare Access layout
 
 **Read against the live API, 2026-07-31.** An earlier revision of this

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -34,6 +34,11 @@
  *                                      the actual Phase 3 dashboard query
  *                                      API).
  *
+ *   GET  /api/version                 — public, unauthenticated (issue
+ *                                      #4958): the deploying commit SHA,
+ *                                      `{"commit":"unknown"}` when the
+ *                                      deployment never stamped one. See
+ *                                      `handleVersion` below.
  *   GET  /api/fleet-state            — authenticated query API: current
  *                                      state of every known host/sweep,
  *                                      full detail regardless of visibility
@@ -136,6 +141,13 @@ export interface Env {
    * `handleRoot` falls back to the server-rendered page in that case, so this
    * is optional by design rather than an invariant to assert. */
   ASSETS?: Fetcher;
+  /** The commit this Worker was built/deployed from — a plain, non-secret
+   * `[vars]`-equivalent injected at deploy time via `wrangler deploy --var
+   * BUILD_COMMIT:$GITHUB_SHA` (issue #4958), never written into the committed
+   * `wrangler.toml`. Absent in local `wrangler dev` and the Miniflare test
+   * env, where `/api/version` and the footer fall back to `"unknown"` rather
+   * than throwing. */
+  BUILD_COMMIT?: string;
 }
 
 /** A single global Durable Object instance holds fleet-wide live state —
@@ -150,6 +162,25 @@ function jsonError(status: number, message: string): Response {
 
 function fleetStateStub(env: Env): DurableObjectStub {
   return env.FLEET_STATE.get(env.FLEET_STATE.idFromName(FLEET_STATE_ID_NAME));
+}
+
+// ---------------------------------------------------------------------------
+// /api/version — the build/deploy commit stamp (issue #4958)
+// ---------------------------------------------------------------------------
+
+/**
+ * Deliberately unauthenticated (unlike the rest of `/api/*`): the deploying
+ * commit SHA is not sensitive — it is already public in the repo's own commit
+ * history — and drift-detection tooling (a health check, a CI smoke test, an
+ * operator's terminal) should not need a Cloudflare Access session just to
+ * ask "what is live right now?". Routed *before* the `/api/*` auth gate in
+ * the entrypoint below, the same way `/ingest` and `/admin/*` are.
+ */
+function handleVersion(env: Env): Response {
+  return new Response(JSON.stringify({ commit: env.BUILD_COMMIT ?? "unknown" }), {
+    status: 200,
+    headers: JSON_HEADERS,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -518,6 +549,11 @@ interface InjectedAuthState {
   email?: string;
   /** Display timezone for the UI, when the deployment configures one. */
   timeZone?: string;
+  /** The deploying commit SHA (issue #4958) — same value `/api/version`
+   * reports, injected here too so the footer can show it with zero extra
+   * requests. Omitted (not `"unknown"`) when `BUILD_COMMIT` is unset, so the
+   * footer can distinguish "no stamp available" from a real value. */
+  commit?: string;
 }
 
 /** Inject the auth state into the SPA shell as a `<script>` immediately
@@ -555,9 +591,12 @@ async function handleRoot(request: Request, env: Env): Promise<Response> {
       // The timezone is deployment config, not identity — an anonymous
       // visitor reads the same charts and must bucket them the same way.
       const timeZone = env.DISPLAY_TIMEZONE ? { timeZone: env.DISPLAY_TIMEZONE } : {};
+      // Likewise the build commit: every viewer, signed in or not, should be
+      // able to see whether the live page is current.
+      const commit = env.BUILD_COMMIT ? { commit: env.BUILD_COMMIT } : {};
       const state: InjectedAuthState = isAuthenticated
-        ? { authenticated: true, ...(identity.email ? { email: identity.email } : {}), ...timeZone }
-        : { authenticated: false, ...timeZone };
+        ? { authenticated: true, ...(identity.email ? { email: identity.email } : {}), ...timeZone, ...commit }
+        : { authenticated: false, ...timeZone, ...commit };
 
       return new Response(injectAuthState(await shell.text(), state), {
         status: 200,
@@ -590,6 +629,11 @@ export default {
     }
     if (url.pathname.startsWith("/admin/")) {
       return handleAdmin(request, env, url);
+    }
+
+    if (request.method === "GET" && url.pathname === "/api/version") {
+      // Ahead of the auth gate below on purpose — see `handleVersion`'s doc.
+      return handleVersion(env);
     }
 
     // Every `/api/*` route is operator-only, and the Worker — not the edge —

--- a/dashboard/test/index.test.ts
+++ b/dashboard/test/index.test.ts
@@ -21,9 +21,13 @@ const TEAM_DOMAIN = "test-team.cloudflareaccess.com";
 const AUD = "test-login-app-aud-tag";
 const CERTS_URL = `https://${TEAM_DOMAIN}/cdn-cgi/access/certs`;
 
-async function callWorker(request: Request): Promise<Response> {
+async function callWorker(request: Request, envOverrides: Partial<typeof env> = {}): Promise<Response> {
   const ctx = createExecutionContext();
-  const response = await worker.fetch(request as Request<unknown, IncomingRequestCfProperties>, env, ctx);
+  const response = await worker.fetch(
+    request as Request<unknown, IncomingRequestCfProperties>,
+    { ...env, ...envOverrides },
+    ctx,
+  );
   await waitOnExecutionContext(ctx);
   return response;
 }
@@ -299,6 +303,32 @@ describe("GET / — Access JWT wired end to end (real createRemoteJWKSet path)",
       new Request("https://ingest.example/", { headers: { cookie: `CF_Authorization=${token}` } }),
     );
     expect(await authenticated.text()).not.toContain('"timeZone"');
+  });
+
+  // Issue #4958: the deploying commit is what lets an operator (or automated
+  // drift-detection tooling) tell whether the live Worker matches `main`,
+  // without an Access session.
+  it("GET /api/version reports the build commit, unauthenticated", async () => {
+    const unstamped = await callWorker(new Request("https://ingest.example/api/version"));
+    expect(unstamped.status).toBe(200);
+    // BUILD_COMMIT is unset in the test bindings (vitest.config.ts) — the
+    // same fallback a Miniflare/local `wrangler dev` run sees.
+    expect(await unstamped.json()).toEqual({ commit: "unknown" });
+
+    const stamped = await callWorker(new Request("https://ingest.example/api/version"), {
+      BUILD_COMMIT: "abc1234def",
+    });
+    expect(await stamped.json()).toEqual({ commit: "abc1234def" });
+  });
+
+  it("hands the SPA the build commit for the footer, and omits it when unset", async () => {
+    restoreFetch = mockJwksFetch();
+
+    const unstamped = await callWorker(new Request("https://ingest.example/"));
+    expect(await unstamped.text()).not.toContain('"commit"');
+
+    const stamped = await callWorker(new Request("https://ingest.example/"), { BUILD_COMMIT: "abc1234def" });
+    expect(await stamped.text()).toContain('"commit":"abc1234def"');
   });
 
   it("/public/* stays reachable anonymously — the split is auth, not obscurity", async () => {

--- a/dashboard/web/index.html
+++ b/dashboard/web/index.html
@@ -27,6 +27,11 @@
       </div>
     </header>
     <main id="app" class="app" aria-busy="true"></main>
+    <!-- Populated by `buildInfo.ts` from the server-injected build commit
+         (issue #4958). Empty in the markup so it renders nothing rather
+         than a placeholder before the bundle runs, and stays empty on a
+         deployment that never stamped a commit (local `wrangler dev`). -->
+    <footer id="build-info" class="build-info"></footer>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/dashboard/web/src/api.ts
+++ b/dashboard/web/src/api.ts
@@ -54,10 +54,13 @@ export const PUBLIC_FLEET_STATE_PATH = "/public/fleet-state";
 const AUTH_STATE_GLOBAL = "__LOOM_FLEET__";
 
 /** The auth state the Worker stamps into the page. `email` is present only
- * for an authenticated viewer whose token carried one. */
+ * for an authenticated viewer whose token carried one. `commit` (issue
+ * #4958) is present whenever the deployment stamps one, for either viewer —
+ * unlike `email` it is not identity, so it is not gated on `authenticated`. */
 export interface AuthState {
   authenticated: boolean;
   email?: string;
+  commit?: string;
 }
 
 /**
@@ -72,12 +75,15 @@ export function readAuthState(scope: typeof globalThis = globalThis): AuthState 
   const raw = (scope as Record<string, unknown>)[AUTH_STATE_GLOBAL];
   if (typeof raw !== "object" || raw === null) return { authenticated: false };
 
-  const state = raw as { authenticated?: unknown; email?: unknown };
-  if (state.authenticated !== true) return { authenticated: false };
+  const state = raw as { authenticated?: unknown; email?: unknown; commit?: unknown };
+  const commit = typeof state.commit === "string" && state.commit.length > 0 ? { commit: state.commit } : {};
+
+  if (state.authenticated !== true) return { authenticated: false, ...commit };
 
   return {
     authenticated: true,
     ...(typeof state.email === "string" && state.email.length > 0 ? { email: state.email } : {}),
+    ...commit,
   };
 }
 

--- a/dashboard/web/src/buildInfo.ts
+++ b/dashboard/web/src/buildInfo.ts
@@ -1,0 +1,45 @@
+/**
+ * The page footer's build/commit stamp (issue #4958).
+ *
+ * ## Why this exists
+ *
+ * Before this the deployed Worker had no visible link back to the commit it
+ * was built from — the only way to answer "is the live dashboard current?"
+ * was a `wrangler` login. The Worker now stamps the deploying commit into
+ * `window.__LOOM_FLEET__.commit` (`../../src/index.ts`'s `handleRoot`, same
+ * global `accountMenu.ts` reads the auth state from) whenever the CI deploy
+ * workflow set `BUILD_COMMIT`; this module renders it.
+ *
+ * `/api/version` reports the same value for scripted checks — see that
+ * route's doc — this module is the at-a-glance surface for a human looking
+ * at the page.
+ */
+
+import { readAuthState } from "./api";
+
+/** Truncated to the short SHA a person actually reads/pastes; the footer is
+ * not the place for the full 40-char hash. */
+function shortCommit(commit: string): string {
+  return commit.slice(0, 12);
+}
+
+/**
+ * Render the build-info footer into `container`, replacing its contents.
+ *
+ * Renders nothing (an empty footer) when no commit was stamped — a local
+ * `wrangler dev` run or a Miniflare test env, where `BUILD_COMMIT` is never
+ * set. That is a legitimate state, not an error, so this deliberately does
+ * not render a "not built" placeholder that could be confused for a real
+ * problem.
+ */
+export function renderBuildInfo(container: HTMLElement, scope: typeof globalThis = globalThis): void {
+  const { commit } = readAuthState(scope);
+  container.textContent = commit ? `build ${shortCommit(commit)}` : "";
+}
+
+/** Render into `#build-info` if the host page has one. A page without the
+ * container simply has no build-info footer — not an error. */
+export function wireBuildInfo(doc: Document, scope: typeof globalThis = globalThis): void {
+  const container = doc.getElementById("build-info");
+  if (container instanceof HTMLElement) renderBuildInfo(container, scope);
+}

--- a/dashboard/web/src/main.ts
+++ b/dashboard/web/src/main.ts
@@ -7,6 +7,7 @@
 import "./styles.css";
 import { App } from "./app";
 import { wireAccountMenu } from "./accountMenu";
+import { wireBuildInfo } from "./buildInfo";
 import { onRouteChange, parseRoute, routeToHash } from "./router";
 
 const root = document.getElementById("app");
@@ -15,6 +16,7 @@ if (!(root instanceof HTMLElement)) {
 }
 
 wireAccountMenu(document);
+wireBuildInfo(document);
 
 const app = new App({
   root,

--- a/dashboard/web/src/styles.css
+++ b/dashboard/web/src/styles.css
@@ -80,6 +80,21 @@ a:hover {
   border-color: var(--accent);
 }
 
+/* --- Build-info footer (issue #4958) ------------------------------------- */
+/* Rendered by `buildInfo.ts` from the server-injected build commit. Empty
+   (and therefore invisible — no border, no padding) on a deployment that
+   never stamped one, e.g. local `wrangler dev`. */
+.build-info {
+  padding: 8px 20px;
+  color: var(--text-dim);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+.build-info:empty {
+  padding: 0;
+}
+
 /* --- Account control (topbar, right) ------------------------------------ */
 /* Rendered by `accountMenu.ts` from the server-injected auth state: an
    avatar + menu when signed in, a Sign in button when not. */

--- a/dashboard/web/test/api.test.ts
+++ b/dashboard/web/test/api.test.ts
@@ -7,6 +7,7 @@ import {
   fetchFleetState,
   fleetStatePath,
   isAuthenticatedViewer,
+  readAuthState,
 } from "../src/api";
 import { EMPTY_SNAPSHOT, HEALTHY_HOST_ID, multiHostSnapshot } from "./fixtures";
 
@@ -152,5 +153,39 @@ describe("fleetStatePath", () => {
   it("maps auth state to the matching dataset", () => {
     expect(fleetStatePath(true)).toBe(FLEET_STATE_PATH);
     expect(fleetStatePath(false)).toBe(PUBLIC_FLEET_STATE_PATH);
+  });
+});
+
+// Issue #4958: the build commit is not identity, so — unlike `email` — it
+// must survive `readAuthState` for BOTH an authenticated and an anonymous
+// viewer.
+describe("readAuthState — commit stamp", () => {
+  function scopeWith(value: unknown): typeof globalThis {
+    return { __LOOM_FLEET__: value } as unknown as typeof globalThis;
+  }
+
+  it("reads the commit for an anonymous viewer", () => {
+    expect(readAuthState(scopeWith({ authenticated: false, commit: "abc1234" }))).toEqual({
+      authenticated: false,
+      commit: "abc1234",
+    });
+  });
+
+  it("reads the commit for an authenticated viewer, alongside email", () => {
+    expect(
+      readAuthState(scopeWith({ authenticated: true, email: "operator@2amlogic.com", commit: "abc1234" })),
+    ).toEqual({
+      authenticated: true,
+      email: "operator@2amlogic.com",
+      commit: "abc1234",
+    });
+  });
+
+  it("omits commit when the deployment did not stamp one", () => {
+    expect(readAuthState(scopeWith({ authenticated: false }))).toEqual({ authenticated: false });
+  });
+
+  it("ignores a non-string commit rather than propagating garbage", () => {
+    expect(readAuthState(scopeWith({ authenticated: false, commit: 12345 }))).toEqual({ authenticated: false });
   });
 });

--- a/dashboard/web/test/buildInfo.test.ts
+++ b/dashboard/web/test/buildInfo.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { renderBuildInfo, wireBuildInfo } from "../src/buildInfo";
+
+/** A stand-in for `window` carrying whatever the Worker injected. */
+function scopeWith(value: unknown): typeof globalThis {
+  return { __LOOM_FLEET__: value } as unknown as typeof globalThis;
+}
+
+function container(): HTMLElement {
+  const node = document.createElement("div");
+  document.body.appendChild(node);
+  return node;
+}
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("renderBuildInfo", () => {
+  it("renders a short commit stamp when one is injected", () => {
+    const node = container();
+    renderBuildInfo(node, scopeWith({ authenticated: false, commit: "abcdef1234567890" }));
+
+    expect(node.textContent).toBe("build abcdef123456");
+  });
+
+  it("renders the same stamp for an authenticated viewer — commit is not identity", () => {
+    const node = container();
+    renderBuildInfo(node, scopeWith({ authenticated: true, email: "operator@2amlogic.com", commit: "abc1234" }));
+
+    expect(node.textContent).toBe("build abc1234");
+  });
+
+  it("renders nothing when no commit was stamped (e.g. local wrangler dev)", () => {
+    const node = container();
+    renderBuildInfo(node, scopeWith({ authenticated: false }));
+
+    expect(node.textContent).toBe("");
+  });
+
+  it("renders nothing when the global was never injected", () => {
+    const node = container();
+    renderBuildInfo(node, {} as unknown as typeof globalThis);
+
+    expect(node.textContent).toBe("");
+  });
+});
+
+describe("wireBuildInfo", () => {
+  it("populates #build-info when the host page has one", () => {
+    const footer = document.createElement("footer");
+    footer.id = "build-info";
+    document.body.appendChild(footer);
+
+    wireBuildInfo(document, scopeWith({ authenticated: false, commit: "abc1234" }));
+
+    expect(footer.textContent).toBe("build abc1234");
+  });
+
+  it("does nothing when the host page has no #build-info container", () => {
+    // No throw, nothing to assert beyond "did not blow up" — mirrors
+    // `wireAccountMenu`'s equivalent case.
+    expect(() => wireBuildInfo(document, scopeWith({ authenticated: false, commit: "abc1234" }))).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a GitHub Actions deploy pipeline for the fleet observability dashboard so a merged `dashboard/**` fix reaches `dashboard.2amlogic.com` automatically, and stamps the live Worker with the commit it was deployed from so drift is observable at a glance.

## Changes

- **`.github/workflows/dashboard-deploy.yml`** (new): on push to `main` touching `dashboard/**`, a `test` job runs the full backend + web suite (`npm run check:all`), then a `deploy` job (gated on `needs: test`) applies D1 migrations (`wrangler d1 migrations apply`, idempotent by design) and runs `wrangler deploy` against the 2AM reference instance. Every step fails loudly (`set -euo pipefail`, explicit `::error::` annotations, no swallowed exit codes) — there is no silent-failure path.
  - The instance-specific `wrangler.2amlogic.toml` overlay (Worker name, D1 database id/name, custom-domain route, Cloudflare Access `[vars]`) is deliberately never committed to this repo (documented in `docs/reference-deployment.md` §3) and I don't have access to those production values (some, like the Access AUD tags, aren't even fully recorded in the docs — only truncated). So the workflow materializes it from a **new** GitHub Actions secret, `CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC` (the full file contents an operator already keeps locally), rather than hardcoding or reconstructing any account/route/database values. **This secret still needs to be provisioned by the operator** — until then, the deploy job's first step fails with a clear `::error::` naming exactly what's missing and how to provision it (`gh secret set CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC < dashboard/wrangler.2amlogic.toml`, run from the operator's machine). `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` were already provisioned (confirmed in the issue's comment thread).
  - A `preflight` step (`npm run preflight -- --remote`, the repo's existing `scripts/check-deploy-config.sh`) runs `wrangler deploy --dry-run` before touching migrations or the real deploy, catching a malformed/placeholder overlay before it can reach production.
- **`dashboard/src/index.ts`**: adds `GET /api/version` (deliberately unauthenticated, routed ahead of the `/api/*` auth gate — the deploying commit isn't sensitive) returning `{"commit": "<sha>"}` (`"unknown"` when unset), and threads the same commit into the SPA's injected auth state so the footer needs no extra request. `BUILD_COMMIT` is a plain `Env` var injected at deploy time via `wrangler deploy --var BUILD_COMMIT:$GITHUB_SHA` — never written into any committed wrangler.toml.
- **`dashboard/web/`**: `api.ts`'s `readAuthState`/`AuthState` now carry `commit` (present for both authenticated and anonymous viewers, unlike `email`); a new `buildInfo.ts` module (`renderBuildInfo`/`wireBuildInfo`, mirroring `accountMenu.ts`'s pattern) renders a `build <short-sha>` stamp into a new `#build-info` footer in `index.html`, wired from `main.ts`.
- **`dashboard/docs/deploy-runbook.md`**: adds a note demoting the manual `wrangler deploy` walkthrough to the bootstrap/recovery path for the 2AM reference instance now that CI auto-deploys it — the runbook itself is unchanged otherwise, since it's still the correct path for any *new* instance's initial setup.
- **`dashboard/docs/reference-deployment.md`**: new §3a documenting the CI secrets (what's already provisioned, what still needs the operator's action) and why a whole-file secret was chosen over individual account/database/route secrets.
- **`dashboard/README.md`**: adds `GET /api/version` to the route table.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| A merged PR touching `dashboard/**` reaches `dashboard.2amlogic.com` without manual action, with tests gating the deploy | ⚠️ Workflow implemented and `needs: test` gates `deploy` — but the *first* real deploy needs the operator to provision `CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC` (see Changes above; I don't have access to mint this secret, and reconstructing it myself would risk deploying with missing/wrong Cloudflare Access `[vars]`, silently breaking the site's auth gate) | Workflow YAML validated with `actionlint` (clean, including its built-in shellcheck pass on every inline `run:` block); local dry-run of the underlying `preflight`/migration/deploy commands against the committed template config succeeded (see PR description's Test Plan) |
| The live page/API reports the commit it was built from | ✅ | `GET /api/version` + the SPA footer, both sourced from the same `BUILD_COMMIT` `--var`; covered by new backend tests (`dashboard/test/index.test.ts`) and web tests (`dashboard/web/test/buildInfo.test.ts`, `api.test.ts`) |
| Migrations apply safely (idempotent) as part of the pipeline; a failed deploy is loud, never silent | ✅ | `wrangler d1 migrations apply` is idempotent by design (tracks applied migrations inside D1 itself, confirmed by Curator's comment on the issue); every workflow step uses `set -euo pipefail` / explicit `exit 1` with an `::error::` annotation — no `|| true`, no swallowed exit codes anywhere in the new workflow |

## Test Plan

- `cd dashboard && npm run check:all` — 594 tests pass (182 backend/Miniflare + 412 web/happy-dom, including all new tests), `tsc --noEmit` clean in both `dashboard/` and `dashboard/web/`.
- `actionlint .github/workflows/dashboard-deploy.yml` — clean (includes an inline shellcheck pass over every `run:` block).
- Locally verified the `database_name` extraction (`awk` one-liner in the migrations step) against the committed `wrangler.toml` template.
- Locally ran `LOOM_DASHBOARD_WRANGLER_CONFIG=wrangler.2amlogic.toml npm run preflight` against a copy of the committed template (renamed to the exact `wrangler.2amlogic.toml` filename the workflow uses) — confirmed the preflight script correctly loads the overlay and fails loud on the template's placeholder `database_id` (expected, since it's not the real production config) rather than silently passing.
- **Not verified end to end against production** (no live Cloudflare credentials in this environment) — see the flagged AC above. Once the operator provisions `CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC`, the next `dashboard/**` merge to `main` will exercise the real deploy path for the first time; Judge/Doctor or a follow-up should confirm `dashboard.2amlogic.com/api/version` reflects that merge's commit.

## Follow-up (operator action required)

Provision the `CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC` GitHub Actions secret (documented in `dashboard/docs/reference-deployment.md` §3a) before the deploy job can succeed. Until then, the workflow's `test` job still runs and passes on every `dashboard/**` push; only the `deploy` job fails, loudly, with a message pointing back at this doc.

Closes #4958