### PR TITLE
feat(daemon): add `loom-daemon cancel` and persist the sweep pgid so termination reaps the whole process tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,8 @@ worktrees, stuck agents, daemon registry/event-bus/reaper issues, host-sleep and
 `.loom/` resync procedures, and common fixes. Quick fixes: `loom-clean --force`
 (stale worktrees/branches), `loom-recover-orphans --recover` (orphaned
 `loom:building` issues), `gh label sync --file .github/labels.yml` (re-sync
-labels), `mcp__loom__cancel_sweep --sweep_id <id>` (cancel a running sweep).
+labels), `loom-daemon cancel --issue <N>` / `mcp__loom__cancel_sweep` (cancel a
+running sweep — never hand-`kill` its pids, #4980).
 
 ## Migration History
 

--- a/defaults/.claude/agents/loom-daemon.md
+++ b/defaults/.claude/agents/loom-daemon.md
@@ -13,7 +13,7 @@ Follow the complete role definition in `.loom/roles/loom.md` for:
 - Dispatching work — `mcp__loom__dispatch_sweep` launches a `/loom:sweep <issue>` child with multi-account OAuth token rotation via `spawn-claude.sh`
 - Observing state — `mcp__loom__list_sweeps`, `mcp__loom__get_sweep_status`, `mcp__loom__tail_sweep_log`
 - Eventing — `mcp__loom__subscribe_to_events` / `mcp__loom__tail_event_bus` over the frozen 6-topic taxonomy
-- Intervening — `mcp__loom__cancel_sweep` (SIGTERM → grace → SIGKILL); the daemon process itself keeps running
+- Intervening — `mcp__loom__cancel_sweep`, or `loom-daemon cancel <sweep-id|--issue N>` from a shell / over ssh (#4980, same IPC request): SIGTERM → grace → SIGKILL of the sweep's whole process **group**; the daemon process itself keeps running. Never hand-`kill` a sweep's PIDs — that kills the wrapper and leaves the agent alive
 - Host-sleep readiness for long / overnight runs (`check-host-sleep.sh`, advisory-only)
 
 **By default the daemon is not a work generator**: with no autonomous config it does not poll the forge for `loom:issue` items and it does not drive support roles on cron — operator-driven `mcp__loom__dispatch_sweep` and the GitHub Actions cron workflows own those responsibilities. Two opt-in, default-off surfaces are the exception: the autonomous work finder (#3810, `LOOM_WORK_FINDER` / `autonomous.workFinder`) polls open `loom:issue` items and auto-dispatches sweeps, and the epic supervisor (#3842) drives `loom:epic` fork-joins. See `.loom/docs/daemon-reference.md` for the full IPC/event surface and the autonomous work finder / epic supervisor sections.

--- a/defaults/.claude/commands/loom/loom.md
+++ b/defaults/.claude/commands/loom/loom.md
@@ -109,7 +109,7 @@ The `loom-daemon` binary talks to the same running daemon over the same Unix-soc
 |---|---|---|
 | `mcp__loom__list_sweeps` | `loom-daemon status` [`--json`] [`--pipeline`] | Richer than `list_sweeps`: also reports the three dynamic-cap inputs (token-pool size, disk headroom, configured ceiling) + their `min`, the main-health-gate halt state, and per-token usage. `--pipeline` adds the forge-side `gh` snapshot (opt-in — extra API calls). |
 | `mcp__loom__dispatch_sweep` | `loom-daemon dispatch <N>` [`--model`] [`--effort`] [`--depends-on`] [`--workspace`] | First-class non-MCP entry point (#3952) over the same IPC `DispatchSweep` request. Bounded client-side ack timeout — exits nonzero fast instead of hanging (built explicitly to avoid the #4043 MCP wedge). |
-| `mcp__loom__cancel_sweep` | *(none)* | No CLI subcommand cancels an in-flight sweep by ID. Fallback: get the PID from `loom-daemon status` and `kill -TERM <pid>` directly — the `.loom/sweep-checkpoint/` file still survives, so redispatch still resumes. `loom-daemon quarantine clear <issue>` is the adjacent lever for a crash-looping issue (releases the daemon's insta-crash pause), not a manual-cancel substitute. |
+| `mcp__loom__cancel_sweep` | `loom-daemon cancel <sweep-id>` \| `--issue <N>` [`--grace`] [`--workspace`] | First-class non-MCP entry point (#4980) over the same IPC `CancelSweep` request — the `dispatch` sibling, usable over ssh. **Do NOT `kill -TERM <pid>` from `loom-daemon status` instead** (the pre-#4980 fallback): the daemon tracks the *wrapper* pid, so killing it leaves the underlying `claude` agent alive — on 2026-08-03 that survivor relaunched its workload against an issue whose claim had already been returned to the queue. The CLI signals the whole process group. `.loom/sweep-checkpoint/` still survives a cancel, so redispatch still resumes. |
 | `mcp__loom__get_sweep_status` | *(none, partial)* | `loom-daemon status` gives fleet-wide state, not one sweep's phase/blockers. `loom-daemon watch add <N>` (add `--pr` to watch a PR instead of an issue) registers a durable watch on that issue/PR's terminal state instead (persists to `~/.loom/watches.json`, survives a daemon restart, resolves to `~/.loom/logs/watch-results.log`). |
 | `mcp__loom__tail_sweep_log` | *(none)* | `tail -f .loom/logs/sweep-issue-<N>.log` directly. |
 | `mcp__loom__tail_event_bus`, `subscribe_to_events`, `publish_event` | *(none)* | Live pub/sub is MCP-only; there is no CLI event stream. Poll `loom-daemon status` + `gh issue/pr list` on your loop cadence instead. |
@@ -134,7 +134,7 @@ When the daemon is running, you coordinate work via MCP tools where available, a
 |---|---|
 | `mcp__loom__list_sweeps` | `loom-daemon status` |
 | `mcp__loom__dispatch_sweep` | `loom-daemon dispatch <N>` |
-| `mcp__loom__cancel_sweep` | none — see "CLI Fallback" |
+| `mcp__loom__cancel_sweep` | `loom-daemon cancel <sweep-id>` / `--issue <N>` |
 | `mcp__loom__get_sweep_status`, `tail_sweep_log`, `tail_event_bus`, `subscribe_to_events`, `publish_event` | none — MCP-only |
 
 **Each iteration:**
@@ -197,13 +197,18 @@ When the daemon is running, you coordinate work via MCP tools where available, a
    ```
    This sends SIGTERM, waits the configured grace window, then SIGKILL. The `.loom/sweep-checkpoint/issue-<N>.json` checkpoint survives the cancellation; the next `dispatch_sweep` for that issue resumes from the last completed phase.
 
-   **No CLI subcommand cancels a sweep by ID.** If MCP is unavailable: get the
-   PID from `loom-daemon status`, `kill -TERM <pid>` it directly (the checkpoint
-   still survives — cancellation semantics are the same, just invoked manually),
-   and if it keeps crash-looping on redispatch, `loom-daemon quarantine clear
-   <issue>` clears the daemon's insta-crash pause once you're ready to
-   redispatch (quarantine is about crash-loop protection, not manual
-   cancellation, but it's the adjacent CLI lever).
+   **CLI equivalent** (#4980), for when MCP is unavailable or you are on ssh:
+   ```
+   loom-daemon cancel <sweep-id>        # or: loom-daemon cancel --issue <N>
+   ```
+   Same IPC request, same daemon-side termination. **Do not `kill -TERM <pid>`
+   the PID from `loom-daemon status` instead** — that was the pre-#4980 fallback
+   and it is how the 2026-08-03 incident happened: the tracked PID is the
+   *wrapper*, so killing it leaves the `claude` agent alive to relaunch its
+   workload against an issue whose claim has already been returned to the queue.
+   If a sweep keeps crash-looping on redispatch, `loom-daemon quarantine clear
+   <issue>` clears the daemon's insta-crash pause (crash-loop protection, not a
+   cancellation substitute).
 
 6. **Tail per-sweep logs** if you need to inspect output:
    ```
@@ -250,7 +255,7 @@ In-session subagent dispatch (`/loom:sweep` with Stage -1 falling through to sub
 | `/loom:loom` | Check daemon (MCP `list_sweeps`, fallback `loom-daemon status`), start observing/dispatching |
 | `/loom:loom status` | `mcp__loom__list_sweeps`, or `loom-daemon status` if MCP is unavailable |
 | `/loom:loom health` | Display daemon health summary (registry + recent events, or `loom-daemon status` which folds in the health-gate state) |
-| `/loom:loom stop` | Cancel all in-flight sweeps via `mcp__loom__cancel_sweep` (no CLI equivalent — see below); daemon process itself stays alive |
+| `/loom:loom stop` | Cancel all in-flight sweeps via `mcp__loom__cancel_sweep` (CLI: `loom-daemon cancel <sweep-id>`, #4980); daemon process itself stays alive |
 | `/loom:loom help` | Show comprehensive help guide |
 | `/loom:loom help <topic>` | Show help for a specific topic |
 
@@ -267,10 +272,16 @@ For each sweep returned by mcp__loom__list_sweeps:
   mcp__loom__cancel_sweep --sweep_id <sweep_id>
 ```
 
-**No CLI equivalent for cancellation.** If MCP tools are unavailable, get PIDs
-from `loom-daemon status` and `kill -TERM <pid>` each one directly — the
-`.loom/sweep-checkpoint/` files still survive, so a later `dispatch_sweep` /
-`loom-daemon dispatch` for that issue resumes from the last completed phase.
+**CLI equivalent** (#4980), for a shell / ssh session with no MCP server:
+```
+loom-daemon cancel <sweep-id>        # or: loom-daemon cancel --issue <N>
+```
+Same IPC request and same daemon-side termination as the MCP tool, and it signals
+the whole process group. Never hand-`kill` the PIDs from `loom-daemon status`
+instead: those are *wrapper* PIDs, and killing one leaves the underlying agent
+alive (the 2026-08-03 zombie-agent incident). `.loom/sweep-checkpoint/` files
+still survive a cancel, so a later `dispatch_sweep` / `loom-daemon dispatch` for
+that issue resumes from the last completed phase.
 
 **Stop the daemon process itself** is out of scope for this skill — the daemon is a long-lived service that the operator manages outside Claude Code (via their init system, foreman, or shell-level process management).
 
@@ -524,7 +535,7 @@ until stopped.
 | `mcp__loom__dispatch_sweep` | Dispatch a sweep for an issue (returns sweep ID) | `loom-daemon dispatch <N>` (#3952, bounded ack timeout) |
 | `mcp__loom__list_sweeps` | Enumerate registry entries | `loom-daemon status` (also reports dynamic-cap inputs, health-gate state, per-token usage) |
 | `mcp__loom__get_sweep_status` | Inspect a single sweep's state | *(none — closest is `loom-daemon watch add` for durable terminal-state tracking)* |
-| `mcp__loom__cancel_sweep` | SIGTERM -> grace -> SIGKILL | *(none — `kill -TERM <pid>` the PID from `loom-daemon status` directly)* |
+| `mcp__loom__cancel_sweep` | SIGTERM -> grace -> SIGKILL (whole process GROUP) | `loom-daemon cancel <sweep-id>` / `--issue <N>` (#4980) — never hand-`kill` the PID from `loom-daemon status`: that leaves the agent alive |
 | `mcp__loom__tail_sweep_log` | Tail per-issue log file | *(none — `tail -f .loom/logs/sweep-issue-<N>.log`)* |
 | `mcp__loom__publish_event` | Publish a lifecycle event | *(none — daemon-internal)* |
 | `mcp__loom__subscribe_to_events` | Topic-filtered event stream | *(none — poll `loom-daemon status` instead)* |

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -314,6 +314,79 @@ LOOM_SWEEP_CLAIM_OWNED=3952 LOOM_MODEL=sonnet \
 Use `loom-daemon dispatch 3952` instead — it performs the claim flip, registry
 tracking, and event publishing for you, with the bounded timeout as a safety net.
 
+#### `loom-daemon cancel` — operator CLI (Issue #4980)
+
+`loom-daemon cancel` is the `dispatch` sibling on the **stop** side: the non-MCP
+operator entry point onto the same `CancelSweep` IPC request the `cancel_sweep`
+MCP tool uses. It exists because the MCP tool only runs inside the operator's own
+Claude session on their own machine — over ssh to a fleet worker there was
+previously no sanctioned lever at all.
+
+```bash
+loom-daemon cancel sweep-issue-4980-1762000000   # by sweep id (from `loom-daemon status`)
+loom-daemon cancel --issue 4980                  # by issue — resolves the live sweep for you
+loom-daemon cancel --issue 4980 --grace 5        # tighter SIGTERM→SIGKILL window (default 30s)
+loom-daemon cancel --issue 758 --workspace ~/GitHub/anvil
+```
+
+| Flag | Maps to `CancelSweep` field | Notes |
+|------|-----------------------------|-------|
+| `<sweep-id>` (positional) | `sweep_id` | required unless `--issue` is given |
+| `--issue <N>` | `sweep_id` (resolved client-side) | one extra `ListSweeps` round-trip; only **live** (`Running`/`Pending`) entries are candidates, and more than one is an error rather than a guess |
+| `--grace <SECS>` | `grace_secs` | seconds between SIGTERM and SIGKILL; default 30, matching the MCP tool |
+| `--workspace <PATH>` | `workspace_root` | same cwd-default resolution `dispatch` applies (#4299) |
+
+**Never hand-`kill` a sweep instead.** The registry tracks the
+`claude-wrapper.sh` pid; SIGKILLing it leaves the underlying `claude` agent
+alive. On 2026-08-03 that surviving agent noticed its subprocesses had died and
+**relaunched** them (~35 CPU-hours of simulation across two rounds), against an
+issue whose claim the crash path had already returned to `loom:issue` — a zombie
+agent the registry reported as `in_flight: 0`. `loom-daemon cancel` signals the
+whole process **group**, so wrapper, agent, and every descendant die together,
+and it releases the claim lock, restores the label, and emits the lifecycle
+events on the way out.
+
+**One implementation, two callers.** The CLI is a thin client: the termination
+itself runs daemon-side in `cancel_sweep_nonblocking`, so `loom-daemon cancel`
+and `mcp__loom__cancel_sweep` cannot drift apart. The client-side ack budget is
+`grace_secs + 15s` (the daemon acks only after the whole cancel completes), and
+on expiry the CLI exits nonzero with the same "is loom-daemon running?"
+diagnostic `dispatch` uses rather than hanging.
+
+#### Process-group termination and the persisted `pgid` (#3800, #4980)
+
+Sweep children are spawned as their **own process-group leader**
+(`process_group(0)` → `setpgid(0, 0)`), so `kill(-pgid, sig)` reaches the child
+*and* every descendant it forked — Bash-tool commands, MCP servers, git clones,
+simulations, watcher loops.
+
+#3800 delivered the group spawn and the group-kill primitive, but gated the group
+path on the daemon still holding the spawn-time `Child` handle. Two ordinary
+situations have no such handle and silently degraded to a single-PID kill that
+orphaned the whole subtree: an entry rebuilt by `reconstruct()` after a daemon
+restart, and **every** `loom-daemon cancel` invocation (a fresh process that
+never held one). #4980 closes that by persisting the group:
+
+- **At spawn** the child's pgid is verified against the OS (`getpgid(child) ==
+  child`) and written into `.loom/locks/issue-<N>/owner.json` as `pgid`, and onto
+  the registry entry as `SweepInfo.pgid`.
+- **On reconstruct** the persisted value is restored — but re-verified against
+  the live owner first; a value the OS contradicts (a PID recycled across the
+  restart) is discarded rather than used to signal a stranger's group.
+- **On signal** the group path is unconditional. A missing `pgid` (a pre-#4980
+  `owner.json`, a checkpoint-only entry) degrades to single-PID delivery **with a
+  log line**, never silently; a `pgid` matching the daemon's own group is refused
+  outright.
+- **On the crash path** — a dead leader whose group still has members, the zombie-
+  agent shape above — the reaper (and `reconstruct()`'s stale-lock branch) sends
+  the group a SIGTERM and escalates to SIGKILL on a later tick if it survives.
+  The persisted value is the *only* handle available here: the OS will not report
+  a dead pid's process group.
+
+`owner.json`'s `pgid` is `Option` + `#[serde(default)]`, so a lock written by a
+pre-#4980 daemon still deserializes — failing to parse it would be read
+everywhere as "no owner" and would drop a *live* sweep's lock.
+
 ### `list_sweeps` (Phase A)
 
 Return all tracked sweeps, optionally filtered by lifecycle state.
@@ -383,14 +456,20 @@ Inputs:
 
 ### `cancel_sweep` (Phase C)
 
-SIGTERM → wait `grace` seconds → SIGKILL the sweep's child PID.
-Transitions the registry entry from `Running` to `Exited{code: None,
-at: now}` and releases the per-issue lock. Idempotent: cancelling an
-already-terminal sweep returns success with `was_running: false`.
+SIGTERM → wait `grace` seconds → SIGKILL the sweep's **process group** (#3800,
+#4980 — see "Process-group termination and the persisted `pgid`" above; the whole
+subtree dies, not just the tracked leader). Transitions the registry entry from
+`Running` to `Exited{code: None, at: now}` and releases the per-issue lock.
+Idempotent: cancelling an already-terminal sweep returns success with
+`was_running: false`.
 
 Inputs:
 - `sweep_id` (required).
 - `grace` (optional, default 30) — seconds between SIGTERM and SIGKILL.
+
+CLI equivalent: `loom-daemon cancel <sweep-id|--issue N>` (#4980) — same IPC
+request, same daemon-side termination path, usable over ssh where no MCP server
+is attached.
 
 ### `tail_event_bus` (Phase C)
 
@@ -413,6 +492,12 @@ The sweep registry (`loom-daemon/src/sweep_registry.rs`) holds a
 
 - `sweep_id`, `kind` (`Issue(N)` or `PrSet(Vec<u32>)`), `pid`,
   `token_name`, `log_path`.
+- `pgid` (optional, issue #4980) — the process group the child leads
+  (`process_group(0)`, so it equals `pid` for a live dispatch). Persisted to the
+  claim lock's `owner.json` too, so cancellation and crash-path reaping still
+  reach the whole subtree after a daemon restart or from a fresh
+  `loom-daemon cancel` process. `#[serde(default, skip_serializing_if =
+  "Option::is_none")]`, so pre-#4980 wire data and clients remain compatible.
 - `idempotency_key` (optional), `started_at`.
 - `state` — one of `Pending`, `Running`, `Exited{code, at}`,
   `Crashed{at}`.

--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -579,11 +579,30 @@ mcp__loom__tail_sweep_log --sweep_id <id>
 ### Cancel a sweep
 
 ```bash
-# Cancel a running sweep (SIGTERM → grace → SIGKILL)
+# From a Claude session with the MCP server attached:
 mcp__loom__cancel_sweep --sweep_id <id>
+
+# From a shell — including over ssh to a fleet worker (#4980). Same IPC
+# request, same daemon-side termination path:
+loom-daemon cancel <sweep-id>
+loom-daemon cancel --issue 123          # resolves the live sweep for that issue
+loom-daemon cancel --issue 123 --grace 5
 ```
 
-The daemon's reaper task detects dead PIDs (every 30s) and removes them from the registry, emitting `sweep.issue.*.exited` / `sweep.issue.*.crashed` events.
+Both send SIGTERM to the sweep's **process group**, wait the grace window, then
+SIGKILL — so the wrapper, the `claude` agent, and every descendant (build tools,
+simulations, watcher loops) die together.
+
+**Never hand-`kill` a sweep's pids instead.** The registry tracks the
+`claude-wrapper.sh` pid; killing it leaves the underlying agent alive. On
+2026-08-03 that surviving agent noticed its subprocesses had died and
+*relaunched* them, against an issue whose claim the crash path had already
+returned to `loom:issue` — a zombie agent the registry reported as
+`in_flight: 0`. If you have already done this, `loom-daemon status` will not show
+the survivors: find them with `pstree -p <pid>` / `ps -eo pid,pgid,args` and kill
+the whole group (`kill -TERM -<pgid>`).
+
+The daemon's reaper task detects dead PIDs (every 30s) and removes them from the registry, emitting `sweep.issue.*.exited` / `sweep.issue.*.crashed` events. Since #4980 it also reaps a dead leader's *surviving* process group on that same tick, so an orphaned agent no longer keeps running unclaimed work.
 
 ### Stuck sweep child
 
@@ -596,7 +615,8 @@ ls -la .loom/sweep-checkpoint/issue-123.json
 # Look at the child's log for errors
 tail -200 .loom/logs/sweep-issue-123.log
 
-# Cancel it through the daemon:
+# Cancel it through the daemon (MCP tool, or `loom-daemon cancel <id>` from a
+# shell / over ssh):
 mcp__loom__cancel_sweep --sweep_id <id>
 
 # The checkpoint survives cancellation, so re-dispatching the issue resumes

--- a/loom-daemon/src/cli/cancel.rs
+++ b/loom-daemon/src/cli/cancel.rs
@@ -1,0 +1,411 @@
+//! `loom-daemon cancel` handler (Issue #4980).
+//!
+//! CLI parity for the `mcp__loom__cancel_sweep` MCP tool. Before this existed,
+//! the only sanctioned way to stop a wedged sweep was the MCP tool — which lives
+//! in the operator's own Claude session on their own machine. Over ssh (the
+//! normal way a fleet worker is reached) there was no lever at all except raw
+//! `kill`, and hand-killing the tracked wrapper pid is exactly what produced the
+//! 2026-08-03 incident: a surviving `claude` agent that noticed its subprocesses
+//! had died and *relaunched* them, against an issue whose claim had already been
+//! returned to the queue.
+//!
+//! Deliberately a thin client over the **same** `CancelSweep` IPC request the
+//! MCP tool sends (`mcp-loom/src/tools/sweeps.ts` → `sendDaemonRequest`). The
+//! termination itself — SIGTERM to the process group, grace window, SIGKILL
+//! escalation, lock release, label restore, event emission — happens entirely
+//! daemon-side in `cancel_sweep_nonblocking`, so the two operator surfaces
+//! cannot drift apart: there is one implementation and two callers.
+
+use anyhow::Result;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use loom_daemon::types::{Request, Response, SweepInfo, SweepKind, SweepState};
+
+use super::common::{query_daemon_bounded, resolve_socket_path};
+use super::dispatch::resolve_cli_dispatch_workspace;
+
+/// Default seconds between the daemon's SIGTERM and its SIGKILL escalation.
+///
+/// Matches the `grace_secs` default the `cancel_sweep` MCP tool sends, so the
+/// two operator surfaces behave identically for the same sweep unless the
+/// operator explicitly asks otherwise.
+pub(crate) const DEFAULT_CANCEL_GRACE_SECS: u64 = 30;
+
+/// Client-side ceiling on the cancel round-trip.
+///
+/// The daemon acks only after the *whole* cancel completes (it polls the grace
+/// window before replying), so the budget must exceed `grace_secs` or a
+/// perfectly successful cancel reads as a timeout. The buffer mirrors
+/// `mcp-loom`'s `CANCEL_TIMEOUT_BUFFER_MS` treatment of the identical call.
+pub(crate) const CANCEL_ACK_BUFFER: Duration = Duration::from_secs(15);
+
+/// Build the `CancelSweep` IPC request. Pure and side-effect-free so the flag
+/// plumbing is unit-testable without a socket — mirrors `build_dispatch_request`
+/// (#3952) and the field mapping the `mcp__loom__cancel_sweep` tool uses, so
+/// both operator surfaces put byte-for-byte-equivalent frames on the wire.
+fn build_cancel_request(sweep_id: String, grace_secs: u64, workspace: Option<String>) -> Request {
+    Request::CancelSweep {
+        sweep_id,
+        grace_secs,
+        workspace_root: workspace,
+    }
+}
+
+/// Pick the sweep to cancel for `--issue N` out of a `ListSweeps` result.
+///
+/// Only **live** (`Running` / `Pending`) entries are candidates: terminal
+/// entries linger in the registry for an hour after they exit
+/// (`TERMINAL_RETENTION_SECS`), and cancelling one of those would be a
+/// no-op ack that misleads the operator into thinking the sweep they can still
+/// see in `ps` has been dealt with.
+///
+/// Ambiguity is an error rather than a guess — two live sweeps for one issue is
+/// itself a bug worth surfacing, and picking one silently could leave the other
+/// running while reporting success. Pure so the selection rules are testable
+/// without a daemon.
+fn select_sweep_for_issue(sweeps: &[SweepInfo], issue: u32) -> Result<String, String> {
+    let live: Vec<&SweepInfo> = sweeps
+        .iter()
+        .filter(|info| matches!(info.kind, SweepKind::Issue(n) if n == issue))
+        .filter(|info| matches!(info.state, SweepState::Running | SweepState::Pending))
+        .collect();
+    match live.as_slice() {
+        [] => Err(format!(
+            "no running sweep found for issue #{issue}. List what the daemon is tracking with \
+             `loom-daemon status`, or cancel by sweep id directly."
+        )),
+        [only] => Ok(only.sweep_id.clone()),
+        many => Err(format!(
+            "issue #{issue} has {} live sweeps ({}) — refusing to guess. Cancel by sweep id.",
+            many.len(),
+            many.iter()
+                .map(|info| info.sweep_id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
+/// Handle the `cancel` subcommand (Issue #4980).
+///
+/// `--issue N` is resolved to a sweep id client-side via one extra `ListSweeps`
+/// round-trip rather than by teaching the daemon a second cancel-addressing
+/// mode: the wire protocol stays exactly the one `cancel_sweep` already speaks,
+/// and there is no new server-side code path that could diverge from the MCP
+/// tool's.
+pub(crate) async fn handle_cancel_command(
+    sweep_id: Option<String>,
+    issue: Option<u32>,
+    grace_secs: u64,
+    workspace: Option<String>,
+) -> Result<()> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let registry =
+        loom_daemon::workspace_registry::WorkspaceRegistry::load_default().unwrap_or_default();
+    let workspace = resolve_cli_dispatch_workspace(workspace, &cwd, &registry);
+
+    let socket_path = resolve_socket_path()?;
+    let ack_timeout = Duration::from_secs(grace_secs) + CANCEL_ACK_BUFFER;
+
+    let sweep_id = match (sweep_id, issue) {
+        (Some(id), _) => id,
+        (None, Some(issue)) => {
+            let list = Request::ListSweeps {
+                state_filter: None,
+                workspace_root: workspace.clone(),
+            };
+            match query_daemon_bounded(&socket_path, &list, ack_timeout).await {
+                Ok(Response::SweepList { sweeps }) => {
+                    match select_sweep_for_issue(&sweeps, issue) {
+                        Ok(id) => id,
+                        Err(message) => {
+                            eprintln!("{message}");
+                            std::process::exit(1);
+                        }
+                    }
+                }
+                Ok(Response::Error { message }) => {
+                    eprintln!("Daemon rejected the sweep lookup: {message}");
+                    std::process::exit(1);
+                }
+                Ok(Response::StructuredError(err)) => {
+                    eprintln!("Daemon rejected the sweep lookup: {}", err.message);
+                    std::process::exit(1);
+                }
+                Ok(other) => {
+                    eprintln!("Unexpected response from daemon: {other:?}");
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    daemon_unreachable(&e.to_string(), ack_timeout);
+                }
+            }
+        }
+        // clap enforces that one of the two is present; this is unreachable in
+        // practice and stays a plain error rather than a panic.
+        (None, None) => {
+            eprintln!("Specify a sweep id or --issue <N>.");
+            std::process::exit(2);
+        }
+    };
+
+    let request = build_cancel_request(sweep_id.clone(), grace_secs, workspace);
+    match query_daemon_bounded(&socket_path, &request, ack_timeout).await {
+        Ok(Response::SweepCancelled {
+            sweep_id,
+            pid,
+            sigkill_sent,
+            was_running,
+        }) => {
+            if was_running {
+                println!("Cancelled sweep {sweep_id}");
+                println!("  pid:       {pid} (process group torn down)");
+                println!(
+                    "  escalated: {}",
+                    if sigkill_sent {
+                        "SIGKILL (did not exit within the grace window)"
+                    } else {
+                        "no — exited on SIGTERM"
+                    }
+                );
+            } else {
+                // Idempotent by design: a monitor/operator retry against a sweep
+                // that already finished is a success, not an error.
+                println!("Sweep {sweep_id} was already terminal — nothing to cancel (pid {pid}).");
+            }
+            Ok(())
+        }
+        Ok(Response::Error { message }) => {
+            eprintln!("Daemon rejected the cancel: {message}");
+            std::process::exit(1);
+        }
+        Ok(Response::StructuredError(err)) => {
+            eprintln!("Daemon rejected the cancel: {}", err.message);
+            std::process::exit(1);
+        }
+        Ok(other) => {
+            eprintln!("Unexpected response from daemon: {other:?}");
+            std::process::exit(1);
+        }
+        Err(e) => daemon_unreachable(&e.to_string(), ack_timeout),
+    }
+}
+
+/// Render the "is the daemon running?" diagnostic and exit nonzero. Mirrors the
+/// `dispatch` subcommand's wording so both operator surfaces fail the same way.
+fn daemon_unreachable(error: &str, ack_timeout: Duration) -> ! {
+    eprintln!(
+        "Daemon did not ack the cancel within {}s ({error}) — is loom-daemon running?",
+        ack_timeout.as_secs()
+    );
+    eprintln!();
+    eprintln!("Start it with:");
+    eprintln!("  ./.loom/scripts/cli/loom-daemon-start.sh");
+    std::process::exit(1);
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
+mod cancel_tests {
+    //! Tests for the `loom-daemon cancel` subcommand (Issue #4980): flag
+    //! plumbing into the `CancelSweep` IPC request, `--issue N` → sweep-id
+    //! selection, and a round-trip against a fake daemon proving the CLI puts
+    //! the same frame on the wire the MCP `cancel_sweep` tool does.
+    use super::{build_cancel_request, select_sweep_for_issue, DEFAULT_CANCEL_GRACE_SECS};
+    use crate::cli::common::query_daemon_bounded;
+    use chrono::Utc;
+    use loom_daemon::types::{Request, Response, SweepInfo, SweepKind, SweepState};
+    use std::time::Duration;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::UnixListener;
+
+    fn sweep(sweep_id: &str, issue: u32, state: SweepState) -> SweepInfo {
+        SweepInfo {
+            sweep_id: sweep_id.to_string(),
+            kind: SweepKind::Issue(issue),
+            pid: 4242,
+            pgid: Some(4242),
+            token_name: "agent-1.token".to_string(),
+            runtime: "claude".to_string(),
+            runtime_source: None,
+            log_path: std::path::PathBuf::from(".loom/logs/sweep.log"),
+            idempotency_key: None,
+            started_at: Utc::now(),
+            state,
+            latest_phase: None,
+            pr_number: None,
+            model: None,
+            effort: None,
+            depends_on: None,
+            repo: None,
+        }
+    }
+
+    /// `build_cancel_request` maps every flag into the right `CancelSweep`
+    /// field — the core plumbing acceptance criterion.
+    #[test]
+    fn build_cancel_request_plumbs_all_flags() {
+        let request = build_cancel_request(
+            "sweep-issue-4980-1".to_string(),
+            45,
+            Some("/some/repo".to_string()),
+        );
+        match request {
+            Request::CancelSweep {
+                sweep_id,
+                grace_secs,
+                workspace_root,
+            } => {
+                assert_eq!(sweep_id, "sweep-issue-4980-1");
+                assert_eq!(grace_secs, 45);
+                assert_eq!(workspace_root.as_deref(), Some("/some/repo"));
+            }
+            other => panic!("expected CancelSweep, got {other:?}"),
+        }
+    }
+
+    /// With no `--workspace` the request leaves `workspace_root` unset so the
+    /// daemon's own default-workspace resolution applies, and the default grace
+    /// matches the MCP tool's.
+    #[test]
+    fn build_cancel_request_defaults_match_the_mcp_tool() {
+        let request = build_cancel_request("sweep-x".to_string(), DEFAULT_CANCEL_GRACE_SECS, None);
+        match request {
+            Request::CancelSweep {
+                grace_secs,
+                workspace_root,
+                ..
+            } => {
+                assert_eq!(grace_secs, 30, "must match mcp-loom's cancel_sweep default");
+                assert!(workspace_root.is_none());
+            }
+            other => panic!("expected CancelSweep, got {other:?}"),
+        }
+    }
+
+    /// `--issue N` resolves to the one LIVE sweep for that issue.
+    #[test]
+    fn select_sweep_for_issue_picks_the_live_entry() {
+        let sweeps = vec![
+            sweep("sweep-other", 99, SweepState::Running),
+            sweep(
+                "sweep-old",
+                4980,
+                SweepState::Exited {
+                    code: Some(0),
+                    at: Utc::now(),
+                },
+            ),
+            sweep("sweep-live", 4980, SweepState::Running),
+        ];
+        assert_eq!(select_sweep_for_issue(&sweeps, 4980).unwrap(), "sweep-live");
+    }
+
+    /// A terminal entry is NOT a candidate: those linger in the registry for an
+    /// hour after exit, and "cancelling" one would ack success while whatever
+    /// the operator is actually looking at keeps running.
+    #[test]
+    fn select_sweep_for_issue_ignores_terminal_entries() {
+        let sweeps = vec![sweep(
+            "sweep-dead",
+            4980,
+            SweepState::Crashed { at: Utc::now() },
+        )];
+        let err = select_sweep_for_issue(&sweeps, 4980).unwrap_err();
+        assert!(err.contains("no running sweep"), "{err}");
+    }
+
+    /// Two live sweeps for one issue is itself a bug — refuse rather than guess,
+    /// which would leave one running while reporting success.
+    #[test]
+    fn select_sweep_for_issue_refuses_to_guess_when_ambiguous() {
+        let sweeps = vec![
+            sweep("sweep-a", 4980, SweepState::Running),
+            sweep("sweep-b", 4980, SweepState::Pending),
+        ];
+        let err = select_sweep_for_issue(&sweeps, 4980).unwrap_err();
+        assert!(err.contains("refusing to guess"), "{err}");
+        assert!(err.contains("sweep-a") && err.contains("sweep-b"), "{err}");
+    }
+
+    /// Full client round-trip: the CLI's frame arrives on the wire as the exact
+    /// `CancelSweep` request the MCP `cancel_sweep` tool sends, and the
+    /// `SweepCancelled` reply parses back with its outcome fields intact.
+    #[tokio::test]
+    async fn round_trip_sends_cancel_sweep_and_parses_the_outcome() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("daemon.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind");
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let (reader, mut writer) = stream.into_split();
+            let mut lines = BufReader::new(reader).lines();
+            let line = lines.next_line().await.expect("read").expect("line");
+            let request: Request = serde_json::from_str(&line).expect("parse request");
+            match request {
+                Request::CancelSweep {
+                    sweep_id,
+                    grace_secs,
+                    workspace_root,
+                } => {
+                    assert_eq!(sweep_id, "sweep-issue-4980-1");
+                    assert_eq!(grace_secs, 30);
+                    assert_eq!(workspace_root.as_deref(), Some("/repo"));
+                }
+                other => panic!("expected CancelSweep, got {other:?}"),
+            }
+            let response = Response::SweepCancelled {
+                sweep_id: "sweep-issue-4980-1".to_string(),
+                pid: 4242,
+                sigkill_sent: true,
+                was_running: true,
+            };
+            let json = serde_json::to_string(&response).expect("serialize");
+            writer.write_all(json.as_bytes()).await.expect("write");
+            writer.write_all(b"\n").await.expect("newline");
+            writer.flush().await.expect("flush");
+        });
+
+        let request = build_cancel_request(
+            "sweep-issue-4980-1".to_string(),
+            DEFAULT_CANCEL_GRACE_SECS,
+            Some("/repo".to_string()),
+        );
+        let response = query_daemon_bounded(&socket_path, &request, Duration::from_secs(5))
+            .await
+            .expect("round-trip ok");
+
+        match response {
+            Response::SweepCancelled {
+                sweep_id,
+                pid,
+                sigkill_sent,
+                was_running,
+            } => {
+                assert_eq!(sweep_id, "sweep-issue-4980-1");
+                assert_eq!(pid, 4242);
+                assert!(sigkill_sent);
+                assert!(was_running);
+            }
+            other => panic!("expected SweepCancelled, got {other:?}"),
+        }
+
+        server.await.expect("server task");
+    }
+
+    /// A missing socket (no daemon listening at all) surfaces a connect error
+    /// promptly rather than hanging — the operator's "is the daemon running?"
+    /// case, and the reason this command can be trusted over ssh.
+    #[tokio::test]
+    async fn absent_socket_errors_fast() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("nonexistent.sock");
+
+        let request = build_cancel_request("sweep-x".to_string(), 1, None);
+        let result = query_daemon_bounded(&socket_path, &request, Duration::from_millis(500)).await;
+
+        assert!(result.is_err(), "expected a connect error, got {result:?}");
+    }
+}

--- a/loom-daemon/src/cli/dispatch.rs
+++ b/loom-daemon/src/cli/dispatch.rs
@@ -53,7 +53,12 @@ fn build_dispatch_request(
 /// unit-testable without touching the real filesystem/env; `cwd`/`registry`
 /// are resolved once by [`handle_dispatch_command`] via `std::env::current_dir()`
 /// / `WorkspaceRegistry::load_default()`.
-fn resolve_cli_dispatch_workspace(
+///
+/// Shared with `loom-daemon cancel` (#4980) rather than duplicated: the two
+/// commands must resolve the *same* repo from the same cwd, or an operator
+/// standing in a registered repo could dispatch into it and then fail to cancel
+/// the sweep they just started.
+pub(crate) fn resolve_cli_dispatch_workspace(
     explicit: Option<String>,
     cwd: &Path,
     registry: &loom_daemon::workspace_registry::WorkspaceRegistry,

--- a/loom-daemon/src/cli/mod.rs
+++ b/loom-daemon/src/cli/mod.rs
@@ -7,6 +7,7 @@
 //! bootstrap/service-loop body, which is not a CLI subcommand handler.
 
 pub(crate) mod accounts;
+pub(crate) mod cancel;
 pub(crate) mod cleanup_ops;
 pub(crate) mod common;
 pub(crate) mod dispatch;

--- a/loom-daemon/src/cli/status_render.rs
+++ b/loom-daemon/src/cli/status_render.rs
@@ -1759,6 +1759,7 @@ mod in_flight_repo_column_tests {
     /// `mk()` helper pattern used by `sweep_registry.rs`'s own tests.
     fn mk(issue: u32, repo: Option<&str>) -> SweepInfo {
         SweepInfo {
+            pgid: None,
             sweep_id: format!("s{issue}"),
             kind: SweepKind::Issue(issue),
             pid: 4242,

--- a/loom-daemon/src/daemon_service.rs
+++ b/loom-daemon/src/daemon_service.rs
@@ -140,6 +140,15 @@ pub(crate) async fn run_daemon() -> Result<()> {
                 depends_on,
                 force,
             } => handle_dispatch_command(issue, workspace, model, effort, depends_on, force).await,
+            // `cancel` connects to the running daemon over its Unix socket to
+            // terminate a sweep (Issue #4980) — the `dispatch` sibling, same
+            // socket, same reason it needs the async runtime.
+            Commands::Cancel {
+                sweep_id,
+                issue,
+                grace,
+                workspace,
+            } => cli::cancel::handle_cancel_command(sweep_id, issue, grace, workspace).await,
             // `watch` connects to the running daemon over its Unix socket to
             // register/list/remove durable watches (Issue #3971).
             Commands::Watch { action } => handle_watch_command(action).await,

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -5273,6 +5273,126 @@ exit 0
         }
     }
 
+    /// Issue #4980 acceptance criterion 3: `loom-daemon cancel` (CLI) and
+    /// `cancel_sweep` (MCP) must **share** the termination implementation.
+    ///
+    /// The structural guarantee is that both surfaces put the *same frame* on
+    /// the wire, so there is exactly one server-side path and nothing to
+    /// diverge. This asserts it at the byte level: the JSON `mcp-loom`'s
+    /// `cancelSweep` sends and the JSON the CLI serializes from
+    /// `build_cancel_request` deserialize to the identical
+    /// `Request::CancelSweep`.
+    #[test]
+    fn test_cancel_sweep_cli_and_mcp_frames_are_identical_on_the_wire() {
+        // Exactly what `mcp-loom/src/tools/sweeps.ts` `cancelSweep` sends
+        // (`sendDaemonRequest` writes the `{type, payload}` shape verbatim).
+        let mcp_frame = r#"{"type":"CancelSweep","payload":{"sweep_id":"sweep-issue-4980-1","grace_secs":30,"workspace_root":null}}"#;
+        let from_mcp: Request = serde_json::from_str(mcp_frame).expect("MCP frame must parse");
+
+        // Exactly what the `loom-daemon cancel` CLI serializes.
+        let from_cli: Request = serde_json::from_str(
+            &serde_json::to_string(&Request::CancelSweep {
+                sweep_id: "sweep-issue-4980-1".to_string(),
+                grace_secs: 30,
+                workspace_root: None,
+            })
+            .unwrap(),
+        )
+        .expect("CLI frame must parse");
+
+        match (&from_mcp, &from_cli) {
+            (
+                Request::CancelSweep {
+                    sweep_id: mcp_id,
+                    grace_secs: mcp_grace,
+                    workspace_root: mcp_ws,
+                },
+                Request::CancelSweep {
+                    sweep_id: cli_id,
+                    grace_secs: cli_grace,
+                    workspace_root: cli_ws,
+                },
+            ) => {
+                assert_eq!(mcp_id, cli_id);
+                assert_eq!(mcp_grace, cli_grace);
+                assert_eq!(mcp_ws, cli_ws);
+            }
+            other => panic!("expected two CancelSweep requests, got {other:?}"),
+        }
+    }
+
+    /// Issue #4980: a CLI-invoked cancel runs the full daemon-side termination
+    /// path — terminal transition plus claim-lock release — exercised through a
+    /// frame parsed off the wire rather than one constructed in-process, so a
+    /// wire-format regression fails here too.
+    #[test]
+    #[serial_test::serial]
+    fn test_handle_request_cancel_sweep_from_cli_frame_runs_the_shared_path() {
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr, dir, _rec) = setup_sweep_registry_in_tempdir();
+        let _registry_guard = seed_temp_registry(&[]);
+
+        let dispatched = handle_request(
+            Request::DispatchSweep {
+                kind: SweepKind::Issue(4980),
+                idempotency_key: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                // `None` resolves to the default registry `sr` — the same
+                // tempdir-rooted registry the cancel below targets.
+                workspace_root: None,
+                force: false,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &test_pool(),
+        );
+        let sweep_id = match dispatched {
+            Response::SweepDispatched { sweep_id, .. } => sweep_id,
+            other => panic!("Expected SweepDispatched, got: {other:?}"),
+        };
+        let lock_dir = dir.path().join(".loom").join("locks").join("issue-4980");
+        assert!(lock_dir.exists(), "dispatch should have taken the claim lock");
+
+        // Parse the CLI's frame off the wire, exactly as `handle_client` would.
+        let frame = serde_json::to_string(&Request::CancelSweep {
+            sweep_id: sweep_id.clone(),
+            grace_secs: 1,
+            workspace_root: None,
+        })
+        .unwrap();
+        let request: Request = serde_json::from_str(&frame).expect("CLI frame must parse");
+
+        let response = handle_request(request, &tm, &db, &sr, &bus, &test_pool());
+        match response {
+            Response::SweepCancelled {
+                sweep_id: cancelled,
+                ..
+            } => assert_eq!(cancelled, sweep_id),
+            other => panic!("Expected SweepCancelled, got: {other:?}"),
+        }
+
+        let state = sr
+            .lock()
+            .unwrap()
+            .get(&sweep_id)
+            .expect("entry should still be tracked")
+            .state
+            .clone();
+        assert!(
+            matches!(state, crate::types::SweepState::Exited { .. }),
+            "a CLI-invoked cancel must run the same terminal transition the MCP tool does, \
+             got {state:?}"
+        );
+        assert!(
+            !lock_dir.exists(),
+            "a CLI-invoked cancel must release the claim lock, exactly like the MCP path"
+        );
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_handle_request_get_sweep_status_returns_existing() {

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -253,6 +253,42 @@ enum Commands {
         force: bool,
     },
 
+    /// Cancel a running sweep via the running daemon (Issue #4980): the `dispatch`
+    /// sibling, over the same `CancelSweep` IPC request the
+    /// `mcp__loom__cancel_sweep` tool uses.
+    ///
+    /// This is the sanctioned way to stop a wedged sweep over ssh, where no MCP
+    /// server is attached. Do NOT hand-`kill` a sweep's pids instead: the daemon
+    /// tracks the wrapper, and killing it leaves the underlying `claude` agent
+    /// alive — in the 2026-08-03 incident that surviving agent noticed its
+    /// subprocesses had died and relaunched them, against an issue whose claim
+    /// had already been returned to the queue. The daemon signals the whole
+    /// process GROUP (SIGTERM, then SIGKILL after the grace window), releases the
+    /// claim lock, restores the label, and emits the lifecycle events.
+    Cancel {
+        /// The sweep id to cancel (as shown by `loom-daemon status`). Mutually
+        /// exclusive with `--issue`.
+        #[arg(value_name = "SWEEP_ID", required_unless_present = "issue")]
+        sweep_id: Option<String>,
+
+        /// Cancel the live sweep for this issue instead of naming a sweep id.
+        /// Resolved client-side against the daemon's registry; refuses rather
+        /// than guesses if the issue somehow has more than one live sweep.
+        #[arg(long, value_name = "N", conflicts_with = "sweep_id")]
+        issue: Option<u32>,
+
+        /// Seconds to wait between SIGTERM and SIGKILL. Defaults to the same
+        /// value the `cancel_sweep` MCP tool sends.
+        #[arg(long, value_name = "SECS", default_value_t = cli::cancel::DEFAULT_CANCEL_GRACE_SECS)]
+        grace: u64,
+
+        /// Target managed-workspace root (Issue #3929). Omit to use the daemon's
+        /// default workspace, or the registered repo the CLI's own cwd falls
+        /// under (#4299) — the same resolution `dispatch` applies.
+        #[arg(long, value_name = "PATH")]
+        workspace: Option<String>,
+    },
+
     /// Start a minimal read-only HTTP status-snapshot listener + embedded
     /// dashboard (Issue #4391 phase 1, #4392 phase 2, #4393 phase 3 of
     /// #4329). `GET /api/status` (#4391) serializes the same
@@ -2109,6 +2145,11 @@ fn handle_cli_command(command: Commands) -> Result<()> {
             // Routed directly in `main()` (it needs the async runtime for the
             // socket round-trip), never dispatched through this sync handler.
             unreachable!("Dispatch is handled in main() before handle_cli_command")
+        }
+        Commands::Cancel { .. } => {
+            // Routed directly in `main()` (it needs the async runtime for the
+            // socket round-trip), never dispatched through this sync handler.
+            unreachable!("Cancel is handled in main() before handle_cli_command")
         }
         Commands::Watch { .. } => {
             // Routed directly in `main()` (it needs the async runtime for the

--- a/loom-daemon/src/sweep_registry/crash_signals.rs
+++ b/loom-daemon/src/sweep_registry/crash_signals.rs
@@ -786,6 +786,7 @@ pub(crate) fn is_pid_alive(_pid: u32) -> bool {
 #[cfg(unix)]
 extern "C" {
     fn kill(pid: i32, sig: i32) -> i32;
+    fn getpgid(pid: i32) -> i32;
 }
 
 #[cfg(unix)]
@@ -793,6 +794,55 @@ extern "C" {
 pub(crate) fn libc_kill(pid: i32, sig: i32) -> i32 {
     // Indirection so we can stub this in unit tests if needed.
     unsafe { kill(pid, sig) }
+}
+
+/// The process-group ID `pid` currently belongs to, or `None` when it cannot be
+/// determined (the process is gone — `ESRCH` — or the pid is out of range).
+///
+/// Issue #4980: the registry persists a sweep's pgid so a *reconstructed* entry
+/// (post-restart) or a fresh `loom-daemon cancel` process can still group-kill
+/// the whole tree. This probe is how the recorded value is **verified** rather
+/// than assumed: a sweep child spawned with `process_group(0)` is its own group
+/// leader, so `getpgid(child) == child`. Anything else means the spawn did not
+/// take (or the pid was recycled), and the caller must degrade to single-PID
+/// signalling instead of blast-radiusing an unrelated group.
+///
+/// `pid == 0` is rejected: `getpgid(0)` means "the caller's own group", which is
+/// never a meaningful answer for a *tracked child* and would invite exactly the
+/// self-group kill this module's `pgid == 0` guards exist to prevent.
+#[cfg(unix)]
+pub(crate) fn process_group_of(pid: u32) -> Option<u32> {
+    if pid == 0 {
+        return None;
+    }
+    let pid_t: i32 = pid.try_into().ok()?;
+    // SAFETY: `getpgid` is a read-only query with no memory arguments.
+    let pgid = unsafe { getpgid(pid_t) };
+    u32::try_from(pgid).ok().filter(|&p| p != 0)
+}
+
+#[cfg(not(unix))]
+pub(crate) fn process_group_of(_pid: u32) -> Option<u32> {
+    None
+}
+
+/// The process group **this daemon/CLI process itself** belongs to (Issue
+/// #4980).
+///
+/// Load-bearing safety input, not a diagnostic: `kill(-pgid, sig)` against our
+/// own group would signal the daemon (and every one of its children) — the
+/// catastrophic mis-target that `send_group_signal`'s `pgid == 0` rejection
+/// already guards for the literal-zero case. A persisted-but-stale pgid read
+/// back from an old `owner.json` could name our own group by coincidence of PID
+/// recycling, so every group-signal caller cross-checks against this first.
+#[cfg(unix)]
+pub(crate) fn current_process_group() -> Option<u32> {
+    process_group_of(std::process::id())
+}
+
+#[cfg(not(unix))]
+pub(crate) fn current_process_group() -> Option<u32> {
+    None
 }
 
 #[cfg(test)]
@@ -1034,6 +1084,7 @@ mod tests {
         std::fs::create_dir(&lock).unwrap();
         let sweep_id = "sweep-issue-404-adopt";
         let owner = LockOwner {
+            pgid: None,
             issue: 404,
             owner_pid: std::process::id(),
             acquired_at: Utc::now().to_rfc3339(),

--- a/loom-daemon/src/sweep_registry/dispatch.rs
+++ b/loom-daemon/src/sweep_registry/dispatch.rs
@@ -11,6 +11,45 @@ use super::*;
 /// killed mid-build.
 pub const BG_WAIT_CEILING_ENV: &str = "CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS";
 
+/// Resolve the process group of a just-spawned sweep leader (Issue #4980).
+///
+/// `spawn_child` sets `process_group(0)` on every Unix spawn (#3800), so the
+/// child is its own group leader and `getpgid(child) == child`. We *verify* that
+/// rather than assume it, because the recorded value later authorizes a
+/// `kill(-pgid, …)`: recording a group the child does not actually lead would
+/// aim a SIGKILL at unrelated processes (in the worst case the daemon's own
+/// group).
+///
+/// The three outcomes:
+///
+/// - **Confirmed leader** (`getpgid == pid`) → `Some(pid)`.
+/// - **Contradiction** (`getpgid` names some other group) → `None` + a warning.
+///   `process_group(0)` did not take; degrade to single-PID signalling rather
+///   than signal a group we do not own.
+/// - **Unanswerable** (the child already exited, `ESRCH`) → `Some(pid)`. The
+///   spawn unconditionally requested its own group, so `pgid == pid` is the only
+///   shape this spawn can have, and this is precisely the crash case where the
+///   persisted group is the only handle on any surviving descendants. Every
+///   consumer re-checks `group_has_members` before signalling, so a fully-dead
+///   group is a no-op.
+fn spawned_leader_pgid(pid: u32) -> Option<u32> {
+    if !cfg!(unix) {
+        return None;
+    }
+    match process_group_of(pid) {
+        Some(pgid) if pgid == pid => Some(pid),
+        Some(other) => {
+            log::warn!(
+                "sweep_registry: spawned child pid {pid} reports process group {other} rather \
+                 than leading its own — `process_group(0)` did not take. Recording NO group; \
+                 cancellation will degrade to single-PID signalling (#4980)."
+            );
+            None
+        }
+        None => Some(pid),
+    }
+}
+
 /// Typed, matchable error returned by [`SweepRegistry::dispatch`] when the
 /// open-PR guard (Issue #4123, step 2.6) refuses a dispatch because the target
 /// issue already has an **open** linked pull request.
@@ -1111,6 +1150,10 @@ impl SweepRegistry {
         }
 
         let pid = child.id();
+        // Issue #4980: capture the child's process group NOW, while it is alive
+        // — `getpgid` cannot answer for a dead pid, so a group handle acquired
+        // any later is unavailable in exactly the crash case that needs it most.
+        let pgid = spawned_leader_pgid(pid);
         // Retain the handle so the reaper can `try_wait()` it (Issue #3801).
         self.children.insert(sweep_id.clone(), child);
 
@@ -1121,10 +1164,16 @@ impl SweepRegistry {
         // daemon PID is gone after any restart, so keeping it would make even a
         // still-live daemon-dispatched child look stale in `reconstruct()`'s
         // lock pass. Rewrite `owner_pid` now that the child exists.
-        if let Err(e) = self.record_child_pid_in_lock(issue_number, pid) {
+        //
+        // The same write persists the child's process group (#4980) so a
+        // post-restart `reconstruct()` — and a fresh `loom-daemon cancel`
+        // process, which never held the spawn-time `Child` handle — can still
+        // tear down the WHOLE tree instead of orphaning it.
+        if let Err(e) = self.record_child_pid_in_lock(issue_number, pid, pgid) {
             log::warn!(
-                "failed to record child pid {pid} in lock for issue #{issue_number} \
-                 (reconstruct may treat it as stale after a daemon restart): {e}"
+                "failed to record child pid {pid} (pgid {pgid:?}) in lock for issue \
+                 #{issue_number} (reconstruct may treat it as stale after a daemon restart, \
+                 and a post-restart cancel may not reach the whole process group): {e}"
             );
         }
 
@@ -1137,6 +1186,8 @@ impl SweepRegistry {
             sweep_id: sweep_id.clone(),
             kind: kind.clone(),
             pid,
+            // Group handle for cancellation / crash-path reaping (#4980).
+            pgid,
             token_name: token_name.clone(),
             runtime,
             runtime_source: runtime_admission.as_ref().map(|a| a.source.clone()),
@@ -1670,6 +1721,7 @@ mod tests {
 
         let mk_info =
             |sweep_id: &str, issue: u32, state: SweepState, log_path: PathBuf| SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.to_string(),
                 kind: SweepKind::Issue(issue),
                 pid: 0,

--- a/loom-daemon/src/sweep_registry/locks.rs
+++ b/loom-daemon/src/sweep_registry/locks.rs
@@ -118,12 +118,28 @@ impl LockReleaseOutcome {
 
 /// On-disk owner metadata written inside the lock dir. Schema mirrors
 /// `defaults/scripts/spawn-loop.sh:299-305`.
+///
+/// # Schema evolution (Issue #4980)
+///
+/// `pgid` was added after the fact, so it is `Option<u32>` + `#[serde(default)]`:
+/// an `owner.json` written by a pre-#4980 daemon binary (no `pgid` key at all)
+/// **must** still deserialize. Failing to parse it would be far worse than
+/// missing the field — `reconstruct()`, `lock_owned_by_other()`, and
+/// `live_sweep_lock_owner_pid()` all treat an unparseable owner as "no owner",
+/// which drops a *live* sweep's lock. The absent-pgid case degrades to
+/// single-PID signalling with a log line instead.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct LockOwner {
     pub(crate) issue: u32,
     pub(crate) owner_pid: u32,
     pub(crate) acquired_at: String,
     pub(crate) sweep_id: SweepId,
+    /// Process group led by `owner_pid` (Issue #4980). Written by
+    /// [`SweepRegistry::record_child_pid_in_lock`] once the child exists;
+    /// `None` on a provisional (pre-spawn) record and on any `owner.json`
+    /// written before this field existed.
+    #[serde(default)]
+    pub(crate) pgid: Option<u32>,
 }
 
 impl SweepRegistry {
@@ -222,6 +238,12 @@ impl SweepRegistry {
                     owner_pid: std::process::id(),
                     acquired_at: Utc::now().to_rfc3339(),
                     sweep_id: sweep_id.to_string(),
+                    // Provisional too (Issue #4980): the child's process group
+                    // does not exist yet, and recording the DAEMON's group here
+                    // would be actively dangerous — a later group-kill would
+                    // target the daemon itself. `record_child_pid_in_lock`
+                    // stamps the real value once the child is running.
+                    pgid: None,
                 };
                 let owner_json =
                     serde_json::to_string_pretty(&owner).context("serialize lock owner")?;
@@ -250,7 +272,19 @@ impl SweepRegistry {
     /// `Crashed` entry even for a child that was still alive. Storing the
     /// child PID lets the lock pass admit a genuinely-live child as `Running`
     /// across a restart. The rest of the owner record is preserved.
-    pub(crate) fn record_child_pid_in_lock(&self, issue: u32, child_pid: u32) -> Result<()> {
+    ///
+    /// Issue #4980 additionally stamps `pgid` — the process group the child
+    /// leads (`process_group(0)`, #3800). The pid alone is not enough to tear
+    /// down a sweep after the spawning daemon is gone: the OS can only report a
+    /// *live* process's group, so once the wrapper dies its surviving
+    /// descendants become unreachable-by-group unless the value was persisted
+    /// while it was alive. `None` leaves the field untouched (unknown group).
+    pub(crate) fn record_child_pid_in_lock(
+        &self,
+        issue: u32,
+        child_pid: u32,
+        pgid: Option<u32>,
+    ) -> Result<()> {
         let owner_path = self
             .config
             .locks_dir()
@@ -261,6 +295,9 @@ impl SweepRegistry {
         let mut owner: LockOwner =
             serde_json::from_str(&existing).context("parse lock owner.json")?;
         owner.owner_pid = child_pid;
+        if pgid.is_some() {
+            owner.pgid = pgid;
+        }
         let owner_json = serde_json::to_string_pretty(&owner).context("serialize lock owner")?;
         std::fs::write(&owner_path, owner_json)
             .with_context(|| format!("write lock owner {}", owner_path.display()))?;
@@ -460,6 +497,10 @@ impl SweepRegistry {
             owner_pid: std::process::id(),
             acquired_at: Utc::now().to_rfc3339(),
             sweep_id: watchdog_sweep_id.clone(),
+            // The watchdog holds this lock itself while it cleans a worktree —
+            // there is no sweep child, and recording OUR OWN group would let a
+            // later group-kill target the daemon (#4980).
+            pgid: None,
         };
         let takeover = serde_json::to_string_pretty(&owner)
             .context("serialize midbuild-watchdog lock owner")
@@ -578,6 +619,19 @@ impl SweepRegistry {
                     // dispatched this issue, so record the issue — the
                     // checkpoint pass may recover it as `Crashed` — then drop
                     // the stale lock and continue.
+                    //
+                    // Issue #4980 crash-path reap: a dead *leader* does not mean
+                    // a dead *tree*. The 2026-08-03 incident was exactly this
+                    // shape — the tracked wrapper was gone while the `claude`
+                    // agent it had spawned kept running (and relaunched its
+                    // workload) against an issue whose claim had already been
+                    // returned to the queue. The persisted `pgid` is the only
+                    // remaining handle on those survivors (the OS cannot report
+                    // a dead pid's group), so reap the group before dropping the
+                    // lock that records it.
+                    if let Some(pgid) = owner.pgid {
+                        self.reap_orphaned_group(&owner.sweep_id, Some(issue), pgid);
+                    }
                     daemon_owned_dead.insert(issue);
                     let _ = std::fs::remove_dir_all(&path);
                     continue;
@@ -593,12 +647,37 @@ impl SweepRegistry {
                 // to `unknown`. Degrades gracefully — adoption never fails here.
                 let token_name = recover_adopted_token_name(&log_path, &owner.sweep_id);
                 let runtime = recover_adopted_runtime(&log_path, &owner.sweep_id);
+                // Issue #4980: carry the persisted process group onto the
+                // reconstructed entry so a post-restart cancel still tears down
+                // the WHOLE tree instead of degrading to a single-PID kill that
+                // orphans the `claude` agent and its descendants. Re-verified
+                // against the live owner rather than trusted blindly: the owner
+                // is alive here (checked above), so the OS can confirm the
+                // recorded group is still the one it leads. A disagreement means
+                // the record is stale (PID recycled between daemons), and
+                // group-killing a stranger's group is exactly the blast radius
+                // this must never have — drop to `None` and degrade.
+                let pgid = owner.pgid.filter(|&recorded| {
+                    let actual = process_group_of(owner.owner_pid);
+                    if actual == Some(recorded) {
+                        true
+                    } else {
+                        log::warn!(
+                            "reconstruct: issue #{issue} lock records pgid {recorded} for owner \
+                             pid {} but the OS reports {actual:?} — ignoring the recorded group \
+                             and degrading to single-PID signalling (#4980)",
+                            owner.owner_pid
+                        );
+                        false
+                    }
+                });
                 self.entries.insert(
                     owner.sweep_id.clone(),
                     SweepInfo {
                         sweep_id: owner.sweep_id.clone(),
                         kind: SweepKind::Issue(issue),
                         pid: owner.owner_pid,
+                        pgid,
                         token_name,
                         runtime,
                         runtime_source: None,
@@ -675,6 +754,11 @@ impl SweepRegistry {
                         sweep_id,
                         kind: SweepKind::Issue(issue),
                         pid: 0, // unknown — owner is gone
+                        // Likewise unknown (#4980): the lock that recorded the
+                        // process group was already removed as stale by the pass
+                        // above, and its group (if any survivors remained) was
+                        // reaped there.
+                        pgid: None,
                         // Issue #4173: a checkpoint-only entry has no lock
                         // `sweep_id` anchor to recover the token against (the
                         // lock was already removed as stale above), so this
@@ -730,6 +814,7 @@ mod tests {
         let lock = locks.join("issue-77");
         std::fs::create_dir(&lock).unwrap();
         let owner = LockOwner {
+            pgid: None,
             issue: 77,
             owner_pid: std::process::id(),
             acquired_at: Utc::now().to_rfc3339(),
@@ -760,6 +845,7 @@ mod tests {
         let lock = locks.join("issue-4201");
         std::fs::create_dir(&lock).unwrap();
         let owner = LockOwner {
+            pgid: None,
             issue: 4201,
             owner_pid: std::process::id(), // guaranteed alive
             acquired_at: Utc::now().to_rfc3339(),
@@ -789,6 +875,7 @@ mod tests {
         let lock = locks.join("issue-4202");
         std::fs::create_dir(&lock).unwrap();
         let owner = LockOwner {
+            pgid: None,
             issue: 4202,
             owner_pid: std::process::id(),
             acquired_at: Utc::now().to_rfc3339(),
@@ -822,6 +909,7 @@ mod tests {
         let lock = locks.join("issue-4203");
         std::fs::create_dir(&lock).unwrap();
         let owner = LockOwner {
+            pgid: None,
             issue: 4203,
             owner_pid: 2_147_483_640, // dead
             acquired_at: Utc::now().to_rfc3339(),
@@ -848,6 +936,7 @@ mod tests {
         let lock = locks.join("issue-78");
         std::fs::create_dir(&lock).unwrap();
         let owner = LockOwner {
+            pgid: None,
             issue: 78,
             owner_pid: 2_147_483_640, // dead
             acquired_at: Utc::now().to_rfc3339(),
@@ -898,6 +987,7 @@ mod tests {
         let lock = locks.join("issue-91");
         std::fs::create_dir(&lock).unwrap();
         let owner = LockOwner {
+            pgid: None,
             issue: 91,
             owner_pid: 2_147_483_640, // dead
             acquired_at: Utc::now().to_rfc3339(),
@@ -1064,6 +1154,7 @@ mod tests {
         std::fs::create_dir(&lock).unwrap();
         let sweep_id = "sweep-issue-401-adopt";
         let owner = LockOwner {
+            pgid: None,
             issue: 401,
             owner_pid: std::process::id(), // alive → admitted as Running
             acquired_at: Utc::now().to_rfc3339(),
@@ -1109,6 +1200,7 @@ mod tests {
         let lock_a = locks.join("issue-402");
         std::fs::create_dir(&lock_a).unwrap();
         let owner_a = LockOwner {
+            pgid: None,
             issue: 402,
             owner_pid: std::process::id(),
             acquired_at: Utc::now().to_rfc3339(),
@@ -1125,6 +1217,7 @@ mod tests {
         let lock_b = locks.join("issue-403");
         std::fs::create_dir(&lock_b).unwrap();
         let owner_b = LockOwner {
+            pgid: None,
             issue: 403,
             owner_pid: std::process::id(),
             acquired_at: Utc::now().to_rfc3339(),

--- a/loom-daemon/src/sweep_registry/mod.rs
+++ b/loom-daemon/src/sweep_registry/mod.rs
@@ -554,6 +554,21 @@ pub struct SweepRegistry {
     /// capped at [`MAX_PHASE_OBSERVATIONS`] so a pathological Judge/Doctor loop
     /// cannot grow it without bound.
     phase_history: HashMap<SweepId, Vec<PhaseObservation>>,
+    /// Orphaned process groups awaiting SIGKILL escalation (Issue #4980).
+    ///
+    /// Written by [`reap_orphaned_group`](Self::reap_orphaned_group) when a
+    /// crash path (the reaper's dead-leader branch, or `reconstruct()`'s
+    /// stale-lock branch) finds a *dead* sweep leader whose process group still
+    /// has live members, and drained by
+    /// [`escalate_pending_group_reaps`](Self::escalate_pending_group_reaps) at
+    /// the top of each [`reap_once`](Self::reap_once) tick.
+    ///
+    /// Deferring the escalation to a later tick — rather than sleeping through
+    /// the grace inline — is deliberate: `reap_once` also runs on the
+    /// `ListSweeps` / `GetSweepStatus` read path while holding the registry
+    /// mutex, and blocking there is the 2026-07-26 wedge shape. Entries are
+    /// removed as soon as the group drains, so this never accumulates.
+    pending_group_reaps: HashMap<SweepId, PendingGroupReap>,
 }
 
 /// Resolve this host's identity string for collision records (Issue #4085) and
@@ -697,6 +712,7 @@ impl SweepRegistry {
             label_flip_log: HashMap::new(),
             flap_warned_at: HashMap::new(),
             phase_history: HashMap::new(),
+            pending_group_reaps: HashMap::new(),
         }
     }
 
@@ -738,6 +754,7 @@ impl SweepRegistry {
             label_flip_log: HashMap::new(),
             flap_warned_at: HashMap::new(),
             phase_history: HashMap::new(),
+            pending_group_reaps: HashMap::new(),
         }
     }
 
@@ -1229,6 +1246,9 @@ mod tests {
             sweep_id: "sweep-issue-42-1700000000".to_string(),
             kind: SweepKind::Issue(42),
             pid: 12_345,
+            // Issue #4980: a sweep is spawned as its own group leader, so a
+            // live dispatch's pgid equals its pid.
+            pgid: Some(12_345),
             token_name: "agent-1.token".to_string(),
             runtime: "unknown".into(),
             runtime_source: None,
@@ -1250,6 +1270,7 @@ mod tests {
             "sweep_id": "sweep-issue-42-1700000000",
             "kind": {"type": "Issue", "value": 42},
             "pid": 12_345,
+            "pgid": 12_345,
             "token_name": "agent-1.token",
             "runtime": "unknown",
             "log_path": ".loom/logs/sweep-issue-42.log",
@@ -1285,6 +1306,10 @@ mod tests {
         // None (#[serde(default)]) and be omitted on re-serialization
         // (skip_serializing_if).
         assert_eq!(legacy.effort, None);
+        // Pre-#4980 JSON lacks `pgid` too — it must default to None and be
+        // omitted on re-serialization, so an older client/daemon on the other
+        // end of the socket is unaffected.
+        assert_eq!(legacy.pgid, None);
         assert_eq!(legacy.runtime, "unknown");
         let reserialized = serde_json::to_value(&legacy).unwrap();
         assert!(

--- a/loom-daemon/src/sweep_registry/outcome_journal.rs
+++ b/loom-daemon/src/sweep_registry/outcome_journal.rs
@@ -672,6 +672,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: kind.clone(),
                 pid: 2_147_483_640,

--- a/loom-daemon/src/sweep_registry/reaper.rs
+++ b/loom-daemon/src/sweep_registry/reaper.rs
@@ -290,6 +290,65 @@ pub(crate) fn send_group_signal(_pgid: u32, _sig: i32) -> bool {
     false
 }
 
+/// Whether the process group `pgid` still has at least one member (Issue
+/// #4980).
+///
+/// `kill(-pgid, 0)` is the group-scoped twin of the `kill(pid, 0)` liveness
+/// probe: it succeeds while *any* process remains in the group and fails with
+/// `ESRCH` once the group is empty. This is what lets the crash-path reaper
+/// distinguish "the leader died and took its tree with it" (nothing to do) from
+/// "the leader died and left an agent running unclaimed work" (the incident this
+/// issue exists to close).
+///
+/// `EPERM` counts as *present* for the same fail-safe reason
+/// [`is_pid_alive`](crate::sweep_registry::is_pid_alive) treats it as alive: the
+/// group demonstrably exists, we merely may not signal it.
+#[cfg(unix)]
+pub(crate) fn group_has_members(pgid: u32) -> bool {
+    if pgid == 0 {
+        return false;
+    }
+    let Ok(pgid_t): Result<i32, _> = pgid.try_into() else {
+        return false;
+    };
+    if libc_kill(-pgid_t, 0) == 0 {
+        return true;
+    }
+    std::io::Error::last_os_error().raw_os_error() == Some(EPERM)
+}
+
+#[cfg(not(unix))]
+pub(crate) fn group_has_members(_pgid: u32) -> bool {
+    false
+}
+
+/// Grace between the crash-path reaper's group SIGTERM and its SIGKILL
+/// escalation (Issue #4980).
+///
+/// The escalation is deliberately deferred to a later reaper tick rather than
+/// slept through inline: [`SweepRegistry::reap_once`] also runs on the
+/// `ListSweeps` / `GetSweepStatus` read path (via `reap_liveness`) while holding
+/// the registry mutex, and blocking there for a grace window is the exact
+/// 2026-07-26 wedge [`REAP_GH_TIMEOUT`] exists to prevent. Five seconds means
+/// the next ordinary tick (30s) is always past the deadline.
+pub(crate) const ORPHAN_GROUP_REAP_GRACE: Duration = Duration::from_secs(5);
+
+/// One entry's snapshot taken at the top of a [`SweepRegistry::reap_once`] tick:
+/// `(sweep_id, pid, pgid, state, kind, started_at)`. Snapshotted (rather than
+/// iterated in place) so the loop body can borrow the registry mutably; `pgid`
+/// joined the tuple in #4980 so the crash path can reap a dead leader's
+/// surviving process group.
+pub(crate) type ReapCandidate = (SweepId, u32, Option<u32>, SweepState, SweepKind, DateTime<Utc>);
+
+/// A crash-path group reap awaiting SIGKILL escalation (Issue #4980).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PendingGroupReap {
+    /// The process group that was SIGTERM'd.
+    pub(crate) pgid: u32,
+    /// When SIGKILL becomes due if the group still has members.
+    pub(crate) escalate_at: Instant,
+}
+
 /// Read the last `n` lines of a file. Returns an empty vec when the
 /// file is empty; returns an error when the file does not exist (so the
 /// caller can distinguish "no log yet" from "log gone").
@@ -328,17 +387,143 @@ impl SweepRegistry {
         Some(info)
     }
 
-    /// Signal a sweep's process. When this daemon still owns a retained
-    /// `Child` handle for `sweep_id` (i.e. we spawned it into its own process
-    /// group via `process_group(0)`), the signal is delivered to the WHOLE
-    /// process group (`kill(-pgid, sig)`, and the leader's pgid == its pid)
-    /// so the entire `claude` subprocess subtree is reached (Issue #3800).
-    /// Reconstructed entries with no handle fall back to single-PID delivery.
+    /// Signal a sweep's process **group** (`kill(-pgid, sig)`), so the entire
+    /// `claude` subprocess subtree — wrapper, agent, build tools, simulations,
+    /// watcher loops — is reached rather than just the tracked leader PID
+    /// (Issue #3800).
+    ///
+    /// # Why this is no longer gated on a retained `Child` handle (Issue #4980)
+    ///
+    /// It used to be: `if self.children.contains_key(sweep_id)`. That made
+    /// group delivery an accident of *which process is asking*. Two ordinary
+    /// situations have no handle and silently degraded to a single-PID kill:
+    ///
+    /// - a `reconstruct()`-ed entry after a daemon restart, and
+    /// - **every** invocation from a fresh `loom-daemon cancel` CLI process,
+    ///   which never held a spawn-time handle at all.
+    ///
+    /// Degrading there is precisely the 2026-08-03 incident: SIGKILLing the
+    /// tracked wrapper left the `claude` agent alive, which noticed its
+    /// subprocesses had died and *relaunched them*. So the group is now resolved
+    /// from durable state — [`SweepInfo::pgid`], persisted at spawn time and
+    /// restored by `reconstruct()` — and used unconditionally.
+    ///
+    /// # Fallbacks (log, never panic, never mis-target)
+    ///
+    /// - No recorded pgid but we DO hold the handle ⇒ the leader is live and was
+    ///   spawned by us with `process_group(0)`, so `pgid == pid` holds by
+    ///   construction (the pre-#4980 behavior, retained for entries created
+    ///   before the field was populated).
+    /// - No recorded pgid and no handle (a pre-#4980 `owner.json`, a
+    ///   checkpoint-only entry, a non-Unix host) ⇒ single-PID delivery, with a
+    ///   log line naming the degradation rather than a silent one.
+    /// - A recorded pgid equal to **our own** process group ⇒ refuse the group
+    ///   signal outright. `kill(-our_pgid, 9)` would kill the daemon and every
+    ///   sweep it owns; a stale record naming our group (PID recycling across a
+    ///   restart) must never be able to do that.
     pub(crate) fn signal_sweep(&self, sweep_id: &str, pid: u32, sig: i32) -> bool {
-        if self.children.contains_key(sweep_id) {
-            send_group_signal(pid, sig)
-        } else {
-            send_signal(pid, sig)
+        let recorded = self.entries.get(sweep_id).and_then(|info| info.pgid);
+        let retained_handle = self.children.contains_key(sweep_id);
+        let Some(pgid) = recorded.or_else(|| retained_handle.then_some(pid)) else {
+            log::warn!(
+                "signal_sweep: sweep {sweep_id} (pid {pid}) has no recorded process group \
+                 (pre-#4980 lock record or unknown-group entry) — falling back to single-PID \
+                 signal {sig}; descendants may survive"
+            );
+            return send_signal(pid, sig);
+        };
+        if Some(pgid) == current_process_group() {
+            log::error!(
+                "signal_sweep: refusing to send signal {sig} to process group {pgid} for sweep \
+                 {sweep_id} — that is THIS process's own group (stale/incorrect pgid record). \
+                 Falling back to single-PID delivery to pid {pid} (#4980)."
+            );
+            return send_signal(pid, sig);
+        }
+        send_group_signal(pgid, sig)
+    }
+
+    /// Terminate the surviving process group of a sweep whose **leader is
+    /// already dead** (Issue #4980) — the crash path.
+    ///
+    /// A dead wrapper does not imply a dead tree. In the 2026-08-03 incident the
+    /// tracked pid was gone while the `claude` agent it had spawned kept running
+    /// against an issue whose claim had already been returned to the queue: a
+    /// zombie agent, invisible to the registry (`in_flight: 0`), burning CPU and
+    /// mutating a repo it no longer held. `signal_sweep` cannot help here — the
+    /// OS refuses to report a dead pid's group — which is exactly why the pgid is
+    /// persisted while the leader is alive.
+    ///
+    /// Sends SIGTERM now and registers a deferred SIGKILL escalation
+    /// ([`ORPHAN_GROUP_REAP_GRACE`]) picked up by a later
+    /// [`reap_once`](Self::reap_once) tick, so no caller ever blocks on a grace
+    /// window while holding the registry mutex. A no-op (returning `false`) when
+    /// the group is already empty — the overwhelmingly common case, where the
+    /// leader's death took its whole tree with it.
+    pub(crate) fn reap_orphaned_group(
+        &mut self,
+        sweep_id: &str,
+        issue: Option<u32>,
+        pgid: u32,
+    ) -> bool {
+        if pgid == 0 || Some(pgid) == current_process_group() {
+            log::error!(
+                "reap_orphaned_group: refusing to signal process group {pgid} for sweep \
+                 {sweep_id} — it is zero or THIS process's own group (#4980)"
+            );
+            return false;
+        }
+        if !group_has_members(pgid) {
+            return false;
+        }
+        let scope = issue.map_or_else(String::new, |n| format!(" (issue #{n})"));
+        log::warn!(
+            "reap_orphaned_group: sweep {sweep_id}{scope} has a DEAD leader but its process \
+             group {pgid} still has members — an orphaned agent/subtree running unclaimed work. \
+             Sending SIGTERM to the group; escalating to SIGKILL in {}s if it survives (#4980).",
+            ORPHAN_GROUP_REAP_GRACE.as_secs()
+        );
+        send_group_signal(pgid, 15);
+        self.pending_group_reaps.insert(
+            sweep_id.to_string(),
+            PendingGroupReap {
+                pgid,
+                escalate_at: Instant::now() + ORPHAN_GROUP_REAP_GRACE,
+            },
+        );
+        true
+    }
+
+    /// SIGKILL any orphaned group that survived its crash-path SIGTERM past
+    /// [`ORPHAN_GROUP_REAP_GRACE`] (Issue #4980). Called at the top of every
+    /// [`reap_once`](Self::reap_once) tick, mirroring how
+    /// `retry_pending_quarantine_releases` drains its own deferred work.
+    /// Cheap early-return when nothing is pending.
+    pub(crate) fn escalate_pending_group_reaps(&mut self) {
+        if self.pending_group_reaps.is_empty() {
+            return;
+        }
+        let now = Instant::now();
+        let mut done: Vec<SweepId> = Vec::new();
+        for (sweep_id, pending) in &self.pending_group_reaps {
+            if !group_has_members(pending.pgid) {
+                // The SIGTERM worked (or the group drained on its own).
+                done.push(sweep_id.clone());
+                continue;
+            }
+            if now < pending.escalate_at {
+                continue;
+            }
+            log::warn!(
+                "reap_orphaned_group: process group {} for sweep {sweep_id} survived SIGTERM — \
+                 escalating to SIGKILL (#4980)",
+                pending.pgid
+            );
+            send_group_signal(pending.pgid, 9);
+            done.push(sweep_id.clone());
+        }
+        for sweep_id in done {
+            self.pending_group_reaps.remove(&sweep_id);
         }
     }
 
@@ -656,14 +841,27 @@ impl SweepRegistry {
         // Retry any previously-failed quarantine label restores (Issue #4110).
         // Cheap early-return when nothing is pending.
         self.retry_pending_quarantine_releases();
+        // SIGKILL-escalate any orphaned process group that survived a
+        // crash-path SIGTERM (Issue #4980). Cheap early-return when nothing is
+        // pending; never blocks (the grace is deadline-based, not slept).
+        self.escalate_pending_group_reaps();
 
         // Snapshot keys + pids first so we can borrow mutably below.
         // Capture started_at so we can compute durations for Exited events.
-        let candidates: Vec<(SweepId, u32, SweepState, SweepKind, chrono::DateTime<Utc>)> = self
+        // `pgid` rides along so the crash path can reap a dead leader's
+        // surviving process group (#4980).
+        let candidates: Vec<ReapCandidate> = self
             .entries
             .iter()
             .map(|(id, info)| {
-                (id.clone(), info.pid, info.state.clone(), info.kind.clone(), info.started_at)
+                (
+                    id.clone(),
+                    info.pid,
+                    info.pgid,
+                    info.state.clone(),
+                    info.kind.clone(),
+                    info.started_at,
+                )
             })
             .collect();
 
@@ -672,7 +870,7 @@ impl SweepRegistry {
         // registry mutex's lifetime budget unnecessarily.
         let mut events_to_emit: Vec<Event> = Vec::new();
 
-        for (sweep_id, pid, state, kind, started_at) in candidates {
+        for (sweep_id, pid, pgid, state, kind, started_at) in candidates {
             if !matches!(state, SweepState::Running | SweepState::Pending) {
                 continue;
             }
@@ -689,6 +887,21 @@ impl SweepRegistry {
             // handle fall back to the `kill(pid, 0)` probe.
             let (is_dead, exit_code) = self.poll_liveness(&sweep_id, pid);
             if is_dead {
+                // Issue #4980 crash-path reap: the tracked leader is gone, but
+                // its process group may still hold a live `claude` agent and
+                // whatever that agent spawned — the zombie-agent shape of the
+                // 2026-08-03 incident, which the registry rendered as
+                // `in_flight: 0` while the survivors kept mutating the repo.
+                // Signal the group before the entry transitions terminal (after
+                // which nothing tracks the pgid at all). No-op when the group is
+                // already empty, which is the ordinary case.
+                if let Some(pgid) = pgid {
+                    let issue = match &kind {
+                        SweepKind::Issue(n) => Some(*n),
+                        SweepKind::PrSet(_) => None,
+                    };
+                    self.reap_orphaned_group(&sweep_id, issue, pgid);
+                }
                 // #4493: account health must be updated before any bounded
                 // re-dispatch path below asks the selector for another profile.
                 self.apply_provider_health_feedback(&sweep_id, exit_code);
@@ -1356,6 +1569,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(41_110),
                 pid,
@@ -1624,6 +1838,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(55),
                 pid: 2_147_483_640,
@@ -1712,6 +1927,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(57),
                 pid: 2_147_483_641,
@@ -1773,6 +1989,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(66),
                 pid: 2_147_483_640,
@@ -1830,6 +2047,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(21),
                 pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
@@ -1909,6 +2127,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(77),
                 pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
@@ -1976,6 +2195,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: kind.clone(),
                 pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
@@ -2041,6 +2261,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: kind.clone(),
                 pid: 2_147_483_640,
@@ -2105,6 +2326,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: kind.clone(),
                 pid: 2_147_483_640,
@@ -2152,6 +2374,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(33),
                 pid: 2_147_483_640,
@@ -2212,6 +2435,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: kind.clone(),
                 pid: 2_147_483_640,
@@ -2278,6 +2502,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(42),
                 pid: 1234,
@@ -2320,6 +2545,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(99),
                 pid: 1,
@@ -2381,6 +2607,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(11),
                 pid: 1,
@@ -2426,6 +2653,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(22),
                 pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
@@ -2486,6 +2714,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(77),
                 pid,
@@ -2565,6 +2794,7 @@ mod tests {
             reg.entries.insert(
                 target.clone(),
                 SweepInfo {
+                    pgid: None,
                     sweep_id: target.clone(),
                     kind: SweepKind::Issue(880),
                     pid: target_pid,
@@ -2586,6 +2816,7 @@ mod tests {
             reg.entries.insert(
                 other.clone(),
                 SweepInfo {
+                    pgid: None,
                     sweep_id: other.clone(),
                     kind: SweepKind::Issue(881),
                     pid: 2_147_483_640, // ~i32::MAX, harmless dead pid
@@ -2682,6 +2913,7 @@ mod tests {
         registry.entries.insert(
             sweep_id.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sweep_id.clone(),
                 kind: SweepKind::Issue(88),
                 pid: 2_147_483_640,
@@ -2787,6 +3019,382 @@ mod tests {
 
         let info = registry.get(&sweep_id).unwrap();
         assert!(matches!(info.state, SweepState::Exited { .. }));
+    }
+
+    /// Issue #4980, the crux regression test: cancelling a **reconstructed**
+    /// entry must still tear down the whole process group.
+    ///
+    /// [`cancel_terminates_whole_process_group_including_grandchild`] above only
+    /// proves group-kill works while the *spawning* registry still holds the
+    /// in-memory `Child` handle. That was the entire gate on the group path
+    /// (`if self.children.contains_key(sweep_id)`), so the two situations an
+    /// operator actually hits at 3am both silently degraded to a single-PID kill:
+    /// a daemon that has since restarted (this test, via `reconstruct()`), and
+    /// **every** `loom-daemon cancel` invocation, which runs in a fresh process
+    /// that never held a handle at all.
+    ///
+    /// The second registry here models both: same workspace, same on-disk lock,
+    /// zero retained handles. The grandchild assertion is what fails on a
+    /// regression — a single-PID kill leaves it running, which is precisely the
+    /// zombie-agent shape of the 2026-08-03 incident.
+    #[test]
+    #[serial]
+    fn cancel_reconstructed_entry_kills_whole_group() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+        let gc_pidfile = workspace.join("grandchild.pid");
+
+        let script = format!(
+            "#!/usr/bin/env bash\nsleep 300 &\necho \"$!\" > \"{gc}\"\nsleep 300\n",
+            gc = gc_pidfile.display()
+        );
+        let mut spawner = lifecycle_registry(workspace, &script);
+
+        let outcome = spawner
+            .dispatch(&SweepKind::Issue(4980), None, None, None, None)
+            .expect("dispatch should succeed");
+        let leader_pid = outcome.pid;
+        let sweep_id = outcome.sweep_id.clone();
+
+        let gc_pid = read_pid_file(&gc_pidfile, FIXTURE_CHILD_WAIT_MS)
+            .expect("grandchild pid should be recorded");
+        assert!(is_pid_alive(leader_pid), "leader should be running post-dispatch");
+        assert!(is_pid_alive(gc_pid), "grandchild should be running post-dispatch");
+
+        // The pgid must have been persisted to the claim lock at spawn time —
+        // this is what survives the daemon, and the OS cannot re-derive it once
+        // the leader dies.
+        let owner_path = spawner
+            .config
+            .locks_dir()
+            .join("issue-4980")
+            .join("owner.json");
+        let owner: LockOwner =
+            serde_json::from_str(&std::fs::read_to_string(&owner_path).unwrap()).unwrap();
+        assert_eq!(owner.owner_pid, leader_pid);
+        assert_eq!(
+            owner.pgid,
+            Some(leader_pid),
+            "owner.json must record the child's process group (#4980)"
+        );
+
+        // Simulate the daemon restart / fresh CLI process: a brand-new registry
+        // over the same workspace, rebuilt from disk. It has NO `Child` handle
+        // for this sweep — the exact condition that used to disable group-kill.
+        let mut restarted = lifecycle_registry(workspace, &script);
+        let admitted = restarted.reconstruct().expect("reconstruct should succeed");
+        assert_eq!(admitted, 1, "the live lock should be admitted as a Running entry");
+        assert!(
+            !restarted.children.contains_key(&sweep_id),
+            "a reconstructed entry must not have a retained Child handle — that is the \
+             whole point of this test"
+        );
+        assert_eq!(
+            restarted.get(&sweep_id).unwrap().pgid,
+            Some(leader_pid),
+            "reconstruct() must restore the persisted process group"
+        );
+
+        let cancel = restarted
+            .cancel(&sweep_id, Duration::from_secs(1))
+            .expect("cancel should succeed");
+        assert!(cancel.was_running);
+
+        // THE assertion: the grandchild is not a direct child of anything this
+        // registry tracks, so only a group-scoped signal can reach it.
+        assert!(
+            wait_until_dead(gc_pid, FIXTURE_CHILD_WAIT_MS),
+            "grandchild survived a cancel of a RECONSTRUCTED entry — the group-kill degraded \
+             to a single-PID kill (#4980 regression)"
+        );
+
+        // The leader was SIGKILLed but is still a child of THIS test process
+        // (the original registry spawned it), so it lingers as a zombie until
+        // someone `wait()`s it — in production the old daemon is gone and init
+        // reaps it. Reap it through the spawner's retained handle, then assert
+        // it is genuinely gone.
+        let _ = spawner.reap_handle(&sweep_id);
+        assert!(
+            wait_until_dead(leader_pid, FIXTURE_CHILD_WAIT_MS),
+            "leader still alive after cancel"
+        );
+    }
+
+    /// Issue #4980 edge case: an `owner.json` written by a **pre-#4980** daemon
+    /// binary has no `pgid` key at all. It must still deserialize (a parse
+    /// failure is read everywhere as "no owner", which would drop a *live*
+    /// sweep's lock), reconstruct into an entry with `pgid: None`, and cancel
+    /// via a documented single-PID fallback rather than panicking.
+    #[test]
+    #[serial]
+    fn reconstruct_tolerates_pre_pgid_owner_json_and_degrades_gracefully() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+        let mut registry = lifecycle_registry(workspace, "#!/usr/bin/env bash\nsleep 300\n");
+
+        // A long-lived process to stand in for the live sweep leader. Spawned
+        // WITHOUT `process_group(0)`, exactly like a pre-#4980 daemon's child
+        // would appear to a registry that has no record of its group.
+        let mut child = Command::new("bash")
+            .arg("-c")
+            .arg("sleep 300")
+            .spawn()
+            .expect("spawn fixture child");
+        let pid = child.id();
+
+        // Byte-for-byte the old on-disk schema: four keys, no `pgid`.
+        let locks = registry.config.locks_dir();
+        let lock = locks.join("issue-4979");
+        std::fs::create_dir_all(&lock).unwrap();
+        std::fs::write(
+            lock.join("owner.json"),
+            format!(
+                r#"{{"issue":4979,"owner_pid":{pid},"acquired_at":"{}","sweep_id":"sweep-legacy"}}"#,
+                Utc::now().to_rfc3339()
+            ),
+        )
+        .unwrap();
+
+        let admitted = registry
+            .reconstruct()
+            .expect("a pre-#4980 owner.json must not fail reconstruction");
+        assert_eq!(admitted, 1, "the legacy lock must still be admitted");
+        let info = registry.get("sweep-legacy").expect("legacy entry admitted");
+        assert_eq!(info.pid, pid);
+        assert_eq!(info.pgid, None, "no group is recorded in a pre-#4980 owner.json");
+
+        // Cancel must fall back to single-PID delivery — no panic, no
+        // group-signal against an unknown group.
+        let outcome = registry
+            .cancel("sweep-legacy", Duration::from_secs(1))
+            .expect("cancel of a legacy entry should succeed");
+        assert!(outcome.was_running);
+        let _ = child.wait();
+        assert!(wait_until_dead(pid, FIXTURE_CHILD_WAIT_MS), "legacy child should be gone");
+    }
+
+    /// Issue #4980: a recorded pgid that the OS contradicts (PID recycled across
+    /// a daemon restart, so the live `owner_pid` leads some *other* group) must
+    /// be discarded, not trusted. Trusting it would aim a later `kill(-pgid, 9)`
+    /// at a stranger's process group.
+    #[test]
+    #[serial]
+    fn reconstruct_discards_a_pgid_the_os_contradicts() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+        let mut registry = lifecycle_registry(workspace, "#!/usr/bin/env bash\nsleep 300\n");
+
+        let mut child = Command::new("bash")
+            .arg("-c")
+            .arg("sleep 300")
+            .spawn()
+            .expect("spawn fixture child");
+        let pid = child.id();
+
+        // This child was NOT spawned as a group leader, so `getpgid(pid)` is the
+        // test harness's group — never `pid` itself. Claim otherwise on disk.
+        let lock = registry.config.locks_dir().join("issue-4978");
+        std::fs::create_dir_all(&lock).unwrap();
+        let owner = LockOwner {
+            issue: 4978,
+            owner_pid: pid,
+            acquired_at: Utc::now().to_rfc3339(),
+            sweep_id: "sweep-stale-pgid".to_string(),
+            pgid: Some(pid),
+        };
+        std::fs::write(lock.join("owner.json"), serde_json::to_string_pretty(&owner).unwrap())
+            .unwrap();
+
+        registry.reconstruct().expect("reconstruct should succeed");
+        assert_eq!(
+            registry.get("sweep-stale-pgid").unwrap().pgid,
+            None,
+            "a pgid the OS does not confirm must be discarded (#4980)"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// Issue #4980 acceptance criterion 2 (the crash path): a sweep whose
+    /// **leader is already dead** but whose process group still holds live
+    /// members must have that group reaped — not left running unclaimed work.
+    ///
+    /// This is the incident shape verbatim: the registry showed `in_flight: 0`
+    /// while a surviving `claude` agent kept mutating a repo whose claim had
+    /// already been returned to the queue. `signal_sweep` cannot help here (the
+    /// OS will not report a dead pid's group), which is exactly why the pgid is
+    /// persisted while the leader is alive.
+    #[test]
+    #[serial]
+    fn reaper_reaps_the_surviving_group_of_a_dead_leader() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let gc_pidfile = dir.path().join("orphan.pid");
+
+        // A group leader that forks a long-lived background child and then
+        // exits: the leader dies, the group lives on with an orphan in it.
+        let mut leader = {
+            let mut cmd = Command::new("bash");
+            cmd.arg("-c").arg(format!(
+                "sleep 300 &\necho \"$!\" > \"{gc}\"\nexit 0\n",
+                gc = gc_pidfile.display()
+            ));
+            #[cfg(unix)]
+            cmd.process_group(0);
+            cmd.spawn().expect("spawn fixture leader")
+        };
+        let leader_pid = leader.id();
+        let orphan_pid = read_pid_file(&gc_pidfile, FIXTURE_CHILD_WAIT_MS)
+            .expect("orphan pid should be recorded");
+        // Reap the leader so it is genuinely dead (not a zombie that
+        // `kill(pid, 0)` would still report as alive).
+        let _ = leader.wait();
+        assert!(wait_until_dead(leader_pid, FIXTURE_CHILD_WAIT_MS), "leader should be gone");
+        assert!(is_pid_alive(orphan_pid), "orphan should have survived its leader");
+
+        let sweep_id = "sweep-orphaned-group".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(4977),
+                pid: leader_pid,
+                // Persisted at spawn time; the ONLY remaining handle on the
+                // survivors now that the leader is gone.
+                pgid: Some(leader_pid),
+                token_name: "unknown".into(),
+                runtime: "unknown".into(),
+                runtime_source: None,
+                log_path: registry.compute_log_path(4977),
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                repo: None,
+            },
+        );
+
+        registry.reap_once();
+
+        assert!(
+            wait_until_dead(orphan_pid, FIXTURE_CHILD_WAIT_MS),
+            "the dead leader's surviving process group was not reaped — a zombie agent would \
+             keep running unclaimed work (#4980)"
+        );
+    }
+
+    /// Issue #4980: a group that ignores the crash-path SIGTERM is escalated to
+    /// SIGKILL on a later reaper tick. The escalation is deliberately deferred
+    /// rather than slept through inline — `reap_once` runs on the `ListSweeps`
+    /// read path under the registry mutex, where blocking is the 2026-07-26
+    /// wedge shape — so this test drives the two ticks directly.
+    #[test]
+    #[serial]
+    fn pending_group_reap_escalates_to_sigkill_on_a_later_tick() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let gc_pidfile = dir.path().join("stubborn.pid");
+
+        // The background child traps (ignores) SIGTERM, so only SIGKILL ends it.
+        let mut leader = {
+            let mut cmd = Command::new("bash");
+            cmd.arg("-c").arg(format!(
+                "bash -c 'trap \"\" TERM; sleep 300' &\necho \"$!\" > \"{gc}\"\nexit 0\n",
+                gc = gc_pidfile.display()
+            ));
+            #[cfg(unix)]
+            cmd.process_group(0);
+            cmd.spawn().expect("spawn fixture leader")
+        };
+        let leader_pid = leader.id();
+        let orphan_pid = read_pid_file(&gc_pidfile, FIXTURE_CHILD_WAIT_MS)
+            .expect("orphan pid should be recorded");
+        let _ = leader.wait();
+        // Give the inner bash a moment to install its TERM trap.
+        std::thread::sleep(Duration::from_millis(200));
+
+        assert!(
+            registry.reap_orphaned_group("sweep-stubborn", Some(4976), leader_pid),
+            "a group with live members must be reaped"
+        );
+        assert!(
+            registry.pending_group_reaps.contains_key("sweep-stubborn"),
+            "a SIGKILL escalation must be registered"
+        );
+        // The SIGTERM is ignored, so the orphan is still there.
+        std::thread::sleep(Duration::from_millis(200));
+        assert!(is_pid_alive(orphan_pid), "trap-TERM orphan should have survived SIGTERM");
+
+        // Bring the deadline forward rather than sleeping out the real grace.
+        registry
+            .pending_group_reaps
+            .get_mut("sweep-stubborn")
+            .unwrap()
+            .escalate_at = Instant::now();
+        registry.escalate_pending_group_reaps();
+
+        assert!(
+            wait_until_dead(orphan_pid, FIXTURE_CHILD_WAIT_MS),
+            "the stubborn orphan survived the SIGKILL escalation (#4980)"
+        );
+        assert!(
+            registry.pending_group_reaps.is_empty(),
+            "a completed escalation must be dropped from the pending map"
+        );
+    }
+
+    /// Issue #4980 safety floor: a recorded pgid naming **this process's own
+    /// group** must never be signalled. `kill(-our_pgid, 9)` would take down the
+    /// daemon and every sweep it owns — the one mistake in this area that is
+    /// worse than the bug being fixed.
+    #[test]
+    #[serial]
+    fn group_signalling_refuses_this_processs_own_group() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        let own_group = current_process_group().expect("unix test host");
+
+        assert!(
+            !registry.reap_orphaned_group("sweep-self", None, own_group),
+            "reap_orphaned_group must refuse our own process group"
+        );
+        assert!(registry.pending_group_reaps.is_empty());
+
+        // `signal_sweep` falls back to single-PID delivery rather than group
+        // delivery. Signal 0 (liveness probe) keeps the test harmless: it proves
+        // which target was chosen without killing anything.
+        let sweep_id = "sweep-self-entry".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(4975),
+                pid: std::process::id(),
+                pgid: Some(own_group),
+                token_name: "unknown".into(),
+                runtime: "unknown".into(),
+                runtime_source: None,
+                log_path: registry.compute_log_path(4975),
+                idempotency_key: None,
+                started_at: Utc::now(),
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                repo: None,
+            },
+        );
+        assert!(
+            registry.signal_sweep(&sweep_id, std::process::id(), 0),
+            "the single-PID fallback should still reach the (live) pid"
+        );
     }
 
     /// Issue #3801: a child killed OUT OF BAND (operator `kill -KILL`, not via
@@ -3252,6 +3860,7 @@ mod tests {
         reg.entries.insert(
             "sweep-issue-9256-newer".to_string(),
             SweepInfo {
+                pgid: None,
                 sweep_id: "sweep-issue-9256-newer".to_string(),
                 kind: SweepKind::Issue(9256),
                 pid: std::process::id(), // alive

--- a/loom-daemon/src/sweep_registry/stacking.rs
+++ b/loom-daemon/src/sweep_registry/stacking.rs
@@ -169,6 +169,7 @@ mod tests {
             registry.entries.insert(
                 sid.to_string(),
                 SweepInfo {
+                    pgid: None,
                     sweep_id: sid.to_string(),
                     kind: SweepKind::Issue(issue),
                     pid: 2_147_483_640,
@@ -215,6 +216,7 @@ mod tests {
 
         fn mk(issue: u32, dep: Option<u32>, state: SweepState) -> SweepInfo {
             SweepInfo {
+                pgid: None,
                 sweep_id: format!("s{issue}"),
                 kind: SweepKind::Issue(issue),
                 pid: 2_147_483_640,

--- a/loom-daemon/src/sweep_registry/test_support.rs
+++ b/loom-daemon/src/sweep_registry/test_support.rs
@@ -336,6 +336,7 @@ pub(crate) fn insert_clean_exit_running(
     registry.entries.insert(
         sweep_id.clone(),
         SweepInfo {
+            pgid: None,
             sweep_id: sweep_id.clone(),
             kind: SweepKind::Issue(issue),
             pid,
@@ -446,6 +447,7 @@ pub(crate) fn insert_running_at(
     registry.entries.insert(
         sweep_id.clone(),
         SweepInfo {
+            pgid: None,
             sweep_id: sweep_id.clone(),
             kind: SweepKind::Issue(issue),
             pid: std::process::id(), // any live-looking pid; list() never probes liveness
@@ -509,6 +511,7 @@ pub(crate) fn insert_dead_running_at(
     registry.entries.insert(
         sweep_id.clone(),
         SweepInfo {
+            pgid: None,
             sweep_id: sweep_id.clone(),
             kind: SweepKind::Issue(issue),
             pid: 2_147_483_640, // ~i32::MAX, almost certainly dead
@@ -793,6 +796,7 @@ pub(crate) fn insert_terminal_issue(
     reg.entries.insert(
         sid.to_string(),
         SweepInfo {
+            pgid: None,
             sweep_id: sid.to_string(),
             kind: SweepKind::Issue(issue),
             pid: 2_147_483_640,
@@ -1109,6 +1113,7 @@ pub(crate) fn write_lock_owner(
     let lock = locks.join(format!("issue-{issue}"));
     std::fs::create_dir_all(&lock).unwrap();
     let owner = LockOwner {
+        pgid: None,
         issue,
         owner_pid,
         acquired_at: Utc::now().to_rfc3339(),
@@ -1138,6 +1143,7 @@ pub(crate) fn insert_dead_running_entry(reg: &mut SweepRegistry, issue: u32, swe
     reg.entries.insert(
         sweep_id.to_string(),
         SweepInfo {
+            pgid: None,
             sweep_id: sweep_id.to_string(),
             kind: SweepKind::Issue(issue),
             pid: 2_147_483_641,

--- a/loom-daemon/src/sweep_registry/watchdog.rs
+++ b/loom-daemon/src/sweep_registry/watchdog.rs
@@ -2347,6 +2347,7 @@ mod tests {
         reg.entries.insert(
             "sweep-issue-6006-live".to_string(),
             SweepInfo {
+                pgid: None,
                 sweep_id: "sweep-issue-6006-live".to_string(),
                 kind: SweepKind::Issue(6006),
                 pid: 2_147_483_640,
@@ -2612,6 +2613,7 @@ mod tests {
         reg.entries.insert(
             sid.clone(),
             SweepInfo {
+                pgid: None,
                 sweep_id: sid.clone(),
                 kind: SweepKind::Issue(6001),
                 pid: 2_147_483_640,

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -797,6 +797,23 @@ pub struct SweepInfo {
     pub kind: SweepKind,
     /// PID of the detached child process.
     pub pid: u32,
+    /// Process-group ID of the detached child (Issue #4980). Sweeps are spawned
+    /// as their own group leader (`process_group(0)`, #3800), so for a live
+    /// dispatch this equals [`pid`](Self::pid) — but recording it explicitly is
+    /// what makes group termination survive the loss of the spawning process:
+    ///
+    /// - a `reconstruct()`-ed entry (daemon restart) has no retained `Child`
+    ///   handle, and used to silently degrade cancellation to a single-PID kill
+    ///   that orphaned the whole subtree;
+    /// - the crash-path reaper needs a group handle to reap survivors of a
+    ///   *dead* leader, whose pgid can no longer be queried from the OS.
+    ///
+    /// `None` for entries whose group is unknown (a pre-#4980 `owner.json`, a
+    /// checkpoint-only recovery entry, a non-Unix host, or a test-injected
+    /// entry) — every consumer degrades to single-PID signalling and logs,
+    /// never assumes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pgid: Option<u32>,
     /// Token account name selected by `spawn-claude.sh` (e.g. `agent-2.token`).
     /// "unknown" when not surfaced by the wrapper (Phase A logs this in
     /// the per-sweep log rather than recording it on the entry).


### PR DESCRIPTION
## Summary

Closes the two gaps behind the 2026-08-03 wedged-sweep incident, where cancelling a sweep over ssh turned into a three-round manual process hunt and hand-killing the tracked pid left a zombie `claude` agent that **relaunched its ngspice workload** (~35 CPU-hours) against an issue whose claim the crash path had already returned to `loom:issue`.

1. **No CLI cancel primitive.** `cancel_sweep` existed only as an MCP tool — i.e. only inside the operator's own Claude session on their own machine. Over ssh the only lever was raw `kill`.
2. **Killing the tracked pid did not terminate the sweep.** Group-kill was gated on the spawn-time in-memory `Child` handle, so a post-restart entry — and *every* fresh-process invocation — silently degraded to a single-PID kill that orphaned the subtree.

`cmd.process_group(0)` (#3800) already existed, so this is not "add process groups"; it is persisting the pgid and using it unconditionally, plus the missing CLI verb.

## Changes

### `loom-daemon cancel <sweep-id|--issue N>` (new)

- `loom-daemon/src/cli/cancel.rs` (new), registered in `cli/mod.rs`, `main.rs` (`Commands::Cancel`), `daemon_service.rs` (match arm). Flags: `--issue`, `--grace` (default 30, matching the MCP tool), `--workspace` (same #4299 cwd-default resolution `dispatch` uses — `resolve_cli_dispatch_workspace` is now shared rather than duplicated).
- A **thin client** over the same `CancelSweep` IPC frame the MCP tool sends: the termination itself stays entirely in `cancel_sweep_nonblocking`, so the two operator surfaces cannot drift. `--issue N` is resolved to a sweep id client-side via one extra `ListSweeps` round-trip (live `Running`/`Pending` entries only; more than one is an error, not a guess), so the wire protocol is untouched.
- Client ack budget is `grace_secs + 15s` (the daemon acks only after the whole cancel completes) and bounded — it exits nonzero with the same "is loom-daemon running?" diagnostic `dispatch` uses rather than hanging.

### Process-group termination that survives the spawning process

- **`SweepInfo.pgid` / `LockOwner.pgid`** (`types.rs`, `sweep_registry/locks.rs`) — both `Option<u32>` + `#[serde(default, skip_serializing_if)]`.
- **Stamped at spawn** (`sweep_registry/dispatch.rs`) via `spawned_leader_pgid`, which **verifies** `getpgid(child) == child` rather than assuming it: a contradiction records no group (degrade) rather than aiming a later `kill(-pgid, 9)` at a group we do not own. Persisted into `owner.json` by `record_child_pid_in_lock`.
- **`signal_sweep` no longer gates on `self.children.contains_key(sweep_id)`** (`sweep_registry/reaper.rs`). It resolves the group from durable state and uses it unconditionally. Absent pgid ⇒ single-PID delivery **with a log line** (never silent); pgid equal to *this process's own group* ⇒ refused outright (a `kill(-our_pgid, 9)` would take down the daemon and every sweep it owns).
- **`reconstruct()` restores the pgid** (`locks.rs`) but re-verifies it against the live owner first — a value the OS contradicts (PID recycled across daemons) is discarded, not used.

### Crash-path reap (a dead leader is not a dead tree)

- New `reap_orphaned_group` / `escalate_pending_group_reaps` + `pending_group_reaps` map. The reaper's dead-pid branch and `reconstruct()`'s stale-lock branch group-SIGTERM a dead leader's surviving members and escalate to SIGKILL on a later tick.
- The escalation is **deferred, not slept**: `reap_once` also runs on the `ListSweeps` read path under the registry mutex, and blocking there is the 2026-07-26 wedge shape.
- The persisted pgid is the only handle available here — the OS will not report a dead pid's process group.

### Back-compat

`owner.json` written by a pre-change binary has no `pgid` key and **must** still deserialize: an unparseable owner is read everywhere (`reconstruct`, `lock_owned_by_other`, `live_sweep_lock_owner_pid`) as "no owner", which would drop a *live* sweep's lock. Covered by a dedicated test.

### Docs

`defaults/docs/daemon-reference.md` (new `loom-daemon cancel` section + a "Process-group termination and the persisted `pgid`" section + `SweepInfo.pgid`), `defaults/docs/troubleshooting.md`, `defaults/.claude/commands/loom/loom.md` and `defaults/.claude/agents/loom-daemon.md` (four places asserted "no CLI subcommand cancels a sweep by ID" and recommended the exact `kill -TERM <pid>` fallback that caused the incident — all corrected), and one line in `CLAUDE.md`.

## Acceptance Criteria Verification

- [x] **`loom-daemon cancel` cancels a sweep on the host it runs on, killing the entire process tree (including reparented processes).** Verified end-to-end against a live daemon (below): the wrapper had been reparented to systemd (`ppid 844`) after the daemon was SIGKILLed, the entry was rebuilt by `reconstruct()` with no `Child` handle, and a fresh CLI process removed all three processes and the claim lock.
- [x] **The crash-path reaper reaps a dead wrapper's surviving process group instead of leaving a zombie agent.** Verified live (below) and by `reaper_reaps_the_surviving_group_of_a_dead_leader` + `pending_group_reap_escalates_to_sigkill_on_a_later_tick`.
- [x] **`cancel_sweep` (MCP) and the CLI share the termination implementation.** Structural: the CLI sends the identical `CancelSweep` frame, and all termination is daemon-side. Pinned by `test_cancel_sweep_cli_and_mcp_frames_are_identical_on_the_wire` (byte-level frame parity) and `test_handle_request_cancel_sweep_from_cli_frame_runs_the_shared_path`.

## Test Plan

New automated coverage (all passing):

| Test | Covers |
|---|---|
| `cancel_reconstructed_entry_kills_whole_group` (reaper.rs) | The crux. Dispatch → real daemon-restart simulation via a second registry + `reconstruct()` (no retained handle) → cancel → the **grandchild** must be dead. |
| `reconstruct_tolerates_pre_pgid_owner_json_and_degrades_gracefully` | Pre-change `owner.json` (literal 4-key JSON, no `pgid`): parses, admits, cancels via the single-PID fallback — no panic. |
| `reconstruct_discards_a_pgid_the_os_contradicts` | A recorded pgid the OS disagrees with is dropped, not trusted. |
| `reaper_reaps_the_surviving_group_of_a_dead_leader` | Crash path: leader dead + orphan alive in the group ⇒ reaped by `reap_once`. |
| `pending_group_reap_escalates_to_sigkill_on_a_later_tick` | A trap-TERM orphan is SIGKILLed on the deferred tick. |
| `group_signalling_refuses_this_processs_own_group` | Safety floor: our own group is never signalled. |
| `build_cancel_request_plumbs_all_flags`, `..._defaults_match_the_mcp_tool`, `select_sweep_for_issue_*` (×3), `round_trip_sends_cancel_sweep_and_parses_the_outcome`, `absent_socket_errors_fast` (cli/cancel.rs) | CLI flag plumbing, `--issue` selection rules, wire round-trip. |
| `test_cancel_sweep_cli_and_mcp_frames_are_identical_on_the_wire`, `test_handle_request_cancel_sweep_from_cli_frame_runs_the_shared_path` (ipc.rs) | Shared-path guarantee. |
| `sweep_info_schema_snapshot` (updated) | `pgid` pinned in the wire schema; pre-#4980 JSON still deserializes to `None` and re-serializes without the key. |

**Mutation-checked**: `cancel_reconstructed_entry_kills_whole_group` was re-run with `signal_sweep` reverted to the old `children.contains_key` gate and **fails** with `grandchild survived a cancel of a RECONSTRUCTED entry` — it is not a vacuous test.

**Manual verification (performed, not skipped)** — a real `loom-daemon` binary against a throwaway workspace with a fixture spawn adapter modelling the real tree shape (`wrapper → agent → workload`) and a stub `gh`:

```
# owner.json after dispatch
{"issue":4980,"owner_pid":2574933,...,"pgid":2574933}

# tree
sleep(2574933)---sleep(2574934)---sleep(2574935)

# SIGKILL the daemon; wrapper reparents to systemd
2574933 2574933  844 sleep 600        <- ppid 844 (reparented)

# restart daemon -> "reconstructed 1 sweep entry"; then, from a separate shell:
$ loom-daemon cancel --issue 4980 --grace 3
Cancelled sweep sweep-issue-4980-1785729217
  pid:       2574933 (process group torn down)
  escalated: no — exited on SIGTERM
# survivors: none. claim lock: released.
```

Crash path, same fixture (`LOOM_SWEEP_REAPER_INTERVAL_SECS=5`), hand-killing only the tracked wrapper pid — the exact 2026-08-03 mistake:

```
# after kill -9 <wrapper>: agent+workload survive, agent reparented to 844
# one reaper tick later:
[WARN] reap_orphaned_group: sweep sweep-issue-4980-... (issue #4980) has a DEAD leader
       but its process group 2582893 still has members — an orphaned agent/subtree
       running unclaimed work. Sending SIGTERM to the group; escalating to SIGKILL in 5s...
# survivors: none.
```

Also run: `cargo fmt`, `cargo clippy -p loom-daemon --all-targets` (clean), `cargo test -p loom-daemon` (full suite, green).

## Notes for the reviewer

- Adding `SweepInfo.pgid` required a one-line `pgid: None,` in ~40 existing struct literals (almost all test fixtures). Those insertions are mechanical; the substantive changes are in `reaper.rs`, `locks.rs`, `dispatch.rs`, `types.rs`, and the new `cli/cancel.rs`.
- The main checkout in this environment had pre-existing uncommitted `.loom/` resync drift (present before this work started); nothing in it belongs to this PR.

Closes #4980
