### PR TITLE
fix(daemon-cli): name the resolved loom-daemon binary + add LOOM_PREFER_REPO_BUILD opt-in

### DIFF
--- a/defaults/scripts/lib/locate-daemon-bin.sh
+++ b/defaults/scripts/lib/locate-daemon-bin.sh
@@ -15,13 +15,20 @@
 #
 # Resolution precedence (first match wins):
 #   1. $LOOM_DAEMON_BIN — must be executable.
-#   2. `loom-daemon` on PATH.
-#   3. The machine-level install location: $LOOM_DAEMON_BIN_DIR (default
+#   2. Only when $LOOM_PREFER_REPO_BUILD=1: the build-output-relative
+#      candidates under <repo_root> (see step 4 below), hoisted above the
+#      installed binary so a developer who just `cargo build`ed in a
+#      checkout runs what they built instead of a stale
+#      $HOME/.local/bin/loom-daemon (#4997). Off by default — the plain
+#      `loom-daemon-start.sh` / `.loom/bin/loom` production path must keep
+#      preferring the machine-level install unconditionally.
+#   3. `loom-daemon` on PATH.
+#   4. The machine-level install location: $LOOM_DAEMON_BIN_DIR (default
 #      $HOME/.local/bin) — this is where loom-daemon-update.sh's --provision
 #      path installs, and the location `ssh host 'cmd'` (a non-interactive
 #      shell that never sources the login profile, so $HOME/.local/bin is
 #      NOT on PATH) needs an explicit check for (#4875).
-#   4. Build-output-relative candidates under <repo_root>:
+#   5. Build-output-relative candidates under <repo_root>:
 #        loom-daemon/target/release/loom-daemon
 #        loom-daemon/target/debug/loom-daemon
 #        target/release/loom-daemon
@@ -30,34 +37,91 @@
 # Extracted (issue #4080) from the identical inline copies in
 # loom-daemon-start.sh and loom-daemon-update.sh so probe-tokens.sh's
 # daemon-binary resolution does not add a fourth copy of this logic. #4875
-# added the machine-level install fallback (step 3) plus
+# added the machine-level install fallback (step 4) plus
 # loom_daemon_bin_search_paths(), and migrated the remaining inline copies in
 # loom-daemon-start.sh / loom-daemon-watchdog.sh / loom-daemon-update.sh /
 # loom-status.sh / .loom/bin/loom onto this single shared definition so a
 # future new candidate path never has to be ported by hand across six copies
-# again.
+# again. #4997 added the diagnostic stderr line (every resolution names the
+# path + provenance + mtime it landed on, so "which binary ran" is always
+# answerable from a sweep/session log) and the opt-in $LOOM_PREFER_REPO_BUILD
+# precedence hoist (step 2).
+
+# Best-effort mtime, formatted for a human-readable log line. GNU `stat -c`
+# first (illegal option on BSD/macOS, so it fails cleanly there), then BSD
+# `stat -f`. Echoes "unknown" if neither works (e.g. the path vanished
+# between resolution and logging) rather than failing the caller.
+_loom_daemon_bin_mtime_human() {
+    local path="$1" epoch
+    epoch="$(stat -c %Y "$path" 2>/dev/null || true)"
+    if [[ ! "$epoch" =~ ^[0-9]+$ ]]; then
+        epoch="$(stat -f %m "$path" 2>/dev/null || true)"
+    fi
+    if [[ ! "$epoch" =~ ^[0-9]+$ ]]; then
+        echo "unknown"; return 0
+    fi
+    date -r "$epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null \
+        || date -d "@$epoch" '+%Y-%m-%d %H:%M:%S' 2>/dev/null \
+        || echo "unknown"
+}
 
 loom_locate_daemon_bin() {
     local root="$1"
+    local resolved="" via=""
+
     if [[ -n "${LOOM_DAEMON_BIN:-}" && -x "${LOOM_DAEMON_BIN}" ]]; then
-        echo "${LOOM_DAEMON_BIN}"; return 0
+        resolved="${LOOM_DAEMON_BIN}"
+        via="\$LOOM_DAEMON_BIN"
     fi
-    if command -v loom-daemon >/dev/null 2>&1; then
-        command -v loom-daemon; return 0
+
+    if [[ -z "$resolved" && "${LOOM_PREFER_REPO_BUILD:-}" == "1" ]]; then
+        local repo_candidate
+        for repo_candidate in \
+            "$root/loom-daemon/target/release/loom-daemon" \
+            "$root/loom-daemon/target/debug/loom-daemon" \
+            "$root/target/release/loom-daemon" \
+            "$root/target/debug/loom-daemon"; do
+            if [[ -x "$repo_candidate" ]]; then
+                resolved="$repo_candidate"
+                via="repo-local build (\$LOOM_PREFER_REPO_BUILD=1)"
+                break
+            fi
+        done
     fi
-    local machine_bin="${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}/loom-daemon"
-    if [[ -x "$machine_bin" ]]; then
-        echo "$machine_bin"; return 0
+
+    if [[ -z "$resolved" ]] && command -v loom-daemon >/dev/null 2>&1; then
+        resolved="$(command -v loom-daemon)"
+        via="\$PATH"
     fi
-    local candidate
-    for candidate in \
-        "$root/loom-daemon/target/release/loom-daemon" \
-        "$root/loom-daemon/target/debug/loom-daemon" \
-        "$root/target/release/loom-daemon" \
-        "$root/target/debug/loom-daemon"; do
-        if [[ -x "$candidate" ]]; then echo "$candidate"; return 0; fi
-    done
-    echo ""
+
+    if [[ -z "$resolved" ]]; then
+        local machine_bin="${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}/loom-daemon"
+        if [[ -x "$machine_bin" ]]; then
+            resolved="$machine_bin"
+            via="machine-level install (\${LOOM_DAEMON_BIN_DIR:-\$HOME/.local/bin})"
+        fi
+    fi
+
+    if [[ -z "$resolved" ]]; then
+        local candidate
+        for candidate in \
+            "$root/loom-daemon/target/release/loom-daemon" \
+            "$root/loom-daemon/target/debug/loom-daemon" \
+            "$root/target/release/loom-daemon" \
+            "$root/target/debug/loom-daemon"; do
+            if [[ -x "$candidate" ]]; then
+                resolved="$candidate"
+                via="repo-local build"
+                break
+            fi
+        done
+    fi
+
+    if [[ -n "$resolved" ]]; then
+        echo "loom_locate_daemon_bin: resolved $resolved via $via (mtime: $(_loom_daemon_bin_mtime_human "$resolved"))" >&2
+    fi
+
+    echo "$resolved"
 }
 
 # loom_daemon_bin_search_paths <repo_root> -- render the candidate list for
@@ -67,6 +131,12 @@ loom_daemon_bin_search_paths() {
     local root="$1"
     if [[ -n "${LOOM_DAEMON_BIN:-}" ]]; then
         echo "\$LOOM_DAEMON_BIN=${LOOM_DAEMON_BIN}"
+    fi
+    if [[ "${LOOM_PREFER_REPO_BUILD:-}" == "1" ]]; then
+        echo "$root/loom-daemon/target/release/loom-daemon (\$LOOM_PREFER_REPO_BUILD=1)"
+        echo "$root/loom-daemon/target/debug/loom-daemon (\$LOOM_PREFER_REPO_BUILD=1)"
+        echo "$root/target/release/loom-daemon (\$LOOM_PREFER_REPO_BUILD=1)"
+        echo "$root/target/debug/loom-daemon (\$LOOM_PREFER_REPO_BUILD=1)"
     fi
     echo "loom-daemon on \$PATH"
     echo "${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}/loom-daemon"

--- a/defaults/scripts/tests/test-locate-daemon-bin.sh
+++ b/defaults/scripts/tests/test-locate-daemon-bin.sh
@@ -129,6 +129,94 @@ paths_out=$( env -i PATH="$MINIMAL_PATH" HOME="$WORKDIR/t8-home" \
 assert_contains "$WORKDIR/t8-home/.local/bin/loom-daemon" "$paths_out" "search-paths summary names the machine-level ~/.local/bin install location"
 assert_contains "$WORKDIR/t8-root/target/release/loom-daemon" "$paths_out" "search-paths summary still names the in-repo build-output candidates"
 
+# ---------- 9. resolving a binary logs its path on stderr (#4997 AC1) ----------
+# The diagnostic line must not contaminate stdout (callers capture stdout via
+# command substitution to get the path itself).
+BIN9_HOME="$WORKDIR/t9-home"
+BIN9="$BIN9_HOME/.local/bin/loom-daemon"
+make_fake_bin "$BIN9"
+stdout_out=$( env -i PATH="$MINIMAL_PATH" HOME="$BIN9_HOME" \
+    bash -c "source '$LIB'; loom_locate_daemon_bin '$WORKDIR/t9-root'" 2>"$WORKDIR/t9-stderr" )
+stderr_out="$(cat "$WORKDIR/t9-stderr")"
+assert_eq "$BIN9" "$stdout_out" "stdout still carries only the resolved path (diagnostics do not contaminate it)"
+assert_contains "$BIN9" "$stderr_out" "stderr names the resolved binary path (#4997 AC1)"
+assert_contains "machine-level install" "$stderr_out" "stderr names which precedence tier the binary was resolved from"
+
+# ---------- 10. $LOOM_PREFER_REPO_BUILD=1 hoists the repo-local build above
+#                the machine-level install and $PATH (#4997) ----------
+REPO10="$WORKDIR/t10-repo"
+make_fake_bin "$REPO10/target/release/loom-daemon"
+PATH10_DIR="$WORKDIR/t10-on-path"
+make_fake_bin "$PATH10_DIR/loom-daemon"
+HOME10="$WORKDIR/t10-home"
+make_fake_bin "$HOME10/.local/bin/loom-daemon"
+
+# Without the opt-in, $PATH still wins (unchanged default precedence).
+out=$( env -i PATH="$PATH10_DIR:$MINIMAL_PATH" HOME="$HOME10" \
+    bash -c "source '$LIB'; loom_locate_daemon_bin '$REPO10'" 2>/dev/null )
+assert_eq "$PATH10_DIR/loom-daemon" "$out" "without LOOM_PREFER_REPO_BUILD, \$PATH still wins over the fresh repo build (default precedence unchanged)"
+
+# With the opt-in, the repo-local build wins over both $PATH and the
+# machine-level install, even though both of those also resolve.
+out=$( env -i PATH="$PATH10_DIR:$MINIMAL_PATH" HOME="$HOME10" LOOM_PREFER_REPO_BUILD=1 \
+    bash -c "source '$LIB'; loom_locate_daemon_bin '$REPO10'" 2>"$WORKDIR/t10-stderr" )
+stderr_out="$(cat "$WORKDIR/t10-stderr")"
+assert_eq "$REPO10/target/release/loom-daemon" "$out" "LOOM_PREFER_REPO_BUILD=1 hoists the fresh repo-local build above \$PATH and the machine-level install"
+assert_contains "LOOM_PREFER_REPO_BUILD" "$stderr_out" "stderr names LOOM_PREFER_REPO_BUILD as the provenance when the opt-in fires"
+
+# ---------- 11. #4875 regression still holds under LOOM_PREFER_REPO_BUILD=1:
+#                a non-login SSH session with no repo-local build present and
+#                no $PATH entry still finds the machine-level install ----------
+SSH11_HOME="$WORKDIR/t11-ssh-home"
+SSH11_BIN="$SSH11_HOME/.local/bin/loom-daemon"
+make_fake_bin "$SSH11_BIN"
+out=$( env -i PATH="$MINIMAL_PATH" HOME="$SSH11_HOME" LOOM_PREFER_REPO_BUILD=1 \
+    bash -c "source '$LIB'; loom_locate_daemon_bin '$WORKDIR/t11-root'" 2>/dev/null )
+assert_eq "$SSH11_BIN" "$out" "LOOM_PREFER_REPO_BUILD=1 does not break the #4875 non-login-\$PATH ssh case when no repo build exists"
+
+# ---------- 12. LOCKSTEP: loom_locate_daemon_bin must always agree with the
+#                first existing candidate in loom_daemon_bin_search_paths's
+#                own ordering (#4997 AC2 -- fails if the two functions
+#                disagree on precedence, in either default or
+#                LOOM_PREFER_REPO_BUILD=1 mode). ----------
+assert_lockstep() { # <label> <extra_env...=value...> -- reads globals REPO/HOME/PATH via env args
+    local label="$1"; shift
+    local resolved first_existing
+    resolved=$(env -i "$@" LOCKSTEP_LIB="$LIB" bash -c 'source "$LOCKSTEP_LIB"; loom_locate_daemon_bin "$LOCKSTEP_ROOT"' 2>/dev/null)
+    # Resolve loom_daemon_bin_search_paths's own ordering to real, checkable
+    # filesystem paths in the SAME environment (so a "loom-daemon on \$PATH"
+    # descriptive line resolves via that env's own $PATH, not the test
+    # runner's), then walk it to find the first one that actually exists.
+    first_existing=$(env -i "$@" LOCKSTEP_LIB="$LIB" bash -c '
+        source "$LOCKSTEP_LIB"
+        while IFS= read -r line; do
+            path="${line%% (*}"
+            path="${path#\$LOOM_DAEMON_BIN=}"
+            if [[ "$path" == "loom-daemon on \$PATH" ]]; then
+                path="$(command -v loom-daemon 2>/dev/null || true)"
+            fi
+            if [[ -n "$path" && -x "$path" ]]; then echo "$path"; break; fi
+        done <<< "$(loom_daemon_bin_search_paths "$LOCKSTEP_ROOT")"
+    ')
+    assert_eq "$first_existing" "$resolved" "$label: loom_locate_daemon_bin agrees with loom_daemon_bin_search_paths's first existing candidate"
+}
+
+LOCK12_ROOT="$WORKDIR/t12-repo"
+make_fake_bin "$LOCK12_ROOT/target/release/loom-daemon"
+LOCK12_PATH_DIR="$WORKDIR/t12-on-path"
+make_fake_bin "$LOCK12_PATH_DIR/loom-daemon"
+LOCK12_HOME="$WORKDIR/t12-home"
+make_fake_bin "$LOCK12_HOME/.local/bin/loom-daemon"
+
+assert_lockstep "default precedence" \
+    PATH="$LOCK12_PATH_DIR:$MINIMAL_PATH" HOME="$LOCK12_HOME" LOCKSTEP_ROOT="$LOCK12_ROOT"
+assert_lockstep "LOOM_PREFER_REPO_BUILD=1 precedence" \
+    PATH="$LOCK12_PATH_DIR:$MINIMAL_PATH" HOME="$LOCK12_HOME" LOCKSTEP_ROOT="$LOCK12_ROOT" LOOM_PREFER_REPO_BUILD=1
+assert_lockstep "default precedence, nothing but the machine install resolves" \
+    PATH="$MINIMAL_PATH" HOME="$LOCK12_HOME" LOCKSTEP_ROOT="$WORKDIR/t12-empty-root"
+assert_lockstep "LOOM_PREFER_REPO_BUILD=1, no repo build present falls through to machine install" \
+    PATH="$MINIMAL_PATH" HOME="$LOCK12_HOME" LOCKSTEP_ROOT="$WORKDIR/t12-empty-root" LOOM_PREFER_REPO_BUILD=1
+
 # ---------- summary ----------
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
## Problem

`loom_locate_daemon_bin` resolved the *installed* binary (`$PATH` or
`$HOME/.local/bin`) before any repo-local build output on every normal dev
host, so a developer who just ran `cargo build --release` and then any
script that sources this lib silently ran the *old* binary — with nothing
in the output naming which binary actually ran.

## Fix

Least-intrusive change that satisfies all three acceptance criteria without
touching default production precedence:

1. **Diagnostic log (AC1)** — `loom_locate_daemon_bin` now logs the resolved
   path, which precedence tier it came from, and its mtime to **stderr**
   (stdout still carries only the bare path, so every caller that captures
   it via `$(...)` is unaffected). This lands in the shared lib, so all six
   call sites (`loom-daemon-start.sh`, `loom-daemon-update.sh`,
   `loom-daemon-watchdog.sh`, `loom-status.sh`, `probe-tokens.sh`,
   `.loom/bin/loom`) get it for free with no per-site changes.
2. **Opt-in `LOOM_PREFER_REPO_BUILD=1` (root-cause fix)** — hoists the
   repo-local build candidates (`loom-daemon/target/{release,debug}`,
   `target/{release,debug}`) above `$PATH` and the machine-level install.
   Off by default, so the production start/update/watchdog/status paths keep
   preferring the machine-level install unconditionally — this is a
   developer convenience, not a behavior change for the fleet.
3. **Lockstep (AC2)** — `loom_daemon_bin_search_paths` mirrors the new
   precedence tier exactly (same ordering, same opt-in gate), and a new
   test walks `loom_daemon_bin_search_paths`'s own ordering to find the
   first existing candidate and asserts `loom_locate_daemon_bin` agrees,
   in both default and `LOOM_PREFER_REPO_BUILD=1` modes — this fails if the
   two functions ever disagree, rather than encoding one specific case.
4. **#4875 regression (AC3)** — new test cases explicitly confirm the
   non-login-`$PATH` ssh scenario (no `~/.local/bin` on `$PATH`) still
   resolves the machine-level install, both with and without
   `LOOM_PREFER_REPO_BUILD=1` set.

## Testing

- `defaults/scripts/tests/test-locate-daemon-bin.sh`: 20/20 passed (8 new
  cases added: diagnostic-log-on-stderr, `LOOM_PREFER_REPO_BUILD=1`
  precedence hoist + provenance label, #4875 regression under the opt-in,
  and 4 lockstep-agreement cases).
- `defaults/scripts/tests/test-loom-daemon-watchdog.sh`: 68/68 passed.
- `defaults/scripts/tests/test-loom-daemon-update.sh`: 162/162 passed.
- `defaults/scripts/tests/test-sweep-experiment.sh`: 22/22 passed.
- `defaults/scripts/tests/test-clean-stale-binary.sh`: 34/42 passed — **8
  failures are pre-existing on `main`** (confirmed by running the
  unmodified `main` copy of the lib+test against this same host, same
  34/42 result). The failures are a test hygiene gap unrelated to this
  change: the test's "no resolvable binary" scenario doesn't override
  `$HOME`, so on any dev machine that actually has a real
  `~/.local/bin/loom-daemon` (this host does), the machine-level-install
  fallback finds it — both before and after this PR. Not touched here;
  worth a follow-up issue if desired.
- Shellcheck (`--severity=warning --format=gcc`, matching
  `.github/workflows/shell-lint.yml`) clean on both modified files.
- Smoke-checked all six call sites (`bash -n` + a live run of
  `.loom/bin/loom health`, `loom-status.sh`, `probe-tokens.sh --help`) —
  the new diagnostic line appears inline and none of the six broke.

Closes #4997