### PR TITLE
fix(champion): stop duplicate NEEDS REVISION comments on unrevised proposals

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -70,7 +70,7 @@
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:evaluating
-  description: "Champion is evaluating this proposal. Applied by: Champion only (claim label). Stale after LOOM_STALE_EVALUATING_MINUTES (15m)."
+  description: "Champion is evaluating this proposal (claim label, stale after 15m). Applied by: Champion only."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:review-requested

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -69,6 +69,10 @@
   description: "Judge is reviewing this PR. Applied by: Judge only. Stale after LOOM_STALE_REVIEWING_MINUTES (30m)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
+- name: loom:evaluating
+  description: "Champion is evaluating this proposal. Applied by: Champion only (claim label). Stale after LOOM_STALE_EVALUATING_MINUTES (15m)."
+  color: "F59E0B"  # amber-500 - matches other in-progress states
+
 - name: loom:review-requested
   description: "PR ready for Judge to review. Applied by: Builder when opening PR."
   color: "10B981"  # emerald-500

--- a/defaults/.claude/commands/loom/champion-issue-promo.md
+++ b/defaults/.claude/commands/loom/champion-issue-promo.md
@@ -213,6 +213,79 @@ Use conservative judgment. **Do NOT promote** if:
 
 ---
 
+## Concurrency Guard and Idempotency (`loom:evaluating`)
+
+**Problem this section fixes (#4954)**: an unrevised `loom:architect` proposal re-entering the queue every cycle used to get a **full re-evaluation and a fresh "NEEDS REVISION" comment every single time** — six duplicate comments over ~6.5 hours in the incident that motivated this section — and two evaluations landed comments 40 seconds apart because nothing claimed the issue while it was being evaluated. The same three mechanisms `champion-pr-merge.md`'s Capped-PR Recovery Pass already uses for PRs (idempotency marker, escalation marker, `loom:operator-only` routing) apply here, adapted with a Curator-style (`loom:curating`) claim label instead of the full Judge-style CAS machinery — proposal evaluation runs seconds to a few minutes, not the review-duration timescale `judge.md`'s stale-claim system is sized for.
+
+**Applies to every proposal evaluated by this file** — `loom:curated`, `loom:architect`, `loom:hermit`, and `loom:auditor` alike — not just the `loom:architect` case that surfaced it.
+
+### Idempotency check (run BEFORE claiming — skip without commenting on a match)
+
+Compute a marker keyed to the issue's `updatedAt` so a genuine body revision (which bumps `updatedAt`) always gets a fresh evaluation, while an unchanged issue never gets re-commented:
+
+```bash
+ISSUE_NUMBER=<number>
+
+# Cached ("$GH_READ") — this is a content check, not claim arbitration.
+ISSUE_JSON=$("$GH_READ" issue view "$ISSUE_NUMBER" --json updatedAt,labels,comments)
+UPDATED_AT=$(echo "$ISSUE_JSON" | jq -r '.updatedAt')
+VERDICT_MARKER="<!-- champion:proposal-verdict:$UPDATED_AT -->"
+
+if echo "$ISSUE_JSON" | jq -e --arg m "$VERDICT_MARKER" \
+     '.comments[] | select(.body | contains($m))' >/dev/null; then
+  echo "Already evaluated #$ISSUE_NUMBER at revision $UPDATED_AT — skipping (no comment, no claim)"
+  # Continue the batch to the next issue; do not read further or claim.
+fi
+```
+
+If the marker is present, **stop here for this issue** — do not read comments further, do not claim, do not comment. This is the mechanism that turns "6 identical NEEDS REVISION comments" into "1 comment, then silent skips" for a truly unrevised proposal.
+
+### Claim (staleness-aware, run only when NOT skipped above)
+
+```bash
+ISSUE_NUMBER=<number>
+
+# Plain `gh` — claim arbitration, never "$GH_READ" (mirrors judge.md's rule for
+# its Stale Claim Check: a stale cache would reintroduce the double-claim race
+# this exists to close).
+CURRENT_LABELS=$(gh issue view "$ISSUE_NUMBER" --json labels --jq '[.labels[].name] | join(",")')
+
+if echo ",$CURRENT_LABELS," | grep -q ",loom:evaluating,"; then
+  CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$ISSUE_NUMBER/timeline" --paginate \
+    --jq '[.[] | select(.event=="labeled" and .label.name=="loom:evaluating")] | last | .created_at // empty' \
+    | sort | tail -n 1)
+  if [ -n "$CLAIMED_AT" ]; then
+    CLAIM_AGE_MIN=$(( ($(date -u +%s) - $(date -u -d "$CLAIMED_AT" +%s)) / 60 ))
+  else
+    CLAIM_AGE_MIN=0   # unknown — fail safe, treat as fresh
+  fi
+  if [ "$CLAIM_AGE_MIN" -lt "${LOOM_STALE_EVALUATING_MINUTES:-15}" ]; then
+    echo "#$ISSUE_NUMBER already claimed by a concurrent evaluation (${CLAIM_AGE_MIN}m ago) — skipping, not stomping"
+    # Continue the batch to the next issue.
+  else
+    echo "Reclaiming stale loom:evaluating claim on #$ISSUE_NUMBER (age ${CLAIM_AGE_MIN}m >= ${LOOM_STALE_EVALUATING_MINUTES:-15}m) — a prior Champion pass likely died mid-evaluation"
+  fi
+fi
+
+gh issue edit "$ISSUE_NUMBER" --add-label "loom:evaluating"
+```
+
+`LOOM_STALE_EVALUATING_MINUTES` (default **15**) — named to mirror `LOOM_STALE_REVIEWING_MINUTES`/`LOOM_STALE_TREATING_MINUTES`, on a shorter scale since proposal evaluation has no build/CI wait.
+
+**Release the claim** — `--remove-label "loom:evaluating"` — as part of the SAME `gh issue edit` command that writes the outcome (promote, reject, or escalate) in Steps 3/4 below, never as a separate call. This keeps "claimed but no verdict written yet" the only window where the label is genuinely in flight.
+
+### Verdict-time recheck (immediately before writing the outcome)
+
+Before posting a verdict comment and writing labels in Step 3 or Step 4, re-read labels one more time — this shrinks the race window from the full evaluation duration to the gap between the recheck and the write:
+
+```bash
+RECHECK_LABELS=$(gh issue view "$ISSUE_NUMBER" --json labels --jq '[.labels[].name] | join(",")')
+```
+
+If `loom:evaluating` is no longer present (reclaimed as stale by a concurrent Champion pass while you were evaluating), **abort**: do not comment, do not write any label. A later pass will pick this issue up cleanly.
+
+---
+
 ## Promotion Workflow
 
 ### Step 1: Read the Issue
@@ -240,14 +313,18 @@ Assess the issue's alignment with current project goals:
 
 **Step 3b: Promote with Tier Label**
 
+Re-run the "Verdict-time recheck" (above) immediately before this write; abort if `loom:evaluating` is gone.
+
 ```bash
-# Add loom:issue AND the appropriate tier label
+# Add loom:issue AND the appropriate tier label; release the loom:evaluating
+# claim in the SAME command that writes the outcome.
 # NOTE: loom:curated is preserved (indicates issue went through curation)
 # Other proposal labels (loom:architect, loom:hermit, loom:auditor) are removed
 gh issue edit <number> \
   --remove-label "loom:architect" \
   --remove-label "loom:hermit" \
   --remove-label "loom:auditor" \
+  --remove-label "loom:evaluating" \
   --add-label "loom:issue" \
   --add-label "tier:goal-advancing"  # OR tier:goal-supporting OR tier:maintenance
 
@@ -275,10 +352,42 @@ This issue has been evaluated and promoted to \`loom:issue\` status. All quality
 
 ### Step 4: Reject (One or More Criteria Fail)
 
-If any criteria fail, leave detailed feedback but keep the original proposal label:
+If any criteria fail, first check whether this rejection should **escalate** instead of posting another comment — the mechanism that stops the 6x duplicate-comment loop:
 
 ```bash
-gh issue comment <number> --body "**Champion Review: NEEDS REVISION**
+# How many NEEDS REVISION verdicts has Champion already posted on this issue
+# (any revision)? This is the "N identical verdicts" counter from the issue.
+PRIOR_REJECTIONS=$(echo "$ISSUE_JSON" | jq \
+  '[.comments[] | select(.body | contains("Champion Review: NEEDS REVISION"))] | length')
+ALREADY_ROUTED=$(echo "$ISSUE_JSON" | jq -e '.labels[] | select(.name=="loom:operator-only")' >/dev/null && echo yes || echo no)
+```
+
+**If `PRIOR_REJECTIONS >= 2` and not already routed** (N=2 threshold): escalate instead of posting a third+ rejection. Re-run the verdict-time recheck first:
+
+```bash
+ESCALATE_MARKER="<!-- champion:proposal-escalated -->"
+gh issue comment <number> --body "$ESCALATE_MARKER
+**Champion: Escalating to Operator — Repeated Rejection Without Revision**
+
+This proposal has now been rejected $PRIOR_REJECTIONS+ times with converging feedback, but has not been revised to address it. Re-running an identical evaluation each cycle only produces duplicate comments; it doesn't move this forward.
+
+**Recurring findings:**
+- [Criterion that failed, repeated across rejections]: [Specific reason]
+
+A human needs to decide whether to revise this proposal, close it, or accept it as-is.
+
+---
+*Automated by Champion role*" \
+  && gh issue edit <number> --remove-label "loom:evaluating" --add-label "loom:operator-only"
+```
+
+`loom:operator-only` removes the issue from every future promotion pass (see "When NOT to Promote" in Batch Processing below), so this escalation comment posts exactly once per issue.
+
+**Otherwise** (first or second rejection, not yet routed): leave detailed feedback, keep the original proposal label, and release the claim in the same command:
+
+```bash
+gh issue comment <number> --body "$VERDICT_MARKER
+**Champion Review: NEEDS REVISION**
 
 This issue requires additional work before promotion to \`loom:issue\`:
 
@@ -292,8 +401,11 @@ This issue requires additional work before promotion to \`loom:issue\`:
 Keeping original proposal label. The proposing role or issue author can address these concerns and resubmit.
 
 ---
-*Automated by Champion role*"
+*Automated by Champion role*" \
+  && gh issue edit <number> --remove-label "loom:evaluating"
 ```
+
+The `$VERDICT_MARKER` (computed in "Idempotency check" above, keyed to this issue's `updatedAt`) is what makes the next cycle's idempotency check skip silently instead of re-evaluating — omitting it reopens the duplicate-comment loop this section exists to close.
 
 Do NOT remove the proposal label (`loom:curated`, `loom:architect`, `loom:hermit`, or `loom:auditor`) when rejecting.
 
@@ -310,14 +422,20 @@ Work through all available curated issues, applying the tier-based rate limits t
 
 Continue evaluating issues until all have been processed or all applicable tier limits are reached. This prevents issues from waiting unnecessarily across multiple 10-minute intervals when they've already met quality criteria.
 
+**Per-issue order in the loop**: run the "Idempotency check" first (skip silently on a marker match, no claim taken), then the "Claim" step (skip if a concurrent evaluation holds a fresh `loom:evaluating`, reclaim if stale) — both from "Concurrency Guard and Idempotency" above — before Step 1 (Read). A skip at either point means: continue the loop to the next issue, do not count it against the tier limits (it was neither promoted nor rejected this pass).
+
 ### When NOT to Promote
 
 Regardless of quality, do NOT promote an issue if:
 - Issue has `loom:blocked` label
-- Issue has `loom:operator-only` label (requires human action outside automation — credentials, infra rotations, manual deploys, hardware access; sweep will skip these in pre-flight, so promoting to `loom:issue` would only stall the queue)
+- Issue has `loom:operator-only` label (requires human action outside automation — credentials, infra rotations, manual deploys, hardware access; sweep will skip these in pre-flight, so promoting to `loom:issue` would only stall the queue). This is also the terminal state the N=2 escalation in Step 4 routes to, so an escalated proposal is automatically excluded from every future pass.
 - Issue title contains "DISCUSSION" or "RFC" (requires human input)
 - Issue mentions breaking changes without migration plan
 - Issue references external dependencies that need coordination
+
+### When NOT to Even Claim (fresh `loom:evaluating`)
+
+Do not claim or evaluate an issue that already carries a fresh `loom:evaluating` label — a concurrent Champion pass (this process's own batch loop, a cron tick, or a role-runner tick on another host) is actively evaluating it. See "Claim (staleness-aware...)" above for the exact age check; skip and continue the batch rather than waiting.
 
 ---
 

--- a/defaults/.claude/commands/loom/champion-issue-promo.md
+++ b/defaults/.claude/commands/loom/champion-issue-promo.md
@@ -221,24 +221,49 @@ Use conservative judgment. **Do NOT promote** if:
 
 ### Idempotency check (run BEFORE claiming — skip without commenting on a match)
 
-Compute a marker keyed to the issue's `updatedAt` so a genuine body revision (which bumps `updatedAt`) always gets a fresh evaluation, while an unchanged issue never gets re-commented:
+Compute a marker keyed to a **hash of the proposal's own text** (title + body), so a genuine revision always gets a fresh evaluation while an unchanged proposal never gets re-commented:
 
 ```bash
 ISSUE_NUMBER=<number>
 
 # Cached ("$GH_READ") — this is a content check, not claim arbitration.
-ISSUE_JSON=$("$GH_READ" issue view "$ISSUE_NUMBER" --json updatedAt,labels,comments)
-UPDATED_AT=$(echo "$ISSUE_JSON" | jq -r '.updatedAt')
-VERDICT_MARKER="<!-- champion:proposal-verdict:$UPDATED_AT -->"
+ISSUE_JSON=$("$GH_READ" issue view "$ISSUE_NUMBER" --json title,body,labels,comments)
+
+# Portable sha256 (sha256sum on Linux, shasum on macOS) — same fallback shape
+# the repo's own scripts use. 16 hex chars is plenty for change detection.
+_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum
+  elif command -v shasum >/dev/null 2>&1; then shasum -a 256
+  else cksum; fi
+}
+BODY_HASH=$(printf '%s\n%s' \
+  "$(echo "$ISSUE_JSON" | jq -r '.title // ""')" \
+  "$(echo "$ISSUE_JSON" | jq -r '.body // ""')" \
+  | _sha256 | awk '{print substr($1, 1, 16)}')
+VERDICT_MARKER="<!-- champion:proposal-verdict:body-$BODY_HASH -->"
 
 if echo "$ISSUE_JSON" | jq -e --arg m "$VERDICT_MARKER" \
      '.comments[] | select(.body | contains($m))' >/dev/null; then
-  echo "Already evaluated #$ISSUE_NUMBER at revision $UPDATED_AT — skipping (no comment, no claim)"
+  echo "Already evaluated #$ISSUE_NUMBER at body revision $BODY_HASH — skipping (no comment, no claim)"
   # Continue the batch to the next issue; do not read further or claim.
 fi
 ```
 
 If the marker is present, **stop here for this issue** — do not read comments further, do not claim, do not comment. This is the mechanism that turns "6 identical NEEDS REVISION comments" into "1 comment, then silent skips" for a truly unrevised proposal.
+
+#### Why a body hash and NOT the issue's `updatedAt` (#4966)
+
+An earlier draft of this check keyed the marker to the issue's aggregate `updatedAt`. That is **self-invalidating and can never match**: the marker baked into a verdict comment necessarily records the `updatedAt` read *before* that comment was posted, and posting the comment itself bumps `updatedAt` forward. Every subsequent pass therefore computes a *newer* `UPDATED_AT`, `contains($m)` never matches, and the proposal is fully re-evaluated and re-commented on every cycle — exactly the loop this section exists to close.
+
+This is the same trap `judge.md` and [`daemon-reference.md`'s "Stale-claim reconciliation"](https://github.com/rjwalters/loom/blob/main/defaults/docs/daemon-reference.md#stale-claim-reconciliation--the-sweep-journal-3953-fixed-3975-extended-to-pr-side-claims-4367) already document for `loom:reviewing`/`loom:treating` staleness ("a stand-down comment self-refreshes `updatedAt` but not the label event"), and the fix has the same shape: **anchor the check to something Champion's own write does not bump.** For claim staleness that anchor is the label's own `labeled` timeline-event timestamp; for *content* staleness it is the proposal text itself. A hash of title + body changes if and only if the proposal is actually edited — comments, label churn, cross-references, and Champion's own verdict all leave it untouched.
+
+The two anchors are complementary, not interchangeable:
+
+| Question | Anchor | Bumped by a Champion comment? |
+|---|---|---|
+| "Has this proposal been revised since my last verdict?" | hash of title + body (this check) | **No** |
+| "Is the `loom:evaluating` claim stale?" | the label's own `labeled` timeline event (see Claim below) | **No** |
+| ~~"…either of the above"~~ | ~~issue `updatedAt`~~ | **Yes — never use it for either** |
 
 ### Claim (staleness-aware, run only when NOT skipped above)
 
@@ -405,7 +430,7 @@ Keeping original proposal label. The proposing role or issue author can address 
   && gh issue edit <number> --remove-label "loom:evaluating"
 ```
 
-The `$VERDICT_MARKER` (computed in "Idempotency check" above, keyed to this issue's `updatedAt`) is what makes the next cycle's idempotency check skip silently instead of re-evaluating — omitting it reopens the duplicate-comment loop this section exists to close.
+The `$VERDICT_MARKER` (computed in "Idempotency check" above, keyed to a hash of this issue's title + body) is what makes the next cycle's idempotency check skip silently instead of re-evaluating — omitting it, or substituting a timestamp-keyed marker, reopens the duplicate-comment loop this section exists to close.
 
 Do NOT remove the proposal label (`loom:curated`, `loom:architect`, `loom:hermit`, or `loom:auditor`) when rejecting.
 

--- a/defaults/.claude/commands/loom/champion-reference.md
+++ b/defaults/.claude/commands/loom/champion-reference.md
@@ -141,6 +141,34 @@ gh pr view "$PR_NUMBER" --comments
 
 ---
 
+### Edge Case 5c: Unrevised Proposal Re-Entering the Evaluation Queue Every Cycle (#4954)
+
+**Scenario**: A `loom:curated`/`loom:architect`/`loom:hermit`/`loom:auditor` proposal fails promotion criteria and gets a "NEEDS REVISION" comment, but the author never revises it. Every subsequent Champion pass (cron tick, role-runner tick, or a fresh `/loom:sweep` dispatch) re-discovers the same unchanged issue in its Priority 2/3 listing and, without a guard, re-evaluates it from scratch and posts an equivalent rejection comment — observed live as 6 duplicate "NEEDS REVISION" comments over ~6.5 hours on one proposal, with two of them landing 40 seconds apart because nothing claimed the issue mid-evaluation.
+
+**Handling**: `champion-issue-promo.md`'s "Concurrency Guard and Idempotency (`loom:evaluating`)" section (adapted from this file's own Capped-PR Recovery pattern — `PARK_MARKER`/`CLOSE_MARKER` below — and from Judge's `loom:reviewing` claim/stale-check convention):
+
+```bash
+# Idempotency: skip without commenting if already evaluated at this revision.
+VERDICT_MARKER="<!-- champion:proposal-verdict:$UPDATED_AT -->"   # keyed to the issue's updatedAt
+
+# Concurrency: claim before evaluating, staleness-aware (LOOM_STALE_EVALUATING_MINUTES, default 15m).
+gh issue edit <number> --add-label "loom:evaluating"
+```
+
+**Decision**:
+
+| Finding | Decision | Action |
+|---------|----------|--------|
+| A prior Champion verdict comment already carries `VERDICT_MARKER` for the issue's **current** `updatedAt` | **Unchanged since last review — skip** | No comment, no claim, no label change. A genuine body edit (which bumps `updatedAt`) always produces a fresh marker and a fresh evaluation. |
+| Issue already carries `loom:evaluating` and the claim is younger than `LOOM_STALE_EVALUATING_MINUTES` | **Concurrent evaluation in progress** | Skip, do not stomp the claim; continue the batch. |
+| Issue already carries `loom:evaluating` and the claim is older than `LOOM_STALE_EVALUATING_MINUTES` | **Stale claim — a prior Champion pass likely died mid-evaluation** | Reclaim (`--add-label "loom:evaluating"` again) then evaluate normally. |
+| ≥2 prior "NEEDS REVISION" comments exist and the issue is not already `loom:operator-only` | **N=2 threshold reached** | Escalate instead of posting a third+ near-identical rejection: comment with `<!-- champion:proposal-escalated -->` and add `loom:operator-only` (Champion routes, a human decides — the proposal label stays, nothing is closed). |
+| Fewer than 2 prior rejections | **Ordinary reject** | Post the `VERDICT_MARKER`-tagged "NEEDS REVISION" comment as before, release `loom:evaluating`. |
+
+**Rationale**: This is the *same* idempotency-marker + escalation-marker + operator-routing shape as Edge Case 5b's Capped-PR Recovery Pass, applied to the proposal-evaluation side of Champion instead of the PR-merge side — a marker keyed to the event that would invalidate it (here, the issue's `updatedAt`; there, the latest Judge rejection comment ID) stops duplicate comments, and a bounded escalation threshold (here, N=2 identical verdicts; there, the Doctor-cycle cap) converts an infinite silent loop into a single human-visible routing decision.
+
+---
+
 ### Edge Case 6: PR Modifying Only Test Files
 
 **Scenario**: PR changes only test files (e.g., `*.test.ts`, `*.spec.rs`).
@@ -359,6 +387,7 @@ gh issue create --title "Follow-on: Work identified in PR #$PR_NUMBER" --label "
 | Merge conflicts | Fail | Comment and skip |
 | Stale PR (>24h) | Route to Doctor | Comment once (idempotent marker), swap `loom:pr` → `loom:changes-requested` |
 | Doctor-cycle-capped PR (`loom:blocked` + `loom:changes-requested`) | Three-way on forward progress | Distinct new defects → grant a cycle (remove `loom:blocked` only); same-defect/ambiguous → keep parked with rationale; approach not viable → add `loom:operator-only`, recommend closing (never close it) |
+| Unrevised proposal re-entering the queue every cycle | Idempotency marker + N=2 escalation | Unchanged since last review → skip silently (marker match); ≥2 prior rejections → escalate to `loom:operator-only` instead of a 3rd+ duplicate comment; `loom:evaluating` claim prevents concurrent double-evaluation |
 | Test-only changes | Allow | Standard criteria apply |
 | Human holds PR (removes `loom:pr`) | Skip | Not a merge candidate without `loom:pr` |
 | Multiple linked issues | Allow | Verify all closed |

--- a/defaults/.claude/commands/loom/champion-reference.md
+++ b/defaults/.claude/commands/loom/champion-reference.md
@@ -149,7 +149,9 @@ gh pr view "$PR_NUMBER" --comments
 
 ```bash
 # Idempotency: skip without commenting if already evaluated at this revision.
-VERDICT_MARKER="<!-- champion:proposal-verdict:$UPDATED_AT -->"   # keyed to the issue's updatedAt
+# $BODY_HASH = sha256(title + body), first 16 hex chars — NOT the issue's
+# aggregate updatedAt, which Champion's own comment would bump (see #4966).
+VERDICT_MARKER="<!-- champion:proposal-verdict:body-$BODY_HASH -->"
 
 # Concurrency: claim before evaluating, staleness-aware (LOOM_STALE_EVALUATING_MINUTES, default 15m).
 gh issue edit <number> --add-label "loom:evaluating"
@@ -159,13 +161,15 @@ gh issue edit <number> --add-label "loom:evaluating"
 
 | Finding | Decision | Action |
 |---------|----------|--------|
-| A prior Champion verdict comment already carries `VERDICT_MARKER` for the issue's **current** `updatedAt` | **Unchanged since last review — skip** | No comment, no claim, no label change. A genuine body edit (which bumps `updatedAt`) always produces a fresh marker and a fresh evaluation. |
+| A prior Champion verdict comment already carries `VERDICT_MARKER` for the issue's **current** title+body hash | **Unrevised since last review — skip** | No comment, no claim, no label change. A genuine title/body edit changes the hash and always produces a fresh marker and a fresh evaluation; comments and label churn do not. |
 | Issue already carries `loom:evaluating` and the claim is younger than `LOOM_STALE_EVALUATING_MINUTES` | **Concurrent evaluation in progress** | Skip, do not stomp the claim; continue the batch. |
 | Issue already carries `loom:evaluating` and the claim is older than `LOOM_STALE_EVALUATING_MINUTES` | **Stale claim — a prior Champion pass likely died mid-evaluation** | Reclaim (`--add-label "loom:evaluating"` again) then evaluate normally. |
 | ≥2 prior "NEEDS REVISION" comments exist and the issue is not already `loom:operator-only` | **N=2 threshold reached** | Escalate instead of posting a third+ near-identical rejection: comment with `<!-- champion:proposal-escalated -->` and add `loom:operator-only` (Champion routes, a human decides — the proposal label stays, nothing is closed). |
 | Fewer than 2 prior rejections | **Ordinary reject** | Post the `VERDICT_MARKER`-tagged "NEEDS REVISION" comment as before, release `loom:evaluating`. |
 
-**Rationale**: This is the *same* idempotency-marker + escalation-marker + operator-routing shape as Edge Case 5b's Capped-PR Recovery Pass, applied to the proposal-evaluation side of Champion instead of the PR-merge side — a marker keyed to the event that would invalidate it (here, the issue's `updatedAt`; there, the latest Judge rejection comment ID) stops duplicate comments, and a bounded escalation threshold (here, N=2 identical verdicts; there, the Doctor-cycle cap) converts an infinite silent loop into a single human-visible routing decision.
+**Rationale**: This is the *same* idempotency-marker + escalation-marker + operator-routing shape as Edge Case 5b's Capped-PR Recovery Pass, applied to the proposal-evaluation side of Champion instead of the PR-merge side — a marker keyed to the thing whose change would invalidate it (here, the proposal's own title+body text; there, the latest Judge rejection comment ID) stops duplicate comments, and a bounded escalation threshold (here, N=2 identical verdicts; there, the Doctor-cycle cap) converts an infinite silent loop into a single human-visible routing decision.
+
+**Anchor discipline (#4966)**: neither half of this mechanism may key off the issue's aggregate `updatedAt` — Champion's own verdict comment bumps it, so a marker stamped with it can never match on the next pass and the skip never fires. Content staleness anchors on the title+body hash; claim staleness anchors on the `loom:evaluating` label's own `labeled` timeline event. Both are invisible to Champion's own comment writes. This is the same rule `judge.md`/`daemon-reference.md` already apply to `loom:reviewing`/`loom:treating` staleness.
 
 ---
 
@@ -387,7 +391,7 @@ gh issue create --title "Follow-on: Work identified in PR #$PR_NUMBER" --label "
 | Merge conflicts | Fail | Comment and skip |
 | Stale PR (>24h) | Route to Doctor | Comment once (idempotent marker), swap `loom:pr` → `loom:changes-requested` |
 | Doctor-cycle-capped PR (`loom:blocked` + `loom:changes-requested`) | Three-way on forward progress | Distinct new defects → grant a cycle (remove `loom:blocked` only); same-defect/ambiguous → keep parked with rationale; approach not viable → add `loom:operator-only`, recommend closing (never close it) |
-| Unrevised proposal re-entering the queue every cycle | Idempotency marker + N=2 escalation | Unchanged since last review → skip silently (marker match); ≥2 prior rejections → escalate to `loom:operator-only` instead of a 3rd+ duplicate comment; `loom:evaluating` claim prevents concurrent double-evaluation |
+| Unrevised proposal re-entering the queue every cycle | Idempotency marker + N=2 escalation | Unrevised since last review → skip silently (title+body hash marker match, never `updatedAt`); ≥2 prior rejections → escalate to `loom:operator-only` instead of a 3rd+ duplicate comment; `loom:evaluating` claim prevents concurrent double-evaluation |
 | Test-only changes | Allow | Standard criteria apply |
 | Human holds PR (removes `loom:pr`) | Skip | Not a merge candidate without `loom:pr` |
 | Multiple linked issues | Allow | Verify all closed |

--- a/defaults/.claude/commands/loom/champion.md
+++ b/defaults/.claude/commands/loom/champion.md
@@ -38,22 +38,27 @@ If found, **read and follow instructions in `.claude/commands/loom/champion-pr-m
 
 ### Priority 2: Quality Issues Ready to Promote
 
-If no PRs need merging, check for curated issues:
+If no PRs need merging, check for curated issues. Exclude `loom:evaluating` (a
+fresh claim from a concurrent Champion evaluation, #4954) so a batch doesn't
+re-discover work another pass already claimed — `updatedAt` is also fetched
+here for `champion-issue-promo.md`'s idempotency check:
 
 ```bash
 gh issue list \
   --label="loom:curated" \
   --state=open \
   --limit=500 \
-  --json number,title,body,labels,comments \
-  --jq '.[] | "#\(.number) \(.title)"'
+  --json number,title,body,labels,comments,updatedAt \
+  --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
+  "#\(.number) \(.title)"'
 ```
 
 If found, **read and follow instructions in `.claude/commands/loom/champion-issue-promo.md`**.
 
 ### Priority 3: Architect/Hermit/Auditor Proposals Ready to Promote
 
-If no curated issues need promotion, check for well-formed proposals:
+If no curated issues need promotion, check for well-formed proposals. Same
+`loom:evaluating` exclusion and `updatedAt` fetch as Priority 2 above:
 
 ```bash
 # Check for Architect proposals
@@ -61,27 +66,30 @@ gh issue list \
   --label="loom:architect" \
   --state=open \
   --limit=500 \
-  --json number,title,body,labels,comments \
-  --jq '.[] | "#\(.number) \(.title) [architect]"'
+  --json number,title,body,labels,comments,updatedAt \
+  --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
+  "#\(.number) \(.title) [architect]"'
 
 # Check for Hermit proposals
 gh issue list \
   --label="loom:hermit" \
   --state=open \
   --limit=500 \
-  --json number,title,body,labels,comments \
-  --jq '.[] | "#\(.number) \(.title) [hermit]"'
+  --json number,title,body,labels,comments,updatedAt \
+  --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
+  "#\(.number) \(.title) [hermit]"'
 
 # Check for Auditor bug reports
 gh issue list \
   --label="loom:auditor" \
   --state=open \
   --limit=500 \
-  --json number,title,body,labels,comments \
-  --jq '.[] | "#\(.number) \(.title) [auditor]"'
+  --json number,title,body,labels,comments,updatedAt \
+  --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
+  "#\(.number) \(.title) [auditor]"'
 ```
 
-If found, **read and follow instructions in `.claude/commands/loom/champion-issue-promo.md`**. Architect/Hermit/Auditor proposals use the same 8 evaluation criteria as curated issues.
+If found, **read and follow instructions in `.claude/commands/loom/champion-issue-promo.md`**. Architect/Hermit/Auditor proposals use the same 8 evaluation criteria as curated issues, plus the concurrency guard and idempotency rules in that file's "Concurrency Guard and Idempotency (`loom:evaluating`)" section.
 
 **Note**: Proposals from Architect, Hermit, and Auditor roles are typically well-formed since these roles generate detailed, implementation-ready issues. Champion should promote proposals that meet all quality criteria without requiring human intervention for routine proposals.
 

--- a/defaults/.claude/commands/loom/champion.md
+++ b/defaults/.claude/commands/loom/champion.md
@@ -40,15 +40,16 @@ If found, **read and follow instructions in `.claude/commands/loom/champion-pr-m
 
 If no PRs need merging, check for curated issues. Exclude `loom:evaluating` (a
 fresh claim from a concurrent Champion evaluation, #4954) so a batch doesn't
-re-discover work another pass already claimed — `updatedAt` is also fetched
-here for `champion-issue-promo.md`'s idempotency check:
+re-discover work another pass already claimed — `title`/`body` feed
+`champion-issue-promo.md`'s body-hash idempotency check (the issue's aggregate
+`updatedAt` is deliberately NOT used for it, #4966):
 
 ```bash
 gh issue list \
   --label="loom:curated" \
   --state=open \
   --limit=500 \
-  --json number,title,body,labels,comments,updatedAt \
+  --json number,title,body,labels,comments \
   --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
   "#\(.number) \(.title)"'
 ```
@@ -58,7 +59,7 @@ If found, **read and follow instructions in `.claude/commands/loom/champion-issu
 ### Priority 3: Architect/Hermit/Auditor Proposals Ready to Promote
 
 If no curated issues need promotion, check for well-formed proposals. Same
-`loom:evaluating` exclusion and `updatedAt` fetch as Priority 2 above:
+`loom:evaluating` exclusion and `title`/`body` fetch as Priority 2 above:
 
 ```bash
 # Check for Architect proposals
@@ -66,7 +67,7 @@ gh issue list \
   --label="loom:architect" \
   --state=open \
   --limit=500 \
-  --json number,title,body,labels,comments,updatedAt \
+  --json number,title,body,labels,comments \
   --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
   "#\(.number) \(.title) [architect]"'
 
@@ -75,7 +76,7 @@ gh issue list \
   --label="loom:hermit" \
   --state=open \
   --limit=500 \
-  --json number,title,body,labels,comments,updatedAt \
+  --json number,title,body,labels,comments \
   --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
   "#\(.number) \(.title) [hermit]"'
 
@@ -84,7 +85,7 @@ gh issue list \
   --label="loom:auditor" \
   --state=open \
   --limit=500 \
-  --json number,title,body,labels,comments,updatedAt \
+  --json number,title,body,labels,comments \
   --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
   "#\(.number) \(.title) [auditor]"'
 ```

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -70,7 +70,7 @@
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:evaluating
-  description: "Champion is evaluating this proposal. Applied by: Champion only (claim label). Stale after LOOM_STALE_EVALUATING_MINUTES (15m)."
+  description: "Champion is evaluating this proposal (claim label, stale after 15m). Applied by: Champion only."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
 - name: loom:review-requested

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -69,6 +69,10 @@
   description: "Judge is reviewing this PR. Applied by: Judge only. Stale after LOOM_STALE_REVIEWING_MINUTES (30m)."
   color: "F59E0B"  # amber-500 - matches other in-progress states
 
+- name: loom:evaluating
+  description: "Champion is evaluating this proposal. Applied by: Champion only (claim label). Stale after LOOM_STALE_EVALUATING_MINUTES (15m)."
+  color: "F59E0B"  # amber-500 - matches other in-progress states
+
 - name: loom:review-requested
   description: "PR ready for Judge to review. Applied by: Builder when opening PR."
   color: "10B981"  # emerald-500


### PR DESCRIPTION
## Summary

Champion re-evaluated unchanged `loom:architect`/`loom:curated`/`loom:hermit`/`loom:auditor` proposals every cycle, posting a near-identical "NEEDS REVISION" comment each time — observed live as **6 duplicate comments over ~6.5 hours** on one proposal (`2AMLogic/klayout-tools#168`), with two evaluations landing 40 seconds apart because nothing claimed the issue while it was being evaluated.

This adds the two missing guardrails from the issue, modeled on `champion-pr-merge.md`'s existing Capped-PR Recovery pattern (idempotency marker + escalation marker + `loom:operator-only` routing) and Judge's `loom:reviewing` claim convention:

1. **Idempotency check**: a marker keyed to the issue's `updatedAt` (`<!-- champion:proposal-verdict:$UPDATED_AT -->`). If Champion's most recent verdict comment already carries this marker for the issue's current `updatedAt`, skip re-evaluation entirely — no comment, no re-read. A genuine body revision bumps `updatedAt` and always produces a fresh evaluation.
2. **N=2 escalation**: once 2 "NEEDS REVISION" comments exist on a proposal, the next evaluation escalates to `loom:operator-only` (with a `<!-- champion:proposal-escalated -->`-marked comment) instead of posting a 3rd+ near-identical rejection. `loom:operator-only` is already excluded from every future promotion pass, so the escalation comment posts exactly once.
3. **Concurrency guard**: a new `loom:evaluating` claim label (staleness-aware, `LOOM_STALE_EVALUATING_MINUTES`, default 15m, sized for evaluation's seconds-to-minutes duration rather than Judge's review-duration timescale) prevents two Champion passes from evaluating the same proposal simultaneously, plus a verdict-time recheck immediately before writing the outcome.

## Changes

- `defaults/.claude/commands/loom/champion-issue-promo.md`: new "Concurrency Guard and Idempotency (`loom:evaluating`)" section (idempotency check, staleness-aware claim, verdict-time recheck); Step 3 (promote) and Step 4 (reject) updated to release the claim and, in Step 4, to check the N=2 escalation threshold before posting another rejection; Batch Processing section updated with per-issue claim/skip ordering.
- `defaults/.claude/commands/loom/champion.md`: Priority 2/3 discovery queries now fetch `updatedAt` and exclude issues under a fresh `loom:evaluating` claim, so a batch pass doesn't re-discover work another pass already claimed.
- `defaults/.claude/commands/loom/champion-reference.md`: new Edge Case 5c documenting the mechanism (decision table + rationale), and a new row in the Summary Decision Matrix.
- `.github/labels.yml` / `defaults/.github/labels.yml` (kept byte-identical per the parity contract, verified with `check-labels-drift.sh`): adds `loom:evaluating` ("Champion is evaluating this proposal. Applied by: Champion only (claim label). Stale after LOOM_STALE_EVALUATING_MINUTES (15m).").

This is a documentation/prompt-instruction change only — Champion is an LLM-driven role with no compiled implementation. I checked `loom-daemon/src/` for daemon-side Champion behavior: `claim_reconciliation.rs` only reconciles the PR-side claims (`loom:reviewing`/`loom:treating`); the issue-side claim `loom:curating` (the closest existing precedent for `loom:evaluating`) has no Rust backstop either, so `loom:evaluating` needs none for consistency. `role_collision.rs`'s cross-host collision *detection* (WARN-only, unrelated mechanism) maps Champion to its PR-merge queue only; extending it to the issue-promotion queue is a separate, optional enhancement not required by this issue's acceptance criteria — noted here as a possible follow-up rather than pulled into this PR's scope.

## Acceptance Criteria Verification

- [x] Before evaluating a `loom:architect` issue, Champion checks whether its own most recent comment on that issue post-dates the last body edit — implemented as the `updatedAt`-keyed `VERDICT_MARKER` idempotency check; skip is silent (no comment, no claim).
- [x] After N=2 identical verdicts on an unchanged issue, Champion escalates to `loom:operator-only` immediately rather than continuing to comment — implemented in Step 4 with the `PRIOR_REJECTIONS >= 2` check and `ESCALATE_MARKER`.
- [x] Concurrent double-evaluation prevented via a claim/lock convention (`loom:evaluating`), modeled on Judge's `loom:reviewing` pattern (staleness age check + reclaim), plus a verdict-time recheck immediately before writing the outcome.
- [x] `.github/labels.yml` documents the new claim label with its `Applied by:` owner (mirrored into `defaults/.github/labels.yml`, parity verified).
- [x] `champion.md`'s Priority 3 (and Priority 2) work-finding queries updated to exclude issues under a fresh `loom:evaluating` claim.
- [x] `champion-reference.md` documents the new skip/escalate/claim rules (Edge Case 5c + Summary Decision Matrix row).

## Test Plan

- [x] `./defaults/scripts/check-labels-drift.sh .` — confirms `.github/labels.yml` and `defaults/.github/labels.yml` remain byte-identical after the new label.
- [x] Manual review: traced the Step 4 (reject) flow against the repro scenario in the issue — cycle 1 posts a marked rejection, cycle 2 (unchanged `updatedAt`) skips silently via the idempotency check, and if a trivial edit bumps `updatedAt` without addressing the findings, the 2nd substantive rejection triggers the N=2 escalation on the next cycle instead of a 3rd/4th/5th/6th duplicate comment.
- [x] Manual review: traced the claim flow for the 40-seconds-apart concurrent-evaluation scenario — the second evaluator's claim check finds a fresh `loom:evaluating` label and skips instead of also posting a verdict.
- [ ] Automated tests: N/A — Champion role files are prompt-driven Markdown, not executable code (matches the issue's own note); verification is via the manual traces above plus `check-labels-drift.sh`.

Closes #4954