### PR TITLE
test(daemon): make config-surface tests hermetic against the machine-level defaults tier

### DIFF
--- a/loom-daemon/src/auto_update.rs
+++ b/loom-daemon/src/auto_update.rs
@@ -1086,23 +1086,35 @@ mod tests {
     // ===================================================================
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_missing_file_is_default() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
-        assert_eq!(read_auto_update_config(tmp.path()), AutoUpdateConfig::default());
+        let cfg = read_auto_update_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, AutoUpdateConfig::default());
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_malformed_json_is_default() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), "{not valid json");
-        assert_eq!(read_auto_update_config(tmp.path()), AutoUpdateConfig::default());
+        let cfg = read_auto_update_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, AutoUpdateConfig::default());
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_missing_block_is_default() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"enabled": true}}}"#);
-        assert_eq!(read_auto_update_config(tmp.path()), AutoUpdateConfig::default());
+        let cfg = read_auto_update_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, AutoUpdateConfig::default());
     }
 
     #[test]

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -4692,30 +4692,46 @@ exit 0
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_missing_file_is_all_none() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
-        assert_eq!(read_work_finder_config(tmp.path()), WorkFinderConfig::default());
+        let cfg = read_work_finder_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, WorkFinderConfig::default());
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_malformed_json_is_all_none() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), "{not valid json");
-        assert_eq!(read_work_finder_config(tmp.path()), WorkFinderConfig::default());
+        let cfg = read_work_finder_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, WorkFinderConfig::default());
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_missing_autonomous_block_is_all_none() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"terminals": []}"#);
-        assert_eq!(read_work_finder_config(tmp.path()), WorkFinderConfig::default());
+        let cfg = read_work_finder_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, WorkFinderConfig::default());
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_missing_work_finder_block_is_all_none() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"mainHealthGate": {"enabled": true}}}"#);
-        assert_eq!(read_work_finder_config(tmp.path()), WorkFinderConfig::default());
+        let cfg = read_work_finder_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, WorkFinderConfig::default());
     }
 
     #[test]
@@ -4764,10 +4780,12 @@ exit 0
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_deprecated_cpu_knobs_accepted_at_any_value_including_nonsense() {
         // Pre-#4512 these were range-filtered/type-checked because a value was
         // consumed. Nothing consumes them now, so out-of-range, wrong-type, and
         // even absurd values are all equally inert — and equally non-fatal.
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         for body in [
             r#"{"autonomous": {"cpuUtilizationTarget": 0}}"#,
             r#"{"autonomous": {"cpuUtilizationTarget": 1.5}}"#,
@@ -4783,6 +4801,7 @@ exit 0
             assert_eq!(cfg.max_concurrent, None);
             assert_eq!(cfg.enabled, None);
         }
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
     }
 
     #[test]
@@ -4874,12 +4893,15 @@ exit 0
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_per_token_concurrency_read_without_work_finder_block() {
         // `perTokenConcurrency` lives at the `autonomous` level (#3947), so it is
         // read even when the `workFinder` sub-block is absent.
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"perTokenConcurrency": 3}}"#);
         let cfg = read_work_finder_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
         assert_eq!(cfg.per_token_concurrency, Some(3));
         assert_eq!(cfg.enabled, None);
         assert_eq!(cfg.max_concurrent, None);
@@ -4895,10 +4917,13 @@ exit 0
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_enabled_false_is_disabled_flag() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"enabled": false}}}"#);
         let cfg = read_work_finder_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
         assert_eq!(cfg.enabled, Some(false));
         assert_eq!(cfg.interval_secs, None);
         assert_eq!(cfg.max_concurrent, None);

--- a/loom-daemon/src/worktree_reaper.rs
+++ b/loom-daemon/src/worktree_reaper.rs
@@ -832,23 +832,35 @@ mod tests {
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_missing_file_is_default() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
-        assert_eq!(read_worktree_reaper_config(tmp.path()), WorktreeReaperConfig::default());
+        let cfg = read_worktree_reaper_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, WorktreeReaperConfig::default());
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_malformed_json_is_default() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), "{not valid json");
-        assert_eq!(read_worktree_reaper_config(tmp.path()), WorktreeReaperConfig::default());
+        let cfg = read_worktree_reaper_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, WorktreeReaperConfig::default());
     }
 
     #[test]
+    #[serial(loom_config_env)]
     fn test_config_missing_block_is_default() {
+        std::env::set_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV, "");
         let tmp = tempfile::tempdir().unwrap();
         write_config(tmp.path(), r#"{"autonomous": {"workFinder": {"enabled": true}}}"#);
-        assert_eq!(read_worktree_reaper_config(tmp.path()), WorktreeReaperConfig::default());
+        let cfg = read_worktree_reaper_config(tmp.path());
+        std::env::remove_var(crate::config_resolver::PRIVATE_DEFAULTS_ENV);
+        assert_eq!(cfg, WorktreeReaperConfig::default());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`loom-daemon`'s config-surface unit tests in `work_finder.rs`, `auto_update.rs`, and `worktree_reaper.rs` construct a `tempfile::tempdir()` and assert the resolved config equals `Default::default()`. `read_work_finder_config`, `read_auto_update_config`, and `read_worktree_reaper_config` all go through `config_resolver::resolve_effective_config`, whose highest-precedence tier is the machine-level private defaults file (`~/.local/share/loom/config/defaults.json`, overridable via `LOOM_CONFIG_DEFAULTS_FILE`). The tempdir does not shadow that tier, so on a host with a populated `defaults.json` these tests silently read the host's values instead of true defaults.

This applies the existing, already-used-elsewhere `#[serial(loom_config_env)]` + `PRIVATE_DEFAULTS_ENV=""` guard pattern (see `role_runner.rs`, `daemon_heartbeat.rs`, `token_ranking_refresh.rs`, `config_resolver.rs`'s own tests, and the later "tier precedence" tests already in these same two files) to the 13 affected tests:

- `work_finder.rs` (7 tests): `test_config_missing_file_is_all_none`, `test_config_malformed_json_is_all_none`, `test_config_missing_autonomous_block_is_all_none`, `test_config_missing_work_finder_block_is_all_none`, `test_config_enabled_false_is_disabled_flag`, `test_config_per_token_concurrency_read_without_work_finder_block`, `test_deprecated_cpu_knobs_accepted_at_any_value_including_nonsense`
- `auto_update.rs` (3 tests): `test_config_missing_file_is_default`, `test_config_malformed_json_is_default`, `test_config_missing_block_is_default`
- `worktree_reaper.rs` (3 tests): `test_config_missing_file_is_default`, `test_config_malformed_json_is_default`, `test_config_missing_block_is_default` — these had **no guard at all** (not even bare `#[serial]`), the third gap the Curator's enhancement flagged.

No production code paths touched — test-only, non-behavioral change. `config_resolver.rs` itself is untouched, per the issue's scope note.

## Verification

- Confirmed the pre-fix repro: pointing `LOOM_CONFIG_DEFAULTS_FILE` at a scratch file with `autonomous.workFinder`/`autonomous.perTokenConcurrency`/`autonomous.autoUpdate` keys set caused `work_finder`/`auto_update` tests to fail against the unpatched code (`worktree_reaper` tests weren't hit by that particular scratch file's keys, but the same mechanism applies — fixed defensively per the Curator's note).
- After the fix, ran `cargo test -p loom-daemon --lib test_config` **3 consecutive times** with `LOOM_CONFIG_DEFAULTS_FILE` pointed at a populated scratch file (setting `autonomous.workFinder.enabled`, `autonomous.perTokenConcurrency`, `autonomous.autoUpdate.enabled`, and `autonomous.worktreeReaper.*`) — all green (64 passed each run).
- Ran the same suite with `LOOM_CONFIG_DEFAULTS_FILE` unset — all green.
- Full suite: `cargo test -p loom-daemon --lib` — 3138 passed, 0 failed.
- `cargo fmt -p loom-daemon -- --check` and `cargo clippy -p loom-daemon --lib --tests` both clean.

## Test plan

- [x] `cargo test -p loom-daemon --lib test_config` x3 with a populated `LOOM_CONFIG_DEFAULTS_FILE`
- [x] Same, with `LOOM_CONFIG_DEFAULTS_FILE` unset
- [x] `cargo test -p loom-daemon --lib` (full suite)
- [x] `cargo fmt` / `cargo clippy` clean

Closes #4983