### PR TITLE
feat(release): build prebuilt loom-daemon artifacts + checksums for all target platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,28 @@
 name: Build and Release
+#
+# Release artifacts (Epic #4990 Phase 1, #5003): on GitHub Release creation
+# this workflow cross-builds `loom-daemon` for every platform in the fleet's
+# target triples and uploads, for EACH one, both the binary and a `.sha256`
+# checksum file as Release assets:
+#
+#   - loom-daemon-aarch64-apple-darwin(.sha256)
+#   - loom-daemon-x86_64-unknown-linux-gnu(.sha256)
+#   - loom-daemon-aarch64-unknown-linux-gnu(.sha256)
+#
+# This is Phase 1 of #4990 (foundation only): NO code signing, notarization,
+# or org-specific identity of any kind is applied here — every artifact is
+# unsigned, verified only by its checksum. Platform signing is a later,
+# secrets-gated phase (#4990 Phase 2); nothing here should ever need to name a
+# cert, team ID, or signing identity — if it does, that's a scope regression.
+# Consuming these artifacts from `loom-daemon-update.sh` / the daemon
+# auto-updater is also out of scope here (#4990 Phase 3) — the LOCAL
+# `cargo build` path in `loom-daemon-update.sh` remains the default/fallback
+# for dev machines, canaries, and forks with no Release access.
+#
+# Each target builds in its own matrix job with `fail-fast: false`: one
+# platform's build failure fails that job (and therefore the overall workflow
+# run) loudly — it never silently drops just that platform's artifact while
+# reporting overall success.
 
 on:
   release:
@@ -15,52 +39,80 @@ permissions:
 
 jobs:
   build-daemon:
-    name: Build loom-daemon
-    runs-on: macos-14  # Apple Silicon runner
+    name: Build loom-daemon (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Never mask a platform's failure with another's success, and never let
+      # one platform's failure cancel an in-flight build for another.
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-14 # Apple Silicon runner (native build)
+            cross: false
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest # native build
+            cross: false
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            # No native aarch64 Linux runner assumption is made here — cross
+            # compile via an aarch64 gcc/binutils toolchain instead, which
+            # works on any ubuntu-latest runner regardless of arm64-runner
+            # availability for this repo/org.
+            cross: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin,x86_64-apple-darwin
+          targets: ${{ matrix.target }}
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
             .
+          key: ${{ matrix.target }}
 
-      - name: Ensure both Apple targets installed
+      - name: Install cross-compilation toolchain
+        if: matrix.cross
         run: |
-          rustup target add aarch64-apple-darwin
-          rustup target add x86_64-apple-darwin
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
 
-      - name: Build daemon (ARM64)
-        run: |
-          cargo build --package loom-daemon --release --target aarch64-apple-darwin
-          mkdir -p target/release
-          cp target/aarch64-apple-darwin/release/loom-daemon target/release/loom-daemon-aarch64-apple-darwin
+      - name: Build loom-daemon
+        env:
+          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+          CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
+          AR_aarch64_unknown_linux_gnu: aarch64-linux-gnu-ar
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: cargo build --package loom-daemon --release --target ${{ matrix.target }}
 
-      - name: Build daemon (x86_64)
+      - name: Package artifact + checksum
         run: |
-          cargo build --package loom-daemon --release --target x86_64-apple-darwin
-          mkdir -p target/release
-          cp target/x86_64-apple-darwin/release/loom-daemon target/release/loom-daemon-x86_64-apple-darwin || true
-
-      - name: List build artifacts
-        run: |
-          echo "=== Daemon binaries ==="
-          ls -la target/release/loom-daemon-* || true
+          set -euo pipefail
+          mkdir -p dist
+          artifact="dist/loom-daemon-${{ matrix.target }}"
+          cp "target/${{ matrix.target }}/release/loom-daemon" "$artifact"
+          cd dist
+          if command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 "loom-daemon-${{ matrix.target }}" > "loom-daemon-${{ matrix.target }}.sha256"
+          else
+            sha256sum "loom-daemon-${{ matrix.target }}" > "loom-daemon-${{ matrix.target }}.sha256"
+          fi
+          ls -la
 
       - name: Upload release assets
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v3
         with:
           files: |
-            target/release/loom-daemon-aarch64-apple-darwin
-            target/release/loom-daemon-x86_64-apple-darwin
+            dist/loom-daemon-${{ matrix.target }}
+            dist/loom-daemon-${{ matrix.target }}.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -68,8 +120,8 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
-          name: loom-daemon-binaries
+          name: loom-daemon-${{ matrix.target }}
           path: |
-            target/release/loom-daemon-aarch64-apple-darwin
-            target/release/loom-daemon-x86_64-apple-darwin
+            dist/loom-daemon-${{ matrix.target }}
+            dist/loom-daemon-${{ matrix.target }}.sha256
           retention-days: 7

--- a/README.md
+++ b/README.md
@@ -366,6 +366,15 @@ git push origin main --tags
 gh release create vX.Y.Z --title "vX.Y.Z" --notes "Release notes..."
 ```
 
+Creating the Release triggers [`.github/workflows/release.yml`](.github/workflows/release.yml),
+which cross-builds `loom-daemon` for `aarch64-apple-darwin`,
+`x86_64-unknown-linux-gnu`, and `aarch64-unknown-linux-gnu`, and uploads each
+platform's binary plus a `.sha256` checksum file as Release assets. These
+artifacts are unsigned as of this writing (platform code signing is a
+secrets-gated, opt-in follow-up); verify integrity via the checksum. Each
+platform builds in its own CI job, so one platform failing to build never
+silently drops that platform's artifact from an otherwise-"successful" run.
+
 ## Bootstrap New Projects
 
 ```bash


### PR DESCRIPTION
## Summary

Epic #4990 Phase 1: add a release workflow (extending the existing `.github/workflows/release.yml`, triggered on GitHub Release creation) that cross-builds `loom-daemon` for the three fleet target triples and uploads each binary plus a SHA-256 checksum to the Release.

- Matrix job per target: `aarch64-apple-darwin` (native, `macos-14`), `x86_64-unknown-linux-gnu` (native, `ubuntu-latest`), `aarch64-unknown-linux-gnu` (cross-compiled via `gcc-aarch64-linux-gnu` on `ubuntu-latest`, since a native arm64 Linux runner isn't assumed to be available for this repo/org)
- `strategy.fail-fast: false` — each platform's build/upload is independent; one platform failing to build fails that job (and the overall workflow run) loudly rather than silently dropping just that platform's artifact
- Each artifact gets a `.sha256` file (`shasum -a 256` / `sha256sum`), uploaded alongside the binary via `softprops/action-gh-release` (on `release`) or `actions/upload-artifact` (on manual `workflow_dispatch`, for testing)
- No code signing, notarization, or org-specific identity in this phase — that's Epic #4990 Phase 2, secrets-gated. Confirmed via `grep` that no cert/team-id/identity string was introduced.
- Documented what a Release now contains in a workflow header comment and a new paragraph in README.md's "Releasing" section

Local build via `loom-daemon-update.sh` is untouched and remains the default/fallback path (Phase 3 wires artifact-based self-update into it, not this issue).

## Test plan

- [x] `actionlint .github/workflows/release.yml` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — parses without error
- [x] `git grep` for signing/cert/identity terms in the new workflow — only appears in comments describing what's explicitly NOT present (Phase 2 scope)
- [ ] Actual GitHub Actions execution (can't be run locally) — will be exercised on the next Release creation

Closes #5003