### PR TITLE
feat(daemon): loom-daemon validate proactively checks runtimes.roles

### DIFF
--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -532,6 +532,10 @@ silently ignored entry: `runtimes.roles.not-a-role` (or a typo such as
 the offending key, so a misconfigured binding can never leave a role quietly
 running on the default runtime. A known key with an **empty** value keeps its
 established "unset" meaning and falls through to the next precedence tier.
+`loom-daemon validate` also checks `runtimes.roles` proactively (#5006), using
+the identical fail-closed rules, so a bad binding is caught any time an
+operator runs the command — not only the next time a role's tick actually hits
+it.
 
 Daemon admission runs before any claim lock, forge mutation, account selection,
 log header, or child spawn. Successful sweep status and

--- a/loom-daemon/src/role_validation.rs
+++ b/loom-daemon/src/role_validation.rs
@@ -215,6 +215,14 @@ pub fn validate_role_completeness(config_json: &str, mode: ValidationMode) -> Va
 /// resolves the effective config through the tier chain. Behaviorally identical
 /// to [`validate_role_completeness`]; it just skips the file-read + string-parse
 /// round-trip.
+///
+/// Also proactively checks the config's `runtimes.roles` map (#5006) using the
+/// same fail-closed rules `runtime_admission::config_runtime` already enforces
+/// at admission time, so a misconfigured entry (unknown role key, non-string
+/// value, non-object shape) is caught here instead of only surfacing the next
+/// time that role's tick actually runs. This is unconditional — it does not
+/// depend on `terminals` being present — since `runtimes.roles` is a config
+/// key in its own right.
 #[must_use]
 pub fn validate_from_config(config: &serde_json::Value, mode: ValidationMode) -> ValidationResult {
     if mode == ValidationMode::Ignore {
@@ -226,7 +234,7 @@ pub fn validate_from_config(config: &serde_json::Value, mode: ValidationMode) ->
         };
     }
 
-    match extract_roles_from_value(config) {
+    let mut result = match extract_roles_from_value(config) {
         Ok(roles) => check_role_dependencies(roles),
         Err(e) => ValidationResult {
             valid: false,
@@ -234,7 +242,15 @@ pub fn validate_from_config(config: &serde_json::Value, mode: ValidationMode) ->
             warnings: Vec::new(),
             errors: vec![e],
         },
+    };
+
+    let runtime_errors = crate::runtime_admission::check_runtimes_roles_config(config);
+    if !runtime_errors.is_empty() {
+        result.valid = false;
+        result.errors.extend(runtime_errors);
     }
+
+    result
 }
 
 /// Shared dependency-satisfaction check over an extracted role set.
@@ -460,6 +476,63 @@ mod tests {
         let result = validate_from_config(&config, ValidationMode::Warn);
         assert!(result.valid);
         assert_eq!(result.configured_roles, vec!["doctor", "judge"]);
+    }
+
+    /// #5006: `validate_from_config` proactively surfaces a misconfigured
+    /// `runtimes.roles` (the same fail-closed rules `runtime_admission`
+    /// enforces at admission time) as a validation error, so `loom-daemon
+    /// validate` catches it any time an operator runs it.
+    #[test]
+    fn test_validate_from_config_reports_bad_runtimes_roles() {
+        let config = serde_json::json!({
+            "terminals": [
+                {"roleConfig": {"roleFile": "judge.md"}},
+                {"roleConfig": {"roleFile": "champion.md"}},
+                {"roleConfig": {"roleFile": "doctor.md"}},
+                {"roleConfig": {"roleFile": "builder.md"}},
+                {"roleConfig": {"roleFile": "curator.md"}},
+            ],
+            "runtimes": {"roles": {"buidler": "claude"}},
+        });
+        let result = validate_from_config(&config, ValidationMode::Warn);
+        assert!(!result.valid);
+        assert_eq!(result.errors.len(), 1);
+        assert!(result.errors[0].contains("buidler"), "{}", result.errors[0]);
+        assert!(result.errors[0].contains("unknown role name"), "{}", result.errors[0]);
+        // Role-completeness warnings are computed independently and still fire.
+        assert!(result.warnings.is_empty());
+    }
+
+    /// A well-formed (or absent) `runtimes.roles` produces no new errors —
+    /// no regression for the common case.
+    #[test]
+    fn test_validate_from_config_silent_on_valid_runtimes_roles() {
+        let config = serde_json::json!({
+            "terminals": [
+                {"roleConfig": {"roleFile": "judge.md"}},
+                {"roleConfig": {"roleFile": "champion.md"}},
+                {"roleConfig": {"roleFile": "doctor.md"}},
+                {"roleConfig": {"roleFile": "builder.md"}},
+                {"roleConfig": {"roleFile": "curator.md"}},
+            ],
+            "runtimes": {"default": "codex", "roles": {"curator": "claude"}},
+        });
+        let result = validate_from_config(&config, ValidationMode::Warn);
+        assert!(result.valid);
+        assert!(result.errors.is_empty());
+
+        let config_no_runtimes = serde_json::json!({
+            "terminals": [
+                {"roleConfig": {"roleFile": "judge.md"}},
+                {"roleConfig": {"roleFile": "champion.md"}},
+                {"roleConfig": {"roleFile": "doctor.md"}},
+                {"roleConfig": {"roleFile": "builder.md"}},
+                {"roleConfig": {"roleFile": "curator.md"}},
+            ],
+        });
+        let result = validate_from_config(&config_no_runtimes, ValidationMode::Warn);
+        assert!(result.valid);
+        assert!(result.errors.is_empty());
     }
 
     #[test]

--- a/loom-daemon/src/runtime_admission.rs
+++ b/loom-daemon/src/runtime_admission.rs
@@ -168,41 +168,73 @@ pub fn canonical_role(role: &str) -> Option<&'static str> {
 /// Empty-value semantics are preserved exactly: `"curator": ""` is a *valid*
 /// key with an unset value (it falls through to the next precedence tier), and
 /// an absent `runtimes.roles` block is not an error.
+/// Validate a resolved `runtimes.roles` JSON value's shape: must be an
+/// object; every key a known role name; every value a string.
+///
+/// Factored out of [`config_runtime`] (#5006) so the exact same rule set can
+/// be run twice: once here at admission time (unchanged behavior, #4494),
+/// and once proactively from `loom-daemon validate`
+/// ([`check_runtimes_roles_config`]) — before any role actually ticks and
+/// fails on it. Keeping one function means the two call sites can never
+/// silently drift apart.
+pub fn validate_runtimes_roles_shape(roles: &serde_json::Value) -> Result<(), String> {
+    let Some(map) = roles.as_object() else {
+        return Err(format!(
+            "runtimes.roles must be an object mapping role names to runtimes, got {}",
+            type_name_of(roles)
+        ));
+    };
+    let mut unknown: Vec<String> = map
+        .keys()
+        .filter(|key| canonical_role(key).is_none())
+        .cloned()
+        .collect();
+    unknown.sort();
+    if !unknown.is_empty() {
+        return Err(format!(
+            "unknown role name(s) in runtimes.roles: {} (known roles: {})",
+            unknown.join(", "),
+            KNOWN_ROLE_KEYS.join(", ")
+        ));
+    }
+    let mut non_string: Vec<String> = map
+        .iter()
+        .filter(|(_, value)| !value.is_string())
+        .map(|(key, _)| key.clone())
+        .collect();
+    non_string.sort();
+    if !non_string.is_empty() {
+        return Err(format!("runtimes.roles value(s) must be strings: {}", non_string.join(", ")));
+    }
+    Ok(())
+}
+
+/// Proactively check an already-resolved config's `runtimes.roles` map for
+/// the same fail-closed problems [`config_runtime`] rejects at admission
+/// time (unknown role keys, non-string values, a non-object shape). Returns
+/// one formatted message per problem found — currently at most one, since
+/// [`validate_runtimes_roles_shape`] stops at the first violation — so
+/// `loom-daemon validate` can surface a `runtimes.roles` misconfiguration
+/// any time an operator runs it, rather than only when a specific role's
+/// tick fails (#5006). An absent `runtimes.roles` block is not an error and
+/// yields an empty vec, matching [`config_runtime`]'s own empty-is-fine
+/// semantics.
+#[must_use]
+pub fn check_runtimes_roles_config(config: &serde_json::Value) -> Vec<String> {
+    let Some(roles) = crate::config_resolver::get_path(config, "runtimes.roles") else {
+        return Vec::new();
+    };
+    match validate_runtimes_roles_shape(roles) {
+        Ok(()) => Vec::new(),
+        Err(message) => vec![format!("runtimes.roles: {message}")],
+    }
+}
+
 fn config_runtime(root: &Path, role: &str) -> Result<(Option<String>, Option<String>), String> {
     let config = crate::config_resolver::resolve_effective_config(root);
     let roles = crate::config_resolver::get_path(&config, "runtimes.roles");
     if let Some(roles) = roles {
-        let Some(map) = roles.as_object() else {
-            return Err(format!(
-                "runtimes.roles must be an object mapping role names to runtimes, got {}",
-                type_name_of(roles)
-            ));
-        };
-        let mut unknown: Vec<String> = map
-            .keys()
-            .filter(|key| canonical_role(key).is_none())
-            .cloned()
-            .collect();
-        unknown.sort();
-        if !unknown.is_empty() {
-            return Err(format!(
-                "unknown role name(s) in runtimes.roles: {} (known roles: {})",
-                unknown.join(", "),
-                KNOWN_ROLE_KEYS.join(", ")
-            ));
-        }
-        let mut non_string: Vec<String> = map
-            .iter()
-            .filter(|(_, value)| !value.is_string())
-            .map(|(key, _)| key.clone())
-            .collect();
-        non_string.sort();
-        if !non_string.is_empty() {
-            return Err(format!(
-                "runtimes.roles value(s) must be strings: {}",
-                non_string.join(", ")
-            ));
-        }
+        validate_runtimes_roles_shape(roles)?;
     }
     let per_role = roles
         .and_then(|v| v.get(role))
@@ -758,6 +790,54 @@ mod tests {
         let admitted = resolve_and_admit(d.path(), "curator", None).unwrap();
         assert_eq!(admitted.runtime, "claude");
         assert_eq!(admitted.source, RuntimeSource::BuiltIn);
+    }
+
+    /// `check_runtimes_roles_config` (#5006) must report exactly the same
+    /// fail-closed problems `config_runtime` rejects at admission time —
+    /// unknown role key, non-string value, non-object shape — so
+    /// `loom-daemon validate` can catch a bad `runtimes.roles` before any
+    /// role's tick actually runs into it.
+    #[test]
+    fn check_runtimes_roles_config_reports_unknown_key() {
+        let config = serde_json::json!({"runtimes": {"roles": {"buidler": "claude"}}});
+        let errors = check_runtimes_roles_config(&config);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("buidler"), "{}", errors[0]);
+        assert!(errors[0].contains("unknown role name"), "{}", errors[0]);
+    }
+
+    #[test]
+    fn check_runtimes_roles_config_reports_non_string_value() {
+        let config = serde_json::json!({"runtimes": {"roles": {"curator": true}}});
+        let errors = check_runtimes_roles_config(&config);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("must be strings"), "{}", errors[0]);
+        assert!(errors[0].contains("curator"), "{}", errors[0]);
+    }
+
+    #[test]
+    fn check_runtimes_roles_config_reports_non_object_shape() {
+        let config = serde_json::json!({"runtimes": {"roles": "codex"}});
+        let errors = check_runtimes_roles_config(&config);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("must be an object"), "{}", errors[0]);
+    }
+
+    /// Well-formed or absent `runtimes.roles` produces no findings — no
+    /// regression for the common (zero-config, or valid config) case.
+    #[test]
+    fn check_runtimes_roles_config_is_silent_on_valid_or_absent_config() {
+        assert!(check_runtimes_roles_config(&serde_json::json!({})).is_empty());
+        assert!(check_runtimes_roles_config(&serde_json::json!({"terminals": []})).is_empty());
+        assert!(check_runtimes_roles_config(
+            &serde_json::json!({"runtimes": {"default": "codex", "roles": {"curator": "claude"}}})
+        )
+        .is_empty());
+        // Empty-value semantics (an unset per-role binding) are preserved.
+        assert!(check_runtimes_roles_config(
+            &serde_json::json!({"runtimes": {"roles": {"curator": ""}}})
+        )
+        .is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`loom-daemon validate` now proactively checks the workspace's resolved `runtimes.roles` map for the same fail-closed misconfigurations `runtime_admission::config_runtime()` already rejects at admission time (unknown role key, non-string value, non-object shape). Previously this class of misconfiguration only surfaced the next time a specific role's tick actually ran into it.

- Factored the key/value validation logic out of `config_runtime()` in `loom-daemon/src/runtime_admission.rs` into a reusable `validate_runtimes_roles_shape()`, plus a new `check_runtimes_roles_config()` that runs it proactively against a resolved config `Value`.
- `role_validation::validate_from_config()` now also calls `check_runtimes_roles_config()` and folds any findings into `ValidationResult.errors` (and flips `valid` to `false`), so `handle_validate_command` — which already exits 1 on any error — surfaces it with no further wiring needed.
- `format_validation_result` (text and `--format json`) already renders `errors` generically, so both output modes pick up the new finding with no changes there.
- Documented the new coverage in `defaults/docs/runtime-adapters.md` § "Daemon runtime binding and admission".

Closes #5006

## Test plan

- [x] New unit tests in `runtime_admission.rs`: unknown role key, non-string value, non-object shape are each reported by `check_runtimes_roles_config`; a well-formed or absent `runtimes.roles` produces no findings.
- [x] New unit tests in `role_validation.rs`: `validate_from_config` reports a bad `runtimes.roles` as an error (and flips `valid` to `false`) while role-completeness warnings are computed independently; a well-formed/absent `runtimes.roles` produces no new errors.
- [x] Full existing `runtime_admission` test suite (15 tests, including `unknown_configured_role_keys_fail_closed`) still passes — the refactor preserves admission-time behavior byte-for-byte.
- [x] `cargo clippy -p loom-daemon --lib -- -D warnings` clean.