### PR TITLE
feat(daemon,dashboard): show each host's managed repositories on the fleet card

### DIFF
--- a/.loom/docs/telemetry-schema.md
+++ b/.loom/docs/telemetry-schema.md
@@ -266,7 +266,11 @@ probe stays absent rather than being coerced to a fake zero (the daemon's
   "cpu_idle_fraction": 0.83,
   "load_per_core": 0.51,
   "worktree_root_free_gb": 200,
-  "dispatch_halted": false
+  "dispatch_halted": false,
+  "managed_repos": [
+    { "slug": "rjwalters/loom", "visibility": "public" },
+    { "slug": "2AMLogic/gf180-pll", "visibility": "private" }
+  ]
 }
 ```
 
@@ -318,6 +322,31 @@ Both fields are additive and pass through public redaction unchanged (they
 describe the released binary, not any repo or operator — see
 `dashboard/src/redaction.ts`), so an older consumer that ignores unknown keys is
 unaffected.
+
+**`managed_repos` (#4976, redaction class: per-entry, public-visible slug
+only).** This host's managed-repository roster — every workspace root the
+daemon's workspace registry currently tracks, resolved to its forge
+`owner/repo` slug and a [`RepoVisibility`](#repovisibility-contract--private-by-default)
+tag derived exactly the way a sweep record's own `visibility` is derived
+(`visibility::derive_visibility`). Sourced from the registry itself, **not**
+inferred from `active_sweep_ids` — a registered-but-idle repo (no sweep ever
+dispatched into it this run) still appears, which is the whole point: it lets
+the dashboard show a host's quiet as "roster-shaped" (nothing ready in any of
+its registered repos) rather than as an unexplained gap.
+
+- Omitted entirely (`#[serde(default, skip_serializing_if = "Vec::is_empty")]`)
+  when the host has no registered workspaces, or on a record from a pre-#4976
+  daemon — an older/partial record decodes with an empty roster rather than
+  failing.
+- **Unlike every other field in this record, `managed_repos` does NOT pass
+  through public redaction unchanged.** Each entry names a specific
+  repository, so the anti-leak contract applies per entry, not to the whole
+  record: a `public`-visibility entry's `slug` survives to the public
+  (unauthenticated) view; a `private` entry's `slug` is dropped but the entry
+  itself is kept, so the roster's size — and therefore "how many are private"
+  — stays visible without naming any of them (`dashboard/src/redaction.ts`'s
+  `redactManagedRepos`). The authenticated view always sees every entry in
+  full, including private slugs.
 
 ## Persistence & read surface (`sweep.outcome`, Issue #4704)
 

--- a/dashboard/src/redaction.ts
+++ b/dashboard/src/redaction.ts
@@ -54,8 +54,14 @@
  * Neither references a repository, issue, branch, or PR — the four leak
  * vectors the epic's acceptance criteria name.
  *
- * `host.health` is pure capacity telemetry (CPU/uptime/disk) and passes
- * through in full for every viewer.
+ * `host.health` is mostly pure capacity telemetry (CPU/uptime/disk) and
+ * passes through in full for every viewer. The one exception is its
+ * `managed_repos` roster (#4976): each entry names a specific repository, so
+ * — like `tokens.snapshot`'s `accounts` below — it is deliberately absent
+ * from the allowlist and instead redacted through `redactManagedRepos`: a
+ * public entry's slug survives, a private entry's slug is dropped but the
+ * entry itself is kept (so the roster's size, and therefore "how many are
+ * private", stays visible without naming any of them).
  *
  * `tokens.snapshot` does **not**. Its `accounts` array names the pool's
  * accounts and gives each one's rank and burn — operational detail about
@@ -126,6 +132,10 @@ const RECORD_FIELD_ALLOWLIST: Readonly<Record<string, readonly string[]>> = {
     // directly above.
     "dispatch_halted",
     "halt_reason",
+    // `managed_repos` (#4976) is deliberately ABSENT here: each entry names a
+    // specific repository, so — like `tokens.snapshot`'s `accounts` above —
+    // it only ever reaches a public response through `PUBLIC_RECORD_
+    // DERIVATIONS`'s `redactManagedRepos`, never a raw copy.
   ],
 };
 
@@ -199,6 +209,35 @@ export function deriveTokenPoolAggregate(payload: Record<string, unknown>): Toke
   };
 }
 
+/** One entry inside `host.health`'s `managed_repos` roster, as the daemon
+ * sends it — always the real slug, regardless of visibility (see
+ * `ManagedRepoEntry`'s Rust-side doc: the daemon carries full detail, the
+ * redaction boundary is here). */
+interface ManagedRepoRow {
+  slug?: unknown;
+  visibility?: unknown;
+}
+
+/**
+ * Redact one `host.health.managed_repos` array for a public, unauthenticated
+ * viewer (Issue #4976's anti-leak contract): a `public`-visibility entry's
+ * slug survives; a `private` entry's slug is dropped but the entry itself is
+ * kept (so the roster's total count — and therefore "how many private repos"
+ * — is still visible without naming any of them). Mirrors
+ * `redactActiveSweep`'s "null the identifying field, keep the entry" strategy
+ * for a private sweep.
+ *
+ * A malformed row (wrong-typed `slug`, or any `visibility` other than the
+ * literal string `"public"`) is treated as private — the same fail-safe
+ * default every visibility decode in this system uses.
+ */
+export function redactManagedRepos(rows: readonly ManagedRepoRow[]): { slug?: string; visibility: "public" | "private" }[] {
+  return rows.map((row) => {
+    const isPublic = row?.visibility === "public" && typeof row.slug === "string";
+    return isPublic ? { slug: row.slug as string, visibility: "public" as const } : { visibility: "private" as const };
+  });
+}
+
 /**
  * Per-kind *derivations* layered on top of the field allowlist: fields the
  * public view gets that are computed from redacted-away input rather than
@@ -214,6 +253,17 @@ export function deriveTokenPoolAggregate(payload: Record<string, unknown>): Toke
 const PUBLIC_RECORD_DERIVATIONS: Readonly<Record<string, (payload: Record<string, unknown>) => Record<string, unknown>>> =
   {
     "tokens.snapshot": (payload) => deriveTokenPoolAggregate(payload) as unknown as Record<string, unknown>,
+    // `managed_repos` is deliberately ABSENT from `RECORD_FIELD_ALLOWLIST` —
+    // like `tokens.snapshot`'s `accounts`, its raw form can name a private
+    // repo, so it only ever reaches a public response through this
+    // derivation. Absent entirely from the output when the payload carries
+    // no roster at all (a pre-#4976 daemon, or a host with no registered
+    // workspaces), so the field-presence contract stays "the daemon sent
+    // this" rather than "this module always adds it".
+    "host.health": (payload) =>
+      Array.isArray(payload.managed_repos)
+        ? { managed_repos: redactManagedRepos(payload.managed_repos as ManagedRepoRow[]) }
+        : {},
   };
 
 /** The fail-safe allowlist for a `kind` this table does not (yet) recognize

--- a/dashboard/test/redaction.test.ts
+++ b/dashboard/test/redaction.test.ts
@@ -7,6 +7,7 @@ import {
   redactFleetSnapshot,
   redactHistoryQueryResult,
   redactHistoryRecord,
+  redactManagedRepos,
   redactPayload,
   redactSseFrame,
 } from "../src/redaction";
@@ -266,6 +267,36 @@ describe("redactPayload — per-kind field allowlist", () => {
     expect(redactPayload("host.health", payload)).toEqual(payload);
   });
 
+  it("host.health: a private repo's slug is redacted, but every other field survives unchanged (#4976)", () => {
+    const payload = {
+      kind: "host.health",
+      captured_at: "2026-08-02T12:00:00Z",
+      daemon_version: "0.17.0",
+      uptime_sec: 86400,
+      logical_cpus: 28,
+      managed_repos: [
+        { slug: "rjwalters/loom", visibility: "public" },
+        { slug: "2AMLogic/gf180-pll", visibility: "private" },
+      ],
+    };
+    const redacted = redactPayload("host.health", payload);
+    expect(redacted).toMatchObject({
+      daemon_version: "0.17.0",
+      uptime_sec: 86400,
+      logical_cpus: 28,
+    });
+    expect(redacted.managed_repos).toEqual([
+      { slug: "rjwalters/loom", visibility: "public" },
+      { visibility: "private" },
+    ]);
+    expect(JSON.stringify(redacted)).not.toContain("gf180-pll");
+  });
+
+  it("host.health: no managed_repos key at all when the payload carries no roster", () => {
+    const payload = { kind: "host.health", daemon_version: "0.17.0", uptime_sec: 100 };
+    expect(redactPayload("host.health", payload)).not.toHaveProperty("managed_repos");
+  });
+
   it("an unrecognized (forward-compatible) kind reveals only `kind`", () => {
     const redacted = redactPayload("future.kind", {
       kind: "future.kind",
@@ -410,6 +441,40 @@ describe("redactFleetSnapshot", () => {
     expect(redacted.activeSweeps[0]).not.toHaveProperty("sweepId");
   });
 
+  it("collapses a private repo's slug for a public viewer, and shows every slug to an authenticated one (#4976)", () => {
+    const snapshot: FleetSnapshot = {
+      hosts: {
+        "host-abc": {
+          health: {
+            record: {
+              kind: "host.health",
+              uptime_sec: 100,
+              managed_repos: [
+                { slug: "rjwalters/loom", visibility: "public" },
+                { slug: "2AMLogic/gf180-pll", visibility: "private" },
+              ],
+            },
+            updatedAt: "2026-07-30T12:00:00Z",
+          },
+        },
+      },
+      activeSweeps: [],
+    };
+
+    const publicRecord = redactFleetSnapshot(snapshot, false).hosts["host-abc"]?.health?.record;
+    expect(publicRecord?.managed_repos).toEqual([
+      { slug: "rjwalters/loom", visibility: "public" },
+      { visibility: "private" },
+    ]);
+    expect(JSON.stringify(publicRecord)).not.toContain("gf180-pll");
+
+    const authedRecord = redactFleetSnapshot(snapshot, true).hosts["host-abc"]?.health?.record;
+    expect(authedRecord?.managed_repos).toEqual([
+      { slug: "rjwalters/loom", visibility: "public" },
+      { slug: "2AMLogic/gf180-pll", visibility: "private" },
+    ]);
+  });
+
   it("summarizes the token pool for a public viewer", () => {
     const snapshot: FleetSnapshot = {
       hosts: {
@@ -452,6 +517,37 @@ describe("redactFleetSnapshot", () => {
 
     const record = redactFleetSnapshot(snapshot, true).hosts["host-abc"]?.tokens?.record;
     expect(record).toEqual({ kind: "tokens.snapshot", accounts });
+  });
+});
+
+describe("redactManagedRepos", () => {
+  it("keeps a public entry's slug, strips a private entry's slug but keeps its place", () => {
+    expect(
+      redactManagedRepos([
+        { slug: "rjwalters/loom", visibility: "public" },
+        { slug: "2AMLogic/gf180-pll", visibility: "private" },
+        { slug: "2AMLogic/gf180-trng", visibility: "private" },
+      ]),
+    ).toEqual([
+      { slug: "rjwalters/loom", visibility: "public" },
+      { visibility: "private" },
+      { visibility: "private" },
+    ]);
+  });
+
+  it("treats a malformed row (missing/wrong-typed slug, any non-\"public\" visibility) as private", () => {
+    expect(
+      redactManagedRepos([
+        { visibility: "public" }, // no slug at all
+        { slug: 42, visibility: "public" }, // wrong-typed slug
+        { slug: "owner/repo", visibility: "internal" }, // unrecognized visibility label
+        { slug: "owner/repo" }, // missing visibility
+      ]),
+    ).toEqual([{ visibility: "private" }, { visibility: "private" }, { visibility: "private" }, { visibility: "private" }]);
+  });
+
+  it("an empty roster redacts to an empty roster", () => {
+    expect(redactManagedRepos([])).toEqual([]);
   });
 });
 

--- a/dashboard/web/src/parse.ts
+++ b/dashboard/web/src/parse.ts
@@ -22,6 +22,7 @@ import type {
   FleetSnapshot,
   HostEntry,
   HostHealthRecord,
+  ManagedRepoEntry,
   TokenAccount,
   TokensSnapshotRecord,
   Timestamped,
@@ -45,6 +46,20 @@ function bool(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
 }
 
+/** A `managed_repos` entry. `slug` is dropped by `stripUndefined` when
+ * wrong-typed, or when the backend has already redacted it away (a private
+ * repo, unauthenticated viewer) — see `ManagedRepoEntry`'s doc.
+ * `visibility` always defaults to `"private"` on anything but the exact
+ * string `"public"` — the same fail-safe-default `ActiveSweep.visibility`
+ * already applies, never left `undefined`. */
+export function parseManagedRepoEntry(value: unknown): ManagedRepoEntry | undefined {
+  if (!isObject(value)) return undefined;
+  return stripUndefined<ManagedRepoEntry>({
+    slug: str(value.slug),
+    visibility: value.visibility === "public" ? "public" : "private",
+  });
+}
+
 export function parseHostHealth(value: unknown): HostHealthRecord {
   if (!isObject(value)) return {};
   return stripUndefined<HostHealthRecord>({
@@ -60,6 +75,9 @@ export function parseHostHealth(value: unknown): HostHealthRecord {
     worktree_root_free_gb: num(value.worktree_root_free_gb),
     dispatch_halted: bool(value.dispatch_halted),
     halt_reason: str(value.halt_reason),
+    managed_repos: Array.isArray(value.managed_repos)
+      ? value.managed_repos.map(parseManagedRepoEntry).filter((entry): entry is ManagedRepoEntry => entry !== undefined)
+      : undefined,
   });
 }
 

--- a/dashboard/web/src/styles.css
+++ b/dashboard/web/src/styles.css
@@ -309,6 +309,26 @@ a:hover {
   font-size: 12px;
   margin-left: auto;
 }
+.card__repos {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 10px 0 0;
+  border-top: 1px solid var(--border);
+}
+.card__repo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+  font-size: 13px;
+}
+.card__repo-label {
+  font-variant-numeric: tabular-nums;
+}
+.card__repo--private {
+  color: var(--text-dim);
+  font-style: italic;
+}
 
 /* ---- badges + chips ------------------------------------------------------ */
 

--- a/dashboard/web/src/types.ts
+++ b/dashboard/web/src/types.ts
@@ -25,6 +25,17 @@
  *    from the schema doc's `host.health` / `tokens.snapshot` sections.
  */
 
+/** One repository in a host's `managed_repos` roster (#4976). `slug` is
+ * present for a public repo, or a private one on the authenticated view; the
+ * public (unauthenticated) view drops `slug` for a private entry — the
+ * backend's redaction keeps the entry (so its count still shows) but strips
+ * the identifying field, mirroring `PublicActiveSweep`'s repo-nulling for a
+ * private sweep (`dashboard/src/redaction.ts`). */
+export interface ManagedRepoEntry {
+  slug?: string;
+  visibility?: "public" | "private";
+}
+
 /** `host.health` — CPU/disk headroom, daemon version, uptime.
  *
  * Every measured field is optional by design: the daemon's "unknown != zero"
@@ -58,6 +69,11 @@ export interface HostHealthRecord {
    * sustained for 3 consecutive tick(s)"`), naming the specific breaker/gate
    * that tripped. Absent when `dispatch_halted` is absent/`false`. */
   halt_reason?: string;
+  /** This host's managed-repository roster (#4976) — sourced from the
+   * daemon's workspace registry, not inferred from in-flight sweeps, so an
+   * idle-but-registered repo still appears. Absent entirely on a host
+   * running a pre-#4976 daemon, or one with no registered workspaces. */
+  managed_repos?: ManagedRepoEntry[];
 }
 
 /** One account inside a `tokens.snapshot`. Only `exhausted` is always sent;

--- a/dashboard/web/src/views/fleetOverview.ts
+++ b/dashboard/web/src/views/fleetOverview.ts
@@ -23,7 +23,7 @@ import {
   formatCount,
 } from "../format";
 import type { FleetView, HostStatus, HostView } from "../fleet";
-import type { HostHealthRecord } from "../types";
+import type { HostHealthRecord, ManagedRepoEntry } from "../types";
 import { emptyFleetView } from "./states";
 
 const STATUS_LABEL: Record<HostStatus, string> = {
@@ -117,8 +117,36 @@ export function healthFields(host: HostView, now: Date = new Date()): DocumentFr
   return fragment;
 }
 
+/** This host's managed-repository roster (#4976), or `[]` when the host has
+ * not reported one yet (a pre-#4976 daemon, or no registered workspaces). */
+function managedRepos(host: HostView): ManagedRepoEntry[] {
+  return host.entry.health?.record.managed_repos ?? [];
+}
+
+/** How many of `host.sweeps` are in flight against each named repo — the
+ * card's existing sweep list already carries a repo slug per entry (#4868),
+ * so the roster section's per-repo counts are grouped from it rather than
+ * plumbing a second, redundant count through `host.health`. */
+function sweepCountsByRepo(host: HostView): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const sweep of host.sweeps) {
+    if (!sweep.repo) continue;
+    counts.set(sweep.repo, (counts.get(sweep.repo) ?? 0) + 1);
+  }
+  return counts;
+}
+
 export function hostCard(host: HostView, now: Date = new Date()): HTMLElement {
   const sweepCount = host.sweeps.length;
+  const repos = managedRepos(host);
+  const repoCount = repos.length;
+  const sweepCounts = sweepCountsByRepo(host);
+  // A repo whose `slug` was stripped by the public-view redaction (a private
+  // repo, unauthenticated viewer — `dashboard/src/redaction.ts`) collapses
+  // into one trailing "+N private" row rather than N rows that each say
+  // nothing but "private" (Issue #4976's anti-leak contract).
+  const namedRepos = repos.filter((repo): repo is ManagedRepoEntry & { slug: string } => Boolean(repo.slug));
+  const hiddenPrivateCount = repoCount - namedRepos.length;
   return el(
     "article",
     { class: `card card--${host.status}`, data: { testid: "host-card", host: host.hostId } },
@@ -151,6 +179,11 @@ export function hostCard(host: HostView, now: Date = new Date()): HTMLElement {
         sweepCount === 0 ? "none" : String(sweepCount),
         "Sweeps currently in flight on this host",
       ),
+      field(
+        "Repositories",
+        repoCount === 0 ? "none" : String(repoCount),
+        "Repositories this host's daemon manages (its workspace registry, whether idle or busy)",
+      ),
     ),
     sweepCount > 0
       ? el(
@@ -173,6 +206,31 @@ export function hostCard(host: HostView, now: Date = new Date()): HTMLElement {
               sweep.repo ? el("span", { class: "card__sweep-repo" }, sweep.repo) : null,
             ),
           ),
+        )
+      : null,
+    repoCount > 0
+      ? el(
+          "ul",
+          { class: "card__repos", data: { testid: "card-repos" } },
+          namedRepos
+            .slice()
+            .sort((a, b) => a.slug.localeCompare(b.slug))
+            .map((repo) => {
+              const count = sweepCounts.get(repo.slug) ?? 0;
+              return el(
+                "li",
+                { class: "card__repo" },
+                el("span", { class: "card__repo-label" }, repo.slug),
+                count > 0 ? el("span", { class: "chip" }, `×${count}`) : null,
+              );
+            }),
+          hiddenPrivateCount > 0
+            ? el(
+                "li",
+                { class: "card__repo card__repo--private" },
+                `+ ${hiddenPrivateCount} private`,
+              )
+            : null,
         )
       : null,
   );

--- a/dashboard/web/test/fixtures.ts
+++ b/dashboard/web/test/fixtures.ts
@@ -163,6 +163,14 @@ export function multiHostSnapshot(): unknown {
             cpu_idle_fraction: 0.83,
             load_per_core: 0.51,
             worktree_root_free_gb: 200,
+            // #4976 roster: one repo with two in-flight sweeps (matching the
+            // activeSweeps below), plus two registered-but-idle repos — the
+            // "roster-shaped idle" case the feature exists for.
+            managed_repos: [
+              { slug: "rjwalters/loom", visibility: "public" },
+              { slug: "2AMLogic/gf180-pll", visibility: "private" },
+              { slug: "2AMLogic/gf180-trng", visibility: "private" },
+            ],
           },
           updatedAt: isoMinutesBefore(2),
         },
@@ -274,6 +282,12 @@ export function multiHostSnapshot(): unknown {
             cpu_idle_fraction: 0.99,
             load_per_core: 0.02,
             worktree_root_free_gb: 512,
+            // Stands in for the redacted, unauthenticated shape
+            // (`dashboard/src/redaction.ts`'s `redactManagedRepos`): a
+            // private entry keeps its place in the roster but loses `slug`,
+            // so the UI collapses it into a "+N private" count instead of
+            // naming it.
+            managed_repos: [{ slug: "rjwalters/loom", visibility: "public" }, { visibility: "private" }, { visibility: "private" }],
           },
           updatedAt: isoMinutesBefore(3),
         },

--- a/dashboard/web/test/fleetOverview.test.ts
+++ b/dashboard/web/test/fleetOverview.test.ts
@@ -162,6 +162,43 @@ describe("hostCard", () => {
     expect(idle.querySelector('[data-testid="card-sweeps"]')).toBeNull();
   });
 
+  // #4976: the "Repositories" section, below "Active sweeps".
+  it("lists the host's managed repositories, with an in-flight count for the busy one", () => {
+    const card = hostCard(findHost(view(), HEALTHY_HOST_ID)!, NOW);
+    expect(fieldValue(card, "Repositories")).toBe("3");
+    const repoRows = [...card.querySelectorAll(".card__repo")];
+    expect(repoRows).toHaveLength(3);
+    // Both live sweeps target "rjwalters/loom" — its row must show ×2.
+    const loomRow = repoRows.find((row) => row.textContent?.includes("rjwalters/loom"));
+    expect(loomRow?.querySelector(".chip")?.textContent).toBe("×2");
+    // The two idle, registered-but-never-dispatched-into repos still appear
+    // — an idle repo is not the same as an unregistered one (#4976's whole
+    // point) — but carry no in-flight chip.
+    const idleRow = repoRows.find((row) => row.textContent?.includes("2AMLogic/gf180-pll"));
+    expect(idleRow?.querySelector(".chip")).toBeNull();
+  });
+
+  it("says 'none' for a host with no registered repos", () => {
+    const card = hostCard(findHost(view(), DEGRADED_HOST_ID)!, NOW);
+    expect(fieldValue(card, "Repositories")).toBe("none");
+    expect(card.querySelector('[data-testid="card-repos"]')).toBeNull();
+  });
+
+  it("collapses a private, redacted repo entry to a count instead of naming it", () => {
+    // IDLE_HOST_ID's fixture stands in for the unauthenticated, redacted wire
+    // shape: two `managed_repos` entries carry `visibility: "private"` with
+    // no `slug` at all (`dashboard/src/redaction.ts`'s `redactManagedRepos`).
+    const card = hostCard(findHost(view(), IDLE_HOST_ID)!, NOW);
+    expect(fieldValue(card, "Repositories")).toBe("3");
+    const repoRows = [...card.querySelectorAll(".card__repo")];
+    // One named public repo, plus ONE collapsed "+2 private" row — not two
+    // separate unnamed rows.
+    expect(repoRows).toHaveLength(2);
+    expect(repoRows.some((row) => row.textContent?.includes("rjwalters/loom"))).toBe(true);
+    const privateRow = card.querySelector(".card__repo--private");
+    expect(privateRow?.textContent).toContain("2 private");
+  });
+
   // #4868: the card used to stop at three and append "+N more", which on a
   // working fleet hid most of what the overview exists to show.
   it("renders every in-flight sweep rather than truncating", () => {

--- a/dashboard/web/test/parse.test.ts
+++ b/dashboard/web/test/parse.test.ts
@@ -148,4 +148,68 @@ describe("parseFleetSnapshot", () => {
     expect(snapshot.hosts.bad?.health?.record).not.toHaveProperty("build_commit");
     expect(snapshot.hosts.bad?.health?.record).not.toHaveProperty("built_at");
   });
+
+  it("narrows host.health's managed_repos roster (#4976)", () => {
+    const snapshot = parseFleetSnapshot(multiHostSnapshot());
+    const repos = snapshot.hosts[HEALTHY_HOST_ID]?.health?.record.managed_repos;
+    expect(repos).toEqual([
+      { slug: "rjwalters/loom", visibility: "public" },
+      { slug: "2AMLogic/gf180-pll", visibility: "private" },
+      { slug: "2AMLogic/gf180-trng", visibility: "private" },
+    ]);
+  });
+
+  it("narrows a redacted managed_repos entry (slug stripped, visibility kept)", () => {
+    const snapshot = parseFleetSnapshot({
+      hosts: {
+        h: {
+          health: {
+            record: { managed_repos: [{ visibility: "private" }, { slug: "owner/repo", visibility: "public" }] },
+            updatedAt: "2026-07-30T12:00:00Z",
+          },
+        },
+      },
+      activeSweeps: [],
+    });
+    const repos = snapshot.hosts.h?.health?.record.managed_repos ?? [];
+    expect(repos).toEqual([{ visibility: "private" }, { slug: "owner/repo", visibility: "public" }]);
+    expect("slug" in repos[0]!).toBe(false);
+  });
+
+  it("degrades a wrong-typed managed_repos to absent rather than throwing", () => {
+    const snapshot = parseFleetSnapshot({
+      hosts: {
+        h: {
+          health: {
+            record: { managed_repos: "not-an-array" },
+            updatedAt: "2026-07-30T12:00:00Z",
+          },
+        },
+      },
+      activeSweeps: [],
+    });
+    expect(snapshot.hosts.h?.health?.record.managed_repos).toBeUndefined();
+  });
+
+  it("drops a malformed managed_repos row rather than the whole roster", () => {
+    const snapshot = parseFleetSnapshot({
+      hosts: {
+        h: {
+          health: {
+            record: {
+              managed_repos: [null, "nope", { slug: 42 }, { slug: "owner/repo", visibility: "public" }],
+            },
+            updatedAt: "2026-07-30T12:00:00Z",
+          },
+        },
+      },
+      activeSweeps: [],
+    });
+    // `null`/`"nope"` are dropped entirely (not objects); `{ slug: 42 }` keeps
+    // its place as a slugless (private-by-default) row rather than vanishing.
+    expect(snapshot.hosts.h?.health?.record.managed_repos).toEqual([
+      { visibility: "private" },
+      { slug: "owner/repo", visibility: "public" },
+    ]);
+  });
 });

--- a/loom-daemon/src/observability/collector.rs
+++ b/loom-daemon/src/observability/collector.rs
@@ -43,8 +43,9 @@ use chrono::{DateTime, Utc};
 
 use crate::event_bus::{EventBus, RecvError};
 use crate::telemetry::{
-    visibility::derive_visibility, HostHealthRecord, PhaseDuration, RepoVisibility, SweepResult,
-    SweepStartedRecord, TelemetryEnvelope, TelemetryRecord, TokenAccountState, TokenSnapshotRecord,
+    visibility::derive_visibility, HostHealthRecord, ManagedRepoEntry, PhaseDuration,
+    RepoVisibility, SweepResult, SweepStartedRecord, TelemetryEnvelope, TelemetryRecord,
+    TokenAccountState, TokenSnapshotRecord,
 };
 use crate::types::{Event, SweepKind};
 use crate::workspace_pool::WorkspacePool;
@@ -134,7 +135,15 @@ async fn run_collector(
             }
 
             _ = snapshot_timer.tick() => {
-                sample_snapshots(&queue, &workspace_root, &host_id, daemon_started_at, &workspace_pool).await;
+                sample_snapshots(
+                    &queue,
+                    &workspace_root,
+                    &host_id,
+                    daemon_started_at,
+                    &workspace_pool,
+                    &mut slug_cache,
+                )
+                .await;
             }
         }
     }
@@ -386,17 +395,22 @@ async fn resolve_visibility(slug: &str) -> RepoVisibility {
 }
 
 /// Sample the two host-level record kinds that have no corresponding bus
-/// event and push them onto `queue`.
+/// event and push them onto `queue`. `slug_cache` is the same per-workspace
+/// slug memoization `handle_event` uses, threaded through so the periodic
+/// `managed_repos` roster sample does not re-shell out to `gh repo view` for
+/// a workspace root already resolved this run.
 async fn sample_snapshots(
     queue: &DurableQueue,
     workspace_root: &Path,
     host_id: &str,
     daemon_started_at: Instant,
     workspace_pool: &WorkspacePool,
+    slug_cache: &mut HashMap<String, String>,
 ) {
     let token_record = sample_token_snapshot(workspace_root);
     queue.push(TelemetryEnvelope::new(host_id, TelemetryRecord::TokensSnapshot(token_record)));
-    let health_record = sample_host_health(workspace_root, daemon_started_at, workspace_pool).await;
+    let health_record =
+        sample_host_health(workspace_root, daemon_started_at, workspace_pool, slug_cache).await;
     queue.push(TelemetryEnvelope::new(host_id, TelemetryRecord::HostHealth(health_record)));
 }
 
@@ -466,6 +480,7 @@ async fn sample_host_health(
     workspace_root: &Path,
     started_at: Instant,
     workspace_pool: &WorkspacePool,
+    slug_cache: &mut HashMap<String, String>,
 ) -> HostHealthRecord {
     // CPU idle refresh can block ~1s on macOS (`iostat`) — dispatched through
     // `spawn_blocking` per the exact pattern `work_finder`'s dynamic-cap tick
@@ -495,6 +510,7 @@ async fn sample_host_health(
         active_sweep_ids: collect_active_sweep_ids(workspace_pool),
         dispatch_halted,
         halt_reason,
+        managed_repos: collect_managed_repos(workspace_pool, slug_cache).await,
     }
 }
 
@@ -517,6 +533,79 @@ fn dispatch_halt_from_breaker(
         Some(snapshot) if snapshot.suppressed => (true, snapshot.reason),
         _ => (false, None),
     }
+}
+
+/// This host's currently managed repository roster (Issue #4976): every
+/// workspace root [`WorkspacePool::provisioned_registries`] currently tracks,
+/// resolved to its forge `owner/repo` slug and [`RepoVisibility`] — the same
+/// derivation [`handle_event`] uses for a sweep record. Feeds `host.health`'s
+/// `managed_repos` so the Phase-2 dashboard can show a host's roster even
+/// when a registered repo has no sweeps at all (`active_sweep_ids` alone
+/// cannot answer "is this repo idle or simply not registered here").
+///
+/// Best-effort per repo: a workspace whose slug cannot be resolved (no `gh`,
+/// not a git remote, a timed-out probe) is silently dropped from the roster
+/// rather than failing the whole `host.health` sample — mirrors every other
+/// best-effort probe this collector already makes.
+async fn collect_managed_repos(
+    workspace_pool: &WorkspacePool,
+    slug_cache: &mut HashMap<String, String>,
+) -> Vec<ManagedRepoEntry> {
+    collect_managed_repos_with(workspace_pool, slug_cache, derive_visibility).await
+}
+
+/// Testable core of [`collect_managed_repos`]: `resolve_visibility` (a plain
+/// sync fn, dispatched through `spawn_blocking` exactly like the standalone
+/// [`resolve_visibility`] helper does) is injected so a unit test can
+/// substitute a deterministic fake for the real `gh api` probe — the same
+/// seam [`crate::telemetry::visibility::refresh_visibility_cache_with`] gives
+/// its own tests, so this roster helper never has to make a live network call
+/// to be exercised hermetically.
+async fn collect_managed_repos_with<F>(
+    workspace_pool: &WorkspacePool,
+    slug_cache: &mut HashMap<String, String>,
+    resolve_visibility: F,
+) -> Vec<ManagedRepoEntry>
+where
+    F: Fn(&str) -> RepoVisibility + Copy + Send + Sync + 'static,
+{
+    // Collect the roots first and drop every registry lock before the async
+    // slug/visibility resolution below — never hold a `std::sync::Mutex`
+    // guard across an `.await` point.
+    let roots: Vec<PathBuf> = workspace_pool
+        .provisioned_registries()
+        .into_iter()
+        .map(|registry| {
+            registry
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .config()
+                .workspace_root
+                .clone()
+        })
+        .collect();
+
+    let mut entries = Vec::with_capacity(roots.len());
+    for root in roots {
+        let root_str = root.to_string_lossy().to_string();
+        let Some(slug) = resolve_repo_slug_cached(slug_cache, &root_str).await else {
+            log::debug!("observability: could not resolve a repo slug for {root_str}; dropping it from the roster");
+            continue;
+        };
+        let owned = slug.clone();
+        // Mirrors `resolve_visibility`'s own contract: a `spawn_blocking` join
+        // failure degrades to the private-safe default rather than propagating.
+        let visibility = tokio::task::spawn_blocking(move || resolve_visibility(&owned))
+            .await
+            .unwrap_or(RepoVisibility::Private);
+        entries.push(ManagedRepoEntry { slug, visibility });
+    }
+    // Deterministic order (the dashboard renders this list directly) and
+    // de-duplicated in case two provisioned roots ever resolve to the same
+    // forge slug (e.g. two worktrees of one repo).
+    entries.sort_by(|a, b| a.slug.cmp(&b.slug));
+    entries.dedup_by(|a, b| a.slug == b.slug);
+    entries
 }
 
 /// This host's currently in-flight (`Pending`/`Running`, i.e. non-terminal)
@@ -908,12 +997,16 @@ mod tests {
         WorkspacePool::new(Arc::new(EventBus::new()), tokio::runtime::Handle::current())
     }
 
+    fn empty_slug_cache() -> HashMap<String, String> {
+        HashMap::new()
+    }
+
     #[tokio::test]
     async fn host_health_sample_populates_daemon_version_and_uptime() {
         let dir = tempfile::tempdir().unwrap();
         let started = Instant::now();
         let pool = empty_pool();
-        let record = sample_host_health(dir.path(), started, &pool).await;
+        let record = sample_host_health(dir.path(), started, &pool, &mut empty_slug_cache()).await;
         assert_eq!(record.daemon_version, env!("CARGO_PKG_VERSION"));
         assert!(record.logical_cpus >= 1);
     }
@@ -922,7 +1015,8 @@ mod tests {
     async fn host_health_sample_stamps_the_running_binarys_build_identity() {
         let dir = tempfile::tempdir().unwrap();
         let pool = empty_pool();
-        let record = sample_host_health(dir.path(), Instant::now(), &pool).await;
+        let record =
+            sample_host_health(dir.path(), Instant::now(), &pool, &mut empty_slug_cache()).await;
 
         // The sample must carry the SAME commit `loom-daemon --version`
         // prints — that identity is what lets the dashboard tell two
@@ -963,10 +1057,22 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let started = Instant::now();
         let pool = empty_pool();
-        let record = sample_host_health(dir.path(), started, &pool).await;
+        let record = sample_host_health(dir.path(), started, &pool, &mut empty_slug_cache()).await;
         assert!(
             record.active_sweep_ids.is_empty(),
             "an empty pool has no in-flight sweeps to report"
+        );
+    }
+
+    #[tokio::test]
+    async fn host_health_sample_reports_no_managed_repos_when_pool_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let started = Instant::now();
+        let pool = empty_pool();
+        let record = sample_host_health(dir.path(), started, &pool, &mut empty_slug_cache()).await;
+        assert!(
+            record.managed_repos.is_empty(),
+            "an empty pool has no registered repos to report"
         );
     }
 
@@ -1100,5 +1206,61 @@ mod tests {
         let (halted, reason) = dispatch_halt_from_breaker(Some(snapshot));
         assert!(halted, "CoolDown still suppresses dispatch, so it must count as halted");
         assert!(reason.is_some());
+    }
+
+    #[tokio::test]
+    async fn collect_managed_repos_reports_every_provisioned_registrys_repo_even_when_idle() {
+        // Registered but never dispatched into: this is the exact "idle
+        // roster" case #4976 exists for — `collect_active_sweep_ids` would
+        // report nothing for either root, but the roster must still list
+        // both.
+        let dir = tempfile::tempdir().unwrap();
+        let a_root = dir.path().join("a");
+        let b_root = dir.path().join("b");
+        std::fs::create_dir_all(&a_root).unwrap();
+        std::fs::create_dir_all(&b_root).unwrap();
+        let pool = empty_pool();
+        pool.seed(a_root.clone(), Arc::new(std::sync::Mutex::new(dispatchable_registry(&a_root))));
+        pool.seed(b_root.clone(), Arc::new(std::sync::Mutex::new(dispatchable_registry(&b_root))));
+
+        // Pre-populate the slug cache so slug resolution never shells out to
+        // `gh repo view` against these bare tempdirs (which have no git
+        // remote at all) — the exact seam `resolve_repo_slug_cached` exists
+        // for.
+        let mut slug_cache = HashMap::new();
+        slug_cache
+            .insert(a_root.to_string_lossy().to_string(), "loom-test-fixture/repo-a".to_string());
+        slug_cache
+            .insert(b_root.to_string_lossy().to_string(), "loom-test-fixture/repo-b".to_string());
+
+        // A deterministic fake visibility resolver — never a real `gh api`
+        // call — that reports repo-a public and repo-b private, so the
+        // per-entry visibility assertion below is not a coin flip on live
+        // forge state.
+        fn fake_visibility(slug: &str) -> RepoVisibility {
+            if slug == "loom-test-fixture/repo-a" {
+                RepoVisibility::Public
+            } else {
+                RepoVisibility::Private
+            }
+        }
+
+        let mut repos = collect_managed_repos_with(&pool, &mut slug_cache, fake_visibility).await;
+        repos.sort_by(|a, b| a.slug.cmp(&b.slug));
+        assert_eq!(
+            repos,
+            vec![
+                ManagedRepoEntry {
+                    slug: "loom-test-fixture/repo-a".to_string(),
+                    visibility: RepoVisibility::Public,
+                },
+                ManagedRepoEntry {
+                    slug: "loom-test-fixture/repo-b".to_string(),
+                    visibility: RepoVisibility::Private,
+                },
+            ],
+            "both registered repos are in the roster, each with its derived visibility, \
+             despite neither having a sweep in flight"
+        );
     }
 }

--- a/loom-daemon/src/observability/exporter.rs
+++ b/loom-daemon/src/observability/exporter.rs
@@ -516,6 +516,7 @@ mod tests {
                 active_sweep_ids: Vec::new(),
                 dispatch_halted: false,
                 halt_reason: None,
+                managed_repos: Vec::new(),
             }),
         )
     }

--- a/loom-daemon/src/observability/otlp/mapping.rs
+++ b/loom-daemon/src/observability/otlp/mapping.rs
@@ -590,6 +590,7 @@ mod tests {
                 active_sweep_ids: Vec::new(),
                 dispatch_halted: false,
                 halt_reason: None,
+                managed_repos: Vec::new(),
             }),
         )
     }
@@ -801,6 +802,7 @@ mod tests {
             active_sweep_ids: Vec::new(),
             dispatch_halted: false,
             halt_reason: None,
+            managed_repos: Vec::new(),
         };
         let batch = vec![envelope(
             "host-c",

--- a/loom-daemon/src/observability/otlp/mod.rs
+++ b/loom-daemon/src/observability/otlp/mod.rs
@@ -314,6 +314,7 @@ mod tests {
                 active_sweep_ids: Vec::new(),
                 dispatch_halted: false,
                 halt_reason: None,
+                managed_repos: Vec::new(),
             }),
         )
     }

--- a/loom-daemon/src/observability/sender.rs
+++ b/loom-daemon/src/observability/sender.rs
@@ -154,6 +154,7 @@ mod tests {
                 active_sweep_ids: Vec::new(),
                 dispatch_halted: false,
                 halt_reason: None,
+                managed_repos: Vec::new(),
             }),
         )
     }

--- a/loom-daemon/src/telemetry/mod.rs
+++ b/loom-daemon/src/telemetry/mod.rs
@@ -519,6 +519,44 @@ pub struct HostHealthRecord {
     /// `dispatch_halted` is `false`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub halt_reason: Option<String>,
+    /// This host's managed-repository roster (Issue #4976): every workspace
+    /// root the daemon's [`crate::workspace_pool::WorkspacePool`] has a
+    /// provisioned registry for, resolved to its forge `owner/repo` slug and
+    /// [`RepoVisibility`] — sourced from the workspace registry itself, not
+    /// inferred from `active_sweep_ids`, so an idle-but-registered repo still
+    /// appears. Feeds the Phase-2 dashboard's "Repositories" fleet-card
+    /// section.
+    ///
+    /// `#[serde(default)]` so a pre-#4976 record still decodes (as an empty
+    /// roster) rather than failing the whole envelope — the same
+    /// backward-compatibility contract `active_sweep_ids` established.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub managed_repos: Vec<ManagedRepoEntry>,
+}
+
+/// One repository this host's daemon is currently managing (Issue #4976) —
+/// the machine-level workspace registry, surfaced in `status --json`'s
+/// `per_repo` but otherwise reaching the backend only via individual sweep
+/// records. `visibility` is derived exactly the way sweep records already
+/// derive theirs ([`visibility::derive_visibility`]), so the same
+/// private-safe-default tag governs redaction here too.
+///
+/// This struct carries the repo's **real** slug regardless of visibility —
+/// exactly like [`SweepStartedRecord::repo`] always carries the real slug.
+/// The anti-leak control is enforced at the Phase-2 dashboard's redaction
+/// boundary (`dashboard/src/redaction.ts`), not here; the daemon's own push
+/// to the observability backend is authenticated and never reaches an
+/// unauthenticated viewer directly.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ManagedRepoEntry {
+    /// The `owner/repo` forge slug.
+    pub slug: String,
+    /// This repo's visibility class. `#[serde(default)]` so a repo entry
+    /// missing the tag (should never happen from this daemon, but matches
+    /// every other visibility field's defensive posture) decodes to
+    /// `Private`, never `Public`.
+    #[serde(default)]
+    pub visibility: RepoVisibility,
 }
 
 #[cfg(test)]
@@ -634,6 +672,16 @@ mod tests {
             active_sweep_ids: vec!["sweep-issue-4703-0".to_string()],
             dispatch_halted: false,
             halt_reason: None,
+            managed_repos: vec![
+                ManagedRepoEntry {
+                    slug: "rjwalters/loom".to_string(),
+                    visibility: RepoVisibility::Public,
+                },
+                ManagedRepoEntry {
+                    slug: "2AMLogic/gf180-pll".to_string(),
+                    visibility: RepoVisibility::Private,
+                },
+            ],
         })
     }
 
@@ -857,6 +905,7 @@ mod tests {
             active_sweep_ids: Vec::new(),
             dispatch_halted: false,
             halt_reason: None,
+            managed_repos: Vec::new(),
         });
         let value = serde_json::to_value(&record).unwrap();
         assert!(
@@ -896,5 +945,96 @@ mod tests {
             }
             other => panic!("expected HostHealth, got {other:?}"),
         }
+    }
+
+    // ------------------------------------------------------------------
+    // host.health managed_repos roster (#4976).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn host_health_serializes_managed_repos_with_slug_and_visibility() {
+        let value = serde_json::to_value(host_health()).unwrap();
+        let repos = value
+            .get("managed_repos")
+            .and_then(serde_json::Value::as_array)
+            .unwrap();
+        assert_eq!(repos.len(), 2);
+        assert_eq!(
+            repos[0].get("slug").and_then(serde_json::Value::as_str),
+            Some("rjwalters/loom")
+        );
+        assert_eq!(
+            repos[0]
+                .get("visibility")
+                .and_then(serde_json::Value::as_str),
+            Some("public")
+        );
+        assert_eq!(
+            repos[1].get("slug").and_then(serde_json::Value::as_str),
+            Some("2AMLogic/gf180-pll")
+        );
+        assert_eq!(
+            repos[1]
+                .get("visibility")
+                .and_then(serde_json::Value::as_str),
+            Some("private")
+        );
+    }
+
+    #[test]
+    fn host_health_omits_managed_repos_when_empty() {
+        // `skip_serializing_if = "Vec::is_empty"` — a host with no registered
+        // workspaces sends no key at all, mirroring `active_sweep_ids`.
+        let record = TelemetryRecord::HostHealth(HostHealthRecord {
+            captured_at: ts(),
+            daemon_version: "0.17.0".to_string(),
+            build_commit: "unknown".to_string(),
+            built_at: None,
+            uptime_sec: 1,
+            logical_cpus: 4,
+            cpu_idle_fraction: None,
+            load_per_core: None,
+            worktree_root_free_gb: None,
+            active_sweep_ids: Vec::new(),
+            dispatch_halted: false,
+            halt_reason: None,
+            managed_repos: Vec::new(),
+        });
+        let value = serde_json::to_value(&record).unwrap();
+        assert!(
+            value.get("managed_repos").is_none(),
+            "an empty roster must be absent from the wire, not an empty array"
+        );
+    }
+
+    #[test]
+    fn host_health_from_a_pre_4976_daemon_still_decodes() {
+        // Backward compatibility: a record emitted by a daemon that predates
+        // the managed-repo roster must decode with an empty roster, not fail
+        // the whole envelope.
+        let json = r#"{
+            "kind": "host.health",
+            "captured_at": "2026-07-30T12:00:00Z",
+            "daemon_version": "0.16.0",
+            "uptime_sec": 86400,
+            "logical_cpus": 28
+        }"#;
+        let decoded: TelemetryRecord = serde_json::from_str(json).unwrap();
+        match decoded {
+            TelemetryRecord::HostHealth(r) => {
+                assert!(r.managed_repos.is_empty());
+            }
+            other => panic!("expected HostHealth, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn managed_repo_entry_with_missing_visibility_defaults_to_private() {
+        // A repo entry with no `visibility` tag at all must decode Private —
+        // the same private-safe-default every other visibility field holds.
+        let json = r#"{"slug": "owner/repo"}"#;
+        let decoded: ManagedRepoEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(decoded.visibility, RepoVisibility::Private);
+        assert_eq!(decoded.slug, "owner/repo");
     }
 }


### PR DESCRIPTION
## Summary

Fleet cards now show which repositories each host's daemon is managing — a
"Repositories" section below "Active sweeps" — sourced from the daemon's
workspace registry rather than inferred from recent sweeps, so an idle,
registered repo still shows up.

## Changes

**Daemon (`loom-daemon`):**
- `telemetry/mod.rs`: new `ManagedRepoEntry { slug, visibility }` and a
  `managed_repos: Vec<ManagedRepoEntry>` field on `HostHealthRecord`
  (`#[serde(default, skip_serializing_if = "Vec::is_empty")]`, matching the
  `active_sweep_ids` backward-compat pattern).
- `observability/collector.rs`: `collect_managed_repos` iterates every
  `WorkspacePool::provisioned_registries()` root, resolves its `owner/repo`
  slug (`resolve_repo_slug_cached`) and `RepoVisibility`
  (`visibility::derive_visibility` — the same derivation sweep records use),
  and threads the slug cache through `sample_snapshots`/`sample_host_health`
  so it doesn't re-shell to `gh repo view` every tick. The visibility
  resolution is injected via a testable core (`collect_managed_repos_with`)
  so the unit test never makes a live `gh api` network call.

**Dashboard backend (`dashboard/src/redaction.ts`):**
- `managed_repos` is deliberately absent from `host.health`'s
  `RECORD_FIELD_ALLOWLIST` (it can name a private repo) and instead redacted
  through a new `redactManagedRepos`: a `public`-visibility entry's slug
  survives to the public view; a `private` entry's slug is dropped but the
  entry itself is kept, so the roster's size (and "how many are private")
  stays visible without naming any of them. The authenticated view always
  sees the raw array.

**Dashboard frontend (`dashboard/web`):**
- `types.ts` / `parse.ts`: `ManagedRepoEntry` + `HostHealthRecord.managed_repos`
  parsing (wrong-typed/missing `visibility` fails safe to `"private"`,
  matching `ActiveSweep.visibility`'s existing convention).
- `views/fleetOverview.ts`: a "Repositories" section below "Active sweeps",
  grouping the card's *existing* sweep list by repo slug for a per-repo
  in-flight count (no new daemon-side count needed) and collapsing any
  slug-less (redacted-private) entries into one "+N private" row.
- `styles.css`: `.card__repos`/`.card__repo(--private)` mirroring the
  existing `.card__sweeps` styling.

**Docs:** `.loom/docs/telemetry-schema.md`'s `host.health` section documents
`managed_repos` and its redaction class.

## Acceptance Criteria Verification

- [x] Each fleet card lists the host's managed repositories, sourced from the
      daemon's workspace registry (not inferred from recent sweeps) — an idle
      repo still appears: `collect_managed_repos` iterates
      `provisioned_registries()` directly, independent of any sweep state;
      pinned by `collect_managed_repos_reports_every_provisioned_registrys_repo_even_when_idle`.
- [x] Private repo slugs never appear on the signed-out view (collapsed to a
      count); the authed view shows all: `redactManagedRepos` /
      `redactFleetSnapshot`, pinned by new tests in `dashboard/test/redaction.test.ts`
      and the "collapses a private, redacted repo entry to a count" UI test.
- [x] Roster changes (workspace add/remove, `fleet drain`) are reflected
      within one reporting cadence: the roster is recomputed on every
      `sample_host_health` tick (same cadence as every other `host.health`
      field) directly off the live `WorkspacePool`, not a cached snapshot.
- [x] `.loom/docs/telemetry-schema.md` documents the new field and its
      redaction class.

## Test Plan

- `cargo test --lib telemetry` (38 passed) and `cargo test --lib observability`
  (72 passed) in `loom-daemon/`, including two new tests:
  `collect_managed_repos_reports_every_provisioned_registrys_repo_even_when_idle`
  and the `host_health_*managed_repos*` serde round-trip/back-compat tests.
- `cargo test --lib` (full crate): 3133 passed, 1 pre-existing unrelated
  failure (`config_resolver::tests::test_resolve_nested_autonomous_block_merges_across_tiers`
  — a live tier-1 private-defaults file on this host leaking into config
  resolution tests; `config_resolver.rs` is untouched by this PR).
- `cargo clippy --lib --all-targets -- -D warnings` and `cargo fmt -- --check`: clean.
- `dashboard`: `npm run check:all` (typecheck + `vitest run` for both the
  Worker backend and the `web/` frontend) — 207 + 427 tests passed, including
  new `redactManagedRepos`/`redactPayload("host.health", ...)` tests and new
  `parseHostHealth`/`hostCard` "Repositories" section tests.

Closes #4976