### PR TITLE
ci(dashboard-deploy): failed deploys surface as a forge issue; judge checklist covers new secrets

### DIFF
--- a/.github/workflows/dashboard-deploy.yml
+++ b/.github/workflows/dashboard-deploy.yml
@@ -46,15 +46,26 @@ jobs:
     name: Deploy Worker (dashboard.2amlogic.com)
     needs: test
     runs-on: ubuntu-latest
+    # `issues: write` is required by the "File or update a tracking issue for
+    # the failed deploy" step below (#4974) — this workflow is `push`-triggered
+    # (not a PR check), so without this the failure-tracking step's `gh issue
+    # create`/`comment` would itself fail silently.
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v7
+        id: checkout
       - uses: actions/setup-node@v7
+        id: setup-node
         with:
           node-version: "20"
       - name: Install backend dependencies
+        id: install-backend-deps
         run: npm ci
         working-directory: dashboard
       - name: Install web UI dependencies
+        id: install-web-deps
         run: npm ci
         working-directory: dashboard/web
 
@@ -70,6 +81,7 @@ jobs:
       # later change (e.g. epic #4859's production cutover) only requires
       # updating the secret, never this workflow.
       - name: Materialize the 2AM instance's wrangler config
+        id: materialize-wrangler-config
         working-directory: dashboard
         env:
           WRANGLER_CONFIG_2AMLOGIC: ${{ secrets.CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC }}
@@ -82,11 +94,25 @@ jobs:
             echo "dashboard/docs/reference-deployment.md section 3 for what it must contain, and" >&2
             echo "'gh secret set CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC < dashboard/wrangler.2amlogic.toml'" >&2
             echo "run from the operator's machine (where that file already lives) to provision it." >&2
+            # Mirror the same text into a step output (verbatim) so the
+            # failure-tracking step below (#4974) can surface it in the
+            # forge issue/comment it files, without re-deriving the message.
+            {
+              echo "error_detail<<GH_OUTPUT_EOF"
+              echo "CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC secret is not set — deploy cannot proceed."
+              echo "This must be the full contents of the 2AM instance's wrangler.2amlogic.toml overlay"
+              echo "(Worker name, D1 database name/id, custom-domain route, Access vars) — see"
+              echo "dashboard/docs/reference-deployment.md section 3 for what it must contain, and"
+              echo "'gh secret set CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC < dashboard/wrangler.2amlogic.toml'"
+              echo "run from the operator's machine (where that file already lives) to provision it."
+              echo "GH_OUTPUT_EOF"
+            } >> "$GITHUB_OUTPUT"
             exit 1
           fi
           printf '%s\n' "$WRANGLER_CONFIG_2AMLOGIC" > wrangler.2amlogic.toml
 
       - name: Build the dashboard UI
+        id: build-web
         working-directory: dashboard
         run: npm run build:web
 
@@ -95,6 +121,7 @@ jobs:
       # a bad overlay (still-a-placeholder database_id, config that fails to
       # parse) fail here instead of mid-migration.
       - name: Preflight the deploy config
+        id: preflight
         working-directory: dashboard
         env:
           LOOM_DASHBOARD_WRANGLER_CONFIG: wrangler.2amlogic.toml
@@ -107,6 +134,7 @@ jobs:
       # nothing new to apply is a clean no-op — this step does not need its
       # own "only if pending" guard.
       - name: Apply D1 migrations (idempotent)
+        id: apply-migrations
         working-directory: dashboard
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -125,8 +153,71 @@ jobs:
       # config-file change per deploy. Served back by `/api/version` and the
       # dashboard footer (`src/index.ts`, `web/src/buildInfo.ts`).
       - name: Deploy Worker
+        id: deploy-worker
         working-directory: dashboard
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx wrangler deploy --config wrangler.2amlogic.toml --var "BUILD_COMMIT:${{ github.sha }}"
+
+      # #4974: before this step, a failed deploy was a red run in the Actions
+      # tab and nothing else -- no forge-visible artifact entered the normal
+      # triage flow. `if: failure()` runs this only when a prior step in this
+      # job failed; it never flips the job's own conclusion back to green (a
+      # job's conclusion is fixed by its failed step before this one runs --
+      # this step succeeding or failing afterward does not change that). One
+      # dedup'd issue per distinct failing step (title includes the step
+      # name), following the same search-by-exact-title pattern as
+      # fork-drift.yml, so repeated failures of the same underlying cause
+      # comment on one issue instead of spamming a fresh one per run. A green
+      # re-run after the fix does NOT auto-close/clean up the tracking issue
+      # -- that's expected, left for the normal triage flow to close.
+      - name: File or update a tracking issue for the failed deploy
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STEPS_JSON: ${{ toJSON(steps) }}
+          MATERIALIZE_ERROR_DETAIL: ${{ steps.materialize-wrangler-config.outputs.error_detail }}
+        run: |
+          set -euo pipefail
+
+          failing_id="$(echo "$STEPS_JSON" | jq -r \
+            'to_entries | map(select(.value.conclusion == "failure")) | .[0].key // "unknown"')"
+
+          case "$failing_id" in
+            checkout) failing_name="Checkout" ;;
+            setup-node) failing_name="Set up Node.js" ;;
+            install-backend-deps) failing_name="Install backend dependencies" ;;
+            install-web-deps) failing_name="Install web UI dependencies" ;;
+            materialize-wrangler-config) failing_name="Materialize the 2AM instance's wrangler config" ;;
+            build-web) failing_name="Build the dashboard UI" ;;
+            preflight) failing_name="Preflight the deploy config" ;;
+            apply-migrations) failing_name="Apply D1 migrations (idempotent)" ;;
+            deploy-worker) failing_name="Deploy Worker" ;;
+            *) failing_name="an unidentified step" ;;
+          esac
+
+          title="ci(dashboard-deploy): deploy failed at \"${failing_name}\""
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          body="## Dashboard deploy failure"$'\n\n'
+          body+="The \`Deploy Worker (dashboard.2amlogic.com)\` job in \`.github/workflows/dashboard-deploy.yml\` failed."$'\n\n'
+          body+="- **Failing step:** ${failing_name}"$'\n'
+          body+="- **Run:** ${run_url}"$'\n'
+          body+="- **Commit:** ${GITHUB_SHA}"$'\n'
+
+          if [[ -n "${MATERIALIZE_ERROR_DETAIL:-}" ]]; then
+            body+=$'\n**Error detail (verbatim from the failing step):**\n```\n'"${MATERIALIZE_ERROR_DETAIL}"$'\n```\n'
+          fi
+
+          body+=$'\n_Last checked: '"$(date -u +"%Y-%m-%dT%H:%M:%SZ")"$'_'
+
+          existing_number="$(gh issue list --state open --search "\"$title\" in:title" \
+            --json number,title --jq ".[] | select(.title == \"$title\") | .number" | head -1)"
+
+          if [[ -n "$existing_number" ]]; then
+            gh issue comment "$existing_number" --body "$body"
+            echo "Updated existing dashboard-deploy failure issue #$existing_number"
+          else
+            gh issue create --title "$title" --label "loom:triage" --body "$body"
+          fi

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -1607,6 +1607,12 @@ This saves significant time and reduces coordination overhead for issues that ta
 
 When you spot N-bound build-pipeline code, **measure it or block on it** — do not file it as a non-blocking follow-up. A "several minutes added" note in a Judge review can translate directly into a killed production deploy.
 
+### Infrastructure
+
+- **Does this PR introduce a new required repo secret or variable** (a new `secrets.*` / `vars.*` reference in a workflow, a new required env var in a deploy/build script, a new config field with no default)? If so, is it already provisioned (check with `gh secret list` / `gh variable list` if accessible, or ask the PR description to confirm), or is it explicitly flagged to the operator in the PR description/comments before merge?
+- A merged workflow change that references an unprovisioned secret fails silently in CI/CD until an operator notices — treat an unflagged new-secret requirement as blocking, not a non-blocking note (see #4974, where a landed `dashboard-deploy.yml` needed a new secret discovered only post-merge).
+- If the new secret/var is genuinely fine to provision after merge (e.g. the workflow already fails loudly and files a tracking issue rather than deploying silently), confirm that failure path exists and is forge-visible before approving.
+
 ### Test Plan Execution
 
 When a PR includes a "## Test Plan" section in its description, the Judge should extract and execute the automatable steps.


### PR DESCRIPTION
Closes #4974

## Summary

`.github/workflows/dashboard-deploy.yml` (landed via #4963/#4958) had no failure notification — a failed deploy run was a red run in the Actions tab and nothing else. Separately, the judge role prompt had no explicit guidance for reviewing PRs that introduce new required repo secrets/vars.

## Changes

### `.github/workflows/dashboard-deploy.yml`

- Added an `id:` to every step in the `deploy` job.
- Added a final step, `File or update a tracking issue for the failed deploy`, gated `if: failure()`, that:
  - Uses `toJSON(steps)` to find which step's `conclusion` is `"failure"`, and maps that step id to a human-readable name via a `case` statement.
  - Builds a forge-visible issue title `ci(dashboard-deploy): deploy failed at "<step name>"`.
  - Follows `fork-drift.yml`'s dedupe pattern: search for an existing open issue with that exact title (`gh issue list --state open --search "\"$title\" in:title" --json number,title --jq ...`); comment on it if found, otherwise `gh issue create --label "loom:triage"`.
  - For the missing-secret case specifically, includes the exact `::error::`/detail text from the "Materialize the 2AM instance's wrangler config" step. Rather than re-deriving or re-parsing logs, that step now *also* writes the identical text (verbatim, same lines) to a step output (`error_detail`, via the standard multiline `GITHUB_OUTPUT` heredoc pattern) before its `exit 1`; the failure step reads it via `steps.materialize-wrangler-config.outputs.error_detail`.
- Added a job-level `permissions: { contents: read, issues: write }` block to `deploy` (there was none before) — required for `gh issue create`/`gh issue comment` to work, since this workflow is `push`-triggered (not a PR check), so no default PR-scoped token permissions apply.

### `defaults/.claude/commands/loom/judge.md`

Added a new `### Infrastructure` subsection under "Evaluation Focus Areas" (alongside `### Correctness`, `### Design`, etc.):
- Asks whether the PR introduces a new required repo secret/var, and whether it's already provisioned or explicitly flagged to the operator before merge.
- Notes that an unflagged new-secret requirement should be treated as blocking, citing this issue (#4974) as the motivating example.
- Allows an exception when the workflow already fails loudly with a forge-visible tracking artifact (like the new step this PR adds) rather than deploying silently.

`.loom/roles/judge.md` is a symlink to `defaults/.claude/commands/loom/judge.md`, so no separate edit was needed there. `.claude/commands/loom/judge.md` (the installed copy the symlink actually resolves to on disk) is gitignored/generated by the install/resync scripts, so it's not touched by this PR either.

## How each acceptance criterion is met

1. **A failed run produces a forge-visible artifact that enters normal triage** — the new `if: failure()` step files/updates a `loom:triage`-labeled issue, which is exactly the normal issue-triage entry point.
2. **The artifact names the failing step and echoes the exact provisioning command for the missing-secret case** — the issue body includes a `**Failing step:**` line, and for the wrangler-config-secret case, a fenced code block with the verbatim text (including the `gh secret set ...` provisioning command) sourced from the existing step output, not re-derived.
3. **Judge role prompt covers new-secret/var review** — new `### Infrastructure` subsection added.

## Test plan

Full CI automation for GitHub Actions YAML isn't practical/expected in this repo (no workflow test harness); this was validated as follows:

- `actionlint .github/workflows/dashboard-deploy.yml` — clean, no findings.
- `actionlint` (whole repo) — clean, no regressions to any other workflow.
- YAML parses cleanly via `python3 -c "import yaml; yaml.safe_load(...)"`.
- Extracted the new failure step's shell logic into a standalone script and ran `shellcheck` against it — clean.
- Ran that extracted script with synthetic `STEPS_JSON`/`MATERIALIZE_ERROR_DETAIL`/`GITHUB_*` env vars simulating a failure at the `materialize-wrangler-config` step; confirmed the generated title and body correctly name the failing step and include the verbatim error detail block.
- `scripts/check-docs-defaults-parity.sh` — OK, no orphaned/broken doc links introduced.

**Manual verification path for an operator** (not run as part of this PR, documented per the issue's test-plan expectations):
1. Temporarily unset/rename the `CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC` secret (or push a change that breaks another deploy step) and push to `main` under `dashboard/**`.
2. Confirm the run fails and a new `loom:triage` issue titled `ci(dashboard-deploy): deploy failed at "Materialize the 2AM instance's wrangler config"` (or the relevant step name) is created, containing the failing step, run link, commit, and (for the secret case) the exact `gh secret set CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC < dashboard/wrangler.2amlogic.toml` provisioning command.
3. Re-trigger the same failure (push again without fixing it) and confirm the **same** issue receives a new comment rather than a duplicate issue being created.
4. Fix the underlying cause and confirm a green re-run does **not** automatically close/clean up the tracking issue — this is expected/acceptable per the issue's own test-plan note; the tracking issue is left for the normal triage flow to close.
- Also confirmed by inspection: the `if: failure()` step only runs when a prior step already failed, and its own success/failure afterward cannot change the job's already-fixed `failure` conclusion — so it cannot mask the original failure's exit code.

## Deviations from the curated plan

None of substance — the actual current `dashboard-deploy.yml` (post #4963/#4958, 11 commits ahead as flagged in the issue) matched the description closely enough that no rescoping was needed. One addition beyond the literal plan: rather than only reading the "Materialize..." step's existing stderr text, that step now also mirrors the identical text into a step output so the failure step can read it structurally (via `steps.<id>.outputs.<name>`) instead of trying to scrape run logs, which GitHub Actions doesn't expose to a later step natively.