### PR TITLE
feat(release): secrets-gated macOS/Linux signing for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,41 @@
 name: Build and Release
 #
-# Release artifacts (Epic #4990 Phase 1, #5003): on GitHub Release creation
-# this workflow cross-builds `loom-daemon` for every platform in the fleet's
-# target triples and uploads, for EACH one, both the binary and a `.sha256`
-# checksum file as Release assets:
+# Release artifacts (Epic #4990): on GitHub Release creation this workflow
+# cross-builds `loom-daemon` for every platform in the fleet's target triples
+# and uploads, for EACH one, the binary plus a `.sha256` checksum file as
+# Release assets:
 #
 #   - loom-daemon-aarch64-apple-darwin(.sha256)
 #   - loom-daemon-x86_64-unknown-linux-gnu(.sha256)
 #   - loom-daemon-aarch64-unknown-linux-gnu(.sha256)
 #
-# This is Phase 1 of #4990 (foundation only): NO code signing, notarization,
-# or org-specific identity of any kind is applied here — every artifact is
-# unsigned, verified only by its checksum. Platform signing is a later,
-# secrets-gated phase (#4990 Phase 2); nothing here should ever need to name a
-# cert, team ID, or signing identity — if it does, that's a scope regression.
+# Phase 1 (#5003) shipped the unsigned build + checksum foundation. Phase 2
+# (#5011, this change) layers OPTIONAL platform signing on top, following the
+# `dashboard-deploy.yml` public-mechanism/private-identity precedent:
+#
+#   - macOS Developer ID codesign of the aarch64-apple-darwin artifact, plus
+#     optional notarization, when the Developer ID / notary secrets are set.
+#   - Optional cosign detached-signature (`.sig`) over the Linux artifacts when
+#     a cosign key secret is set.
+#
+# EVERY signing step is gated on Actions secrets being present and skips
+# cleanly (with a LOUD entry in the run summary, never silent) when they are
+# absent — a no-secrets release still succeeds with unsigned artifacts +
+# checksums, byte-for-byte as Phase 1 left it. No org name, team ID, cert
+# reference, or other deployer identity lives in this file or any tracked file:
+# all identity comes from secrets only. If you ever need to hardcode one here,
+# that's a scope regression — put it in a secret instead.
+#
+# Output format (for Phase 3's verifier): the checksum is always present and is
+# computed over the FINAL artifact (after any in-place codesign), so it matches
+# whatever bytes are uploaded. macOS signatures are embedded in the Mach-O
+# (verify with `codesign --verify`); Linux signatures are detached `.sig` files
+# (verify with `cosign verify-blob --key <pubkey> --signature <sig>`).
+#
 # Consuming these artifacts from `loom-daemon-update.sh` / the daemon
-# auto-updater is also out of scope here (#4990 Phase 3) — the LOCAL
-# `cargo build` path in `loom-daemon-update.sh` remains the default/fallback
-# for dev machines, canaries, and forks with no Release access.
+# auto-updater is out of scope here (#4990 Phase 3) — the LOCAL `cargo build`
+# path in `loom-daemon-update.sh` remains the default/fallback for dev
+# machines, canaries, and forks with no Release access.
 #
 # Each target builds in its own matrix job with `fail-fast: false`: one
 # platform's build failure fails that job (and therefore the overall workflow
@@ -92,12 +110,167 @@ jobs:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo build --package loom-daemon --release --target ${{ matrix.target }}
 
-      - name: Package artifact + checksum
+      - name: Package artifact
         run: |
           set -euo pipefail
           mkdir -p dist
+          cp "target/${{ matrix.target }}/release/loom-daemon" "dist/loom-daemon-${{ matrix.target }}"
+
+      # Detect which signing secrets are present and record the decision as step
+      # outputs. GitHub Actions cannot reference `secrets.*` directly in an
+      # `if:` condition, so the canonical idiom is: map secrets into env here,
+      # test them, and gate later steps on THESE outputs. This step also emits
+      # the LOUD skip lines the epic's design principle 2 requires — every
+      # absent-secret path writes an explicit "SKIPPED (why)" row to the run
+      # summary, so the skip is asserted, not implied by checksum-only output.
+      - name: Detect signing secrets (loud skip if absent)
+        id: signing
+        env:
+          MACOS_SIGNING_CERT_P12: ${{ secrets.MACOS_SIGNING_CERT_P12 }}
+          MACOS_SIGNING_CERT_PASSWORD: ${{ secrets.MACOS_SIGNING_CERT_PASSWORD }}
+          MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          target="${{ matrix.target }}"
+          macos_sign=false
+          notarize=false
+          linux_sign=false
+
+          summary() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
+          summary "### Signing (${target})"
+
+          case "$target" in
+            *-apple-darwin)
+              if [ -n "${MACOS_SIGNING_CERT_P12:-}" ] \
+                  && [ -n "${MACOS_SIGNING_CERT_PASSWORD:-}" ] \
+                  && [ -n "${MACOS_SIGNING_IDENTITY:-}" ]; then
+                macos_sign=true
+                summary "- Signed: Developer ID secrets present — codesigning \`${target}\` in place."
+                if [ -n "${MACOS_NOTARY_KEY:-}" ] \
+                    && [ -n "${MACOS_NOTARY_KEY_ID:-}" ] \
+                    && [ -n "${MACOS_NOTARY_ISSUER_ID:-}" ]; then
+                  notarize=true
+                  summary "- Notarized: notary API key secrets present — notarizing after signing."
+                else
+                  summary "- SKIPPED notarization: notary API key secrets absent (belt-and-suspenders only for the curl/gh download path, which sets no quarantine attribute — not required)."
+                  echo "::notice::macOS notarization skipped for ${target} (notary secrets absent)."
+                fi
+              else
+                summary "- SKIPPED signing: Developer ID cert/identity secrets absent — shipping UNSIGNED \`${target}\` + checksum (Phase 1 behavior)."
+                echo "::notice::macOS signing skipped for ${target} (Developer ID secrets absent); shipping unsigned artifact + checksum."
+              fi
+              ;;
+            *-linux-*)
+              if [ -n "${COSIGN_PRIVATE_KEY:-}" ]; then
+                linux_sign=true
+                summary "- Signed: cosign key secret present — writing detached \`${target}.sig\`."
+              else
+                summary "- SKIPPED signing: cosign key secret absent — shipping UNSIGNED \`${target}\` + checksum (Phase 1 behavior)."
+                echo "::notice::Linux signing skipped for ${target} (cosign key absent); shipping unsigned artifact + checksum."
+              fi
+              ;;
+          esac
+
+          {
+            echo "macos_sign=${macos_sign}"
+            echo "notarize=${notarize}"
+            echo "linux_sign=${linux_sign}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sign macOS artifact (Developer ID)
+        if: steps.signing.outputs.macos_sign == 'true'
+        env:
+          MACOS_SIGNING_CERT_P12: ${{ secrets.MACOS_SIGNING_CERT_P12 }}
+          MACOS_SIGNING_CERT_PASSWORD: ${{ secrets.MACOS_SIGNING_CERT_PASSWORD }}
+          MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+        run: |
+          set -euo pipefail
           artifact="dist/loom-daemon-${{ matrix.target }}"
-          cp "target/${{ matrix.target }}/release/loom-daemon" "$artifact"
+          # Import the Developer ID cert into a throwaway keychain scoped to this
+          # job's RUNNER_TEMP so no identity persists on the runner. The p12 and
+          # its password are secrets; the identity string (which embeds the org
+          # name + team ID) is likewise a secret — never spelled out here.
+          keychain="$RUNNER_TEMP/loom-signing.keychain-db"
+          p12="$RUNNER_TEMP/loom-cert.p12"
+          printf '%s' "$MACOS_SIGNING_CERT_P12" | base64 --decode > "$p12"
+          security create-keychain -p "$MACOS_SIGNING_CERT_PASSWORD" "$keychain"
+          security set-keychain-settings -lut 900 "$keychain"
+          security unlock-keychain -p "$MACOS_SIGNING_CERT_PASSWORD" "$keychain"
+          security import "$p12" -k "$keychain" -P "$MACOS_SIGNING_CERT_PASSWORD" -T /usr/bin/codesign
+          # Allow codesign to use the imported key non-interactively.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_SIGNING_CERT_PASSWORD" "$keychain" >/dev/null
+          # Put our keychain on the user search list so codesign resolves the identity.
+          security default-keychain -s "$keychain"
+          security list-keychains -d user -s "$keychain"
+          # `--options runtime` (hardened runtime) is a notarization prerequisite;
+          # `--timestamp` binds a secure timestamp so the signature outlives the
+          # cert's validity window.
+          codesign --force --options runtime --timestamp \
+            --sign "$MACOS_SIGNING_IDENTITY" "$artifact"
+          codesign --verify --strict --verbose=2 "$artifact"
+          rm -f "$p12"
+
+      - name: Notarize macOS artifact
+        if: steps.signing.outputs.notarize == 'true'
+        env:
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          artifact="dist/loom-daemon-${{ matrix.target }}"
+          # notarytool only accepts container formats (zip/dmg/pkg), so submit a
+          # zip of the bare binary. A bare Mach-O cannot be stapled (stapling
+          # supports only bundles/dmg/pkg), so notarization is registered
+          # server-side with no on-disk ticket. For this repo's curl/gh download
+          # path — which sets no quarantine attribute — that server-side record
+          # is all Gatekeeper would ever consult, so no staple is needed and the
+          # uploaded asset stays the bare signed binary.
+          key="$RUNNER_TEMP/notary-key.p8"
+          zip="$RUNNER_TEMP/loom-daemon-${{ matrix.target }}.zip"
+          printf '%s' "$MACOS_NOTARY_KEY" | base64 --decode > "$key"
+          ditto -c -k "$artifact" "$zip"
+          xcrun notarytool submit "$zip" \
+            --key "$key" \
+            --key-id "$MACOS_NOTARY_KEY_ID" \
+            --issuer "$MACOS_NOTARY_ISSUER_ID" \
+            --wait
+          rm -f "$key" "$zip"
+
+      - name: Install cosign
+        if: steps.signing.outputs.linux_sign == 'true'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign Linux artifact (cosign)
+        if: steps.signing.outputs.linux_sign == 'true'
+        env:
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          artifact="dist/loom-daemon-${{ matrix.target }}"
+          # Detached signature so Phase 3 can verify with the matching public key:
+          #   cosign verify-blob --key <pubkey> --signature <target>.sig <binary>
+          # COSIGN_PASSWORD is read from the env by cosign to decrypt the key.
+          key="$RUNNER_TEMP/cosign.key"
+          printf '%s' "$COSIGN_PRIVATE_KEY" > "$key"
+          cosign sign-blob --yes --key "$key" \
+            --output-signature "dist/loom-daemon-${{ matrix.target }}.sig" \
+            "$artifact"
+          rm -f "$key"
+
+      # Checksum is computed AFTER signing so it covers the FINAL bytes (macOS
+      # codesign rewrites the Mach-O in place). Phase 3 verifies this checksum
+      # unconditionally, so it must match whatever is uploaded. In the
+      # no-secrets case nothing above modified the binary, so this is
+      # byte-identical to Phase 1's checksum.
+      - name: Compute checksum
+        run: |
+          set -euo pipefail
           cd dist
           if command -v shasum >/dev/null 2>&1; then
             shasum -a 256 "loom-daemon-${{ matrix.target }}" > "loom-daemon-${{ matrix.target }}.sha256"
@@ -110,9 +283,13 @@ jobs:
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v3
         with:
+          # The `*.sig` glob matches the detached Linux signature when cosign
+          # signing ran and matches nothing otherwise (skipped, not an error) —
+          # so the same block covers signed and unsigned releases.
           files: |
             dist/loom-daemon-${{ matrix.target }}
             dist/loom-daemon-${{ matrix.target }}.sha256
+            dist/loom-daemon-${{ matrix.target }}*.sig
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -124,4 +301,5 @@ jobs:
           path: |
             dist/loom-daemon-${{ matrix.target }}
             dist/loom-daemon-${{ matrix.target }}.sha256
+            dist/loom-daemon-${{ matrix.target }}*.sig
           retention-days: 7


### PR DESCRIPTION
## Summary

Phase 2 of Epic #4990. Layers **optional, secrets-gated** platform signing on top of Phase 1's unsigned artifacts + checksums (`.github/workflows/release.yml`), following the `dashboard-deploy.yml` public-mechanism / private-identity precedent. The public repo ships mechanism only — all deployer identity lives in Actions secrets, never in tracked files. A no-secrets release still succeeds with unsigned artifacts + checksums, byte-for-byte as Phase 1 left it.

## Changes

- **macOS Developer ID signing** of `aarch64-apple-darwin`: imports the Developer ID cert (p12) into a throwaway `RUNNER_TEMP` keychain and `codesign`s in place with `--options runtime --timestamp`, when the Developer ID cert/identity secrets are present.
- **Optional notarization** after signing when the notary API key secrets are present: `xcrun notarytool submit --wait` on a zip of the binary (bare Mach-O cannot be stapled; server-side registration is all the curl/gh download path would ever consult).
- **Optional Linux cosign signing** of both Linux artifacts: `cosign sign-blob` produces a detached `<target>.sig`, uploaded alongside the binary, when the cosign key secret is present.
- **Secrets-in-`if` idiom**: a `Detect signing secrets` step maps `secrets.*` into env, tests presence, and emits step outputs (`macos_sign` / `notarize` / `linux_sign`). All later signing steps gate on those outputs — GitHub Actions cannot reference `secrets.*` directly in `if:`.
- **Loud skip, asserted not silent**: every absent-secret path writes an explicit `SKIPPED (why)` row to `$GITHUB_STEP_SUMMARY` plus a `::notice::` annotation.
- **Checksum moved after signing** so it covers the final (possibly codesigned-in-place) bytes; in the no-secrets case nothing modifies the binary, so the checksum is byte-identical to Phase 1.
- **Upload lists** gain a `*.sig` glob that matches the detached Linux signature when present and matches nothing (skipped, not an error — `fail_on_unmatched_files` defaults false) otherwise, covering signed and unsigned releases with one block.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| macOS artifact signed when Developer ID + team ID secrets present; clean loud skip when absent | ✅ | `Sign macOS artifact` step gated on `steps.signing.outputs.macos_sign`; `Detect signing secrets` writes `SKIPPED signing: Developer ID cert/identity secrets absent …` to the run summary + `::notice::` when absent |
| Optional notarization after signing when notary API key secret present | ✅ | `Notarize macOS artifact` step gated on `steps.signing.outputs.notarize`, ordered after the sign step; skip row emitted when notary secrets absent |
| Optional cosign signing for Linux artifacts when cosign key secret present | ✅ | `Install cosign` + `Sign Linux artifact (cosign)` gated on `steps.signing.outputs.linux_sign`, applied to both `x86_64`/`aarch64` linux matrix entries |
| Output format supports Phase 3 verification (checksum always + signature when present) | ✅ | Checksum computed over the final bytes (after in-place codesign); Linux `.sig` uploaded as a release asset; macOS signature embedded in the Mach-O — all documented in the workflow header + comments |
| `git grep` for org name / team-id / cert identity over tracked files returns nothing | ✅ | `release.yml` references only generic secret names (`MACOS_SIGNING_*`, `MACOS_NOTARY_*`, `COSIGN_*`); scoped grep for concrete team-id/org/cert patterns returns clean |
| No-secrets path unchanged from Phase 1 | ✅ | Sign steps all skip; binary untouched; checksum byte-identical; `*.sig` glob matches nothing; binary + `.sha256` uploaded exactly as before |

## Test Plan

- `actionlint .github/workflows/release.yml` → exit 0 (includes shellcheck of every `run:` block).
- Scoped `git grep` for concrete deployer identity (team-id `[A-Z0-9]{10}`, org name, `Developer ID Application:`, notary issuer UUID) in `release.yml` → no matches; only generic secret names present.
- Reviewed the no-secrets execution path step-by-step: package → detect (all false) → sign steps skipped → checksum over untouched binary → upload binary + `.sha256`, byte-identical to Phase 1.
- Cannot end-to-end exercise the signed path here (no real Developer ID / notary / cosign secrets in this environment); the signed path is verified structurally (conditional gating, tool invocations, artifact naming/upload).

## Notes for Phase 3 (out of scope here)

The Phase 3 verifier will need the cosign **public** key to check the Linux `.sig` (pin it in the repo or publish it as a release asset), and will verify macOS via `codesign --verify` on-host. This PR only produces the output format; the verifier is not built here.

Closes #5011
Part of #4990