### PR TITLE
fix(ci): repair jq/search quoting bug in dashboard-deploy failure tracker

### DIFF
--- a/.github/workflows/dashboard-deploy.yml
+++ b/.github/workflows/dashboard-deploy.yml
@@ -217,8 +217,11 @@ jobs:
           # into either a quoted GitHub search phrase or a jq program string.
           # Narrow the --search to a quote-free constant substring (a superset
           # is fine -- correctness comes from the --arg exact-title match below).
+          # `gh`'s own --jq flag takes exactly one expression argument (it does
+          # not support jq's --arg passthrough), so pipe the raw JSON to a
+          # standalone jq invocation instead of using `gh issue list --jq`.
           existing_number="$(gh issue list --state open --search "deploy failed in:title" \
-            --json number,title --jq --arg t "$title" '.[] | select(.title == $t) | .number' | head -1)"
+            --json number,title | jq -r --arg t "$title" '.[] | select(.title == $t) | .number' | head -1)"
 
           if [[ -n "$existing_number" ]]; then
             gh issue comment "$existing_number" --body "$body"

--- a/.github/workflows/dashboard-deploy.yml
+++ b/.github/workflows/dashboard-deploy.yml
@@ -212,8 +212,13 @@ jobs:
 
           body+=$'\n_Last checked: '"$(date -u +"%Y-%m-%dT%H:%M:%SZ")"$'_'
 
-          existing_number="$(gh issue list --state open --search "\"$title\" in:title" \
-            --json number,title --jq ".[] | select(.title == \"$title\") | .number" | head -1)"
+          # $title always contains literal embedded double quotes (from the
+          # \"${failing_name}\" wrapping above), so it cannot be safely dropped
+          # into either a quoted GitHub search phrase or a jq program string.
+          # Narrow the --search to a quote-free constant substring (a superset
+          # is fine -- correctness comes from the --arg exact-title match below).
+          existing_number="$(gh issue list --state open --search "deploy failed in:title" \
+            --json number,title --jq --arg t "$title" '.[] | select(.title == $t) | .number' | head -1)"
 
           if [[ -n "$existing_number" ]]; then
             gh issue comment "$existing_number" --body "$body"


### PR DESCRIPTION
## Summary

PR #4977 added a "File or update a tracking issue for the failed deploy" step to `.github/workflows/dashboard-deploy.yml`. Its dedupe-lookup line built both a jq filter and a GitHub `--search` phrase by interpolating `$title` as raw text — but `$title` always contains literal embedded double quotes (from the `\"${failing_name}\"` wrapping used to build it). That breaks the jq program's syntax with a compile error, and under `set -euo pipefail` this aborts the whole step, so no tracking issue is ever filed or updated on any deploy failure.

## Fix

- Pass `$title` to `jq` via `--arg t "$title"` instead of interpolating it into the program text — handles arbitrary characters (including embedded quotes) with no manual escaping.
- Narrow the `--search` phrase to a quote-free constant substring (`"deploy failed in:title"`) instead of wrapping the full `$title` (which contains its own literal quotes and would break GitHub's search phrase parsing the same way). Correctness of the dedupe match now comes entirely from the `--arg` exact-title filter in jq, so a broader search superset is safe.
- `set -euo pipefail` is left untouched (still in effect for the step, per acceptance criteria).

## Test plan

- [x] Reproduced the original bug locally: `jq -r ".[] | select(.title == \"$title\") | .number"` with an embedded-quote title fails with a compile error (exit 3), exactly as described in the issue.
- [x] Verified the fix locally: `jq -r --arg t "$title" '.[] | select(.title == $t) | .number'` with the same embedded-quote title succeeds (exit 0) and correctly matches only the exact title against a multi-entry fixture.
- [x] Confirmed `.github/workflows/dashboard-deploy.yml` still parses as valid YAML after the edit.
- [x] Confirmed `fork-drift.yml`'s similar-looking dedupe pattern is unaffected (its `$title` never contains embedded quotes, so it isn't hit by this bug) — left untouched, no scope creep.
- [ ] Manual/live verification (a real or simulated `dashboard-deploy.yml` failure filing/commenting on a `loom:triage` issue) requires a live workflow run and is out of scope for this PR; the local jq-level repro/fix above is the direct regression test for the reported bug.

Closes #4978

🤖 Generated with [Claude Code](https://claude.com/claude-code)