### PR TITLE
fix(fleet): local tailnet self-check before reporting all-hosts-UNREACHABLE

### DIFF
--- a/loom-daemon/src/cli/status.rs
+++ b/loom-daemon/src/cli/status.rs
@@ -482,7 +482,8 @@ fn print_status_unreachable_human(
 /// this binary's own socket/install-state machinery) lives here.
 pub(crate) async fn handle_fleet_status_command(json: bool) -> Result<()> {
     use loom_daemon::fleet::status::{
-        collect_fleet_report, update_last_seen_up_at, SshStatusSource,
+        all_tailnet_hosts_unreachable, collect_fleet_report, update_last_seen_up_at,
+        SshStatusSource,
     };
     use loom_daemon::fleet::FleetRegistry;
 
@@ -493,7 +494,16 @@ pub(crate) async fn handle_fleet_status_command(json: bool) -> Result<()> {
     let source: Arc<dyn loom_daemon::fleet::status::HostStatusSource> =
         Arc::new(SshStatusSource::new());
     let timeout = Duration::from_secs(loom_daemon::fleet::status::DEFAULT_TIMEOUT_SECS);
-    let report = collect_fleet_report(source, registry, local, timeout).await;
+    let mut report = collect_fleet_report(source, registry, local, timeout).await;
+
+    // #4952: when every tailnet-addressed roster host is UNREACHABLE, that
+    // pattern is indistinguishable from a genuine multi-host outage without
+    // checking whether the LOCAL tailnet client is actually the thing that
+    // is down (the 2026-08-02 robb-STUDIO incident this issue documents).
+    // Cheap, local-only, best-effort: never blocks the report on failure.
+    if all_tailnet_hosts_unreachable(&report.hosts) {
+        report.local_tailnet = check_local_tailnet_state();
+    }
 
     // #4697: persist "last observed Up" so a LATER poll that finds this host
     // Unreachable can measure elapsed silence against its configured
@@ -578,6 +588,134 @@ async fn collect_local_fleet_report() -> loom_daemon::fleet::status::HostReport 
             };
             HostReport::local_down(detail)
         }
+    }
+}
+
+/// #4952: cheap, local-only self-check for "is the tailnet client on THIS
+/// host actually the thing that's down" — run only when
+/// [`all_tailnet_hosts_unreachable`](loom_daemon::fleet::status::all_tailnet_hosts_unreachable)
+/// flags every tailnet-addressed remote roster host as `Unreachable`, since
+/// that pattern is otherwise indistinguishable from a genuine multi-host
+/// outage. Never an SSH round-trip (that is [`HostStatusSource`](loom_daemon::fleet::status::HostStatusSource)'s job) —
+/// this shells out to the LOCAL `tailscale` CLI exactly once.
+///
+/// Returns `None` when the check is a no-op — AC 4: a missing `tailscale`
+/// CLI must not become a new hard dependency, so an absent binary
+/// (`ErrorKind::NotFound`) silently skips the check rather than erroring the
+/// whole report (current, pre-#4952 behavior unchanged).
+fn check_local_tailnet_state() -> Option<loom_daemon::fleet::status::LocalTailnetState> {
+    use loom_daemon::fleet::status::LocalTailnetState;
+
+    let output = match std::process::Command::new("tailscale")
+        .args(["status", "--json"])
+        .stdin(std::process::Stdio::null())
+        .output()
+    {
+        Ok(out) => out,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return None,
+        // Some other launch failure (permissions, etc.) — degrade rather
+        // than erroring the report, same as `SafehousedProbe::Unknown`.
+        Err(_) => return Some(LocalTailnetState::Unknown),
+    };
+
+    classify_tailscale_status_output(&output.stdout)
+}
+
+/// Parse `tailscale status --json`'s stdout into a [`LocalTailnetState`]
+/// (split out from [`check_local_tailnet_state`] so it is unit-testable
+/// without shelling out). `BackendState: "Running"` is up; any other
+/// `BackendState` value (`"Stopped"`, `"NeedsLogin"`, …) is down for this
+/// purpose — the self-check only needs to distinguish "the local tailnet
+/// client can currently reach the tailnet" from "it cannot," not classify
+/// every backend state individually. Unparseable output degrades to
+/// `Unknown` rather than misreporting either up or down.
+#[must_use]
+fn classify_tailscale_status_output(
+    stdout: &[u8],
+) -> Option<loom_daemon::fleet::status::LocalTailnetState> {
+    use loom_daemon::fleet::status::LocalTailnetState;
+
+    let text = String::from_utf8_lossy(stdout);
+    match serde_json::from_str::<serde_json::Value>(&text) {
+        Ok(value) => match value.get("BackendState").and_then(|v| v.as_str()) {
+            Some("Running") => Some(LocalTailnetState::Up),
+            Some(_) => Some(LocalTailnetState::Down),
+            None => Some(LocalTailnetState::Unknown),
+        },
+        Err(_) => Some(LocalTailnetState::Unknown),
+    }
+}
+
+#[cfg(test)]
+mod local_tailnet_tests {
+    //! #4952: the local tailnet self-check. `classify_tailscale_status_output`
+    //! is exercised directly against canned JSON (no process spawn, no PATH
+    //! mutation, safe to run in parallel with everything else). The
+    //! CLI-absent path (AC 4) is exercised end-to-end through
+    //! `check_local_tailnet_state` against a PATH with no `tailscale` binary
+    //! on it at all — serialized against any other PATH-mutating test in this
+    //! binary so parallel `cargo test` threads cannot race the shared
+    //! process-wide `PATH` env var.
+    use super::{check_local_tailnet_state, classify_tailscale_status_output};
+    use loom_daemon::fleet::status::LocalTailnetState;
+
+    #[test]
+    fn classifies_running_backend_state_as_up() {
+        let stdout = br#"{"BackendState":"Running","Self":{}}"#;
+        assert_eq!(classify_tailscale_status_output(stdout), Some(LocalTailnetState::Up));
+    }
+
+    #[test]
+    fn classifies_stopped_backend_state_as_down() {
+        let stdout = br#"{"BackendState":"Stopped"}"#;
+        assert_eq!(classify_tailscale_status_output(stdout), Some(LocalTailnetState::Down));
+    }
+
+    #[test]
+    fn classifies_other_non_running_backend_states_as_down() {
+        // NeedsLogin, NeedsMachineAuth, etc. all mean "cannot currently reach
+        // the tailnet" for this self-check's purposes — not just "Stopped".
+        let stdout = br#"{"BackendState":"NeedsLogin"}"#;
+        assert_eq!(classify_tailscale_status_output(stdout), Some(LocalTailnetState::Down));
+    }
+
+    #[test]
+    fn classifies_unparseable_output_as_unknown_not_up_or_down() {
+        assert_eq!(
+            classify_tailscale_status_output(b"not json at all"),
+            Some(LocalTailnetState::Unknown)
+        );
+    }
+
+    #[test]
+    fn classifies_missing_backend_state_field_as_unknown() {
+        assert_eq!(
+            classify_tailscale_status_output(br#"{"Self":{}}"#),
+            Some(LocalTailnetState::Unknown)
+        );
+    }
+
+    /// AC 4: an absent `tailscale` CLI must be a silent no-op (`None`), not
+    /// an error or an `Unknown` state — current, pre-#4952 behavior
+    /// unchanged.
+    #[test]
+    #[serial_test::serial(status_rs_stub_ssh_path)]
+    fn check_local_tailnet_state_is_none_when_tailscale_cli_absent() {
+        let empty_dir = tempfile::tempdir().unwrap();
+        let old_path = std::env::var("PATH").unwrap_or_default();
+        // A PATH containing only an empty directory guarantees `tailscale`
+        // cannot resolve, regardless of what's installed on the real host
+        // running this test.
+        std::env::set_var("PATH", empty_dir.path());
+
+        let result = check_local_tailnet_state();
+
+        std::env::set_var("PATH", old_path);
+
+        assert_eq!(
+            result, None,
+            "absent tailscale CLI must skip the check silently, got {result:?}"
+        );
     }
 }
 

--- a/loom-daemon/src/fleet/status.rs
+++ b/loom-daemon/src/fleet/status.rs
@@ -148,6 +148,41 @@ impl SafehousedProbe {
     }
 }
 
+/// The local host's own tailnet self-check result (#4952). Mirrors
+/// [`SafehousedProbe`]'s three-way shape — a cheap best-effort probe that
+/// must never fail the whole report — but is explicitly **local-only**: run
+/// once, in-process (never over SSH), only when
+/// [`all_tailnet_hosts_unreachable`] flags every tailnet-addressed remote
+/// roster host as [`HostState::Unreachable`]. That pattern (every tailnet
+/// peer failing simultaneously) is indistinguishable from a genuine
+/// multi-host outage without this check — see the module doc's 2026-08-02
+/// incident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalTailnetState {
+    /// The local `tailscale` client reports the tailnet is up/running.
+    Up,
+    /// The local `tailscale` client reports the tailnet is down/stopped —
+    /// the tell this issue exists for: the correct diagnosis (and
+    /// one-command fix) is on the local host, not a fleet-wide outage.
+    Down,
+    /// `tailscale` ran but its output could not be conclusively classified —
+    /// degrade to "unknown" rather than misreporting either up or down.
+    Unknown,
+}
+
+impl LocalTailnetState {
+    /// Fixed label for the human banner / `--json` twin.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            LocalTailnetState::Up => "up",
+            LocalTailnetState::Down => "down",
+            LocalTailnetState::Unknown => "unknown",
+        }
+    }
+}
+
 // ===========================================================================
 // Per-host report
 // ===========================================================================
@@ -542,6 +577,17 @@ pub async fn collect_remote_host(
 pub struct FleetStatusReport {
     pub hosts: Vec<HostReport>,
     pub summary: FleetStatusSummary,
+    /// #4952: the local tailnet self-check result. `None` when the check was
+    /// never run — either [`all_tailnet_hosts_unreachable`] was `false` (no
+    /// reason to suspect a local tailnet outage) or the `tailscale` CLI is
+    /// not installed on this host (AC 4 — a missing CLI must not become a
+    /// new hard dependency, so the caller skips the check silently rather
+    /// than erroring). Populated by the caller
+    /// (`handle_fleet_status_command`) after [`collect_fleet_report`]
+    /// returns, since the check itself is a local shell-out, not part of the
+    /// SSH fanout this module owns.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_tailnet: Option<LocalTailnetState>,
 }
 
 /// Roll-up counts across [`FleetStatusReport::hosts`].
@@ -607,7 +653,38 @@ pub async fn collect_fleet_report(
     }
 
     let summary = summarize(&hosts, empty_roster);
-    FleetStatusReport { hosts, summary }
+    FleetStatusReport {
+        hosts,
+        summary,
+        local_tailnet: None,
+    }
+}
+
+/// #4952 AC 1 + AC 3: true when every remote roster host that has a tailnet
+/// address ([`HostReport::tailnet_name`] is `Some`) is
+/// [`HostState::Unreachable`] — the trigger condition for the local tailnet
+/// self-check. The local host row is always excluded (it is never collected
+/// over the tailnet-dependent SSH path). A host with no tailnet address
+/// (plain LAN/SSH) is also excluded from the inference (AC 3), so a mixed
+/// roster can still surface a genuine partial outage through those hosts'
+/// own states.
+///
+/// Vacuously `false` when there are no tailnet-addressed remote hosts at all
+/// — with nothing to infer from, there is no reason to suspect a local
+/// tailnet outage.
+#[must_use]
+pub fn all_tailnet_hosts_unreachable(hosts: &[HostReport]) -> bool {
+    let mut saw_tailnet_host = false;
+    for host in hosts {
+        if host.is_local || host.tailnet_name.is_none() {
+            continue;
+        }
+        saw_tailnet_host = true;
+        if host.state != HostState::Unreachable {
+            return false;
+        }
+    }
+    saw_tailnet_host
 }
 
 /// After a `fleet status` poll, refresh [`WorkerRecord::last_seen_up_at`] for
@@ -696,6 +773,16 @@ impl FleetStatusReport {
                 "  (no fleet workers registered — showing the local host only; \
                  add one with `loom-daemon fleet add-worker <ssh-host> --repo <owner/name>`)\n",
             );
+        }
+        if self.local_tailnet == Some(LocalTailnetState::Down) {
+            out.push_str(concat!(
+                "  !!! LOCAL TAILNET DOWN — remote states below are UNKNOWN, not a confirmed ",
+                "fleet outage !!!\n",
+                "      every tailnet-addressed roster host below reports UNREACHABLE because ",
+                "the tailnet client on THIS host is down, not because those hosts are down.\n",
+                "      restart it, then re-run `fleet status`: `tailscale up` (or, on macOS, ",
+                "`open -a Tailscale`).\n",
+            ));
         }
         out.push_str(&format!(
             "  {:<20} {:<12} {:<16} {:<8} {:<10} {:<8}\n",
@@ -977,6 +1064,7 @@ mod tests {
                 },
             ],
             summary: summarize(&[], false),
+            local_tailnet: None,
         };
 
         let now = Utc::now();
@@ -1029,6 +1117,133 @@ mod tests {
         assert_eq!(report.summary.unreachable, 1);
         assert_eq!(report.summary.parse_error, 1);
         assert!(!report.summary.empty_roster);
+    }
+
+    // ---- all_tailnet_hosts_unreachable / LOCAL TAILNET DOWN banner (#4952) --
+
+    fn host_report(alias: &str, tailnet_name: Option<&str>, state: HostState) -> HostReport {
+        HostReport {
+            alias: alias.to_string(),
+            tailnet_name: tailnet_name.map(str::to_string),
+            provider_instance_id: None,
+            added_by: None,
+            is_local: false,
+            state,
+            workspaces: Vec::new(),
+            status: None,
+            detail: None,
+            safehoused: SafehousedProbe::Unknown,
+        }
+    }
+
+    #[test]
+    fn all_tailnet_hosts_unreachable_true_when_every_tailnet_host_is_unreachable() {
+        let hosts = vec![
+            HostReport::local_up(serde_json::json!({})),
+            host_report("worker-1", Some("loom-worker-1"), HostState::Unreachable),
+            host_report("worker-2", Some("loom-worker-2"), HostState::Unreachable),
+        ];
+        assert!(all_tailnet_hosts_unreachable(&hosts));
+    }
+
+    #[test]
+    fn all_tailnet_hosts_unreachable_false_when_one_tailnet_host_is_up() {
+        let hosts = vec![
+            host_report("worker-1", Some("loom-worker-1"), HostState::Unreachable),
+            host_report("worker-2", Some("loom-worker-2"), HostState::Up),
+        ];
+        assert!(!all_tailnet_hosts_unreachable(&hosts));
+    }
+
+    /// AC 3: a mixed roster where a plain LAN/SSH host (no tailnet address)
+    /// is also unreachable must NOT be swallowed into the tailnet inference —
+    /// its own unreachable state is excluded from (not required by) the
+    /// trigger condition, so a genuine partial outage on that host still
+    /// surfaces on its own merits elsewhere in the report.
+    #[test]
+    fn all_tailnet_hosts_unreachable_excludes_hosts_without_tailnet_address() {
+        let hosts = vec![
+            host_report("worker-1", Some("loom-worker-1"), HostState::Unreachable),
+            host_report("lan-host", None, HostState::Unreachable),
+        ];
+        assert!(all_tailnet_hosts_unreachable(&hosts));
+
+        // And a non-tailnet host that is merely Up doesn't change the
+        // outcome either — it plays no part in the inference either way.
+        let hosts2 = vec![
+            host_report("worker-1", Some("loom-worker-1"), HostState::Unreachable),
+            host_report("lan-host", None, HostState::Up),
+        ];
+        assert!(all_tailnet_hosts_unreachable(&hosts2));
+    }
+
+    #[test]
+    fn all_tailnet_hosts_unreachable_false_when_no_tailnet_hosts_registered() {
+        // Vacuous case: nothing tailnet-addressed to infer from at all —
+        // must not spuriously trigger the self-check.
+        let hosts = vec![
+            HostReport::local_up(serde_json::json!({})),
+            host_report("lan-host", None, HostState::Unreachable),
+        ];
+        assert!(!all_tailnet_hosts_unreachable(&hosts));
+    }
+
+    #[test]
+    fn render_human_shows_local_tailnet_down_banner_and_names_restart_action() {
+        let hosts = vec![
+            HostReport::local_up(serde_json::json!({})),
+            host_report("worker-1", Some("loom-worker-1"), HostState::Unreachable),
+        ];
+        let summary = summarize(&hosts, false);
+        let report = FleetStatusReport {
+            hosts,
+            summary,
+            local_tailnet: Some(LocalTailnetState::Down),
+        };
+
+        let rendered = report.render_human();
+        assert!(rendered.contains("LOCAL TAILNET DOWN"));
+        assert!(rendered.contains("tailscale up"));
+        // The per-host UNREACHABLE row is still present underneath the
+        // banner (AC 2 reframes it, it does not hide it).
+        assert!(rendered.contains("UNREACHABLE"));
+    }
+
+    /// Regression guard: when the local tailnet check reports `Up` (or was
+    /// never run, i.e. `None`), rendering is unchanged from before #4952 —
+    /// no banner, plain UNREACHABLE reporting.
+    #[test]
+    fn render_human_omits_banner_when_local_tailnet_is_up_or_unchecked() {
+        let hosts = vec![host_report(
+            "worker-1",
+            Some("loom-worker-1"),
+            HostState::Unreachable,
+        )];
+        let base_summary = summarize(&hosts, false);
+
+        let up_report = FleetStatusReport {
+            hosts: hosts.clone(),
+            summary: base_summary.clone(),
+            local_tailnet: Some(LocalTailnetState::Up),
+        };
+        assert!(!up_report.render_human().contains("LOCAL TAILNET DOWN"));
+
+        let unchecked_report = FleetStatusReport {
+            hosts,
+            summary: base_summary,
+            local_tailnet: None,
+        };
+        assert!(!unchecked_report
+            .render_human()
+            .contains("LOCAL TAILNET DOWN"));
+    }
+
+    /// #4952 AC 4: empty roster + no tailnet hosts at all must not panic and
+    /// must not spuriously trigger the self-check condition.
+    #[test]
+    fn empty_roster_never_triggers_tailnet_inference() {
+        assert!(!all_tailnet_hosts_unreachable(&[HostReport::local_up(serde_json::json!({}))]));
+        assert!(!all_tailnet_hosts_unreachable(&[]));
     }
 
     /// #4697: end-to-end through `collect_fleet_report`, an idle-shutdown-


### PR DESCRIPTION
## Summary

Closes #4952

On 2026-08-02, Tailscale on the fleet's control host silently stopped, so every SSH round-trip to remote workers timed out — indistinguishable from a genuine multi-host outage. `fleet status` now detects the "every tailnet-addressed roster host is UNREACHABLE" pattern and runs a cheap, local-only `tailscale status --json` self-check before presenting that as a fleet-wide outage.

- Added `LocalTailnetState` (`Up` / `Down` / `Unknown`) in `loom-daemon/src/fleet/status.rs`, mirroring the existing `SafehousedProbe` shape but explicitly local-only (never SSH).
- Added `all_tailnet_hosts_unreachable(hosts)` — true only when every *remote, tailnet-addressed* roster host is `Unreachable`; hosts with `tailnet_name: None` (plain LAN/SSH) are excluded from the inference so a mixed roster can still surface a genuine partial outage.
- `FleetStatusReport` gained a `local_tailnet: Option<LocalTailnetState>` field (serialized in `--json` output, `skip_serializing_if` when never run).
- `handle_fleet_status_command` (`loom-daemon/src/cli/status.rs`) runs the local `tailscale status --json` shell-out only when `all_tailnet_hosts_unreachable` is true, and only after the SSH fanout — it is deliberately not part of `HostStatusSource`/`SshStatusSource`, which is exclusively the per-remote-host SSH seam.
- `render_human()` prepends a `LOCAL TAILNET DOWN — remote states below are UNKNOWN, not a confirmed fleet outage` banner (mirroring the existing `empty_roster` notice pattern) that names the restart action (`tailscale up` / `open -a Tailscale`) when the local check reports `Down`.
- Absent `tailscale` CLI (`ErrorKind::NotFound`) degrades to a silent no-op — no new hard dependency, current behavior unchanged.

## Acceptance criteria

- [x] When every remote roster host with a tailnet address is `UNREACHABLE`, `fleet status` runs the local tailnet self-check before printing the report.
- [x] If the local tailnet is down, the report shows a prominent `LOCAL TAILNET DOWN` banner instead of presenting N x `UNREACHABLE` as fact, and names the restart action.
- [x] Hosts without tailnet addresses are excluded from the inference.
- [x] Absent `tailscale` CLI skips the check silently (no new hard dependency).

## Test plan

- `cargo test --lib fleet::status` (26 tests, including new coverage for `all_tailnet_hosts_unreachable`, the mixed-roster exclusion case, the vacuous/empty-roster case, and `render_human` banner presence/absence) — pass.
- `cargo test --bin loom-daemon` (`cli::status::local_tailnet_tests`, including a PATH-mutation test proving an absent `tailscale` CLI is a silent no-op) — pass.
- `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean.

## Pre-existing Issues (Not Addressed)

`cargo test` (full workspace `--lib` run) has 9 pre-existing failures in `auto_update::tests::*` and `work_finder::tests::*` — verified to reproduce identically on a fresh clone of unmodified `origin/main` (unrelated to this PR's two changed files, `loom-daemon/src/cli/status.rs` and `loom-daemon/src/fleet/status.rs`). They come from `config_resolver::resolve_effective_config` picking up a machine-level private-defaults config on this host regardless of the test's `tempdir` `repo_root`, not from anything touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)