### PR TITLE
docs(observability): record per-host telemetry redundancy trade study

### DIFF
--- a/.loom/docs/observability.md
+++ b/.loom/docs/observability.md
@@ -146,6 +146,13 @@ provisioning, verifying telemetry lands — is
 This is **your own infrastructure**; nothing in Loom points at a shared
 backend by default.
 
+Per-host reporting is deliberately redundant — every host independently
+emits `tokens.snapshot` / `host.health` for the full account pool it can see,
+at real storage cost but with no single point of failure. This was evaluated
+as a trade study (issue #4999) and kept as-is: see
+[`.loom/docs/telemetry-schema.md`](telemetry-schema.md#per-host-reporting-redundancy-why-3x-storage-is-intentional-issue-4999)
+for the reasoning.
+
 ## 5. Authenticated vs. public: two views, one redaction policy
 
 Every query route exists twice — `/api/*` (authenticated, full detail) and

--- a/.loom/docs/telemetry-schema.md
+++ b/.loom/docs/telemetry-schema.md
@@ -348,6 +348,43 @@ its registered repos) rather than as an unexplained gap.
   `redactManagedRepos`). The authenticated view always sees every entry in
   full, including private slugs.
 
+## Per-host reporting redundancy (why 3x storage is intentional, Issue #4999)
+
+Every host in a fleet independently samples and pushes `tokens.snapshot` and
+`host.health` on its own `SNAPSHOT_INTERVAL` (5 minutes —
+`loom-daemon/src/observability/mod.rs`), each reporting the **same shared
+account pool** every host in the fleet can see. On a 3-host fleet this means
+each of those two record kinds independently accumulates roughly
+`3 hosts x (90d / 5min) ~= 78k rows` per 90-day retention window — about 3x
+what a single elected reporter would produce for the same information.
+
+This redundancy was raised as a possible optimization (#4999) and
+investigated as a trade study rather than assumed to be a bug:
+
+- **The redundancy is load-bearing.** When `loom-worker-1` went dark for ~80
+  minutes on 2026-08-01, the other two hosts kept reporting the same account
+  pool, so the account-level series had no gap. A single elected reporter
+  would have produced exactly that gap during the one window an operator most
+  needs the series to stay continuous — while a host is dying.
+- **Storage is nowhere near a limit that matters.** `records` is already
+  bounded by both an age cutoff (`RETENTION_DAYS`, default 90) and a hard row
+  cap (`MAX_RECORDS`, default 500,000 — `dashboard/src/retention.ts`). Even
+  counting *all* per-host periodic sampling (`tokens.snapshot` + `host.health`
+  together, ~156k rows/90d across 3 hosts) alongside per-sweep lifecycle
+  records, total volume sits well under a third of the configured cap. There
+  is no pressure to relieve.
+
+**Decision: keep the current per-host independent-reporting design.**
+Electing a single reporter (or deduplicating identical rows at write/read
+time) would trade away a real survivability property for a storage saving
+that isn't currently needed. Revisit only if `MAX_RECORDS` eviction starts
+firing routinely (sustained growth actually approaching the cap) — at that
+point, write-time deduplication that preserves per-account distinguishability
+(still being able to tell "account exhausted" from "no host reported" for a
+given account/bucket) is the option to pursue first, since electing a single
+reporter reintroduces the exact single-point-of-failure this trade study
+found unacceptable.
+
 ## Persistence & read surface (`sweep.outcome`, Issue #4704)
 
 The daemon durably records one `sweep.outcome` [`TelemetryEnvelope`] per


### PR DESCRIPTION
## Summary

Issue #4999 was filed as a deliberate trade study, not a fix request: is the
3x per-host telemetry redundancy (`tokens.snapshot` + `host.health`, each
independently sampled and pushed by every host on its own 300s interval)
worth deduplicating?

**Measurement (per the issue's own decision gate):**
- `records` is bounded by `RETENTION_DAYS=90` and `MAX_RECORDS=500,000`
  (`dashboard/wrangler.toml`, `dashboard/src/retention.ts`).
- Per-host periodic sampling produces ~78k rows/90d **per record kind** on a
  3-host fleet (confirms the issue's estimate), ~156k rows/90d for both kinds
  combined — about 31% of the configured cap. Not anywhere near a limit that
  matters.
- The redundancy is the exact property that kept the account-level series
  gap-free when `loom-worker-1` went dark for ~80 minutes on 2026-08-01 (per
  the issue's own provenance note).

**Decision: keep the current per-host independent-reporting design as-is.**
No code change — storage isn't pressured, so trading away the survivability
property for a saving that isn't needed would be the wrong call. Recorded the
reasoning in `.loom/docs/telemetry-schema.md` and pointed to it from
`.loom/docs/observability.md`, per the issue's own suggested outcome ("close
this and keep the redundancy — but close it with the reasoning recorded").

## Test plan

- [x] Measurement: derived row-count math from the actual configured
      `SNAPSHOT_INTERVAL` (300s, `loom-daemon/src/observability/mod.rs`),
      `RETENTION_DAYS`/`MAX_RECORDS` (`dashboard/wrangler.toml`), matching the
      issue's ~78k/90d estimate.
- [x] Decision gate: confirmed current storage is not near the cap (~31%) —
      per the issue, this means "close as won't-fix with reasoning recorded,"
      not a code change.
- [x] Docs updated with the decision and reasoning in both files named in the
      issue's Affected Files list.

Closes #4999