### PR TITLE
fix(daemon): bundle runtime manifests as a fallback for unreachable defaults/ on consumer repos

### DIFF
--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -533,6 +533,28 @@ the offending key, so a misconfigured binding can never leave a role quietly
 running on the default runtime. A known key with an **empty** value keeps its
 established "unset" meaning and falls through to the next precedence tier.
 
+**Runtime manifest resolution and the bundled fallback (#5002).** The role and
+runtime manifest directories are resolved independently (#4688): each prefers
+`.loom/roles` / `.loom/runtimes` when the subdirectory exists on disk, and
+otherwise falls back to `<repo_root>/defaults/roles` / `defaults/runtimes`.
+That `defaults/` fallback only ever resolves on the Loom *source* checkout
+itself — a consumer install has `.loom/`, never `defaults/` — so on every
+other managed repo it was unreachable by construction. If a consumer repo's
+`.loom/runtimes/` is missing entirely, or missing just one runtime's manifest
+(e.g. a pre-#4700 install that was never resynced), a non-builtin runtime had
+no fallback at all and failed closed even though the daemon binary ships an
+adapter for it. The daemon now also carries a **bundled fallback**: manifests
+for the runtimes it ships adapters for (`claude`, `codex`, `aider`) are
+compiled directly into the binary via `include_str!` from
+`defaults/runtimes/*.json` at build time, and consulted whenever the on-disk
+manifest lookup misses. An on-disk `.loom/runtimes/<name>.json` — however it
+got there — always wins over the bundled copy. Only a runtime the binary was
+never built with a manifest for (e.g. an operator-defined custom runtime with
+no on-disk manifest either) still fails closed with no fallback at all — and
+the diagnostic in that case now names `<repo>/.loom/runtimes/<name>.json`, a
+path reachable from a consumer repo, instead of the unreachable
+`defaults/runtimes/<name>.json` fallback path.
+
 Daemon admission runs before any claim lock, forge mutation, account selection,
 log header, or child spawn. Successful sweep status and
 `sweep.global.dispatch` events include both `runtime` and `runtime_source`.

--- a/loom-daemon/src/runtime_admission.rs
+++ b/loom-daemon/src/runtime_admission.rs
@@ -243,6 +243,45 @@ fn type_name_of(value: &serde_json::Value) -> &'static str {
     }
 }
 
+/// Bundled fallback runtime manifests, compiled directly into the daemon
+/// binary via `include_str!` (#5002).
+///
+/// `roots()` above resolves an unpopulated `.loom/runtimes/` to a
+/// `defaults/runtimes/<name>.json` fallback, but `defaults/` is a
+/// Loom-*source*-repo-only directory: a consumer install has `.loom/`, never
+/// `defaults/`. So on every managed repo that is not the Loom checkout
+/// itself, that fallback path is unreachable by construction — a consumer
+/// repo whose `.loom/runtimes/` is missing (or missing just one runtime's
+/// manifest, e.g. a 0.16.0-era install never resynced per #4688/#4700) was
+/// permanently unable to admit a non-builtin runtime the daemon binary
+/// itself ships an adapter for.
+///
+/// This table mirrors the manifests shipped at `defaults/runtimes/*.json` at
+/// build time, so the binary carries its own knowledge of the runtimes it
+/// ships adapters for and does not depend on any on-disk `defaults/` or
+/// `.loom/runtimes/` copy being present or complete. It is consulted only
+/// when the on-disk manifest lookup misses (see `resolve_and_admit` below);
+/// an on-disk `.loom/runtimes/<name>.json` — however it got there — always
+/// wins over the bundled copy, so a repo can still override capabilities
+/// on-disk.
+const BUNDLED_RUNTIME_MANIFESTS: &[(&str, &str)] = &[
+    ("claude", include_str!("../../defaults/runtimes/claude.json")),
+    ("codex", include_str!("../../defaults/runtimes/codex.json")),
+    ("aider", include_str!("../../defaults/runtimes/aider.json")),
+];
+
+/// Look up the bundled fallback manifest contents for `runtime`, if the
+/// daemon binary ships one. Returns `None` for any runtime the binary was
+/// not built with a manifest for (e.g. an operator-defined custom runtime) —
+/// those still fail closed with no fallback, per the unchanged fail-closed
+/// contract for non-builtin runtimes with no reachable manifest anywhere.
+fn bundled_runtime_manifest(runtime: &str) -> Option<&'static str> {
+    BUNDLED_RUNTIME_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == runtime)
+        .map(|(_, contents)| *contents)
+}
+
 fn roots(root: &Path) -> (PathBuf, PathBuf, PathBuf) {
     let installed = root.join(".loom");
     let defaults = root.join("defaults");
@@ -364,6 +403,33 @@ pub fn resolve_and_admit(
                 role_manifest,
                 runtime_manifest,
             });
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Non-builtin runtime, no on-disk manifest at the resolved path
+            // (which may itself be the unreachable `defaults/runtimes/...`
+            // fallback on a consumer install — see `roots()` and
+            // `BUNDLED_RUNTIME_MANIFESTS` above). Fall back to the manifest
+            // the daemon binary was built with, if any (#5002).
+            match bundled_runtime_manifest(&runtime) {
+                Some(bundled) => bundled.as_bytes().to_vec(),
+                None => {
+                    // No bundled fallback for this runtime either: fail
+                    // closed, but name a path that could actually exist in
+                    // THIS repo -- `.loom/runtimes/<name>.json` -- rather
+                    // than `runtime_manifest`, which on a consumer install is
+                    // the unreachable `<repo>/defaults/runtimes/<name>.json`
+                    // fallback path `roots()` computed (`defaults/` only
+                    // exists in the Loom source checkout itself).
+                    let reachable = root.join(".loom/runtimes").join(format!("{runtime}.json"));
+                    return Err(reject(
+                        format!(
+                            "runtime manifest not found at {} (no bundled fallback shipped for runtime {runtime:?})",
+                            reachable.display()
+                        ),
+                        vec![],
+                    ));
+                }
+            }
         }
         Err(e) => {
             return Err(reject(
@@ -817,14 +883,17 @@ mod tests {
             r#"{"runtimeRequirements":["worktreeIsolation","mcp"]}"#,
         )
         .unwrap();
+        fs::write(loom_roles.join("judge.json"), "{}").unwrap();
         let loom_scripts = root.path().join(".loom/scripts");
         fs::create_dir_all(&loom_scripts).unwrap();
-        let adapter = loom_scripts.join("spawn-claude.sh");
-        fs::write(&adapter, "#!/bin/sh\n").unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(&adapter, fs::Permissions::from_mode(0o755)).unwrap();
+        for name in ["claude", "codex"] {
+            let adapter = loom_scripts.join(format!("spawn-{name}.sh"));
+            fs::write(&adapter, "#!/bin/sh\n").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&adapter, fs::Permissions::from_mode(0o755)).unwrap();
+            }
         }
         // No `.loom/runtimes/` and no `defaults/` at all — the exact live
         // incident layout.
@@ -847,12 +916,29 @@ mod tests {
         assert!(admitted
             .runtime_manifest
             .starts_with(root.path().join("defaults/runtimes")));
+
+        // #5002: a non-builtin runtime the daemon ships an adapter for
+        // (codex) ALSO admits in this exact layout — via the bundled
+        // fallback manifest compiled into the binary, not the degrade-open
+        // path exercised above (which is scoped to the builtin runtime
+        // only). `judge` declares no `runtimeRequirements`, so it is
+        // satisfied by codex's real bundled capabilities.
+        let admitted_codex = resolve_and_admit(root.path(), "judge", Some("codex")).unwrap();
+        assert_eq!(admitted_codex.runtime, "codex");
+        assert_eq!(admitted_codex.source, RuntimeSource::Explicit);
     }
 
     /// The degrade-open behaviour is scoped to the builtin `claude` runtime
-    /// only. An explicit non-builtin runtime with a missing manifest must
-    /// still fail closed — a regression guard against over-widening the
-    /// #4688 fix beyond the zero-config default.
+    /// only, and the #5002 bundled-fallback addition is scoped to the
+    /// runtimes the daemon binary actually ships a manifest for. A runtime
+    /// with NO on-disk manifest anywhere AND no bundled fallback (simulated
+    /// here with an operator-defined custom runtime name the binary was
+    /// never built with) must still fail closed — a regression guard
+    /// against over-widening either fix beyond its intended scope. It also
+    /// pins the #5002 corrected error text: the message must name a path
+    /// reachable from THIS repo (`.loom/runtimes/<name>.json`), not the
+    /// unreachable `defaults/runtimes/<name>.json` fallback path `roots()`
+    /// computed (`defaults/` only exists in the Loom source checkout).
     #[test]
     fn consumer_layout_missing_runtimes_dir_non_builtin_still_fails_closed() {
         let root = tempfile::tempdir().unwrap();
@@ -861,15 +947,38 @@ mod tests {
         fs::write(loom_roles.join("judge.json"), "{}").unwrap();
         let loom_scripts = root.path().join(".loom/scripts");
         fs::create_dir_all(&loom_scripts).unwrap();
-        let adapter = loom_scripts.join("spawn-codex.sh");
-        fs::write(&adapter, "#!/bin/sh\n").unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(&adapter, fs::Permissions::from_mode(0o755)).unwrap();
+        for name in ["codex", "acme-runtime"] {
+            let adapter = loom_scripts.join(format!("spawn-{name}.sh"));
+            fs::write(&adapter, "#!/bin/sh\n").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(&adapter, fs::Permissions::from_mode(0o755)).unwrap();
+            }
         }
-        let rejected = resolve_and_admit(root.path(), "judge", Some("codex")).unwrap_err();
+
+        // No on-disk manifest anywhere (no `.loom/runtimes/`, no
+        // `defaults/`) AND no bundled fallback for this made-up runtime
+        // name -- still fails closed exactly as before.
+        let rejected = resolve_and_admit(root.path(), "judge", Some("acme-runtime")).unwrap_err();
         assert!(rejected.reason.contains("runtime manifest"), "{}", rejected.reason);
+        // #5002: the corrected message names a path reachable from a
+        // consumer repo, not the unreachable `defaults/runtimes/...` path.
+        assert!(
+            rejected.reason.contains(".loom/runtimes/acme-runtime.json"),
+            "{}",
+            rejected.reason
+        );
+        assert!(!rejected.reason.contains("defaults/runtimes"), "{}", rejected.reason);
+
+        // #5002: a runtime the daemon DOES ship a bundled manifest for
+        // (codex) is no longer stuck here -- it now admits via the bundled
+        // fallback instead of failing closed, since the compiled-in
+        // manifest is a reachable source of truth even with no on-disk
+        // `.loom/runtimes/` at all. This is the fix under test, not a
+        // weakening of the fail-closed guarantee asserted above.
+        let admitted = resolve_and_admit(root.path(), "judge", Some("codex")).unwrap();
+        assert_eq!(admitted.runtime, "codex");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes Cause 2 from #5002: runtime admission's fallback candidate for a
missing/incomplete `.loom/runtimes/` was `<repo_root>/defaults/runtimes/<name>.json`
— but `defaults/` only exists in the Loom source checkout itself. On every
consumer repo (7 gf180/sky130 clones affected per the issue) that fallback
path is unreachable by construction, so a non-builtin runtime the daemon
binary ships an adapter for could never admit there, and the error text
pointed at a path that was never going to exist.

## Changes

- `loom-daemon/src/runtime_admission.rs`:
  - Added `BUNDLED_RUNTIME_MANIFESTS` / `bundled_runtime_manifest()` — the
    `claude`/`codex`/`aider` manifests are compiled directly into the daemon
    binary via `include_str!` from `defaults/runtimes/*.json` at build time.
  - When the on-disk runtime-manifest lookup misses for a **non-builtin**
    runtime, the resolver now falls back to the bundled copy before failing
    closed. An on-disk `.loom/runtimes/<name>.json` still always wins.
  - When there is genuinely no manifest anywhere (no on-disk file, no
    bundled fallback for that runtime name), the rejection message now names
    `<repo>/.loom/runtimes/<name>.json` — a path that could actually exist in
    that repo — instead of the unreachable `<repo>/defaults/runtimes/<name>.json`.
  - The builtin `claude` degrade-open path (#4688) is unchanged.
  - Extended `consumer_layout_missing_runtimes_dir_still_admits_claude` and
    `consumer_layout_missing_runtimes_dir_non_builtin_still_fails_closed`
    (no new fixture, per curator guidance) to cover: a bundled-fallback
    non-builtin runtime now admitting in the exact "no `.loom/runtimes/`, no
    `defaults/`" layout, and a genuinely-unknown runtime (no bundled
    manifest) still failing closed with the corrected error text.
- `defaults/docs/runtime-adapters.md`: documented the manifest resolution
  order and the new bundled fallback under "Daemon runtime binding and
  admission".

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Consumer repo with no `.loom/runtimes/` and no `defaults/` can still admit a non-builtin runtime the daemon ships an adapter for, or rejects naming a reachable path | ✅ | Bundled fallback added for claude/codex/aider; corrected error message asserted in `consumer_layout_missing_runtimes_dir_non_builtin_still_fails_closed` |
| Non-builtin runtimes still fail closed when truly no manifest is reachable | ✅ | Same test now uses a made-up runtime name (`acme-runtime`, no bundled manifest) and asserts it still fails closed |
| Resyncing a 0.16.0-era install populates `.loom/runtimes/` | N/A (already fixed) | Per curator: already delivered by PR #4700/#4688, not re-implemented here |
| The 7 gf180/sky130 clones accept a non-default runtime after a resync | **Out of scope for this PR** | This is an operational verification step on those hosts, not something verifiable from the loom source repo — see note below |
| Test covers a fixture whose repo root has `.loom/` but no `defaults/` | ✅ | Existing fixtures in both extended tests already have this shape; no new fixture added per curator guidance |

**Out of scope note**: the issue's acceptance item "the 7 gf180/sky130 clones
accept a non-default runtime after a resync" is an operational verification
step that must be performed on those hosts (confirm a non-default-runtime
dispatch admits after `resync-installed.sh` + this fix is deployed) — it
cannot be verified from within this repo/PR.

## Test Plan

- `cargo test -p loom-daemon --lib runtime_admission` — all 11 tests pass,
  including the two extended tests and the full native/shell conformance
  matrix (`native_and_shell_conformance_for_every_shipped_pair`).
- `cargo clippy -p loom-daemon --lib -- -D warnings` — clean.
- `cargo fmt -p loom-daemon -- --check` — clean.

Closes #5002