### PR TITLE
fix(daemon-update): classify ff-abort causes as safely resolvable

### DIFF
--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -124,6 +124,7 @@
 #   ./.loom/scripts/cli/loom-daemon-update.sh --no-restart  Rebuild + provision only; leave the running daemon untouched
 #   ./.loom/scripts/cli/loom-daemon-update.sh --relaunch    Launchd/systemd only: after a refused restart, re-render the plist/unit and relaunch under supervision (SIGTERMs the daemon so sweep children reparent; preserves the live LOOM_* env)
 #   ./.loom/scripts/cli/loom-daemon-update.sh --allow-stale Skip the default ff-first sync with origin/<default-branch> and build the current (possibly stale) checkout as-is (#4330) — for deliberate use: bisecting, testing a local patch
+#   ./.loom/scripts/cli/loom-daemon-update.sh --auto-resolve-safe-abort  When the ff-only sync would otherwise hard-abort (#4330), auto-perform the fix IF the blocking state classifies as safe (#4951): content-identical diverged commits (`git reset --hard origin/<default-branch>`), or dirty tracked files that are ALL Loom-managed installed copies (`git checkout --` them + re-run resync-installed.sh). Any other cause (genuine content divergence, or any unmanaged dirty file) still hard-aborts unchanged — this flag never widens what's classified as safe, only whether the safe cases are printed (default) or performed
 #   ./.loom/scripts/cli/loom-daemon-update.sh --help
 #
 # Environment:
@@ -195,7 +196,12 @@
 #      (diverged local commits, a dirty tracked file conflicting with the
 #      incoming change, or HEAD is not on <default-branch>) — the script
 #      NEVER guesses or hard-resets; resolve manually or pass --allow-stale
-#      (#4330)
+#      (#4330). Two of the ff-abort causes classify as safely resolvable
+#      (#4951): content-identical diverged commits, or dirty tracked files
+#      that are ALL Loom-managed installed copies — by default these still
+#      exit 1 but the abort message names the exact safe command; pass
+#      --auto-resolve-safe-abort to have the script perform it instead (exit
+#      0 on success). Any other cause still hard-aborts unchanged.
 #   3  (--check only) update available
 #   4  build verification FAILED: the freshly-built binary's embedded commit
 #      does not match the source HEAD it was built from. This is a BUILD-SYSTEM
@@ -527,6 +533,7 @@ CHECK_ONLY=false
 NO_RESTART=false
 RELAUNCH=false
 ALLOW_STALE=false
+AUTO_RESOLVE_SAFE_ABORT=false
 [[ "${LOOM_DAEMON_UPDATE_RELAUNCH:-}" =~ ^(1|true|yes)$ ]] && RELAUNCH=true
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -537,6 +544,7 @@ while [[ $# -gt 0 ]]; do
         --no-restart) NO_RESTART=true; shift ;;
         --relaunch) RELAUNCH=true; shift ;;
         --allow-stale) ALLOW_STALE=true; shift ;;
+        --auto-resolve-safe-abort) AUTO_RESOLVE_SAFE_ABORT=true; shift ;;
         *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
     esac
 done
@@ -623,6 +631,146 @@ ORIGIN_COMMIT="unknown"
 ORIGIN_BEHIND_COUNT=0
 FF_SYNCED=false
 
+# ---------- ff-abort classification (#4951) ----------
+# The `git merge --ff-only` failure branch below used to emit ONE generic
+# "resolve manually" message for two structurally distinct, often-safe
+# failure shapes (surfaced by the 2026-08-02 fleet roll aborting on 2/3
+# hosts on local state that turned out to be safely resolvable by hand).
+# These helpers classify which shape applies so the abort message can name
+# (or, with --auto-resolve-safe-abort, perform) the exact safe resolution
+# instead of a bare "resolve manually".
+#
+# Safety note: this is the safety-critical branch of loom-daemon-update.sh —
+# #4381 was a live incident where an update-script code path silently
+# overwrote a real production binary; the same "automation quietly does
+# something destructive to real machine state" risk applies here. Do NOT
+# widen either check below (e.g. a loose substring/prefix match, or an
+# empty-diff check that misses a rename/mode-only change) beyond exactly
+# what's specified in #4951 — when genuinely unsure, both helpers must
+# return false so the caller falls through to the existing hard abort.
+
+# True (exit 0) iff local <default> and origin/<default> are content-IDENTICAL
+# despite having diverged in commit history (e.g. a resync commit + its own
+# revert nets to no change). Deliberately the plain three-dot merge-base diff
+# form with no rename-detection flags, matching the incident's own manual
+# check (`git diff origin/main...main`); `git diff --quiet` also treats a
+# mode-only change as non-empty, which is the conservative (safe) direction.
+#
+# Only meaningful when local <default> has commit(s) NOT reachable from
+# origin/<default> (a genuine history divergence) — the `--is-ancestor` guard
+# below is load-bearing, not an optimization: when local <default> IS an
+# ancestor of origin/<default> (the far more common shape: origin simply
+# advanced and local added no commits of its own), the three-dot form trivially
+# reduces to diffing local HEAD against itself (merge-base == local HEAD),
+# which is ALWAYS empty regardless of what origin changed — so without this
+# guard, every plain "blocked by a dirty tracked file" ff-abort (managed or
+# not) would misclassify as content-identical and risk an incorrect
+# `reset --hard` under --auto-resolve-safe-abort. In that ancestor case the ff
+# failure is necessarily a dirty/conflicting working-tree file instead, which
+# the OTHER classifier below is responsible for.
+_ff_abort_content_identical() {
+    local repo_root="$1" branch="$2"
+    if (cd "$repo_root" && git merge-base --is-ancestor "$branch" "origin/${branch}" 2>/dev/null); then
+        return 1
+    fi
+    (cd "$repo_root" && git diff --quiet "origin/${branch}...${branch}" -- 2>/dev/null)
+}
+
+# Loom-managed installed-surface prefixes/files this script is allowed to
+# discard local edits to when auto-resolving. MUST mirror
+# defaults/scripts/resync-installed.sh's own header comment (search "Surfaces
+# resynced" in that file) — that file, not this list, is the authoritative
+# source; update both together if it ever widens again (#4239 already widened
+# it once).
+_FF_ABORT_MANAGED_PREFIXES=(
+    ".loom/hooks/"
+    ".loom/scripts/"
+    ".loom/roles/"
+    ".loom/docs/"
+    ".loom/runtimes/"
+    ".loom/bin/"
+    ".claude/commands/loom/"
+)
+_FF_ABORT_MANAGED_FILES=(
+    ".loom/install-metadata.json"
+)
+
+# True (exit 0) iff the ONLY diff between the working tree's .gitignore and
+# HEAD's is inside the marker-delimited Loom-managed block (loom-daemon's
+# GITIGNORE_BEGIN_MARKER / GITIGNORE_END_MARKER, loom-daemon/src/init/post_init.rs)
+# — never the whole file, so a consumer's own hand-edited lines outside that
+# block are never silently discarded.
+_ff_abort_gitignore_only_managed_block_dirty() {
+    local repo_root="$1"
+    local file="$repo_root/.gitignore"
+    [[ -f "$file" ]] || return 1
+    local begin='# >>> loom-managed (do not edit) >>>'
+    local end='# <<< loom-managed <<<'
+    local working_stripped head_stripped
+    working_stripped=$(awk -v b="$begin" -v e="$end" 'BEGIN{skip=0} $0==b{skip=1;next} $0==e{skip=0;next} skip==0{print}' "$file" 2>/dev/null)
+    head_stripped=$(cd "$repo_root" && git show "HEAD:.gitignore" 2>/dev/null | awk -v b="$begin" -v e="$end" 'BEGIN{skip=0} $0==b{skip=1;next} $0==e{skip=0;next} skip==0{print}')
+    [[ "$working_stripped" == "$head_stripped" ]]
+}
+
+# True (exit 0) iff $2 (a repo-relative path from `git status --porcelain`) is
+# inside the managed installed-surface set above.
+_ff_abort_is_managed_path() {
+    local repo_root="$1" path="$2" p f
+    for f in "${_FF_ABORT_MANAGED_FILES[@]}"; do
+        [[ "$path" == "$f" ]] && return 0
+    done
+    for p in "${_FF_ABORT_MANAGED_PREFIXES[@]}"; do
+        [[ "$path" == "$p"* ]] && return 0
+    done
+    if [[ "$path" == ".gitignore" ]]; then
+        _ff_abort_gitignore_only_managed_block_dirty "$repo_root" && return 0
+    fi
+    return 1
+}
+
+# Populates the global array _FF_ABORT_DIRTY_MANAGED_PATHS and returns 0 iff
+# (a) at least one TRACKED file is dirty per `git status --porcelain`
+# (untracked `??` entries are excluded — they cannot conflict with a
+# fast-forward merge the way a dirty tracked file can) AND (b) EVERY one of
+# them is a managed path. Conjunctive by design, matching the issue's "every
+# blocking file" wording: one unmanaged dirty file alongside managed ones
+# still falls through to the hard abort.
+_FF_ABORT_DIRTY_MANAGED_PATHS=()
+_ff_abort_all_dirty_tracked_managed() {
+    local repo_root="$1"
+    _FF_ABORT_DIRTY_MANAGED_PATHS=()
+    local line status path found_any=false
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        status="${line:0:2}"
+        [[ "$status" == '??' ]] && continue
+        path="${line:3}"
+        if [[ "$path" == *" -> "* ]]; then
+            path="${path##* -> }"
+        fi
+        path="${path%\"}"
+        path="${path#\"}"
+        found_any=true
+        _ff_abort_is_managed_path "$repo_root" "$path" || return 1
+        _FF_ABORT_DIRTY_MANAGED_PATHS+=("$path")
+    done < <(cd "$repo_root" && git status --porcelain)
+    [[ "$found_any" == "true" ]]
+}
+
+# Best-effort resolve of resync-installed.sh under repo_root: the installed
+# copy first, else the shipped defaults/ source — same installed-then-defaults
+# precedence as resolve_lifecycle_script() above, adjusted for
+# resync-installed.sh living directly under scripts/, not scripts/cli/.
+_ff_abort_resolve_resync_script() {
+    local repo_root="$1" candidate
+    for candidate in \
+        "$repo_root/.loom/scripts/resync-installed.sh" \
+        "$repo_root/defaults/scripts/resync-installed.sh"; do
+        if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
+    done
+    echo ""
+}
+
 sync_with_origin() {
     local repo_root="$1"
     # shellcheck disable=SC1091
@@ -683,6 +831,50 @@ sync_with_origin() {
 
     echo "Local ${DEFAULT_BRANCH} is ${n} commit(s) behind origin/${DEFAULT_BRANCH} — fast-forwarding before building (default; pass --allow-stale to build the current checkout as-is)..."
     if ! (cd "$repo_root" && git merge --ff-only "origin/${DEFAULT_BRANCH}" --quiet); then
+        # Classify the failure (#4951) before falling back to the generic
+        # hard abort — see the "ff-abort classification" helpers above.
+        if _ff_abort_content_identical "$repo_root" "$DEFAULT_BRANCH"; then
+            warn "Fast-forward merge from origin/${DEFAULT_BRANCH} did not apply, but local ${DEFAULT_BRANCH} is content-IDENTICAL to origin/${DEFAULT_BRANCH} (git diff origin/${DEFAULT_BRANCH}...${DEFAULT_BRANCH} is empty) — local-only commit(s) that net to no change (e.g. a resync commit and its own revert)."
+            if [[ "$AUTO_RESOLVE_SAFE_ABORT" == "true" ]]; then
+                if (cd "$repo_root" && git reset --hard "origin/${DEFAULT_BRANCH}" --quiet); then
+                    ok "Auto-resolved (--auto-resolve-safe-abort): reset local ${DEFAULT_BRANCH} to origin/${DEFAULT_BRANCH}."
+                    FF_SYNCED=true
+                    return 0
+                fi
+                err "Auto-resolve (--auto-resolve-safe-abort) failed: 'git reset --hard origin/${DEFAULT_BRANCH}' did not succeed."
+                return 1
+            fi
+            err "Safe to resolve: git -C \"$repo_root\" reset --hard origin/${DEFAULT_BRANCH}"
+            err "Re-run with --auto-resolve-safe-abort to perform this automatically, or run the command above by hand."
+            return 1
+        fi
+        if _ff_abort_all_dirty_tracked_managed "$repo_root"; then
+            warn "Fast-forward merge from origin/${DEFAULT_BRANCH} was blocked by dirty tracked file(s), but ALL of them are Loom-managed installed copies (regenerated from defaults/ by resync-installed.sh, not real local work): ${_FF_ABORT_DIRTY_MANAGED_PATHS[*]}"
+            if [[ "$AUTO_RESOLVE_SAFE_ABORT" == "true" ]]; then
+                if (cd "$repo_root" && git checkout -- "${_FF_ABORT_DIRTY_MANAGED_PATHS[@]}") \
+                    && (cd "$repo_root" && git merge --ff-only "origin/${DEFAULT_BRANCH}" --quiet); then
+                    ok "Auto-resolved (--auto-resolve-safe-abort): discarded local edits to managed file(s) and fast-forwarded to origin/${DEFAULT_BRANCH}."
+                    local resync_script
+                    resync_script="$(_ff_abort_resolve_resync_script "$repo_root")"
+                    if [[ -n "$resync_script" ]]; then
+                        if (cd "$repo_root" && "$resync_script" >/dev/null 2>&1); then
+                            ok "Post-roll resync-installed.sh completed."
+                        else
+                            warn "Post-roll resync-installed.sh failed — run it by hand: $resync_script"
+                        fi
+                    else
+                        warn "Could not resolve resync-installed.sh — run it by hand after this update to re-sync managed files."
+                    fi
+                    FF_SYNCED=true
+                    return 0
+                fi
+                err "Auto-resolve (--auto-resolve-safe-abort) failed: discarding managed edits + fast-forward did not both succeed."
+                return 1
+            fi
+            err "Safe to resolve: git -C \"$repo_root\" checkout -- ${_FF_ABORT_DIRTY_MANAGED_PATHS[*]} && ./.loom/scripts/resync-installed.sh"
+            err "Re-run with --auto-resolve-safe-abort to perform this automatically, or run the commands above by hand."
+            return 1
+        fi
         err "Fast-forward merge from origin/${DEFAULT_BRANCH} did not apply — local commits have diverged, or a dirty tracked file conflicts with the incoming change."
         err "Refusing to guess or hard-reset: resolve manually (rebase/merge by hand), or pass --allow-stale to build the current (stale) checkout as-is."
         return 1

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -124,7 +124,7 @@
 #   ./.loom/scripts/cli/loom-daemon-update.sh --no-restart  Rebuild + provision only; leave the running daemon untouched
 #   ./.loom/scripts/cli/loom-daemon-update.sh --relaunch    Launchd/systemd only: after a refused restart, re-render the plist/unit and relaunch under supervision (SIGTERMs the daemon so sweep children reparent; preserves the live LOOM_* env)
 #   ./.loom/scripts/cli/loom-daemon-update.sh --allow-stale Skip the default ff-first sync with origin/<default-branch> and build the current (possibly stale) checkout as-is (#4330) — for deliberate use: bisecting, testing a local patch
-#   ./.loom/scripts/cli/loom-daemon-update.sh --auto-resolve-safe-abort  When the ff-only sync would otherwise hard-abort (#4330), auto-perform the fix IF the blocking state classifies as safe (#4951): content-identical diverged commits (`git reset --hard origin/<default-branch>`), or dirty tracked files that are ALL Loom-managed installed copies (`git checkout --` them + re-run resync-installed.sh). Any other cause (genuine content divergence, or any unmanaged dirty file) still hard-aborts unchanged — this flag never widens what's classified as safe, only whether the safe cases are printed (default) or performed
+#   ./.loom/scripts/cli/loom-daemon-update.sh --auto-resolve-safe-abort  When the ff-only sync would otherwise hard-abort (#4330), auto-perform the fix IF the blocking state classifies as safe (#4951): content-identical diverged commits with an otherwise-CLEAN working tree (`git reset --hard origin/<default-branch>`), or dirty tracked files that are ALL Loom-managed installed copies (`git checkout --` them + re-run resync-installed.sh). Any other cause (genuine content divergence, any unmanaged dirty file, or a dirty tracked file co-existing with the content-identical divergence) still hard-aborts unchanged — this flag never widens what's classified as safe, only whether the safe cases are printed (default) or performed
 #   ./.loom/scripts/cli/loom-daemon-update.sh --help
 #
 # Environment:
@@ -197,8 +197,9 @@
 #      incoming change, or HEAD is not on <default-branch>) — the script
 #      NEVER guesses or hard-resets; resolve manually or pass --allow-stale
 #      (#4330). Two of the ff-abort causes classify as safely resolvable
-#      (#4951): content-identical diverged commits, or dirty tracked files
-#      that are ALL Loom-managed installed copies — by default these still
+#      (#4951): content-identical diverged commits with an otherwise-CLEAN
+#      working tree, or dirty tracked files that are ALL Loom-managed
+#      installed copies — by default these still
 #      exit 1 but the abort message names the exact safe command; pass
 #      --auto-resolve-safe-abort to have the script perform it instead (exit
 #      0 on success). Any other cause still hard-aborts unchanged.
@@ -649,6 +650,21 @@ FF_SYNCED=false
 # what's specified in #4951 — when genuinely unsure, both helpers must
 # return false so the caller falls through to the existing hard abort.
 
+# True (exit 0) iff NO tracked file is dirty in the working tree per
+# `git status --porcelain`. Untracked (`??`) entries are excluded, matching
+# _ff_abort_all_dirty_tracked_managed below: they cannot conflict with a
+# fast-forward merge, and `git reset --hard` never touches them either.
+_ff_abort_no_dirty_tracked_files() {
+    local repo_root="$1" line status
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        status="${line:0:2}"
+        [[ "$status" == '??' ]] && continue
+        return 1
+    done < <(cd "$repo_root" && git status --porcelain)
+    return 0
+}
+
 # True (exit 0) iff local <default> and origin/<default> are content-IDENTICAL
 # despite having diverged in commit history (e.g. a resync commit + its own
 # revert nets to no change). Deliberately the plain three-dot merge-base diff
@@ -668,11 +684,27 @@ FF_SYNCED=false
 # `reset --hard` under --auto-resolve-safe-abort. In that ancestor case the ff
 # failure is necessarily a dirty/conflicting working-tree file instead, which
 # the OTHER classifier below is responsible for.
+#
+# ALSO requires a CLEAN working tree relative to local HEAD: both checks above
+# compare only COMMITTED refs, so on their own they say nothing about
+# uncommitted work sitting in the working tree. A host can simultaneously have
+# (a) diverged local commits that net to zero content diff vs. origin and (b)
+# an entirely unrelated dirty tracked file (an operator's manual scratch edit,
+# managed or not) — `git merge --ff-only` fails on the history divergence
+# alone, so this branch is reached, and without this guard the caller's
+# --auto-resolve-safe-abort `git reset --hard origin/<default>` would silently
+# discard that file's uncommitted changes. The resolution this classifier
+# vouches for is only safe when there is no uncommitted work for it to
+# destroy, so ANY dirty tracked file makes us return false and fall through —
+# to the managed-dirty classifier below, and failing that to the existing hard
+# abort. Mirrors the strictness _ff_abort_all_dirty_tracked_managed already
+# applies, and the "when genuinely unsure, return false" rule above.
 _ff_abort_content_identical() {
     local repo_root="$1" branch="$2"
     if (cd "$repo_root" && git merge-base --is-ancestor "$branch" "origin/${branch}" 2>/dev/null); then
         return 1
     fi
+    _ff_abort_no_dirty_tracked_files "$repo_root" || return 1
     (cd "$repo_root" && git diff --quiet "origin/${branch}...${branch}" -- 2>/dev/null)
 }
 

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -2360,16 +2360,27 @@ fi
 
 # ============================================================
 # 38. ff-first default: local main is behind origin/main AND has a DIVERGED
-#     local commit -> the ff-merge cannot apply -> abort exit 1, no merge, no
-#     build, working tree untouched. Never guesses or hard-resets.
+#     local commit whose CONTENT genuinely differs from origin's (not merely
+#     its commit history) -> the ff-merge cannot apply -> abort exit 1, no
+#     merge, no build, working tree untouched. Never guesses or hard-resets.
+#     This is the #4951 regression case: real (non-empty) content divergence
+#     must NOT be reclassified as the content-identical case covered by tests
+#     57/58 below — both sides here add a real, DIFFERENT file, so
+#     `git diff origin/main...main` is genuinely non-empty.
 # ============================================================
 W38="$BASE_WORKDIR/w38"
 BARE38="$BASE_WORKDIR/w38-origin.git"
 new_fixture_with_origin "$W38" "$BARE38"
-push_extra_commits_to_origin "$BARE38" 2 >/dev/null
-# Diverge: a local commit that is NOT on origin (so the merge is not a plain
-# fast-forward — `git merge --ff-only` must refuse).
-( cd "$W38" && git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "local diverged commit" )
+TMPCLONE38="$(mktemp -d)"
+git clone -q "$BARE38" "$TMPCLONE38"
+echo "origin-value" > "$TMPCLONE38/origin-only-file.txt"
+( cd "$TMPCLONE38" && git add origin-only-file.txt && git -c user.email=test@test -c user.name=test commit -q -m "origin real change" && git push -q origin HEAD:refs/heads/main )
+rm -rf "$TMPCLONE38"
+# Diverge: a local commit that is NOT on origin, adding DIFFERENT real
+# content (so the merge is not a plain fast-forward, AND the resulting
+# content diff vs origin is genuinely non-empty).
+echo "local-value" > "$W38/local-only-file.txt"
+( cd "$W38" && git add local-only-file.txt && git -c user.email=test@test -c user.name=test commit -q -m "local diverged commit (real content)" )
 HEAD_BEFORE38="$(cd "$W38" && git rev-parse --short HEAD)"
 out38=$( cd "$W38" && PATH="$TEST_PATH" bash "$UPDATE_SCRIPT" 2>&1 )
 rc38=$?
@@ -2947,6 +2958,258 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} failure output loudly reports the unconfirmed relaunch"
     echo "  output: $out56"
+fi
+
+# ============================================================
+# 57. ff-abort classification (#4951): local <default> has DIVERGED from
+#     origin/<default> in commit history, but the two are content-IDENTICAL
+#     (`git diff origin/main...main` is empty — e.g. a local resync commit
+#     and its own revert that net to no change, the robb-STUDIO 2026-08-02
+#     incident shape). Default (no --auto-resolve-safe-abort): still hard
+#     aborts (exit 1, HEAD untouched) but now names the exact safe command
+#     instead of the old bare "resolve manually" message.
+# ============================================================
+W57="$BASE_WORKDIR/w57"
+BARE57="$BASE_WORKDIR/w57-origin.git"
+new_fixture_with_origin "$W57" "$BARE57"
+push_extra_commits_to_origin "$BARE57" 2 >/dev/null
+# Diverge locally with an equally content-free commit -- both sides' extra
+# commits are --allow-empty, so the FINAL tree state matches even though the
+# commit graphs have diverged (git merge --ff-only still refuses).
+( cd "$W57" && git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "local commit that nets to no change" )
+HEAD_BEFORE57="$(cd "$W57" && git rev-parse --short HEAD)"
+out57=$( cd "$W57" && PATH="$TEST_PATH" bash "$UPDATE_SCRIPT" 2>&1 )
+rc57=$?
+assert_eq "1" "$rc57" "content-identical divergence (no flag): still exits 1 by default"
+HEAD_AFTER57="$(cd "$W57" && git rev-parse --short HEAD)"
+assert_eq "$HEAD_BEFORE57" "$HEAD_AFTER57" "content-identical divergence (no flag): HEAD completely untouched"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out57" | grep -qi 'content-IDENTICAL'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} content-identical divergence is classified and named explicitly"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} content-identical divergence is classified and named explicitly"
+    echo "  output: $out57"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out57" | grep -q -- 'reset --hard origin/main'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} abort message names the exact safe reset command"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} abort message names the exact safe reset command"
+    echo "  output: $out57"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out57" | grep -q -- '--auto-resolve-safe-abort'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} abort message names --auto-resolve-safe-abort as the automatic path"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} abort message names --auto-resolve-safe-abort as the automatic path"
+    echo "  output: $out57"
+fi
+
+# ============================================================
+# 58. Same content-identical-divergence shape as test 57, but WITH
+#     --auto-resolve-safe-abort: the script performs `git reset --hard
+#     origin/main` itself, then proceeds to rebuild the now-current HEAD ->
+#     exit 0, HEAD now equals origin's tip.
+# ============================================================
+W58="$BASE_WORKDIR/w58"
+BARE58="$BASE_WORKDIR/w58-origin.git"
+new_fixture_with_origin "$W58" "$BARE58"
+ORIGIN_TIP58="$(push_extra_commits_to_origin "$BARE58" 2)"
+( cd "$W58" && git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "local commit that nets to no change" )
+NEW_FAKE58="$W58/new-fake-daemon"
+write_fake_daemon "$NEW_FAKE58" "$ORIGIN_TIP58" "$W58/new-marker"
+out58=$( cd "$W58" && PATH="$TEST_PATH" NEW_FAKE_BIN_SRC="$NEW_FAKE58" \
+    bash "$UPDATE_SCRIPT" --auto-resolve-safe-abort 2>&1 )
+rc58=$?
+assert_eq "0" "$rc58" "content-identical divergence + --auto-resolve-safe-abort: auto-resolves and succeeds"
+HEAD_AFTER58="$(cd "$W58" && git rev-parse --short HEAD)"
+assert_eq "$ORIGIN_TIP58" "$HEAD_AFTER58" "content-identical divergence + --auto-resolve-safe-abort: HEAD now equals origin/main's tip"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out58" | grep -qi 'Auto-resolved'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} auto-resolve reports what it did"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} auto-resolve reports what it did"
+    echo "  output: $out58"
+fi
+
+# ============================================================
+# 59. ff-abort classification (#4951): the ff-merge is blocked by a dirty
+#     TRACKED file, but it is a Loom-managed installed copy (under
+#     .loom/docs/, regenerated from defaults/ by resync-installed.sh) whose
+#     incoming origin change conflicts with the local edit -- not real local
+#     work (the loom-worker-1 2026-08-02 incident shape). Default (no
+#     --auto-resolve-safe-abort): still hard aborts (exit 1, dirty file left
+#     untouched) but now names the exact safe commands instead of the old
+#     bare "resolve manually" message.
+# ============================================================
+W59="$BASE_WORKDIR/w59"
+BARE59="$BASE_WORKDIR/w59-origin.git"
+new_fixture_with_origin "$W59" "$BARE59"
+mkdir -p "$W59/.loom/docs"
+echo "docv1" > "$W59/.loom/docs/example.md"
+( cd "$W59" && git add .loom/docs/example.md && git -c user.email=test@test -c user.name=test commit -q -m "add managed doc" && git push -q origin HEAD:refs/heads/main )
+TMPCLONE59="$(mktemp -d)"
+git clone -q "$BARE59" "$TMPCLONE59"
+echo "docv2-from-origin" > "$TMPCLONE59/.loom/docs/example.md"
+( cd "$TMPCLONE59" && git commit -aq -m "origin updates the managed doc" && git push -q origin HEAD:refs/heads/main )
+rm -rf "$TMPCLONE59"
+# Dirty (uncommitted) that SAME managed file with a conflicting edit, so
+# `git merge --ff-only` genuinely refuses (an unrelated dirty file would not
+# block a fast-forward).
+echo "docv1-local-edit" > "$W59/.loom/docs/example.md"
+HEAD_BEFORE59="$(cd "$W59" && git rev-parse --short HEAD)"
+out59=$( cd "$W59" && PATH="$TEST_PATH" bash "$UPDATE_SCRIPT" 2>&1 )
+rc59=$?
+assert_eq "1" "$rc59" "managed-only dirty file (no flag): still exits 1 by default"
+HEAD_AFTER59="$(cd "$W59" && git rev-parse --short HEAD)"
+assert_eq "$HEAD_BEFORE59" "$HEAD_AFTER59" "managed-only dirty file (no flag): HEAD untouched"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$(cat "$W59/.loom/docs/example.md")" == "docv1-local-edit" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} dirty managed file is left untouched by default (no checkout performed)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} dirty managed file is left untouched by default (no checkout performed)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out59" | grep -qi 'Loom-managed installed copies'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} managed-only dirty state is classified and named explicitly"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} managed-only dirty state is classified and named explicitly"
+    echo "  output: $out59"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out59" | grep -q -- 'checkout -- .loom/docs/example.md' \
+    && echo "$out59" | grep -q -- 'resync-installed.sh'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} abort message names the exact safe checkout + resync commands"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} abort message names the exact safe checkout + resync commands"
+    echo "  output: $out59"
+fi
+
+# ============================================================
+# 60. Same managed-only-dirty shape as test 59, but WITH
+#     --auto-resolve-safe-abort: the script discards the local edit
+#     (`git checkout --`), fast-forwards, and invokes resync-installed.sh
+#     post-roll -> exit 0, the managed file now matches origin's content, and
+#     the (stubbed) resync-installed.sh was actually invoked.
+# ============================================================
+W60="$BASE_WORKDIR/w60"
+BARE60="$BASE_WORKDIR/w60-origin.git"
+new_fixture_with_origin "$W60" "$BARE60"
+mkdir -p "$W60/.loom/docs"
+echo "docv1" > "$W60/.loom/docs/example.md"
+( cd "$W60" && git add .loom/docs/example.md && git -c user.email=test@test -c user.name=test commit -q -m "add managed doc" && git push -q origin HEAD:refs/heads/main )
+TMPCLONE60="$(mktemp -d)"
+git clone -q "$BARE60" "$TMPCLONE60"
+echo "docv2-from-origin" > "$TMPCLONE60/.loom/docs/example.md"
+( cd "$TMPCLONE60" && git commit -aq -m "origin updates the managed doc" && git push -q origin HEAD:refs/heads/main )
+ORIGIN_TIP60="$(cd "$TMPCLONE60" && git rev-parse --short HEAD)"
+rm -rf "$TMPCLONE60"
+echo "docv1-local-edit" > "$W60/.loom/docs/example.md"
+# Stub resync-installed.sh at the installed-copy resolution path so we can
+# prove it was actually invoked post-roll, without exercising the real
+# script's defaults/-tree assumptions inside this minimal fixture.
+mkdir -p "$W60/.loom/scripts"
+RESYNC_MARKER60="$W60/resync-invoked-marker"
+cat > "$W60/.loom/scripts/resync-installed.sh" <<RESYNCEOF
+#!/usr/bin/env bash
+echo invoked > "$RESYNC_MARKER60"
+RESYNCEOF
+chmod +x "$W60/.loom/scripts/resync-installed.sh"
+NEW_FAKE60="$W60/new-fake-daemon"
+write_fake_daemon "$NEW_FAKE60" "$ORIGIN_TIP60" "$W60/new-marker"
+out60=$( cd "$W60" && PATH="$TEST_PATH" NEW_FAKE_BIN_SRC="$NEW_FAKE60" \
+    bash "$UPDATE_SCRIPT" --auto-resolve-safe-abort 2>&1 )
+rc60=$?
+assert_eq "0" "$rc60" "managed-only dirty file + --auto-resolve-safe-abort: auto-resolves and succeeds"
+HEAD_AFTER60="$(cd "$W60" && git rev-parse --short HEAD)"
+assert_eq "$ORIGIN_TIP60" "$HEAD_AFTER60" "managed-only dirty file + --auto-resolve-safe-abort: HEAD now equals origin/main's tip"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$(cat "$W60/.loom/docs/example.md" 2>/dev/null)" == "docv2-from-origin" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} local edit was discarded; managed file now matches origin's post-merge content"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} local edit was discarded; managed file now matches origin's post-merge content"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$RESYNC_MARKER60" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} post-roll resync-installed.sh was actually invoked"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} post-roll resync-installed.sh was actually invoked"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out60" | grep -qi 'Auto-resolved'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} auto-resolve reports what it did"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} auto-resolve reports what it did"
+    echo "  output: $out60"
+fi
+
+# ============================================================
+# 61. Regression (#4951 safety floor): a dirty tracked file OUTSIDE the
+#     Loom-managed set (a top-level repo file, conflicting with origin's
+#     change) alongside ANOTHER dirty file that IS managed -- the "every
+#     blocking file" wording is conjunctive, not "any": one unmanaged dirty
+#     file must still force the generic hard abort, with NO auto-resolve
+#     attempted, even when --auto-resolve-safe-abort is passed.
+# ============================================================
+W61="$BASE_WORKDIR/w61"
+BARE61="$BASE_WORKDIR/w61-origin.git"
+new_fixture_with_origin "$W61" "$BARE61"
+mkdir -p "$W61/.loom/docs"
+echo "docv1" > "$W61/.loom/docs/example.md"
+echo "unmanagedv1" > "$W61/unmanaged-file.txt"
+( cd "$W61" && git add .loom/docs/example.md unmanaged-file.txt && git -c user.email=test@test -c user.name=test commit -q -m "add managed doc + unmanaged file" && git push -q origin HEAD:refs/heads/main )
+TMPCLONE61="$(mktemp -d)"
+git clone -q "$BARE61" "$TMPCLONE61"
+echo "unmanagedv2-from-origin" > "$TMPCLONE61/unmanaged-file.txt"
+( cd "$TMPCLONE61" && git commit -aq -m "origin updates the unmanaged file" && git push -q origin HEAD:refs/heads/main )
+rm -rf "$TMPCLONE61"
+# Dirty the UNMANAGED tracked file with a conflicting edit (blocks the
+# ff-merge) alongside a dirty MANAGED file (does not itself conflict, but
+# must not let the unmanaged one slip through).
+echo "unmanagedv1-local-edit" > "$W61/unmanaged-file.txt"
+echo "docv1-local-edit" > "$W61/.loom/docs/example.md"
+HEAD_BEFORE61="$(cd "$W61" && git rev-parse --short HEAD)"
+out61=$( cd "$W61" && PATH="$TEST_PATH" bash "$UPDATE_SCRIPT" --auto-resolve-safe-abort 2>&1 )
+rc61=$?
+assert_eq "1" "$rc61" "unmanaged dirty file alongside a managed one, EVEN with --auto-resolve-safe-abort: still hard-aborts"
+HEAD_AFTER61="$(cd "$W61" && git rev-parse --short HEAD)"
+assert_eq "$HEAD_BEFORE61" "$HEAD_AFTER61" "unmanaged dirty file case: HEAD untouched"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$(cat "$W61/unmanaged-file.txt")" == "unmanagedv1-local-edit" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} unmanaged dirty file is left untouched -- no auto-resolve attempted"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} unmanaged dirty file is left untouched -- no auto-resolve attempted"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out61" | grep -qi 'Refusing to guess or hard-reset'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} mixed managed+unmanaged dirty: falls through to the generic hard-abort message"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} mixed managed+unmanaged dirty: falls through to the generic hard-abort message"
+    echo "  output: $out61"
 fi
 
 # ============================================================

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -3213,6 +3213,92 @@ else
 fi
 
 # ============================================================
+# 62. Regression (#4951 safety floor, Judge finding on PR #4965): the
+#     content-identical classifier compares only COMMITTED refs, so a host can
+#     simultaneously have (a) diverged local commits that net to zero content
+#     diff vs. origin (the test-57 shape) AND (b) an entirely unrelated dirty
+#     tracked file OUTSIDE the Loom-managed set. `git merge --ff-only` fails on
+#     the history divergence alone, so this branch is reached — and before the
+#     fix, _ff_abort_content_identical returned true regardless of the working
+#     tree, letting --auto-resolve-safe-abort `git reset --hard` silently
+#     destroy that file's uncommitted changes. It must hard-abort instead, with
+#     the dirty file byte-for-byte intact.
+# ============================================================
+W62="$BASE_WORKDIR/w62"
+BARE62="$BASE_WORKDIR/w62-origin.git"
+new_fixture_with_origin "$W62" "$BARE62"
+echo "scratchv1" > "$W62/unmanaged-scratch.txt"
+( cd "$W62" && git add unmanaged-scratch.txt && git -c user.email=test@test -c user.name=test commit -q -m "add unmanaged scratch file" && git push -q origin HEAD:refs/heads/main )
+# Origin advances with content-free commits, so the two sides' TREES stay
+# identical -- exactly the content-identical divergence of tests 57/58.
+push_extra_commits_to_origin "$BARE62" 2 >/dev/null
+( cd "$W62" && git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "local commit that nets to no change" )
+# ... but now an unrelated, UNMANAGED tracked file is also dirty in the
+# working tree (an operator's manual scratch edit).
+echo "scratchv1-local-edit" > "$W62/unmanaged-scratch.txt"
+HEAD_BEFORE62="$(cd "$W62" && git rev-parse --short HEAD)"
+out62=$( cd "$W62" && PATH="$TEST_PATH" bash "$UPDATE_SCRIPT" --auto-resolve-safe-abort 2>&1 )
+rc62=$?
+assert_eq "1" "$rc62" "content-identical divergence + dirty UNMANAGED file, EVEN with --auto-resolve-safe-abort: still hard-aborts"
+HEAD_AFTER62="$(cd "$W62" && git rev-parse --short HEAD)"
+assert_eq "$HEAD_BEFORE62" "$HEAD_AFTER62" "content-identical divergence + dirty unmanaged file: HEAD untouched (no reset --hard)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$(cat "$W62/unmanaged-scratch.txt")" == "scratchv1-local-edit" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} uncommitted edit to an unmanaged file survives a content-identical divergence"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} uncommitted edit to an unmanaged file survives a content-identical divergence"
+    echo "  file now: $(cat "$W62/unmanaged-scratch.txt" 2>/dev/null)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out62" | grep -qi 'Refusing to guess or hard-reset'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} content-identical + dirty unmanaged file falls through to the generic hard-abort message"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} content-identical + dirty unmanaged file falls through to the generic hard-abort message"
+    echo "  output: $out62"
+fi
+
+# ============================================================
+# 63. Same combined shape as test 62, but the co-existing dirty tracked file IS
+#     Loom-managed. The content-identical classifier must STILL decline (its
+#     `git reset --hard` is only vouched-for on a clean tree), handing the case
+#     to the managed-dirty classifier instead. That one discards the managed
+#     edit it is authorized to discard and retries the fast-forward, which
+#     still cannot apply over the history divergence -- so the run hard-aborts
+#     (exit 1) with local commits intact, rather than silently hard-resetting
+#     from the content-identical branch. Deliberately NOT resolved end-to-end:
+#     widening either classifier to cover the combination is exactly the kind
+#     of "when genuinely unsure" widening the #4381 safety note forbids.
+# ============================================================
+W63="$BASE_WORKDIR/w63"
+BARE63="$BASE_WORKDIR/w63-origin.git"
+new_fixture_with_origin "$W63" "$BARE63"
+mkdir -p "$W63/.loom/docs"
+echo "docv1" > "$W63/.loom/docs/example.md"
+( cd "$W63" && git add .loom/docs/example.md && git -c user.email=test@test -c user.name=test commit -q -m "add managed doc" && git push -q origin HEAD:refs/heads/main )
+push_extra_commits_to_origin "$BARE63" 2 >/dev/null
+( cd "$W63" && git -c user.email=test@test -c user.name=test commit -q --allow-empty -m "local commit that nets to no change" )
+echo "docv1-local-edit" > "$W63/.loom/docs/example.md"
+HEAD_BEFORE63="$(cd "$W63" && git rev-parse --short HEAD)"
+out63=$( cd "$W63" && PATH="$TEST_PATH" bash "$UPDATE_SCRIPT" --auto-resolve-safe-abort 2>&1 )
+rc63=$?
+assert_eq "1" "$rc63" "content-identical divergence + dirty MANAGED file, EVEN with --auto-resolve-safe-abort: still hard-aborts"
+HEAD_AFTER63="$(cd "$W63" && git rev-parse --short HEAD)"
+assert_eq "$HEAD_BEFORE63" "$HEAD_AFTER63" "content-identical divergence + dirty managed file: HEAD untouched (no reset --hard)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out63" | grep -qi 'reset local main to origin/main'; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} content-identical branch never claims a reset --hard while the tree is dirty"
+    echo "  output: $out63"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} content-identical branch never claims a reset --hard while the tree is dirty"
+fi
+
+# ============================================================
 # 25. Launchd-sandbox guards (#4078): the whole suite exercises the REAL
 #     start/stop scripts, so prove it never reached the operator's live daemon.
 #     (a) The suite-level decoy loom-daemon is still alive — no by-name kill


### PR DESCRIPTION
## Summary

`sync_with_origin()`'s `git merge --ff-only` failure branch in
`defaults/scripts/cli/loom-daemon-update.sh` used to emit ONE generic
"resolve manually" message for two structurally distinct, often-safe failure
shapes — both hit on the 2026-08-02 fleet roll:

1. **Content-identical divergence**: local `<default>` diverged from
   `origin/<default>` in commit history, but `git diff origin/<default>...
   <default>` is empty (e.g. a resync commit + its own revert netting to no
   change — the robb-STUDIO incident shape). Safe resolution: `git reset
   --hard origin/<default>`.
2. **Dirty-but-managed-only**: the ff-merge is blocked by dirty tracked
   file(s) that are ALL Loom-managed installed copies (mirroring
   `resync-installed.sh`'s own installed-surface map: `.loom/hooks/`,
   `.loom/scripts/`, `.loom/roles/`, `.loom/docs/`, `.loom/runtimes/`,
   `.loom/bin/`, `.claude/commands/loom/`, `.loom/install-metadata.json`,
   plus the marker-delimited managed block inside `.gitignore` — the
   loom-worker-1 incident shape). Safe resolution: `git checkout --` those
   paths, then re-run `resync-installed.sh`.

By default, the abort message now names the exact safe command instead of a
bare "resolve manually" — **no behavior change to what actually executes**.
A new `--auto-resolve-safe-abort` flag performs the resolution automatically
instead.

Any other cause — genuine content divergence, or **any** dirty file outside
the managed set (even alongside managed ones — the classification is
conjunctive, not "any") — still hard-aborts completely unchanged. This is
the safety-critical branch (#4381's "automation destroys real machine state"
precedent), so the classification is deliberately narrow and falls through
to the existing hard abort whenever genuinely unsure.

## Implementation notes

- `_ff_abort_content_identical()`'s `git merge-base --is-ancestor` guard is
  load-bearing, not an optimization: without it, the three-dot diff
  trivially reduces to "diff local HEAD against itself" whenever local
  hasn't diverged in commit history (the far more common "just behind,
  blocked by a dirty file" shape) — which is *always* empty regardless of
  what origin changed, and would misclassify essentially every plain
  dirty-file abort as "content-identical," risking an incorrect
  `reset --hard` under `--auto-resolve-safe-abort`.
- The managed-surface prefix list is hand-mirrored from
  `resync-installed.sh`'s own header comment (not sourced), with a comment
  pointing back so it's updated in lockstep if that list ever widens again
  (as #4239 already did once).
- `.gitignore` gets special handling: only the marker-delimited Loom-managed
  block (`# >>> loom-managed (do not edit) >>>` / `# <<< loom-managed <<<`,
  matching `loom-daemon`'s `GITIGNORE_BEGIN_MARKER`/`GITIGNORE_END_MARKER`)
  is treated as managed — a consumer's own hand-edited lines outside that
  block are never silently discarded.

## Test plan

- [x] `./defaults/scripts/tests/test-loom-daemon-update.sh` — 153/153 passing
      (5 new test cases added: content-identical default + auto-resolve,
      managed-only-dirty default + auto-resolve, and a regression case
      proving an unmanaged dirty file alongside a managed one still forces
      the hard abort even with `--auto-resolve-safe-abort` passed).
- [x] Fixed test 38's fixture, which previously diverged using two
      `--allow-empty` commits on each side — that setup coincidentally
      produces an empty three-dot diff, so it would have collided with the
      new content-identical classification. Replaced with real (non-empty)
      content divergence on both sides so it still exercises the genuine
      hard-abort regression path.
- [x] `shellcheck` clean on both changed files (only the pre-existing
      unrelated `SC2015` info-level note at line 825).
- [x] The existing #4381 production-binary checksum guard test still passes.

Closes #4951