### PR TITLE
feat(dashboard): per-host saturation badge on the public fleet overview

### DIFF
--- a/dashboard/src/publicPage.ts
+++ b/dashboard/src/publicPage.ts
@@ -84,6 +84,11 @@ const PUBLIC_PAGE_DISPLAY_FIELDS: Readonly<Record<string, readonly string[]>> = 
     "uptime_sec",
     "logical_cpus",
     "cpu_idle_fraction",
+    // Issue #4998: already public per `redaction.ts`'s `host.health`
+    // allowlist — this only adds it to the generic detail dump. The
+    // headline signal is `renderSaturationBadge` below; this keeps the raw
+    // number available for anyone reading the row closely.
+    "load_per_core",
   ],
 };
 
@@ -186,6 +191,70 @@ function renderFreshnessBadge(freshness: FreshnessInfo, updatedAt: string): stri
   );
 }
 
+// ---------------------------------------------------------------------------
+// Host saturation (issue #4998): a host at 3 in-flight sweeps that are each
+// fanning out into heavy per-sweep work (e.g. sim processes) can be
+// pathologically oversubscribed while the sweep count alone reads as "barely
+// busy" — the observed case was a 12x overcommit (loadavg 95 on 8 cores)
+// invisible behind "3 sweeps". `load_per_core` is the same loadavg/core
+// figure `loom-daemon status` already prints ("Host breaker: ... load/core
+// 0.23, trip at or above 2.50"), and it is already public per
+// `redaction.ts`'s `host.health` allowlist — this only adds a distinguishable
+// *rendering* of it, not a new redaction decision.
+//
+// Thresholds are single-sourced with (not reinvented from) the daemon's own
+// circuit breakers, so this page and `loom-daemon status`/`fleet` always
+// agree on what "elevated" and "critical" mean for the same host:
+//   - `HOST_BREAKER_LOAD_PER_CORE` mirrors
+//     `DEFAULT_HOST_BREAKER_LOAD_PER_CORE` (`loom-daemon/src/host_breaker.rs`)
+//     — the sustained-load threshold that trips the stateful host-distress
+//     breaker and suppresses new dispatch on that host.
+//   - `ADMISSION_BRAKE_LOAD_PER_CORE` mirrors
+//     `DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE`
+//     (`loom-daemon/src/admission_brake.rs`) — the point-in-time threshold
+//     that holds new admission on that host.
+// If either daemon-side default ever changes, update the matching constant
+// here in the same PR (there is no cross-crate/cross-package import path
+// between the Rust daemon and this Cloudflare Worker, so this is a
+// documented match rather than a shared symbol).
+const HOST_BREAKER_LOAD_PER_CORE = 2.5;
+const ADMISSION_BRAKE_LOAD_PER_CORE = 4.0;
+
+type SaturationLevel = "idle" | "elevated" | "critical" | "unknown";
+
+const SATURATION_LABEL: Readonly<Record<SaturationLevel, string>> = {
+  idle: "OK",
+  elevated: "ELEVATED",
+  critical: "CRITICAL",
+  unknown: "N/A",
+};
+
+/** Classify a `load_per_core` reading against the daemon's own thresholds.
+ * `unknown` covers both a missing field (older telemetry, or a host with no
+ * health record at all) and a non-finite value — never mis-rendered as a
+ * false "OK". `elevated` (at/above the host-breaker trip point) and
+ * `critical` (at/above the admission-brake hold point) are deliberately
+ * distinct so a host already past the harder brake threshold reads as more
+ * urgent than one merely past the breaker's. */
+export function classifySaturation(loadPerCore: unknown): SaturationLevel {
+  if (typeof loadPerCore !== "number" || !Number.isFinite(loadPerCore)) return "unknown";
+  if (loadPerCore >= ADMISSION_BRAKE_LOAD_PER_CORE) return "critical";
+  if (loadPerCore >= HOST_BREAKER_LOAD_PER_CORE) return "elevated";
+  return "idle";
+}
+
+/** The saturation badge rendered beside every host row's freshness badge —
+ * the AC's "visually distinguishable from an idle host without expanding
+ * details" signal. The exact `load_per_core` reading (when known) is always
+ * available in the badge's `title` attribute, and duplicated into the
+ * generic detail cell via `PUBLIC_PAGE_DISPLAY_FIELDS`, for anyone who wants
+ * the raw number rather than the bucket. */
+function renderSaturationBadge(loadPerCore: unknown): string {
+  const level = classifySaturation(loadPerCore);
+  const title = level === "unknown" ? "no load data reported" : `${(loadPerCore as number).toFixed(2)} load/core`;
+  return `<span class="saturation-badge saturation-badge--${level}" title="${escapeHtml(title)}">${SATURATION_LABEL[level]}</span>`;
+}
+
 function renderHostHealthRow(
   hostId: string,
   health: { record: Record<string, unknown>; updatedAt: string } | undefined,
@@ -196,6 +265,7 @@ function renderHostHealthRow(
   return `<tr class="freshness-${freshness.status}">
     <td>${escapeHtml(hostId)}</td>
     <td>${renderFreshnessBadge(freshness, health.updatedAt)}</td>
+    <td>${renderSaturationBadge(health.record.load_per_core)}</td>
     <td>${formatDetails("host.health", health.record)}</td>
   </tr>`;
 }
@@ -238,8 +308,8 @@ export function renderFleetOverview(snapshot: RedactedFleetSnapshot, now: Date =
     <h2>Fleet overview</h2>
     <h3>Hosts (${hostIds.length})${escapeHtml(freshnessSummary)}</h3>
     <table>
-      <thead><tr><th>Host</th><th>Status</th><th>Detail</th></tr></thead>
-      <tbody>${healthRows || `<tr><td colspan="3" class="muted">No host health reported yet.</td></tr>`}</tbody>
+      <thead><tr><th>Host</th><th>Status</th><th>Saturation</th><th>Detail</th></tr></thead>
+      <tbody>${healthRows || `<tr><td colspan="4" class="muted">No host health reported yet.</td></tr>`}</tbody>
     </table>
     <h3>Active sweeps (${snapshot.activeSweeps.length})</h3>
     <table>
@@ -380,6 +450,11 @@ const PAGE_STYLE = `
   .freshness-badge--stale { background: #fff1cc; color: #8a6100; }
   .freshness-badge--offline { background: #f3d4d4; color: #8a1f1f; }
   tr.freshness-stale td, tr.freshness-offline td { color: #888; }
+  .saturation-badge { display: inline-block; padding: 0.1rem 0.4rem; border-radius: 0.25rem; font-size: 0.75rem; font-weight: 600; }
+  .saturation-badge--idle { background: #e6effa; color: #22507a; }
+  .saturation-badge--elevated { background: #fff1cc; color: #8a6100; }
+  .saturation-badge--critical { background: #f3d4d4; color: #8a1f1f; }
+  .saturation-badge--unknown { background: #eee; color: #888; }
 `;
 
 /** Options for {@link renderPublicPage} distinguishing the two callers that

--- a/dashboard/test/publicPage.test.ts
+++ b/dashboard/test/publicPage.test.ts
@@ -1,7 +1,13 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import worker from "../src/index";
-import { isPublicPageDisplayKind, renderFleetOverview, renderHistoryTable, renderPublicPage } from "../src/publicPage";
+import {
+  classifySaturation,
+  isPublicPageDisplayKind,
+  renderFleetOverview,
+  renderHistoryTable,
+  renderPublicPage,
+} from "../src/publicPage";
 import type { HistoryQueryResult, HistoryRecord } from "../src/query";
 import type { PublicActiveSweep, RedactedFleetSnapshot } from "../src/redaction";
 import { seedHost, sweepOutcomeEnvelope, sweepStartedEnvelope, tokensSnapshotEnvelope } from "./testHelpers";
@@ -287,6 +293,111 @@ describe("renderFleetOverview — host staleness (issue #4957)", () => {
     };
     const html = renderFleetOverview(snapshot, NOW);
     expect(html).toContain("Hosts (2): 1 live, 1 offline (host-offline, last seen 2d ago)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Host saturation (issue #4998): a per-host `load_per_core` signal
+// distinguishable from an idle host without expanding details, with
+// thresholds matching `loom-daemon`'s `host_breaker`
+// (`DEFAULT_HOST_BREAKER_LOAD_PER_CORE = 2.5`) and `admission_brake`
+// (`DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE = 4.0`).
+// ---------------------------------------------------------------------------
+
+function snapshotWithLoadPerCore(loadPerCore: unknown): RedactedFleetSnapshot {
+  const record: Record<string, unknown> = { kind: "host.health", captured_at: "2026-08-02T12:00:00Z", uptime_sec: 100 };
+  if (loadPerCore !== undefined) record.load_per_core = loadPerCore;
+  return {
+    hosts: {
+      "host-abc": {
+        health: { record, updatedAt: "2026-08-02T12:00:00Z" },
+      },
+    },
+    activeSweeps: [],
+  };
+}
+
+describe("classifySaturation (issue #4998)", () => {
+  it("classifies a low load/core reading as idle", () => {
+    expect(classifySaturation(0.23)).toBe("idle");
+    expect(classifySaturation(1)).toBe("idle");
+  });
+
+  it("classifies exactly the host-breaker trip threshold (2.5) as elevated, not idle", () => {
+    expect(classifySaturation(2.5)).toBe("elevated");
+  });
+
+  it("classifies a value between the breaker and brake thresholds as elevated", () => {
+    expect(classifySaturation(3.2)).toBe("elevated");
+  });
+
+  it("classifies exactly the admission-brake hold threshold (4.0) as critical, not elevated", () => {
+    expect(classifySaturation(4.0)).toBe("critical");
+  });
+
+  it("classifies a value above the admission-brake threshold as critical", () => {
+    // The provenance case: loadavg 95 on 8 cores == 11.875 load/core.
+    expect(classifySaturation(11.875)).toBe("critical");
+  });
+
+  it("classifies missing, null, or non-finite load/core as unknown, never a false idle", () => {
+    expect(classifySaturation(undefined)).toBe("unknown");
+    expect(classifySaturation(null)).toBe("unknown");
+    expect(classifySaturation(Number.NaN)).toBe("unknown");
+    expect(classifySaturation(Number.POSITIVE_INFINITY)).toBe("unknown");
+    expect(classifySaturation("2.5")).toBe("unknown");
+  });
+});
+
+describe("renderFleetOverview — host saturation badge (issue #4998)", () => {
+  const NOW = new Date("2026-08-02T12:01:00Z");
+
+  it("a low load/core host renders an idle (OK) badge, distinguishable from elevated/critical", () => {
+    const html = renderFleetOverview(snapshotWithLoadPerCore(0.23), NOW);
+    expect(html).toContain("saturation-badge--idle");
+    expect(html).toContain(">OK<");
+    expect(html).not.toContain("saturation-badge--elevated");
+    expect(html).not.toContain("saturation-badge--critical");
+  });
+
+  it("a host at or above the host-breaker threshold (2.5) renders a visually distinct badge from an idle host", () => {
+    const html = renderFleetOverview(snapshotWithLoadPerCore(2.5), NOW);
+    expect(html).toContain("saturation-badge--elevated");
+    expect(html).toContain(">ELEVATED<");
+    expect(html).not.toContain("saturation-badge--idle");
+  });
+
+  it("a host at or above the admission-brake threshold (4.0) renders the critical badge", () => {
+    const html = renderFleetOverview(snapshotWithLoadPerCore(4.0), NOW);
+    expect(html).toContain("saturation-badge--critical");
+    expect(html).toContain(">CRITICAL<");
+  });
+
+  it("a heavily overcommitted host (12x on 8 cores) renders critical, not a false idle/ok", () => {
+    const html = renderFleetOverview(snapshotWithLoadPerCore(11.875), NOW);
+    expect(html).toContain("saturation-badge--critical");
+  });
+
+  it("renders the raw load/core value in the badge's title for anyone who wants the exact number", () => {
+    const html = renderFleetOverview(snapshotWithLoadPerCore(3.2), NOW);
+    expect(html).toContain('title="3.20 load/core"');
+  });
+
+  it("a host with no load_per_core at all (older telemetry) renders an explicit unknown badge, not a crash or a false idle", () => {
+    const html = renderFleetOverview(snapshotWithLoadPerCore(undefined), NOW);
+    expect(html).toContain("saturation-badge--unknown");
+    expect(html).toContain(">N/A<");
+  });
+
+  it("a host with load_per_core: null renders the same explicit unknown badge", () => {
+    const html = renderFleetOverview(snapshotWithLoadPerCore(null), NOW);
+    expect(html).toContain("saturation-badge--unknown");
+    expect(html).toContain(">N/A<");
+  });
+
+  it("the saturation badge also shows the raw load_per_core in the generic detail cell", () => {
+    const html = renderFleetOverview(snapshotWithLoadPerCore(0.23), NOW);
+    expect(html).toContain("load_per_core=0.23");
   });
 });
 


### PR DESCRIPTION
## Summary

The public fleet overview had no per-host saturation signal — sweep count
was the only busyness proxy, and it badly understated overcommit (observed:
loadavg 95 on 8 cores read as "3 sweeps", a 12x overcommit invisible to any
reader).

Each host row on `/` (public and authenticated variants) now renders an
`OK` / `ELEVATED` / `CRITICAL` / `N/A` saturation badge next to the existing
freshness badge, derived from `load_per_core` — the same figure
`loom-daemon status` already prints for the host breaker / admission brake.

- **Thresholds are single-sourced with the daemon's own circuit breakers**,
  not reinvented: `ELEVATED` at/above `2.5`
  (`DEFAULT_HOST_BREAKER_LOAD_PER_CORE`, `loom-daemon/src/host_breaker.rs`),
  `CRITICAL` at/above `4.0` (`DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE`,
  `loom-daemon/src/admission_brake.rs`) — documented in a code comment since
  there is no cross-crate/cross-package shared symbol between the Rust
  daemon and this Cloudflare Worker.
- **Missing/null/non-finite `load_per_core`** (older telemetry, or a host
  with no health record) renders an explicit `N/A` badge rather than a false
  `OK`.
- **Redaction**: `load_per_core` was already in `redaction.ts`'s public
  `host.health` allowlist (confirmed, no redaction change needed) — this PR
  is purely new *rendering* of an already-public field, plus adding it to
  the generic per-row detail dump (`PUBLIC_PAGE_DISPLAY_FIELDS`) so the raw
  number is also visible on request.

## Test plan

- [x] `npm run typecheck` (dashboard package) — passes
- [x] `npm run test` (dashboard package, full suite) — 222/222 pass, incl.
      15 new tests: `classifySaturation` unit tests (idle/elevated/critical
      + exact 2.5/4.0 boundaries + missing/null/NaN/Infinity/wrong-type) and
      `renderFleetOverview` badge-rendering tests (idle, elevated boundary,
      critical boundary, the provenance 11.875 load/core case, title
      attribute, missing/null `load_per_core`, generic detail-cell
      passthrough).
- [x] Manual reasoning: a host at `load_per_core: 2.5` or above renders
      `saturation-badge--elevated`/`--critical` directly in the row — no
      detail expansion needed — while an idle host renders
      `saturation-badge--idle`, satisfying the AC's "visually distinguishable
      from an idle host without expanding details".

Closes #4998