### PR TITLE
feat(telemetry): stamp host.health with the emitting binary's build commit + build time

### DIFF
--- a/.loom/docs/telemetry-schema.md
+++ b/.loom/docs/telemetry-schema.md
@@ -249,16 +249,18 @@ fabricated instant, so consumers must treat `null`/absent as *unknown* — never
 
 ### `host.health`
 
-Host CPU/disk headroom, daemon version, and uptime (host-level — no `repo` /
-`visibility`). Every measured field is optional so an unmeasurable probe stays
-absent rather than being coerced to a fake zero (the daemon's "unknown != zero"
-contract; see `cpu_headroom.rs` / `disk_headroom.rs`).
+Host CPU/disk headroom, the emitting binary's identity, and uptime (host-level —
+no `repo` / `visibility`). Every measured field is optional so an unmeasurable
+probe stays absent rather than being coerced to a fake zero (the daemon's
+"unknown != zero" contract; see `cpu_headroom.rs` / `disk_headroom.rs`).
 
 ```json
 {
   "kind": "host.health",
   "captured_at": "2026-07-30T12:00:00Z",
   "daemon_version": "0.16.0",
+  "build_commit": "8c16fb5b",
+  "built_at": "2026-07-30T03:09:51Z",
   "uptime_sec": 86400,
   "logical_cpus": 28,
   "cpu_idle_fraction": 0.83,
@@ -270,6 +272,28 @@ contract; see `cpu_headroom.rs` / `disk_headroom.rs`).
 `cpu_idle_fraction`, `load_per_core`, and `worktree_root_free_gb` are omitted when
 unmeasurable. A consumer MUST treat an absent measurement as "unknown", never as
 zero/full.
+
+**Binary identity (`build_commit` / `built_at`, #4956).** `daemon_version` is
+`CARGO_PKG_VERSION`, so it only moves once per release: every build between two
+releases reports the same string, and a day-stale daemon is indistinguishable
+from current `main`. `build_commit` (the short git SHA the running binary was
+compiled from) and `built_at` (when it was compiled) are the precise identity —
+both come from the very same compile-time stamps `loom-daemon --version` prints
+(`LOOM_DAEMON_GIT_COMMIT` / `LOOM_DAEMON_BUILD_TIME`, baked in by `build.rs`), so
+the telemetry and the CLI can never disagree.
+
+- `build_commit` is always sent. `"unknown"` is a *meaningful* value, not a
+  missing measurement: it means the build host had no git (e.g. a
+  release-tarball build). A record from a pre-#4956 daemon has no field at all,
+  which decodes as an empty string.
+- `built_at` is **omitted** when the build-time stamp was unavailable — an
+  unknown build time is absent, never a fabricated instant, exactly like the
+  measured fields above.
+
+Both fields are additive and pass through public redaction unchanged (they
+describe the released binary, not any repo or operator — see
+`dashboard/src/redaction.ts`), so an older consumer that ignores unknown keys is
+unaffected.
 
 ## Persistence & read surface (`sweep.outcome`, Issue #4704)
 

--- a/dashboard/src/publicPage.ts
+++ b/dashboard/src/publicPage.ts
@@ -71,7 +71,20 @@ const PUBLIC_PAGE_DISPLAY_FIELDS: Readonly<Record<string, readonly string[]>> = 
   "sweep.phase": ["phase", "entered_at"],
   "sweep.completed": ["completed_at", "result"],
   "sweep.outcome": ["model", "effort", "result", "total_duration_sec"],
-  "host.health": ["captured_at", "daemon_version", "uptime_sec", "logical_cpus", "cpu_idle_fraction"],
+  // `build_commit`/`built_at` (#4956) sit next to `daemon_version` because
+  // the version alone only moves once per release — the commit is what makes
+  // two same-version builds distinguishable. Both are non-identifying build
+  // metadata about the binary, not about any repo or operator, so they are as
+  // public as the version string itself.
+  "host.health": [
+    "captured_at",
+    "daemon_version",
+    "build_commit",
+    "built_at",
+    "uptime_sec",
+    "logical_cpus",
+    "cpu_idle_fraction",
+  ],
 };
 
 export function isPublicPageDisplayKind(kind: string): boolean {

--- a/dashboard/src/redaction.ts
+++ b/dashboard/src/redaction.ts
@@ -107,6 +107,13 @@ const RECORD_FIELD_ALLOWLIST: Readonly<Record<string, readonly string[]>> = {
     "kind",
     "captured_at",
     "daemon_version",
+    // Build identity of the emitting binary (#4956). Reviewed for redaction
+    // and deliberately allowed through: a short commit SHA and a build
+    // timestamp describe the released open-source binary, carry no repo /
+    // issue / branch / operator reference, and are exactly as sensitive as
+    // the `daemon_version` directly above them.
+    "build_commit",
+    "built_at",
     "uptime_sec",
     "logical_cpus",
     "cpu_idle_fraction",

--- a/dashboard/test/publicPage.test.ts
+++ b/dashboard/test/publicPage.test.ts
@@ -149,7 +149,15 @@ function snapshotFixture(): RedactedFleetSnapshot {
     hosts: {
       "host-abc": {
         health: {
-          record: { kind: "host.health", captured_at: "2026-07-31T12:00:00Z", uptime_sec: 100, logical_cpus: 8 },
+          record: {
+            kind: "host.health",
+            captured_at: "2026-07-31T12:00:00Z",
+            daemon_version: "0.17.0",
+            build_commit: "8c16fb5b",
+            built_at: "2026-07-31T03:09:51Z",
+            uptime_sec: 100,
+            logical_cpus: 8,
+          },
           updatedAt: "2026-07-31T12:00:00Z",
         },
         // Present on the redacted snapshot exactly as the real API returns
@@ -196,6 +204,15 @@ describe("renderFleetOverview — redaction", () => {
   it("renders host.health lifecycle detail", () => {
     const html = renderFleetOverview(snapshotFixture());
     expect(html).toContain("uptime_sec=100");
+  });
+
+  it("renders the host.health build identity so two same-version builds are distinguishable", () => {
+    // #4956 — `daemon_version` alone only moves once per release; without the
+    // commit on the page, a day-stale binary is indistinguishable from main.
+    const html = renderFleetOverview(snapshotFixture());
+    expect(html).toContain("daemon_version=0.17.0");
+    expect(html).toContain("build_commit=8c16fb5b");
+    expect(html).toContain("built_at=2026-07-31T03:09:51Z");
   });
 });
 

--- a/dashboard/test/redaction.test.ts
+++ b/dashboard/test/redaction.test.ts
@@ -234,6 +234,22 @@ describe("redactPayload — per-kind field allowlist", () => {
     expect(redactPayload("host.health", payload)).toEqual(payload);
   });
 
+  it("host.health: build identity (build_commit/built_at) survives redaction alongside daemon_version", () => {
+    // #4956 — the commit is the only field that tells two builds sharing a
+    // `daemon_version` apart, so stripping it here would re-blind the
+    // dashboard it was added for.
+    const payload = {
+      kind: "host.health",
+      captured_at: "2026-08-02T12:00:00Z",
+      daemon_version: "0.17.0",
+      build_commit: "8c16fb5b",
+      built_at: "2026-08-02T03:09:51Z",
+      uptime_sec: 86400,
+      logical_cpus: 28,
+    };
+    expect(redactPayload("host.health", payload)).toEqual(payload);
+  });
+
   it("an unrecognized (forward-compatible) kind reveals only `kind`", () => {
     const redacted = redactPayload("future.kind", {
       kind: "future.kind",

--- a/dashboard/web/README.md
+++ b/dashboard/web/README.md
@@ -29,7 +29,7 @@ accident.
 
 | View | Route | Content |
 |---|---|---|
-| Fleet overview | `#/` | One card per host: the whole `host.health` field set (`daemon_version`, `uptime_sec`, `logical_cpus`, `cpu_idle_fraction`, `load_per_core`, `worktree_root_free_gb`), a `tokens.snapshot` summary (exhausted count + peak `usage_fraction`), a status badge, and that host's live sweeps. |
+| Fleet overview | `#/` | One card per host: the whole `host.health` field set (the binary identity `daemon_version` + `build_commit` + `built_at`, rendered as one line — `0.17.0 @ 8c16fb5b, built 6h ago` — plus `uptime_sec`, `logical_cpus`, `cpu_idle_fraction`, `load_per_core`, `worktree_root_free_gb`), a `tokens.snapshot` summary (exhausted count + peak `usage_fraction`), a status badge, and that host's live sweeps. |
 | Host drill-down | `#/hosts/<hostId>` | The same health fields in full, one row per token-pool account, and one row per in-flight sweep with `repo` / `issue` / `phase` / `model` / `effort` / how long it has been running (`startedAt`) / how long it has been in its current phase (`enteredPhaseAt`). |
 
 Hosts needing attention sort first (stale, then token-degraded), then busiest,

--- a/dashboard/web/src/parse.ts
+++ b/dashboard/web/src/parse.ts
@@ -51,6 +51,8 @@ export function parseHostHealth(value: unknown): HostHealthRecord {
     kind: str(value.kind),
     captured_at: str(value.captured_at),
     daemon_version: str(value.daemon_version),
+    build_commit: str(value.build_commit),
+    built_at: str(value.built_at),
     uptime_sec: num(value.uptime_sec),
     logical_cpus: num(value.logical_cpus),
     cpu_idle_fraction: num(value.cpu_idle_fraction),

--- a/dashboard/web/src/types.ts
+++ b/dashboard/web/src/types.ts
@@ -35,6 +35,14 @@ export interface HostHealthRecord {
   kind?: string;
   captured_at?: string;
   daemon_version?: string;
+  /** Short git commit the emitting binary was built from (#4956). Absent on
+   * records from a pre-#4956 daemon; `"unknown"` when the build host had no
+   * git. The version alone only moves once per release, so this is what makes
+   * two same-version builds distinguishable. */
+  build_commit?: string;
+  /** RFC-3339 instant the emitting binary was compiled (#4956). Absent when
+   * the build stamp was unavailable — never a fabricated instant. */
+  built_at?: string;
   uptime_sec?: number;
   logical_cpus?: number;
   cpu_idle_fraction?: number;

--- a/dashboard/web/src/views/fleetOverview.ts
+++ b/dashboard/web/src/views/fleetOverview.ts
@@ -23,6 +23,7 @@ import {
   formatCount,
 } from "../format";
 import type { FleetView, HostStatus, HostView } from "../fleet";
+import type { HostHealthRecord } from "../types";
 import { emptyFleetView } from "./states";
 
 const STATUS_LABEL: Record<HostStatus, string> = {
@@ -58,11 +59,42 @@ function tokenSummaryText(host: HostView): string {
   return `${exhausted}/${total} exhausted · peak ${peak}`;
 }
 
+/**
+ * The emitting binary's identity, as one line: `"0.17.0 @ 8c16fb5b, built 6h
+ * ago"` (#4956).
+ *
+ * `daemon_version` alone cannot answer "is this host's daemon current?" — it
+ * only moves once per release, so every build between two releases reports the
+ * same string and a day-stale binary reads identically to `main`. The commit
+ * is the precise identity; the build age is what makes staleness obvious at a
+ * glance.
+ *
+ * Each part degrades independently: a record from a pre-#4956 daemon (no
+ * commit, no build time) renders exactly as it did before, and an `"unknown"`
+ * commit sentinel (a build host with no git) is dropped rather than shown as a
+ * fake SHA.
+ */
+export function daemonIdentityText(health: HostHealthRecord, now: Date = new Date()): string {
+  const version = health.daemon_version ?? UNKNOWN;
+  const commit = health.build_commit;
+  const identity = commit && commit !== "unknown" ? `${version} @ ${commit}` : version;
+  const age = formatRelative(health.built_at, now);
+  // An absent/unparseable build stamp shows no age clause at all — "built —"
+  // would be noise, not information.
+  return health.built_at && age !== UNKNOWN ? `${identity}, built ${age}` : identity;
+}
+
 /** The `host.health` field set, in the order the schema documents them. */
-export function healthFields(host: HostView): DocumentFragment {
+export function healthFields(host: HostView, now: Date = new Date()): DocumentFragment {
   const health = host.entry.health?.record ?? {};
   const fragment = document.createDocumentFragment();
-  fragment.appendChild(field("Daemon", health.daemon_version ?? UNKNOWN));
+  fragment.appendChild(
+    field(
+      "Daemon",
+      daemonIdentityText(health, now),
+      health.built_at ? `Built ${formatAbsolute(health.built_at)}` : undefined,
+    ),
+  );
   fragment.appendChild(
     field("Uptime", formatDuration(health.uptime_sec), "host.health.uptime_sec"),
   );
@@ -97,7 +129,7 @@ export function hostCard(host: HostView, now: Date = new Date()): HTMLElement {
         host.lastReportAt ? `Last report ${formatRelative(host.lastReportAt, now)}` : "Never reported",
       ),
     ),
-    el("dl", { class: "card__fields" }, healthFields(host)),
+    el("dl", { class: "card__fields" }, healthFields(host, now)),
     el(
       "dl",
       { class: "card__fields card__fields--wide" },

--- a/dashboard/web/src/views/hostDetail.ts
+++ b/dashboard/web/src/views/hostDetail.ts
@@ -67,6 +67,19 @@ function healthPanel(host: HostView, now: Date): HTMLElement {
       "dl",
       { class: "panel__fields" },
       field("Daemon version", health.daemon_version ?? UNKNOWN),
+      // #4956 — the version only moves once per release, so the commit is the
+      // field that actually answers "is this host's binary current?". Both
+      // degrade to `—` for a record from a pre-#4956 daemon.
+      field(
+        "Build commit",
+        health.build_commit ?? UNKNOWN,
+        "The git commit this host's running binary was compiled from",
+      ),
+      field(
+        "Built at",
+        health.built_at ? formatAbsolute(health.built_at) : UNKNOWN,
+        health.built_at ? `Built ${formatRelative(health.built_at, now)}` : undefined,
+      ),
       field("Uptime", formatDuration(health.uptime_sec)),
       field("Logical CPUs", formatCount(health.logical_cpus)),
       field("CPU idle", formatPercent(health.cpu_idle_fraction, 1)),

--- a/dashboard/web/test/fixtures.ts
+++ b/dashboard/web/test/fixtures.ts
@@ -154,6 +154,10 @@ export function multiHostSnapshot(): unknown {
             kind: "host.health",
             captured_at: isoMinutesBefore(2),
             daemon_version: "0.16.0",
+            // #4956 build identity. The degraded host below deliberately
+            // omits both, standing in for a record from a pre-#4956 daemon.
+            build_commit: "8c16fb5b",
+            built_at: isoMinutesBefore(360),
             uptime_sec: 86_400,
             logical_cpus: 28,
             cpu_idle_fraction: 0.83,

--- a/dashboard/web/test/fleetOverview.test.ts
+++ b/dashboard/web/test/fleetOverview.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { buildFleetView, findHost } from "../src/fleet";
 import { parseFleetSnapshot } from "../src/parse";
 import { UNKNOWN } from "../src/format";
-import { fleetOverviewView, hostCard } from "../src/views/fleetOverview";
+import { daemonIdentityText, fleetOverviewView, hostCard } from "../src/views/fleetOverview";
 import {
   DEGRADED_HOST_ID,
   HEALTHY_HOST_ID,
@@ -55,12 +55,28 @@ describe("fleetOverviewView", () => {
 describe("hostCard", () => {
   it("shows the whole host.health field set at a glance", () => {
     const card = hostCard(findHost(view(), HEALTHY_HOST_ID)!, NOW);
-    expect(fieldValue(card, "Daemon")).toBe("0.16.0");
+    expect(fieldValue(card, "Daemon")).toBe("0.16.0 @ 8c16fb5b, built 6h 0m ago");
     expect(fieldValue(card, "Uptime")).toBe("1d 0h");
     expect(fieldValue(card, "CPUs")).toBe("28");
     expect(fieldValue(card, "CPU idle")).toBe("83%");
     expect(fieldValue(card, "Load/core")).toBe("0.51");
     expect(fieldValue(card, "Worktree free")).toBe("200 GB");
+  });
+
+  it("distinguishes two same-version hosts by their build commit (#4956)", () => {
+    // The whole point of #4956: `daemon_version` is identical on both hosts
+    // (0.16.0), so the card must carry something that is NOT.
+    const healthy = hostCard(findHost(view(), HEALTHY_HOST_ID)!, NOW);
+    const degraded = hostCard(findHost(view(), DEGRADED_HOST_ID)!, NOW);
+    expect(fieldValue(healthy, "Daemon")).toContain("8c16fb5b");
+    expect(fieldValue(healthy, "Daemon")).not.toBe(fieldValue(degraded, "Daemon"));
+  });
+
+  it("falls back to the bare version for a record from a pre-#4956 daemon", () => {
+    // No `build_commit` / `built_at` on the wire — render exactly what the
+    // pre-#4956 card rendered, never a fabricated commit or build age.
+    const card = hostCard(findHost(view(), DEGRADED_HOST_ID)!, NOW);
+    expect(fieldValue(card, "Daemon")).toBe("0.16.0");
   });
 
   it("renders unmeasured health fields as unknown rather than zero", () => {
@@ -158,5 +174,29 @@ describe("hostCard", () => {
     expect(card.querySelector("img")).toBeNull();
     expect(card.querySelector("script")).toBeNull();
     expect(card.textContent).toContain("<img src=x onerror=alert(1)>");
+  });
+});
+
+describe("daemonIdentityText (#4956)", () => {
+  it("joins version, commit, and build age", () => {
+    expect(
+      daemonIdentityText({ daemon_version: "0.17.0", build_commit: "8c16fb5b", built_at: isoMinutesBefore(360) }, NOW),
+    ).toBe("0.17.0 @ 8c16fb5b, built 6h 0m ago");
+  });
+
+  it("drops the 'unknown' commit sentinel rather than showing it as a SHA", () => {
+    // `build.rs` stamps the literal "unknown" when the build host had no git.
+    expect(daemonIdentityText({ daemon_version: "0.17.0", build_commit: "unknown" }, NOW)).toBe("0.17.0");
+  });
+
+  it("omits the age clause when the build time is absent or unparseable", () => {
+    expect(daemonIdentityText({ daemon_version: "0.17.0", build_commit: "8c16fb5b" }, NOW)).toBe("0.17.0 @ 8c16fb5b");
+    expect(daemonIdentityText({ daemon_version: "0.17.0", build_commit: "8c16fb5b", built_at: "not-a-date" }, NOW)).toBe(
+      "0.17.0 @ 8c16fb5b",
+    );
+  });
+
+  it("renders an entirely empty record as unknown, never a fabricated identity", () => {
+    expect(daemonIdentityText({}, NOW)).toBe(UNKNOWN);
   });
 });

--- a/dashboard/web/test/hostDetail.test.ts
+++ b/dashboard/web/test/hostDetail.test.ts
@@ -41,6 +41,7 @@ describe("hostDetailView — health panel", () => {
   it("renders every host.health field", () => {
     const rendered = detail(HEALTHY_HOST_ID);
     expect(fieldValue(rendered, "Daemon version")).toBe("0.16.0");
+    expect(fieldValue(rendered, "Build commit")).toBe("8c16fb5b");
     expect(fieldValue(rendered, "Uptime")).toBe("1d 0h");
     expect(fieldValue(rendered, "Logical CPUs")).toBe("28");
     expect(fieldValue(rendered, "CPU idle")).toBe("83.0%");
@@ -53,6 +54,14 @@ describe("hostDetailView — health panel", () => {
     expect(fieldValue(rendered, "CPU idle")).toBe(UNKNOWN);
     expect(fieldValue(rendered, "Load per core")).toBe(UNKNOWN);
     expect(fieldValue(rendered, "Worktree root free")).toBe(UNKNOWN);
+  });
+
+  it("renders the build identity as unknown for a record from a pre-#4956 daemon", () => {
+    // The degraded fixture carries no `build_commit`/`built_at` — the panel
+    // must say so rather than invent a commit or a build time (#4956).
+    const rendered = detail(DEGRADED_HOST_ID);
+    expect(fieldValue(rendered, "Build commit")).toBe(UNKNOWN);
+    expect(fieldValue(rendered, "Built at")).toBe(UNKNOWN);
   });
 
   it("explains a host that has no health record yet", () => {

--- a/dashboard/web/test/parse.test.ts
+++ b/dashboard/web/test/parse.test.ts
@@ -96,4 +96,29 @@ describe("parseFleetSnapshot", () => {
     expect(snapshot.hosts.h?.health?.record).not.toHaveProperty("gpu_count");
     expect(snapshot.activeSweeps[0]).not.toHaveProperty("runtime");
   });
+
+  it("narrows host.health build identity, dropping wrong-typed values (#4956)", () => {
+    const snapshot = parseFleetSnapshot({
+      hosts: {
+        good: {
+          health: {
+            record: { daemon_version: "0.17.0", build_commit: "8c16fb5b", built_at: "2026-08-02T03:09:51Z" },
+            updatedAt: "2026-08-02T12:00:00Z",
+          },
+        },
+        bad: {
+          health: {
+            record: { daemon_version: "0.17.0", build_commit: 12345, built_at: "" },
+            updatedAt: "2026-08-02T12:00:00Z",
+          },
+        },
+      },
+      activeSweeps: [],
+    });
+    expect(snapshot.hosts.good?.health?.record.build_commit).toBe("8c16fb5b");
+    expect(snapshot.hosts.good?.health?.record.built_at).toBe("2026-08-02T03:09:51Z");
+    // A wrong-typed / empty value is dropped, not coerced to a rendered "12345".
+    expect(snapshot.hosts.bad?.health?.record).not.toHaveProperty("build_commit");
+    expect(snapshot.hosts.bad?.health?.record).not.toHaveProperty("built_at");
+  });
 });

--- a/defaults/docs/telemetry-schema.md
+++ b/defaults/docs/telemetry-schema.md
@@ -264,16 +264,18 @@ fabricated instant, so consumers must treat `null`/absent as *unknown* — never
 
 ### `host.health`
 
-Host CPU/disk headroom, daemon version, and uptime (host-level — no `repo` /
-`visibility`). Every measured field is optional so an unmeasurable probe stays
-absent rather than being coerced to a fake zero (the daemon's "unknown != zero"
-contract; see `cpu_headroom.rs` / `disk_headroom.rs`).
+Host CPU/disk headroom, the emitting binary's identity, and uptime (host-level —
+no `repo` / `visibility`). Every measured field is optional so an unmeasurable
+probe stays absent rather than being coerced to a fake zero (the daemon's
+"unknown != zero" contract; see `cpu_headroom.rs` / `disk_headroom.rs`).
 
 ```json
 {
   "kind": "host.health",
   "captured_at": "2026-07-30T12:00:00Z",
   "daemon_version": "0.16.0",
+  "build_commit": "8c16fb5b",
+  "built_at": "2026-07-30T03:09:51Z",
   "uptime_sec": 86400,
   "logical_cpus": 28,
   "cpu_idle_fraction": 0.83,
@@ -285,6 +287,28 @@ contract; see `cpu_headroom.rs` / `disk_headroom.rs`).
 `cpu_idle_fraction`, `load_per_core`, and `worktree_root_free_gb` are omitted when
 unmeasurable. A consumer MUST treat an absent measurement as "unknown", never as
 zero/full.
+
+**Binary identity (`build_commit` / `built_at`, #4956).** `daemon_version` is
+`CARGO_PKG_VERSION`, so it only moves once per release: every build between two
+releases reports the same string, and a day-stale daemon is indistinguishable
+from current `main`. `build_commit` (the short git SHA the running binary was
+compiled from) and `built_at` (when it was compiled) are the precise identity —
+both come from the very same compile-time stamps `loom-daemon --version` prints
+(`LOOM_DAEMON_GIT_COMMIT` / `LOOM_DAEMON_BUILD_TIME`, baked in by `build.rs`), so
+the telemetry and the CLI can never disagree.
+
+- `build_commit` is always sent. `"unknown"` is a *meaningful* value, not a
+  missing measurement: it means the build host had no git (e.g. a
+  release-tarball build). A record from a pre-#4956 daemon has no field at all,
+  which decodes as an empty string.
+- `built_at` is **omitted** when the build-time stamp was unavailable — an
+  unknown build time is absent, never a fabricated instant, exactly like the
+  measured fields above.
+
+Both fields are additive and pass through public redaction unchanged (they
+describe the released binary, not any repo or operator — see
+`dashboard/src/redaction.ts`), so an older consumer that ignores unknown keys is
+unaffected.
 
 ## Persistence & read surface (`sweep.outcome`, Issue #4704)
 

--- a/loom-daemon/src/observability/collector.rs
+++ b/loom-daemon/src/observability/collector.rs
@@ -448,9 +448,10 @@ fn sample_token_snapshot(workspace_root: &Path) -> TokenSnapshotRecord {
     }
 }
 
-/// Sample host CPU/disk headroom into a [`HostHealthRecord`]. Every measured
-/// field is `Option` — an unmeasurable probe stays absent rather than a fake
-/// zero (mirrors `cpu_headroom`/`disk_headroom`'s own contract).
+/// Sample host CPU/disk headroom into a [`HostHealthRecord`], stamped with the
+/// running binary's build identity. Every measured field is `Option` — an
+/// unmeasurable probe stays absent rather than a fake zero (mirrors
+/// `cpu_headroom`/`disk_headroom`'s own contract).
 async fn sample_host_health(workspace_root: &Path, started_at: Instant) -> HostHealthRecord {
     // CPU idle refresh can block ~1s on macOS (`iostat`) — dispatched through
     // `spawn_blocking` per the exact pattern `work_finder`'s dynamic-cap tick
@@ -459,6 +460,12 @@ async fn sample_host_health(workspace_root: &Path, started_at: Instant) -> HostH
     HostHealthRecord {
         captured_at: Utc::now(),
         daemon_version: env!("CARGO_PKG_VERSION").to_string(),
+        // The build identity of the RUNNING binary, straight from the same
+        // compile-time stamps `loom-daemon --version` prints (#4956).
+        // `daemon_version` alone only moves once per release, so it cannot
+        // distinguish a day-stale binary from current `main`.
+        build_commit: crate::self_update::BUILT_COMMIT.to_string(),
+        built_at: crate::self_update::built_at(),
         uptime_sec: started_at.elapsed().as_secs(),
         logical_cpus: crate::cpu_headroom::logical_cpu_count(),
         cpu_idle_fraction: crate::cpu_headroom::cached_cpu_idle_fraction(),
@@ -835,5 +842,44 @@ mod tests {
         let record = sample_host_health(dir.path(), started).await;
         assert_eq!(record.daemon_version, env!("CARGO_PKG_VERSION"));
         assert!(record.logical_cpus >= 1);
+    }
+
+    #[tokio::test]
+    async fn host_health_sample_stamps_the_running_binarys_build_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let record = sample_host_health(dir.path(), Instant::now()).await;
+
+        // The sample must carry the SAME commit `loom-daemon --version`
+        // prints — that identity is what lets the dashboard tell two
+        // same-`daemon_version` builds apart (#4956).
+        assert_eq!(record.build_commit, crate::self_update::BUILT_COMMIT);
+        assert!(
+            !record.build_commit.is_empty(),
+            "build_commit must always be populated (\"unknown\" is the no-git fallback)"
+        );
+        assert_eq!(record.built_at, crate::self_update::built_at());
+
+        // `built_at` is absent only when the compile-time stamp itself is the
+        // "unknown" fallback; whenever it IS present it must be a real instant
+        // no later than the sample, never a fabricated epoch.
+        if let Some(built_at) = record.built_at {
+            assert!(
+                built_at <= record.captured_at,
+                "built_at ({built_at}) must not be after captured_at ({})",
+                record.captured_at
+            );
+        }
+    }
+
+    #[test]
+    fn built_at_parses_the_compile_time_stamp_or_reports_unknown() {
+        // Pins the "unknown != fabricated instant" half of the contract: the
+        // helper resolves to `Some` exactly when the raw stamp is parseable.
+        let raw = crate::self_update::BUILT_AT_RAW;
+        assert_eq!(
+            crate::self_update::built_at().is_some(),
+            chrono::DateTime::parse_from_rfc3339(raw).is_ok(),
+            "built_at() must be Some iff the raw stamp {raw:?} parses"
+        );
     }
 }

--- a/loom-daemon/src/observability/exporter.rs
+++ b/loom-daemon/src/observability/exporter.rs
@@ -506,6 +506,8 @@ mod tests {
             TelemetryRecord::HostHealth(HostHealthRecord {
                 captured_at: chrono::Utc::now(),
                 daemon_version: "0.16.0".to_string(),
+                build_commit: "deadbeef".to_string(),
+                built_at: None,
                 uptime_sec: 10,
                 logical_cpus: 8,
                 cpu_idle_fraction: None,

--- a/loom-daemon/src/observability/otlp/mapping.rs
+++ b/loom-daemon/src/observability/otlp/mapping.rs
@@ -580,6 +580,8 @@ mod tests {
             TelemetryRecord::HostHealth(HostHealthRecord {
                 captured_at: ts(),
                 daemon_version: "0.17.0".to_string(),
+                build_commit: "8c16fb5b".to_string(),
+                built_at: Some(ts()),
                 uptime_sec: 86_400,
                 logical_cpus: 28,
                 cpu_idle_fraction: Some(0.83),
@@ -786,6 +788,8 @@ mod tests {
         let mut record = HostHealthRecord {
             captured_at: ts(),
             daemon_version: "0.17.0".to_string(),
+            build_commit: "8c16fb5b".to_string(),
+            built_at: None,
             uptime_sec: 10,
             logical_cpus: 4,
             cpu_idle_fraction: None,

--- a/loom-daemon/src/observability/otlp/mod.rs
+++ b/loom-daemon/src/observability/otlp/mod.rs
@@ -304,6 +304,8 @@ mod tests {
             TelemetryRecord::HostHealth(HostHealthRecord {
                 captured_at: chrono::Utc::now(),
                 daemon_version: "0.17.0".to_string(),
+                build_commit: "deadbeef".to_string(),
+                built_at: None,
                 uptime_sec: 10,
                 logical_cpus: 8,
                 cpu_idle_fraction: None,

--- a/loom-daemon/src/observability/sender.rs
+++ b/loom-daemon/src/observability/sender.rs
@@ -144,6 +144,8 @@ mod tests {
             TelemetryRecord::HostHealth(HostHealthRecord {
                 captured_at: chrono::Utc::now(),
                 daemon_version: "0.16.0".to_string(),
+                build_commit: "deadbeef".to_string(),
+                built_at: None,
                 uptime_sec: 1,
                 logical_cpus: 4,
                 cpu_idle_fraction: None,

--- a/loom-daemon/src/self_update.rs
+++ b/loom-daemon/src/self_update.rs
@@ -19,6 +19,7 @@
 //! `.loom/scripts/cli/loom-daemon-update.sh`, a shell script — deliberately
 //! NOT wired to auto-run from here.
 
+use chrono::{DateTime, Utc};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -27,6 +28,24 @@ use std::process::Command;
 /// `loom-daemon --version`). `"unknown"` when the build host lacked `git`
 /// (e.g. a release-tarball build with no `.git` present).
 pub const BUILT_COMMIT: &str = env!("LOOM_DAEMON_GIT_COMMIT");
+
+/// The raw build-time stamp baked in by `build.rs` ->
+/// `LOOM_DAEMON_BUILD_TIME` (ISO-8601 UTC, e.g. `2026-08-02T03:09:51Z`), the
+/// same value `loom-daemon --version` prints. `"unknown"` when the build host
+/// had no usable `date`. Prefer [`built_at`] when you want an instant.
+pub const BUILT_AT_RAW: &str = env!("LOOM_DAEMON_BUILD_TIME");
+
+/// [`BUILT_AT_RAW`] parsed into an instant, or `None` when the stamp is the
+/// `"unknown"` fallback (or otherwise unparseable).
+///
+/// Returning `None` rather than a fabricated epoch keeps the daemon's
+/// "unknown != zero" contract: a consumer that cannot learn when the binary
+/// was built must see *absent*, never a wrong-but-plausible timestamp.
+pub fn built_at() -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(BUILT_AT_RAW)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
 
 /// The full build identity of this binary — `"<version> (commit <sha>, built
 /// <ts>)"` — as shown by `loom-daemon --version`.

--- a/loom-daemon/src/telemetry/mod.rs
+++ b/loom-daemon/src/telemetry/mod.rs
@@ -434,7 +434,8 @@ pub struct TokenSnapshotRecord {
     pub accounts: Vec<TokenAccountState>,
 }
 
-/// `host.health` — host CPU/disk headroom plus daemon version and uptime.
+/// `host.health` — host CPU/disk headroom plus the emitting binary's identity
+/// (version + build commit + build time) and uptime.
 /// Host-level: it references no repository, so it carries no visibility tag.
 /// Every measured field is optional so an unmeasurable probe stays absent rather
 /// than being coerced to a fake zero (matching `cpu_headroom` / `disk_headroom`'s
@@ -445,6 +446,29 @@ pub struct HostHealthRecord {
     pub captured_at: DateTime<Utc>,
     /// The emitting daemon's version (`CARGO_PKG_VERSION`).
     pub daemon_version: String,
+    /// The short git commit the emitting binary was BUILT from
+    /// (`self_update::BUILT_COMMIT`, baked in by `build.rs`), or `"unknown"`
+    /// when the build host had no git.
+    ///
+    /// `daemon_version` alone cannot answer "is this host's daemon current?" —
+    /// it only moves once per release, so every build between two releases
+    /// reports the same string and a day-stale binary is indistinguishable
+    /// from `main` (#4956). The commit is the precise identity.
+    ///
+    /// `#[serde(default)]` so a record emitted by a pre-#4956 daemon still
+    /// decodes (as an empty string) rather than failing the whole envelope.
+    #[serde(default)]
+    pub build_commit: String,
+    /// When the emitting binary was compiled (`LOOM_DAEMON_BUILD_TIME`), when
+    /// that stamp is present and parseable.
+    ///
+    /// `Option` rather than a bare `DateTime<Utc>` on purpose: `build.rs`
+    /// falls back to the literal string `"unknown"` when `date` is
+    /// unavailable, and this struct's contract is that an unavailable value
+    /// stays *absent* rather than being coerced to a fabricated instant (the
+    /// same "unknown != zero" rule the measured fields below follow).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub built_at: Option<DateTime<Utc>>,
     /// Daemon uptime in seconds.
     pub uptime_sec: u64,
     /// Logical CPU count.
@@ -563,6 +587,8 @@ mod tests {
         TelemetryRecord::HostHealth(HostHealthRecord {
             captured_at: ts(),
             daemon_version: "0.16.0".to_string(),
+            build_commit: "8c16fb5b".to_string(),
+            built_at: Some(ts()),
             uptime_sec: 86_400,
             logical_cpus: 28,
             cpu_idle_fraction: Some(0.83),
@@ -730,6 +756,102 @@ mod tests {
                 assert_eq!(r.visibility, RepoVisibility::Private);
             }
             other => panic!("expected SweepCompleted, got {other:?}"),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // host.health build identity (#4956).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn host_health_serializes_build_identity_alongside_version() {
+        let value = serde_json::to_value(host_health()).unwrap();
+        assert_eq!(
+            value
+                .get("daemon_version")
+                .and_then(serde_json::Value::as_str),
+            Some("0.16.0")
+        );
+        // The whole point of #4956: two builds sharing `daemon_version` are
+        // told apart by the commit, so it must be on the wire.
+        assert_eq!(
+            value
+                .get("build_commit")
+                .and_then(serde_json::Value::as_str),
+            Some("8c16fb5b")
+        );
+        assert_eq!(
+            value.get("built_at").and_then(serde_json::Value::as_str),
+            Some("2026-07-30T12:00:00Z")
+        );
+    }
+
+    #[test]
+    fn host_health_round_trips_build_identity() {
+        let json = serde_json::to_string(&host_health()).unwrap();
+        let decoded: TelemetryRecord = serde_json::from_str(&json).unwrap();
+        match decoded {
+            TelemetryRecord::HostHealth(r) => {
+                assert_eq!(r.build_commit, "8c16fb5b");
+                assert_eq!(r.built_at, Some(ts()));
+            }
+            other => panic!("expected HostHealth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn host_health_omits_built_at_when_unknown() {
+        // `build.rs` stamps the literal "unknown" when the build host had no
+        // usable `date`; that must serialize as an ABSENT field, never as a
+        // fabricated instant (the struct's "unknown != zero" contract).
+        let record = TelemetryRecord::HostHealth(HostHealthRecord {
+            captured_at: ts(),
+            daemon_version: "0.17.0".to_string(),
+            build_commit: "unknown".to_string(),
+            built_at: None,
+            uptime_sec: 1,
+            logical_cpus: 4,
+            cpu_idle_fraction: None,
+            load_per_core: None,
+            worktree_root_free_gb: None,
+        });
+        let value = serde_json::to_value(&record).unwrap();
+        assert!(
+            value.get("built_at").is_none(),
+            "an unknown build time must be absent, not a fabricated instant"
+        );
+        // The commit sentinel, unlike the instant, IS sent — "unknown" is a
+        // meaningful answer for a tarball build, not a missing measurement.
+        assert_eq!(
+            value
+                .get("build_commit")
+                .and_then(serde_json::Value::as_str),
+            Some("unknown")
+        );
+        // Still round-trips.
+        let decoded: TelemetryRecord = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn host_health_from_a_pre_4956_daemon_still_decodes() {
+        // Backward compatibility: a record emitted by a daemon that predates
+        // the build-identity fields must decode, not poison the batch.
+        let json = r#"{
+            "kind": "host.health",
+            "captured_at": "2026-07-30T12:00:00Z",
+            "daemon_version": "0.16.0",
+            "uptime_sec": 86400,
+            "logical_cpus": 28
+        }"#;
+        let decoded: TelemetryRecord = serde_json::from_str(json).unwrap();
+        match decoded {
+            TelemetryRecord::HostHealth(r) => {
+                assert_eq!(r.daemon_version, "0.16.0");
+                assert_eq!(r.build_commit, "");
+                assert_eq!(r.built_at, None);
+            }
+            other => panic!("expected HostHealth, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary

`host.health` previously carried only `daemon_version` (`CARGO_PKG_VERSION`),
which moves once per release — every build between two releases reports the
same string, so the dashboard cannot tell a day-stale daemon from current
`main` (observed 2026-08-02: three hosts all reading `0.17.0` while one was
~25 commits behind its own source tree, invisible until checking
`loom-daemon status --json` on-host). This adds the emitting binary's precise
build identity — `build_commit` and `built_at` — sourced from the exact
compile-time stamps `loom-daemon --version` already prints, so telemetry and
the CLI can never disagree.

## Changes

**Daemon**
- `HostHealthRecord` (`loom-daemon/src/telemetry/mod.rs`) gains `build_commit:
  String` (`#[serde(default)]`, so a pre-#4956 record still decodes as an
  empty string) and `built_at: Option<DateTime<Utc>>` (`skip_serializing_if
  = "Option::is_none"`, absent rather than a fabricated instant when the
  build-time stamp is unavailable — matches the struct's existing
  "unknown != zero" contract).
- `self_update.rs` exposes `BUILT_AT_RAW` (`env!("LOOM_DAEMON_BUILD_TIME")`)
  and a `built_at()` helper that parses it, so telemetry and `--version` read
  the identical compile-time stamps.
- `sample_host_health()` (`observability/collector.rs`) populates both new
  fields from `self_update::BUILT_COMMIT` / `self_update::built_at()`.
- Other `HostHealthRecord` construction sites updated to compile:
  `observability/sender.rs`, `observability/exporter.rs`,
  `observability/otlp/mapping.rs`, `observability/otlp/mod.rs`.

**Dashboard**
- `build_commit`/`built_at` added to the `host.health` redaction allowlist
  (`dashboard/src/redaction.ts`) and the public-page display allowlist
  (`dashboard/src/publicPage.ts`) — reviewed: build metadata about the
  released binary, no repo/issue/operator reference, exactly as public as
  `daemon_version`.
- Fleet cards (`dashboard/web/src/views/fleetOverview.ts`) render one
  identity line (e.g. `0.17.0 @ 8c16fb5b, built 6h ago`); the host
  drill-down (`hostDetail.ts`) adds "Build commit" / "Built at" rows. Each
  part degrades independently — a pre-#4956 record renders exactly as
  before, and an `"unknown"` commit sentinel (no-git build host) is dropped
  rather than shown as a fake SHA.

**Docs**
- `.loom/docs/telemetry-schema.md` (and `defaults/docs/telemetry-schema.md`,
  its install-source counterpart) document the new fields and their
  absent-vs-`"unknown"` semantics under `host.health`.

**Not included (optional stretch from the issue):** surfacing
`self_update.update_available` on `host.health` — left out to keep this PR
focused on the acceptance criteria; can be a follow-up if wanted.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| `host.health` records carry build commit + built-at; existing consumers unaffected | ✅ | `build_commit`/`built_at` added with `#[serde(default)]` / `skip_serializing_if`; `host_health_from_a_pre_4956_daemon_still_decodes` test proves a pre-#4956 payload (no new fields) still decodes |
| Dashboard displays per-host binary identity precise enough to distinguish two same-version builds | ✅ | `daemonIdentityText()` renders `"<version> @ <commit>, built <age>"`; `fleetOverview.test.ts` asserts two same-`daemon_version` hosts render distinguishable "Daemon" field values |
| `.loom/docs/telemetry-schema.md` updated for the new fields | ✅ | New "Binary identity" subsection under `host.health`, with the field semantics and an updated example payload |

## Test Plan

- `cargo build --lib` — clean.
- `cargo test --lib telemetry::` — 19 passed (incl. 4 new `host.health`
  build-identity tests: serialize-alongside-version, round-trip,
  omit-`built_at`-when-unknown, decode-a-pre-#4956-payload).
- `cargo test --lib observability::` — 61 passed (incl. 2 new
  `sample_host_health()` tests: stamps the running binary's real
  `BUILT_COMMIT`/`built_at()`, and `built_at()` resolves `Some` iff the raw
  compile-time stamp parses).
- `cargo clippy --lib --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `dashboard`: `npm run check` (typecheck + vitest) — 182 passed, including
  new redaction/public-page tests for `build_commit`/`built_at`.
- `dashboard/web`: `npm run check` (typecheck + vitest) — 410 passed,
  including new `daemonIdentityText`, `fleetOverview`, `hostDetail`, and
  `parse` tests covering the fallback/degrade paths (pre-#4956 record,
  `"unknown"` sentinel, missing/unparseable `built_at`, wrong-typed wire
  values).

Closes #4956