### PR TITLE
feat(observability): surface role-tick health in HostHealthRecord + fleet dashboard

### DIFF
--- a/.loom/docs/telemetry-schema.md
+++ b/.loom/docs/telemetry-schema.md
@@ -394,9 +394,18 @@ happens to run `loom-daemon health` locally on that one host.
   omitted from the wire when empty (`skip_serializing_if = "Vec::is_empty"`),
   mirroring `managed_repos`/`active_sweep_ids`.
 - `root` is a local workspace filesystem path, not a forge `owner/repo`
-  slug — it names no repository, issue, branch, or PR, so (unlike
-  `managed_repos`) `roles` passes through public redaction unchanged
-  (`dashboard/src/redaction.ts`).
+  slug — it names no repository, issue, branch, or PR. But on the common
+  macOS/Linux home-directory layout (`/Users/<user>/…`, `/home/<user>/…`) its
+  leading segment *does* name the **operator**, the same "who runs the fleet"
+  category `tokens.snapshot`'s `accounts` is held back for. So (redaction
+  class: **per-entry, `root` basenamed**) the authenticated `/api/*` surface
+  keeps the full path, but the public, unauthenticated view only ever gets each
+  `root` truncated to its basename — mirroring the daemon's
+  `RoleFailure::label()` and the frontend's `pathBasename`. `total`/`ok` and
+  each failure's `role`/`failures`/`last_at`/`detail` pass through unchanged.
+  Enforced by `redactRoleTickHealth` in `dashboard/src/redaction.ts` (like
+  `managed_repos`, `roles` is deliberately absent from the raw allowlist and
+  only reaches a public response through that derivation).
 
 ## Per-host reporting redundancy (why 3x storage is intentional, Issue #4999)
 

--- a/.loom/docs/telemetry-schema.md
+++ b/.loom/docs/telemetry-schema.md
@@ -348,6 +348,56 @@ its registered repos) rather than as an unexplained gap.
   `redactManagedRepos`). The authenticated view always sees every entry in
   full, including private slugs.
 
+**`roles` (#5022, role-tick health).** The same transient-vs-persistent
+classification `loom-daemon health`'s `roles` section already computes
+(`crate::health::summarize_role_ticks`, fed by
+`crate::role_runner::role_tick_records()`), carried through the telemetry
+pipeline so a role dying on one host (the exact 2026-08-03 Judge outage #5004
+was filed for) is observable fleet-wide rather than only to an operator who
+happens to run `loom-daemon health` locally on that one host.
+
+```json
+{
+  "kind": "host.health",
+  "...": "every field above, plus:",
+  "roles": {
+    "total": 12,
+    "ok": 10,
+    "persistent": [
+      {
+        "root": "/repos/loom",
+        "role": "judge",
+        "failures": 2,
+        "last_at": "2026-08-03T09:14:00Z",
+        "detail": "no-token-pool"
+      }
+    ]
+  }
+}
+```
+
+- `total` / `ok` are the tick counts sampled from the process-global role-tick
+  ring (`crate::role_runner::ROLE_TICK_RING_CAPACITY`-bounded), **not**
+  windowed the way `loom-daemon health --since` is — a periodic `host.health`
+  push always reports the ring's full current contents. `total: 0` means "the
+  role runner sampled nothing" (idle or disabled entirely) and is a normal,
+  healthy state — never render it as degraded.
+- `persistent` lists only the `(root, role)` pairs whose **most recent**
+  sampled tick is still a failure — the ones that make `loom-daemon health`'s
+  `roles` section report `DEGRADED`. A pair that failed but has since
+  recovered (its latest tick is a success) is folded into `total`/`ok` like
+  every other tick and does **not** appear here, mirroring the transient
+  count in `assess_roles`'s own rendered summary line.
+- `#[serde(default)]` on the whole `roles` field, so a record from a
+  pre-#5022 daemon decodes with the zero-value ("nothing sampled") summary
+  rather than failing the whole envelope. `persistent` is additionally
+  omitted from the wire when empty (`skip_serializing_if = "Vec::is_empty"`),
+  mirroring `managed_repos`/`active_sweep_ids`.
+- `root` is a local workspace filesystem path, not a forge `owner/repo`
+  slug — it names no repository, issue, branch, or PR, so (unlike
+  `managed_repos`) `roles` passes through public redaction unchanged
+  (`dashboard/src/redaction.ts`).
+
 ## Per-host reporting redundancy (why 3x storage is intentional, Issue #4999)
 
 Every host in a fleet independently samples and pushes `tokens.snapshot` and

--- a/dashboard/src/redaction.ts
+++ b/dashboard/src/redaction.ts
@@ -136,6 +136,14 @@ const RECORD_FIELD_ALLOWLIST: Readonly<Record<string, readonly string[]>> = {
     // specific repository, so — like `tokens.snapshot`'s `accounts` above —
     // it only ever reaches a public response through `PUBLIC_RECORD_
     // DERIVATIONS`'s `redactManagedRepos`, never a raw copy.
+    //
+    // Role-tick health (#5022): which support role(s) are persistently
+    // failing on this host, and the workspace root each ran against. Neither
+    // names a repo, issue, branch, or operator — same "describes the
+    // machine, not the work" reasoning as `dispatch_halted`/`halt_reason`
+    // above. The workspace root is a local filesystem path, not a forge
+    // slug, so it carries no repo identity either.
+    "roles",
   ],
 };
 

--- a/dashboard/src/redaction.ts
+++ b/dashboard/src/redaction.ts
@@ -137,13 +137,17 @@ const RECORD_FIELD_ALLOWLIST: Readonly<Record<string, readonly string[]>> = {
     // it only ever reaches a public response through `PUBLIC_RECORD_
     // DERIVATIONS`'s `redactManagedRepos`, never a raw copy.
     //
-    // Role-tick health (#5022): which support role(s) are persistently
-    // failing on this host, and the workspace root each ran against. Neither
-    // names a repo, issue, branch, or operator — same "describes the
-    // machine, not the work" reasoning as `dispatch_halted`/`halt_reason`
-    // above. The workspace root is a local filesystem path, not a forge
-    // slug, so it carries no repo identity either.
-    "roles",
+    // Role-tick health (`roles`, #5022) is likewise deliberately ABSENT here:
+    // each `persistent[]` entry carries a `root` — a full absolute filesystem
+    // workspace path whose home-directory segment names the *operator* on the
+    // common macOS/Linux layout (`/Users/<user>/…`, `/home/<user>/…`), the
+    // same category of "who runs the fleet" detail `tokens.snapshot`'s
+    // `accounts` is held back for. So — like `managed_repos` — it only ever
+    // reaches a public response through `PUBLIC_RECORD_DERIVATIONS`'s
+    // `redactRoleTickHealth`, which basenames each `root` (mirroring the
+    // daemon's `RoleFailure::label()` and the frontend's `pathBasename`),
+    // never a raw copy. The authenticated `/api/*` surface keeps the full
+    // path (that path skips redaction entirely).
   ],
 };
 
@@ -246,6 +250,75 @@ export function redactManagedRepos(rows: readonly ManagedRepoRow[]): { slug?: st
   });
 }
 
+/** One `persistent[]` role-tick failure entry inside `host.health`'s `roles`
+ * summary (#5022), as the daemon sends it — `root` is the full absolute
+ * filesystem workspace path the failing role ran against. */
+interface RoleTickFailureRow {
+  root?: unknown;
+  role?: unknown;
+  failures?: unknown;
+  last_at?: unknown;
+  detail?: unknown;
+}
+
+/** `host.health`'s `roles` role-tick health summary (#5022), as the daemon
+ * sends it — the daemon always carries full detail (including each failure's
+ * absolute `root`); the redaction boundary is here. */
+interface RoleTickHealthRow {
+  total?: unknown;
+  ok?: unknown;
+  persistent?: unknown;
+}
+
+/** Truncate an absolute workspace path to its final component — mirrors the
+ * daemon's `RoleFailure::label()` (`loom-daemon/src/health.rs`) and the
+ * frontend's own `pathBasename` (`dashboard/web/src/format.ts`):
+ * `/Users/alice/GitHub/loom` → `"loom"`. An empty / slash-only path degrades
+ * to itself rather than `""`. */
+function pathBasename(root: string): string {
+  const parts = root.split("/").filter((part) => part.length > 0);
+  return parts.length > 0 ? parts[parts.length - 1]! : root;
+}
+
+/**
+ * Redact one `host.health.roles` summary (#5022) for a public, unauthenticated
+ * viewer. The counts (`total`/`ok`) and each persistent failure's non-path
+ * detail (`role`/`failures`/`last_at`/`detail`) survive; every entry's `root`
+ * — a full absolute filesystem workspace path whose home-directory segment
+ * names the *operator* on the common macOS/Linux layout — is truncated to its
+ * basename, exactly as the daemon's `RoleFailure::label()` and the frontend's
+ * `pathBasename` already render it for display. Only the raw wire payload to
+ * the public, unauthenticated API skipped that truncation; this closes it. The
+ * authenticated `/api/*` surface keeps the full path (this derivation runs on
+ * the public path only).
+ *
+ * Like `redactManagedRepos`, a per-field pick (not a spread), so a future
+ * field added to the `roles` schema is dropped from the public view by default
+ * until this table is deliberately updated — the fail-safe direction never
+ * flips silently. A non-string `root` (malformed payload) is dropped rather
+ * than copied through, so a raw path can never reach a public response by any
+ * type-confusion path.
+ */
+export function redactRoleTickHealth(roles: RoleTickHealthRow): Record<string, unknown> {
+  const redacted: Record<string, unknown> = {};
+  if ("total" in roles) redacted.total = roles.total;
+  if ("ok" in roles) redacted.ok = roles.ok;
+  if (Array.isArray(roles.persistent)) {
+    redacted.persistent = (roles.persistent as RoleTickFailureRow[]).map((row) => {
+      const entry: Record<string, unknown> = {};
+      if (row && typeof row === "object") {
+        if (typeof row.root === "string") entry.root = pathBasename(row.root);
+        if ("role" in row) entry.role = row.role;
+        if ("failures" in row) entry.failures = row.failures;
+        if ("last_at" in row) entry.last_at = row.last_at;
+        if ("detail" in row) entry.detail = row.detail;
+      }
+      return entry;
+    });
+  }
+  return redacted;
+}
+
 /**
  * Per-kind *derivations* layered on top of the field allowlist: fields the
  * public view gets that are computed from redacted-away input rather than
@@ -261,17 +334,25 @@ export function redactManagedRepos(rows: readonly ManagedRepoRow[]): { slug?: st
 const PUBLIC_RECORD_DERIVATIONS: Readonly<Record<string, (payload: Record<string, unknown>) => Record<string, unknown>>> =
   {
     "tokens.snapshot": (payload) => deriveTokenPoolAggregate(payload) as unknown as Record<string, unknown>,
-    // `managed_repos` is deliberately ABSENT from `RECORD_FIELD_ALLOWLIST` —
-    // like `tokens.snapshot`'s `accounts`, its raw form can name a private
-    // repo, so it only ever reaches a public response through this
-    // derivation. Absent entirely from the output when the payload carries
-    // no roster at all (a pre-#4976 daemon, or a host with no registered
-    // workspaces), so the field-presence contract stays "the daemon sent
-    // this" rather than "this module always adds it".
-    "host.health": (payload) =>
-      Array.isArray(payload.managed_repos)
-        ? { managed_repos: redactManagedRepos(payload.managed_repos as ManagedRepoRow[]) }
-        : {},
+    // `managed_repos` (#4976) and `roles` (#5022) are both deliberately ABSENT
+    // from `RECORD_FIELD_ALLOWLIST` — like `tokens.snapshot`'s `accounts`,
+    // each has a raw form that can identify a private repo (`managed_repos`)
+    // or the operator via a home-directory path (`roles[].root`), so each only
+    // ever reaches a public response through this derivation. Each is absent
+    // entirely from the output when the payload carries no such field at all
+    // (a pre-#4976 / pre-#5022 daemon, or a host with no registered workspaces
+    // / no sampled role ticks), so the field-presence contract stays "the
+    // daemon sent this" rather than "this module always adds it".
+    "host.health": (payload) => {
+      const derived: Record<string, unknown> = {};
+      if (Array.isArray(payload.managed_repos)) {
+        derived.managed_repos = redactManagedRepos(payload.managed_repos as ManagedRepoRow[]);
+      }
+      if (payload.roles && typeof payload.roles === "object" && !Array.isArray(payload.roles)) {
+        derived.roles = redactRoleTickHealth(payload.roles as RoleTickHealthRow);
+      }
+      return derived;
+    },
   };
 
 /** The fail-safe allowlist for a `kind` this table does not (yet) recognize

--- a/dashboard/test/redaction.test.ts
+++ b/dashboard/test/redaction.test.ts
@@ -267,6 +267,33 @@ describe("redactPayload — per-kind field allowlist", () => {
     expect(redactPayload("host.health", payload)).toEqual(payload);
   });
 
+  it("host.health: role-tick health (roles) survives redaction, including the workspace root (#5022)", () => {
+    // Names a role and a local workspace path, neither of which is a repo,
+    // issue, branch, or operator — same "describes the machine, not the
+    // work" reasoning as dispatch_halted/halt_reason directly above it.
+    const payload = {
+      kind: "host.health",
+      captured_at: "2026-08-02T12:00:00Z",
+      daemon_version: "0.17.0",
+      uptime_sec: 86400,
+      logical_cpus: 28,
+      roles: {
+        total: 3,
+        ok: 1,
+        persistent: [
+          {
+            root: "/repos/loom",
+            role: "judge",
+            failures: 2,
+            last_at: "2026-08-02T11:59:00Z",
+            detail: "no-token-pool",
+          },
+        ],
+      },
+    };
+    expect(redactPayload("host.health", payload)).toEqual(payload);
+  });
+
   it("host.health: a private repo's slug is redacted, but every other field survives unchanged (#4976)", () => {
     const payload = {
       kind: "host.health",

--- a/dashboard/test/redaction.test.ts
+++ b/dashboard/test/redaction.test.ts
@@ -267,10 +267,13 @@ describe("redactPayload — per-kind field allowlist", () => {
     expect(redactPayload("host.health", payload)).toEqual(payload);
   });
 
-  it("host.health: role-tick health (roles) survives redaction, including the workspace root (#5022)", () => {
-    // Names a role and a local workspace path, neither of which is a repo,
-    // issue, branch, or operator — same "describes the machine, not the
-    // work" reasoning as dispatch_halted/halt_reason directly above it.
+  it("host.health: role-tick health (roles) survives redaction, but each persistent root is basenamed for the public view (#5022)", () => {
+    // The counts and each failure's role/detail survive (they describe the
+    // machine, not the work), but the workspace `root` is a full absolute
+    // filesystem path whose home-directory segment names the operator on the
+    // common macOS/Linux layout — so the public, unauthenticated surface only
+    // ever gets its basename, mirroring the daemon's `RoleFailure::label()`
+    // and the frontend's `pathBasename`.
     const payload = {
       kind: "host.health",
       captured_at: "2026-08-02T12:00:00Z",
@@ -282,7 +285,7 @@ describe("redactPayload — per-kind field allowlist", () => {
         ok: 1,
         persistent: [
           {
-            root: "/repos/loom",
+            root: "/Users/alice/GitHub/loom",
             role: "judge",
             failures: 2,
             last_at: "2026-08-02T11:59:00Z",
@@ -291,7 +294,49 @@ describe("redactPayload — per-kind field allowlist", () => {
         ],
       },
     };
-    expect(redactPayload("host.health", payload)).toEqual(payload);
+    const redacted = redactPayload("host.health", payload);
+    // Counts and non-path detail survive unchanged.
+    expect(redacted).toMatchObject({
+      kind: "host.health",
+      captured_at: "2026-08-02T12:00:00Z",
+      daemon_version: "0.17.0",
+      uptime_sec: 86400,
+      logical_cpus: 28,
+    });
+    expect(redacted.roles).toEqual({
+      total: 3,
+      ok: 1,
+      persistent: [
+        {
+          // Basenamed — the operator-identifying home-directory prefix is gone.
+          root: "loom",
+          role: "judge",
+          failures: 2,
+          last_at: "2026-08-02T11:59:00Z",
+          detail: "no-token-pool",
+        },
+      ],
+    });
+    // The raw absolute path (and its operator-identifying username segment)
+    // never reaches the public surface, in any field.
+    expect(JSON.stringify(redacted)).not.toContain("/Users/alice");
+    expect(JSON.stringify(redacted)).not.toContain("alice");
+  });
+
+  it("host.health: no roles key at all when the payload carries no role-tick summary (#5022)", () => {
+    const payload = { kind: "host.health", daemon_version: "0.17.0", uptime_sec: 100 };
+    expect(redactPayload("host.health", payload)).not.toHaveProperty("roles");
+  });
+
+  it("host.health: a total: 0 role-tick summary round-trips distinctly (no persistent list) (#5022)", () => {
+    const payload = {
+      kind: "host.health",
+      daemon_version: "0.17.0",
+      uptime_sec: 100,
+      roles: { total: 0, ok: 0 },
+    };
+    const redacted = redactPayload("host.health", payload);
+    expect(redacted.roles).toEqual({ total: 0, ok: 0 });
   });
 
   it("host.health: a private repo's slug is redacted, but every other field survives unchanged (#4976)", () => {

--- a/dashboard/web/src/fleet.ts
+++ b/dashboard/web/src/fleet.ts
@@ -17,7 +17,7 @@
  *   healthy and must still render its health/token panel.
  */
 
-import { secondsSince } from "./format";
+import { roleFailureLabel, secondsSince } from "./format";
 import type { ActiveSweep, FleetSnapshot, HostEntry, HostHealthRecord, TokenAccount } from "./types";
 
 /**
@@ -165,18 +165,24 @@ const ZERO_IDLE_FRACTION_THRESHOLD = 0.02;
 
 /**
  * Why a host looks distressed, in priority order, or `undefined` when it
- * does not. `dispatch_halted` (a sustained, stateful signal the daemon
- * itself computed — see `host_breaker.rs`'s module doc) is checked first and
- * named with its own reason; the load/idle checks below it are same-number,
- * single-sample fallbacks for a host whose daemon predates/disables that
- * field. A host that is merely busy — high load, but still admitting new
- * dispatch and idle well above zero — returns `undefined` here and stays
- * `"ok"` (busy ≠ degraded, #4975).
+ * does not. `dispatch_halted` and `roles.persistent` (both sustained,
+ * stateful signals the daemon itself computed — see `host_breaker.rs`'s
+ * module doc and `crate::health::summarize_role_ticks`, #5022) are checked
+ * first and named with their own reason; the load/idle checks below them are
+ * same-number, single-sample fallbacks for a host whose daemon
+ * predates/disables those fields. A host that is merely busy — high load,
+ * but still admitting new dispatch and idle well above zero — returns
+ * `undefined` here and stays `"ok"` (busy ≠ degraded, #4975).
  */
 export function distressReason(health: HostHealthRecord | undefined): string | undefined {
   if (!health) return undefined;
   if (health.dispatch_halted) {
     return health.halt_reason ? `dispatch halted: ${health.halt_reason}` : "dispatch halted";
+  }
+  const persistentRoleFailures = health.roles?.persistent ?? [];
+  if (persistentRoleFailures.length > 0) {
+    const names = persistentRoleFailures.map(roleFailureLabel).join(", ");
+    return `role tick(s) persistently failing: ${names}`;
   }
   if (health.load_per_core !== undefined && health.load_per_core >= HOST_DISTRESS_LOAD_PER_CORE) {
     return `load/core ${health.load_per_core.toFixed(2)} at or above the host-distress threshold (${HOST_DISTRESS_LOAD_PER_CORE})`;

--- a/dashboard/web/src/format.ts
+++ b/dashboard/web/src/format.ts
@@ -11,6 +11,7 @@
  */
 
 import { displayTimeZone, timeZoneAbbreviation } from "./timezone";
+import type { RoleTickFailure, RoleTickHealth } from "./types";
 
 export const UNKNOWN = "—";
 
@@ -144,6 +145,52 @@ export function formatClock(at: Date, zone: string = displayTimeZone()): string 
 
 export function formatCount(value: number | undefined): string {
   return value === undefined ? UNKNOWN : String(value);
+}
+
+/** `/repos/loom` → `"loom"` — the final path component, the same "root
+ * basename" the daemon's own `RoleFailure::label()` uses so this UI never
+ * shows a full filesystem path. Falls back to the whole string when it has
+ * no `/` at all (already a bare name, or a wrong-typed value). */
+function pathBasename(root: string): string {
+  const parts = root.split("/").filter((part) => part.length > 0);
+  return parts.length > 0 ? parts[parts.length - 1]! : root;
+}
+
+/** `{ role: "judge", root: "/repos/loom" }` → `"judge @ loom"` — mirrors the
+ * daemon's own `RoleFailure::label()` so a persistent failure reads
+ * identically here and in `loom-daemon health`'s own output. Missing
+ * `role`/`root` degrade to `UNKNOWN` rather than an empty string. */
+export function roleFailureLabel(failure: RoleTickFailure): string {
+  const role = failure.role && failure.role.length > 0 ? failure.role : UNKNOWN;
+  const root = failure.root && failure.root.length > 0 ? pathBasename(failure.root) : UNKNOWN;
+  return `${role} @ ${root}`;
+}
+
+/** Compact `host.health.roles` indicator for the fleet-overview card, where
+ * the full `roleTickSummaryText` sentence would not fit: `"ok"` / `"no role
+ * ticks"` / `"2 failing"`. The host-detail drill-down uses the fuller
+ * `roleTickSummaryText` instead, which names the failing role(s). */
+export function roleTickCompactText(roles: RoleTickHealth | undefined): string {
+  if (roles === undefined || roles.total === undefined) return UNKNOWN;
+  if (roles.total === 0) return "no role ticks";
+  const failing = roles.persistent?.length ?? 0;
+  return failing > 0 ? `${failing} failing` : "ok";
+}
+
+/** One-line `host.health.roles` summary, mirroring `loom-daemon health`'s
+ * own `roles` section line: `"10/12 ticks ok"` when healthy, or `"10/12
+ * ticks ok; 1 persistent failure(s): judge @ loom"` when not. `undefined`
+ * (a pre-#5022 daemon, or the field simply not parsed yet) and `total: 0`
+ * (the role runner idle/disabled) both render distinctly from a real
+ * failure — neither is an alarm. */
+export function roleTickSummaryText(roles: RoleTickHealth | undefined): string {
+  if (roles === undefined || roles.total === undefined) return UNKNOWN;
+  if (roles.total === 0) return "no role ticks";
+  const ok = roles.ok ?? 0;
+  const persistent = roles.persistent ?? [];
+  if (persistent.length === 0) return `${ok}/${roles.total} ticks ok`;
+  const names = persistent.map(roleFailureLabel).join(", ");
+  return `${ok}/${roles.total} ticks ok; ${persistent.length} persistent failure(s): ${names}`;
 }
 
 /** `undefined`/empty → `"—"`, for the optional string fields (`model`,

--- a/dashboard/web/src/parse.ts
+++ b/dashboard/web/src/parse.ts
@@ -23,6 +23,8 @@ import type {
   HostEntry,
   HostHealthRecord,
   ManagedRepoEntry,
+  RoleTickFailure,
+  RoleTickHealth,
   TokenAccount,
   TokensSnapshotRecord,
   Timestamped,
@@ -60,6 +62,34 @@ export function parseManagedRepoEntry(value: unknown): ManagedRepoEntry | undefi
   });
 }
 
+/** A `roles.persistent` entry. `root`/`role` degrade to `undefined` (not a
+ * fabricated empty string) when wrong-typed, matching every other
+ * best-effort field this module narrows. */
+export function parseRoleTickFailure(value: unknown): RoleTickFailure | undefined {
+  if (!isObject(value)) return undefined;
+  return stripUndefined<RoleTickFailure>({
+    root: str(value.root),
+    role: str(value.role),
+    failures: num(value.failures),
+    last_at: str(value.last_at),
+    detail: str(value.detail),
+  });
+}
+
+/** `host.health`'s `roles` summary (#5022). A genuine `total: 0` (the role
+ * runner sampled nothing this snapshot) survives untouched — `num()` only
+ * drops a missing or wrong-typed value, never a real zero. */
+export function parseRoleTickHealth(value: unknown): RoleTickHealth | undefined {
+  if (!isObject(value)) return undefined;
+  return stripUndefined<RoleTickHealth>({
+    total: num(value.total),
+    ok: num(value.ok),
+    persistent: Array.isArray(value.persistent)
+      ? value.persistent.map(parseRoleTickFailure).filter((entry): entry is RoleTickFailure => entry !== undefined)
+      : undefined,
+  });
+}
+
 export function parseHostHealth(value: unknown): HostHealthRecord {
   if (!isObject(value)) return {};
   return stripUndefined<HostHealthRecord>({
@@ -78,6 +108,7 @@ export function parseHostHealth(value: unknown): HostHealthRecord {
     managed_repos: Array.isArray(value.managed_repos)
       ? value.managed_repos.map(parseManagedRepoEntry).filter((entry): entry is ManagedRepoEntry => entry !== undefined)
       : undefined,
+    roles: parseRoleTickHealth(value.roles),
   });
 }
 

--- a/dashboard/web/src/types.ts
+++ b/dashboard/web/src/types.ts
@@ -36,6 +36,33 @@ export interface ManagedRepoEntry {
   visibility?: "public" | "private";
 }
 
+/** One `(root, role)` pair's persistent tick-failure detail inside a host's
+ * `roles` role-tick health summary (#5022). `root` is a filesystem workspace
+ * path (not a forge repo slug) — it names no repository. */
+export interface RoleTickFailure {
+  root?: string;
+  role?: string;
+  failures?: number;
+  last_at?: string;
+  detail?: string;
+}
+
+/** `host.health`'s role-tick health summary (#5022) — the same
+ * transient-vs-persistent classification `loom-daemon health`'s `roles`
+ * section already computes, carried through the telemetry pipeline so a role
+ * dying on one host is visible fleet-wide, not only to an operator who
+ * happens to run `loom-daemon health` locally on that host.
+ *
+ * `total: 0` means "no role ticks sampled" (the role runner idle or
+ * disabled) — a normal state, not an error — same as an empty `persistent`
+ * list with `total > 0` means "every tick ok". Absent entirely on a record
+ * from a pre-#5022 daemon. */
+export interface RoleTickHealth {
+  total?: number;
+  ok?: number;
+  persistent?: RoleTickFailure[];
+}
+
 /** `host.health` — CPU/disk headroom, daemon version, uptime.
  *
  * Every measured field is optional by design: the daemon's "unknown != zero"
@@ -74,6 +101,10 @@ export interface HostHealthRecord {
    * idle-but-registered repo still appears. Absent entirely on a host
    * running a pre-#4976 daemon, or one with no registered workspaces. */
   managed_repos?: ManagedRepoEntry[];
+  /** This host's role-tick health (#5022). Absent on a record from a
+   * pre-#5022 daemon, which is indistinguishable from "nothing sampled yet"
+   * — never render its absence as either healthy or degraded. */
+  roles?: RoleTickHealth;
 }
 
 /** One account inside a `tokens.snapshot`. Only `exhausted` is always sent;

--- a/dashboard/web/src/views/fleetOverview.ts
+++ b/dashboard/web/src/views/fleetOverview.ts
@@ -21,6 +21,7 @@ import {
   formatRelative,
   formatAbsolute,
   formatCount,
+  roleTickCompactText,
 } from "../format";
 import type { FleetView, HostStatus, HostView } from "../fleet";
 import type { HostHealthRecord, ManagedRepoEntry } from "../types";
@@ -114,6 +115,13 @@ export function healthFields(host: HostView, now: Date = new Date()): DocumentFr
   fragment.appendChild(field("CPU idle", formatPercent(health.cpu_idle_fraction)));
   fragment.appendChild(field("Load/core", formatRatio(health.load_per_core)));
   fragment.appendChild(field("Worktree free", formatGigabytes(health.worktree_root_free_gb)));
+  fragment.appendChild(
+    field(
+      "Roles",
+      roleTickCompactText(health.roles),
+      "Role-tick health — see the host drill-down for which role(s) are persistently failing (#5022)",
+    ),
+  );
   return fragment;
 }
 

--- a/dashboard/web/src/views/hostDetail.ts
+++ b/dashboard/web/src/views/hostDetail.ts
@@ -24,6 +24,7 @@ import {
   formatRelative,
   formatCount,
   formatText,
+  roleTickSummaryText,
   secondsSince,
 } from "../format";
 import type { HostView } from "../fleet";
@@ -85,6 +86,11 @@ function healthPanel(host: HostView, now: Date): HTMLElement {
       field("CPU idle", formatPercent(health.cpu_idle_fraction, 1)),
       field("Load per core", formatRatio(health.load_per_core)),
       field("Worktree root free", formatGigabytes(health.worktree_root_free_gb)),
+      field(
+        "Role ticks",
+        roleTickSummaryText(health.roles),
+        "loom-daemon health's own roles section, carried through telemetry (#5022)",
+      ),
       field(
         "Captured at",
         health.captured_at ? formatAbsolute(health.captured_at) : UNKNOWN,

--- a/dashboard/web/test/fixtures.ts
+++ b/dashboard/web/test/fixtures.ts
@@ -171,6 +171,8 @@ export function multiHostSnapshot(): unknown {
               { slug: "2AMLogic/gf180-pll", visibility: "private" },
               { slug: "2AMLogic/gf180-trng", visibility: "private" },
             ],
+            // #5022: every tick ok — must not read as degraded.
+            roles: { total: 12, ok: 12, persistent: [] },
           },
           updatedAt: isoMinutesBefore(2),
         },
@@ -333,3 +335,26 @@ export function multiHostSnapshot(): unknown {
 }
 
 export const EMPTY_SNAPSHOT: unknown = { hosts: {}, activeSweeps: [] };
+
+/**
+ * A `host.health.roles` summary with one persistent tick failure (#5022) —
+ * the wire-shaped fixture `judge @ /repos/loom` failing 2 of its last 3
+ * ticks, matching `.loom/docs/telemetry-schema.md`'s `roles` example. Used by
+ * tests that assert the dashboard surfaces a persistent role-tick failure
+ * without needing a whole new fleet-wide host in `multiHostSnapshot`.
+ */
+export function persistentRoleTickFailureFixture(): unknown {
+  return {
+    total: 3,
+    ok: 1,
+    persistent: [
+      {
+        root: "/repos/loom",
+        role: "judge",
+        failures: 2,
+        last_at: isoMinutesBefore(1),
+        detail: "no-token-pool",
+      },
+    ],
+  };
+}

--- a/dashboard/web/test/fleet.test.ts
+++ b/dashboard/web/test/fleet.test.ts
@@ -21,6 +21,7 @@ import {
   SWEEP_ONLY_HOST_ID,
   isoMinutesBefore,
   multiHostSnapshot,
+  persistentRoleTickFailureFixture,
 } from "./fixtures";
 
 const view = () => buildFleetView(parseFleetSnapshot(multiHostSnapshot()), NOW);
@@ -200,6 +201,31 @@ describe("distressReason / isHostDistressed (#4975)", () => {
     // A real busy host dips well above the near-zero line.
     expect(isHostDistressed({ cpu_idle_fraction: 0.2 })).toBe(false);
   });
+
+  // #5022: role-tick health.
+  it("names the failing role(s) when roles has a persistent failure", () => {
+    const reason = distressReason({
+      roles: { total: 3, ok: 1, persistent: [{ root: "/repos/loom", role: "judge", failures: 2 }] },
+    });
+    expect(reason).toBe("role tick(s) persistently failing: judge @ loom");
+  });
+
+  it("is not distressed when roles reports every tick ok", () => {
+    expect(isHostDistressed({ roles: { total: 12, ok: 12, persistent: [] } })).toBe(false);
+  });
+
+  it("is not distressed when roles reports zero ticks sampled (role runner idle/disabled)", () => {
+    expect(isHostDistressed({ roles: { total: 0, ok: 0, persistent: [] } })).toBe(false);
+  });
+
+  it("takes priority over the load/idle heuristic fallbacks, same as dispatch_halted", () => {
+    const reason = distressReason({
+      roles: { total: 2, ok: 0, persistent: [{ root: "/repos/loom", role: "guide", failures: 2 }] },
+      load_per_core: 0.1,
+      cpu_idle_fraction: 0.9,
+    });
+    expect(reason).toBe("role tick(s) persistently failing: guide @ loom");
+  });
 });
 
 describe("buildFleetView host-distress classification (#4975)", () => {
@@ -229,6 +255,18 @@ describe("buildFleetView host-distress classification (#4975)", () => {
     const host = findHost(built, "h");
     expect(host?.status).toBe("ok");
     expect(host?.degradedReason).toBeUndefined();
+  });
+
+  it("goes degraded when roles reports a persistent tick failure, independent of load/tokens (#5022)", () => {
+    const built = buildFleetView(snapshotFor({ roles: persistentRoleTickFailureFixture() }), NOW);
+    const host = findHost(built, "h");
+    expect(host?.status).toBe("degraded");
+    expect(host?.degradedReason).toBe("role tick(s) persistently failing: judge @ loom");
+  });
+
+  it("stays ok when roles reports zero ticks sampled (role runner idle/disabled) — not an error state", () => {
+    const built = buildFleetView(snapshotFor({ roles: { total: 0, ok: 0, persistent: [] } }), NOW);
+    expect(findHost(built, "h")?.status).toBe("ok");
   });
 
   it("names the token-exhaustion reason when that is the only trigger", () => {

--- a/dashboard/web/test/fleetOverview.test.ts
+++ b/dashboard/web/test/fleetOverview.test.ts
@@ -14,6 +14,7 @@ import {
   SWEEP_ONLY_HOST_ID,
   isoMinutesBefore,
   multiHostSnapshot,
+  persistentRoleTickFailureFixture,
 } from "./fixtures";
 
 const view = () => buildFleetView(parseFleetSnapshot(multiHostSnapshot()), NOW);
@@ -176,6 +177,37 @@ describe("hostCard", () => {
     // point) — but carry no in-flight chip.
     const idleRow = repoRows.find((row) => row.textContent?.includes("2AMLogic/gf180-pll"));
     expect(idleRow?.querySelector(".chip")).toBeNull();
+  });
+
+  // #5022: compact per-host role-tick indicator.
+  it("shows the compact role-tick indicator at a glance", () => {
+    expect(fieldValue(hostCard(findHost(view(), HEALTHY_HOST_ID)!, NOW), "Roles")).toBe("ok");
+  });
+
+  it("shows unknown when the host has never reported roles", () => {
+    expect(fieldValue(hostCard(findHost(view(), DEGRADED_HOST_ID)!, NOW), "Roles")).toBe(UNKNOWN);
+  });
+
+  it("badges a host with a persistent role-tick failure as degraded, distinguishable from a healthy host", () => {
+    const built = buildFleetView(
+      parseFleetSnapshot({
+        hosts: {
+          h: {
+            health: {
+              record: { kind: "host.health", roles: persistentRoleTickFailureFixture() },
+              updatedAt: isoMinutesBefore(1),
+            },
+          },
+        },
+        activeSweeps: [],
+      }),
+      NOW,
+    );
+    const card = hostCard(findHost(built, "h")!, NOW);
+    expect(fieldValue(card, "Roles")).toBe("1 failing");
+    const badge = card.querySelector('[data-testid="status-badge"]');
+    expect(badge?.getAttribute("data-status")).toBe("degraded");
+    expect(badge?.getAttribute("title")).toBe("role tick(s) persistently failing: judge @ loom");
   });
 
   it("says 'none' for a host with no registered repos", () => {

--- a/dashboard/web/test/format.test.ts
+++ b/dashboard/web/test/format.test.ts
@@ -11,6 +11,9 @@ import {
   formatRatio,
   formatRelative,
   formatText,
+  roleFailureLabel,
+  roleTickCompactText,
+  roleTickSummaryText,
   secondsSince,
 } from "../src/format";
 import { NOW, isoMinutesBefore } from "./fixtures";
@@ -126,5 +129,48 @@ describe("formatAbsolute", () => {
 
   it("returns unknown for garbage", () => {
     expect(formatAbsolute("tuesday")).toBe(UNKNOWN);
+  });
+});
+
+describe("roleFailureLabel (#5022)", () => {
+  it("joins the role and the workspace root's basename, mirroring the daemon's RoleFailure::label()", () => {
+    expect(roleFailureLabel({ role: "judge", root: "/repos/loom" })).toBe("judge @ loom");
+  });
+
+  it("falls back to unknown for a missing role or root, never an empty string", () => {
+    expect(roleFailureLabel({ root: "/repos/loom" })).toBe(`${UNKNOWN} @ loom`);
+    expect(roleFailureLabel({ role: "judge" })).toBe(`judge @ ${UNKNOWN}`);
+    expect(roleFailureLabel({})).toBe(`${UNKNOWN} @ ${UNKNOWN}`);
+  });
+});
+
+describe("roleTickSummaryText / roleTickCompactText (#5022)", () => {
+  it("renders unknown when the daemon has not reported roles at all", () => {
+    expect(roleTickSummaryText(undefined)).toBe(UNKNOWN);
+    expect(roleTickCompactText(undefined)).toBe(UNKNOWN);
+  });
+
+  it("reports 'no role ticks' for a genuine total: 0, not an error state", () => {
+    const roles = { total: 0, ok: 0, persistent: [] };
+    expect(roleTickSummaryText(roles)).toBe("no role ticks");
+    expect(roleTickCompactText(roles)).toBe("no role ticks");
+  });
+
+  it("reports every-tick-ok with no alarming detail", () => {
+    const roles = { total: 12, ok: 12, persistent: [] };
+    expect(roleTickSummaryText(roles)).toBe("12/12 ticks ok");
+    expect(roleTickCompactText(roles)).toBe("ok");
+  });
+
+  it("names the failing role(s) in the full summary, and just a count in the compact one", () => {
+    const roles = {
+      total: 3,
+      ok: 1,
+      persistent: [{ root: "/repos/loom", role: "judge", failures: 2 }],
+    };
+    expect(roleTickSummaryText(roles)).toBe(
+      "1/3 ticks ok; 1 persistent failure(s): judge @ loom",
+    );
+    expect(roleTickCompactText(roles)).toBe("1 failing");
   });
 });

--- a/dashboard/web/test/hostDetail.test.ts
+++ b/dashboard/web/test/hostDetail.test.ts
@@ -11,6 +11,7 @@ import {
   NOW,
   SWEEP_ONLY_HOST_ID,
   multiHostSnapshot,
+  persistentRoleTickFailureFixture,
 } from "./fixtures";
 
 // Views call `formatAbsolute()` internally with no zone argument, so they
@@ -62,6 +63,35 @@ describe("hostDetailView — health panel", () => {
     const rendered = detail(DEGRADED_HOST_ID);
     expect(fieldValue(rendered, "Build commit")).toBe(UNKNOWN);
     expect(fieldValue(rendered, "Built at")).toBe(UNKNOWN);
+  });
+
+  it("renders the role-tick health summary, ok for the healthy fixture (#5022)", () => {
+    const rendered = detail(HEALTHY_HOST_ID);
+    expect(fieldValue(rendered, "Role ticks")).toBe("12/12 ticks ok");
+  });
+
+  it("names a persistent role-tick failure in the health panel (#5022)", () => {
+    const built = buildFleetView(
+      parseFleetSnapshot({
+        hosts: {
+          h: {
+            health: {
+              record: { kind: "host.health", roles: persistentRoleTickFailureFixture() },
+              updatedAt: "2026-07-30T12:09:00Z",
+            },
+          },
+        },
+        activeSweeps: [],
+      }),
+      NOW,
+    );
+    const rendered = hostDetailView(built.hosts[0]!, NOW);
+    expect(fieldValue(rendered, "Role ticks")).toBe(
+      "1/3 ticks ok; 1 persistent failure(s): judge @ loom",
+    );
+    expect(rendered.querySelector('[data-testid="status-badge"]')?.getAttribute("data-status")).toBe(
+      "degraded",
+    );
   });
 
   it("explains a host that has no health record yet", () => {

--- a/dashboard/web/test/parse.test.ts
+++ b/dashboard/web/test/parse.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { parseFleetSnapshot } from "../src/parse";
-import { HEALTHY_HOST_ID, multiHostSnapshot } from "./fixtures";
+import { parseFleetSnapshot, parseRoleTickHealth } from "../src/parse";
+import { HEALTHY_HOST_ID, multiHostSnapshot, persistentRoleTickFailureFixture } from "./fixtures";
 
 describe("parseFleetSnapshot", () => {
   it("narrows a well-formed multi-host snapshot", () => {
@@ -211,5 +211,66 @@ describe("parseFleetSnapshot", () => {
       { visibility: "private" },
       { slug: "owner/repo", visibility: "public" },
     ]);
+  });
+
+  // -------------------------------------------------------------------------
+  // host.health.roles — role-tick health (#5022)
+  // -------------------------------------------------------------------------
+
+  it("narrows host.health's roles summary, including a persistent failure", () => {
+    const snapshot = parseFleetSnapshot({
+      hosts: {
+        h: {
+          health: {
+            record: { kind: "host.health", roles: persistentRoleTickFailureFixture() },
+            updatedAt: "2026-07-30T12:00:00Z",
+          },
+        },
+      },
+      activeSweeps: [],
+    });
+    const roles = snapshot.hosts.h?.health?.record.roles;
+    expect(roles?.total).toBe(3);
+    expect(roles?.ok).toBe(1);
+    expect(roles?.persistent).toEqual([
+      {
+        root: "/repos/loom",
+        role: "judge",
+        failures: 2,
+        last_at: "2026-07-30T12:09:00.000Z",
+        detail: "no-token-pool",
+      },
+    ]);
+  });
+
+  it("preserves a genuine total: 0 for roles (role runner idle/disabled), never coercing it to unknown", () => {
+    const parsed = parseRoleTickHealth({ total: 0, ok: 0, persistent: [] });
+    expect(parsed?.total).toBe(0);
+    expect("total" in (parsed ?? {})).toBe(true);
+  });
+
+  it("drops roles entirely when absent — distinct from a genuine zero (a pre-#5022 daemon)", () => {
+    const snapshot = parseFleetSnapshot({
+      hosts: { h: { health: { record: { kind: "host.health" }, updatedAt: "2026-07-30T12:00:00Z" } } },
+      activeSweeps: [],
+    });
+    expect("roles" in (snapshot.hosts.h?.health?.record ?? {})).toBe(false);
+  });
+
+  it("drops a malformed roles.persistent entry rather than the whole roster", () => {
+    const parsed = parseRoleTickHealth({
+      total: 2,
+      ok: 1,
+      persistent: [null, "nope", { role: "judge" }],
+    });
+    // `{ role: "judge" }` (no root/failures/last_at) keeps its place with
+    // just the field it reported; `null`/`"nope"` are dropped entirely.
+    expect(parsed?.persistent).toEqual([{ role: "judge" }]);
+  });
+
+  it("degrades a wrong-typed roles value to absent rather than throwing", () => {
+    expect(parseRoleTickHealth("not-an-object")).toBeUndefined();
+    expect(parseRoleTickHealth(42)).toBeUndefined();
+    expect(parseRoleTickHealth(null)).toBeUndefined();
   });
 });

--- a/loom-daemon/src/observability/collector.rs
+++ b/loom-daemon/src/observability/collector.rs
@@ -44,10 +44,10 @@ use chrono::{DateTime, Utc};
 use crate::event_bus::{EventBus, RecvError};
 use crate::telemetry::{
     visibility::derive_visibility, HostHealthRecord, ManagedRepoEntry, PhaseDuration,
-    RepoVisibility, SweepResult, SweepStartedRecord, TelemetryEnvelope, TelemetryRecord,
-    TokenAccountState, TokenSnapshotRecord,
+    RepoVisibility, RoleTickFailureEntry, RoleTickHealth, SweepResult, SweepStartedRecord,
+    TelemetryEnvelope, TelemetryRecord, TokenAccountState, TokenSnapshotRecord,
 };
-use crate::types::{Event, SweepKind};
+use crate::types::{Event, RoleTickRecord, SweepKind};
 use crate::workspace_pool::WorkspacePool;
 
 use super::queue::DurableQueue;
@@ -511,6 +511,39 @@ async fn sample_host_health(
         dispatch_halted,
         halt_reason,
         managed_repos: collect_managed_repos(workspace_pool, slug_cache).await,
+        roles: sample_role_tick_health(&crate::role_runner::role_tick_records()),
+    }
+}
+
+/// Sample this host's role-tick health (Issue #5022) from the process-global
+/// ring [`crate::role_runner::role_tick_records`] maintains. Reuses
+/// [`crate::health::summarize_role_ticks`] — the exact transient-vs-persistent
+/// classifier `loom-daemon health`'s `roles` section already applies — rather
+/// than inventing a second one, so the two can never disagree about which
+/// `(root, role)` pairs are persistently failing.
+///
+/// Unlike `loom-daemon health --since`, this samples the **entire** ring
+/// ([`DateTime::<Utc>::MIN_UTC`] as the window start) rather than a caller-
+/// chosen window: the ring itself is already bounded
+/// ([`crate::role_runner::ROLE_TICK_RING_CAPACITY`]), so a periodic
+/// `host.health` push has no separate window concept to apply — it always
+/// reports the freshest picture the ring holds.
+fn sample_role_tick_health(records: &[RoleTickRecord]) -> RoleTickHealth {
+    let summary = crate::health::summarize_role_ticks(records, DateTime::<Utc>::MIN_UTC);
+    RoleTickHealth {
+        total: summary.total,
+        ok: summary.ok,
+        persistent: summary
+            .persistent
+            .into_iter()
+            .map(|failure| RoleTickFailureEntry {
+                root: failure.root,
+                role: failure.role,
+                failures: failure.failures,
+                last_at: failure.last_at,
+                detail: failure.detail,
+            })
+            .collect(),
     }
 }
 
@@ -1074,6 +1107,114 @@ mod tests {
             record.managed_repos.is_empty(),
             "an empty pool has no registered repos to report"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // sample_role_tick_health (#5022) — the pure classifier, tested directly
+    // against a hand-built fixture so it needs neither the process-global
+    // ring `crate::role_runner::role_tick_records()` reads (shared across
+    // every test in this binary, with no `pub(crate)` reset hook reachable
+    // from this module) nor a daemon.
+    // ------------------------------------------------------------------
+
+    fn tick(
+        root: &str,
+        role: &str,
+        ok: bool,
+        detail: Option<&str>,
+        at: DateTime<Utc>,
+    ) -> RoleTickRecord {
+        RoleTickRecord {
+            root: PathBuf::from(root),
+            role: role.to_string(),
+            at,
+            ok,
+            detail: detail.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn sample_role_tick_health_reports_totals_and_a_persistent_failure() {
+        let now = Utc::now();
+        let records = vec![
+            tick(
+                "/repos/loom",
+                "judge",
+                false,
+                Some("no-token-pool"),
+                now - chrono::Duration::minutes(5),
+            ),
+            tick("/repos/loom", "judge", false, Some("no-token-pool"), now),
+            tick("/repos/loom", "curator", true, None, now),
+        ];
+        let health = sample_role_tick_health(&records);
+        assert_eq!(health.total, 3);
+        assert_eq!(health.ok, 1);
+        assert_eq!(health.persistent.len(), 1);
+        assert_eq!(health.persistent[0].role, "judge");
+        assert_eq!(health.persistent[0].root, PathBuf::from("/repos/loom"));
+        assert_eq!(health.persistent[0].failures, 2);
+        assert_eq!(health.persistent[0].detail.as_deref(), Some("no-token-pool"));
+    }
+
+    #[test]
+    fn sample_role_tick_health_does_not_surface_a_self_recovered_transient_failure() {
+        let now = Utc::now();
+        let records = vec![
+            tick(
+                "/repos/loom",
+                "guide",
+                false,
+                Some("timeout"),
+                now - chrono::Duration::minutes(1),
+            ),
+            // Same pair's latest record is a success — self-recovered, so it
+            // must not appear in `persistent` (mirrors `assess_roles`'s own
+            // transient-vs-persistent rule).
+            tick("/repos/loom", "guide", true, None, now),
+        ];
+        let health = sample_role_tick_health(&records);
+        assert_eq!(health.total, 2);
+        assert_eq!(health.ok, 1);
+        assert!(health.persistent.is_empty());
+    }
+
+    #[test]
+    fn sample_role_tick_health_of_an_empty_ring_reports_zero_ticks_not_an_error() {
+        // The role runner idle or disabled entirely — "no role ticks", not a
+        // degraded state (the Test Plan's edge case).
+        let health = sample_role_tick_health(&[]);
+        assert_eq!(health.total, 0);
+        assert_eq!(health.ok, 0);
+        assert!(health.persistent.is_empty());
+    }
+
+    #[tokio::test]
+    async fn host_health_sample_surfaces_a_persistent_role_tick_failure() {
+        // Integration-level: goes through the real process-global ring
+        // `crate::role_runner::record_role_tick_at` writes to and
+        // `sample_host_health` reads from. A uniquely-named synthetic root
+        // keeps this deterministic despite the ring being shared with every
+        // other test in this binary (there is no `pub(crate)` reset hook
+        // reachable from outside `role_runner`'s own test module) — this
+        // test asserts the fixture's own pair is present, not the ring's
+        // total contents.
+        let root = Path::new("/repos/collector-test-5022-fixture");
+        let outcome = crate::role_runner::RoleTickOutcome::Failure("synthetic failure".to_string());
+        crate::role_runner::record_role_tick_at("judge", root, &outcome, Utc::now());
+
+        let dir = tempfile::tempdir().unwrap();
+        let pool = empty_pool();
+        let record =
+            sample_host_health(dir.path(), Instant::now(), &pool, &mut empty_slug_cache()).await;
+        assert!(
+            record.roles.persistent.iter().any(|f| f.root == root
+                && f.role == "judge"
+                && f.detail.as_deref() == Some("synthetic failure")),
+            "expected the just-recorded persistent failure in {:?}",
+            record.roles.persistent
+        );
+        assert!(record.roles.total > 0);
     }
 
     /// A hermetic, `dispatch()`-able registry: `skip_label_flip = true` skips

--- a/loom-daemon/src/observability/exporter.rs
+++ b/loom-daemon/src/observability/exporter.rs
@@ -517,6 +517,7 @@ mod tests {
                 dispatch_halted: false,
                 halt_reason: None,
                 managed_repos: Vec::new(),
+                roles: crate::telemetry::RoleTickHealth::default(),
             }),
         )
     }

--- a/loom-daemon/src/observability/otlp/mapping.rs
+++ b/loom-daemon/src/observability/otlp/mapping.rs
@@ -313,6 +313,43 @@ fn metric_samples_for(envelope: &TelemetryEnvelope) -> Vec<MetricSample> {
                     ),
                     time_unix_nano,
                 },
+                // Role-tick health (Issue #5022): unlike the CPU/disk probes
+                // below, a role-tick count of zero is a real, known value
+                // (the role runner sampled nothing this snapshot — idle or
+                // disabled), not an unmeasurable probe — so these are
+                // unconditional, like `uptime_seconds`/`logical_cpus` above,
+                // rather than gated behind an `Option`.
+                MetricSample {
+                    name: "loom.host.roles_total_ticks",
+                    description: "Total role-tick records sampled in this host.health snapshot.",
+                    unit: "{tick}",
+                    attributes: Vec::new(),
+                    value: number_data_point::Value::AsInt(
+                        i64::try_from(r.roles.total).unwrap_or(i64::MAX),
+                    ),
+                    time_unix_nano,
+                },
+                MetricSample {
+                    name: "loom.host.roles_ok_ticks",
+                    description:
+                        "Successful role-tick records sampled in this host.health snapshot.",
+                    unit: "{tick}",
+                    attributes: Vec::new(),
+                    value: number_data_point::Value::AsInt(
+                        i64::try_from(r.roles.ok).unwrap_or(i64::MAX),
+                    ),
+                    time_unix_nano,
+                },
+                MetricSample {
+                    name: "loom.host.roles_persistent_failures",
+                    description: "Count of (root, role) pairs with a persistent tick failure.",
+                    unit: "1",
+                    attributes: Vec::new(),
+                    value: number_data_point::Value::AsInt(
+                        i64::try_from(r.roles.persistent.len()).unwrap_or(i64::MAX),
+                    ),
+                    time_unix_nano,
+                },
             ];
             if let Some(cpu_idle_fraction) = r.cpu_idle_fraction {
                 samples.push(MetricSample {
@@ -591,6 +628,17 @@ mod tests {
                 dispatch_halted: false,
                 halt_reason: None,
                 managed_repos: Vec::new(),
+                roles: crate::telemetry::RoleTickHealth {
+                    total: 12,
+                    ok: 10,
+                    persistent: vec![crate::telemetry::RoleTickFailureEntry {
+                        root: std::path::PathBuf::from("/repos/loom"),
+                        role: "judge".to_string(),
+                        failures: 2,
+                        last_at: ts(),
+                        detail: Some("no-token-pool".to_string()),
+                    }],
+                },
             }),
         )
     }
@@ -761,9 +809,55 @@ mod tests {
             "loom.host.cpu_idle_fraction",
             "loom.host.load_per_core",
             "loom.host.worktree_root_free_gb",
+            "loom.host.roles_total_ticks",
+            "loom.host.roles_ok_ticks",
+            "loom.host.roles_persistent_failures",
         ] {
             assert!(names.contains(&expected), "missing metric {expected} in {names:?}");
         }
+    }
+
+    #[test]
+    fn role_tick_health_becomes_gauge_metrics_with_the_persistent_failure_count() {
+        // #5022: `host_health_envelope`'s fixture carries one persistent
+        // failure (judge @ /repos/loom, 2 failed ticks of 12 total, 10 ok).
+        let batch = vec![host_health_envelope()];
+        let request = build_metrics_request(&batch).unwrap();
+        let metrics = &request.resource_metrics[0].scope_metrics[0].metrics;
+        let value_of = |name: &str| -> i64 {
+            let metric = metrics
+                .iter()
+                .find(|m| m.name == name)
+                .unwrap_or_else(|| panic!("missing metric {name}"));
+            let points = match &metric.data {
+                Some(metric::Data::Gauge(gauge)) => &gauge.data_points,
+                other => panic!("expected a Gauge for {name}, got {other:?}"),
+            };
+            match points[0].value {
+                Some(number_data_point::Value::AsInt(v)) => v,
+                ref other => panic!("expected AsInt for {name}, got {other:?}"),
+            }
+        };
+        assert_eq!(value_of("loom.host.roles_total_ticks"), 12);
+        assert_eq!(value_of("loom.host.roles_ok_ticks"), 10);
+        assert_eq!(value_of("loom.host.roles_persistent_failures"), 1);
+    }
+
+    #[test]
+    fn role_tick_health_with_no_ticks_sampled_reports_zero_not_no_metric() {
+        // `total: 0` (role runner idle/disabled) is a known value, not an
+        // unmeasurable probe — it must still produce a data point (0), unlike
+        // `cpu_idle_fraction: None` which produces none at all.
+        let mut record = host_health_envelope();
+        if let TelemetryRecord::HostHealth(r) = &mut record.record {
+            r.roles = crate::telemetry::RoleTickHealth::default();
+        }
+        let batch = vec![record];
+        let request = build_metrics_request(&batch).unwrap();
+        let metrics = &request.resource_metrics[0].scope_metrics[0].metrics;
+        let names: Vec<&str> = metrics.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"loom.host.roles_total_ticks"));
+        assert!(names.contains(&"loom.host.roles_persistent_failures"));
     }
 
     #[test]
@@ -803,6 +897,7 @@ mod tests {
             dispatch_halted: false,
             halt_reason: None,
             managed_repos: Vec::new(),
+            roles: crate::telemetry::RoleTickHealth::default(),
         };
         let batch = vec![envelope(
             "host-c",

--- a/loom-daemon/src/observability/otlp/mod.rs
+++ b/loom-daemon/src/observability/otlp/mod.rs
@@ -315,6 +315,7 @@ mod tests {
                 dispatch_halted: false,
                 halt_reason: None,
                 managed_repos: Vec::new(),
+                roles: crate::telemetry::RoleTickHealth::default(),
             }),
         )
     }

--- a/loom-daemon/src/observability/sender.rs
+++ b/loom-daemon/src/observability/sender.rs
@@ -155,6 +155,7 @@ mod tests {
                 dispatch_halted: false,
                 halt_reason: None,
                 managed_repos: Vec::new(),
+                roles: crate::telemetry::RoleTickHealth::default(),
             }),
         )
     }

--- a/loom-daemon/src/telemetry/mod.rs
+++ b/loom-daemon/src/telemetry/mod.rs
@@ -51,6 +51,7 @@ use chrono::{DateTime, Utc};
 use serde::de::{self, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::fmt;
+use std::path::PathBuf;
 
 pub mod visibility;
 
@@ -434,6 +435,57 @@ pub struct TokenSnapshotRecord {
     pub accounts: Vec<TokenAccountState>,
 }
 
+/// One `(root, role)` pair's persistent tick-failure detail inside a host's
+/// role-tick health summary (`host.health`'s `roles` field, Issue #5022).
+/// Mirrors `crate::health::RoleFailure`'s shape — `loom-daemon health`'s
+/// `roles` section already classifies exactly this
+/// (`crate::health::summarize_role_ticks`), so the telemetry pipeline carries
+/// the same classification rather than inventing a second one.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RoleTickFailureEntry {
+    /// The workspace root this tick ran for.
+    pub root: PathBuf,
+    /// The role name (`champion`, `curator`, …).
+    pub role: String,
+    /// How many ticks failed for this pair inside the sampled window.
+    pub failures: usize,
+    /// When the most recent record for this pair landed.
+    pub last_at: DateTime<Utc>,
+    /// The most recent failure detail, when the tick reported one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// `host.health`'s role-tick health summary (Issue #5022): the same
+/// transient-vs-persistent classification `loom-daemon health`'s `roles`
+/// section already computes (`crate::health::summarize_role_ticks`), carried
+/// through the telemetry pipeline so a role dying on one host is observable
+/// fleet-wide — not only to an operator who happens to run `loom-daemon
+/// health` locally on that one host. That gap is exactly what #5004 found: a
+/// Judge outage stayed green on every other signal for most of a day.
+///
+/// Deliberately narrower than `crate::health::RoleTickSummary`: only
+/// `persistent` failures are carried — the `(root, role)` pairs whose most
+/// recent tick in the sampled window is still a failure, i.e. the ones that
+/// make `loom-daemon health`'s `roles` section report `DEGRADED`. `transient`
+/// (self-recovered) pairs are folded into `total`/`ok` like every other tick,
+/// exactly as the rendered `roles` summary line already treats them: a count,
+/// not alarming detail.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct RoleTickHealth {
+    /// Total tick records sampled.
+    pub total: usize,
+    /// Successful tick records sampled.
+    pub ok: usize,
+    /// `(root, role)` pairs whose latest sampled record is a failure.
+    ///
+    /// `total: 0` (no ticks sampled — the role runner idle or disabled) means
+    /// "nothing to report", not "healthy": a consumer must not read an empty
+    /// `persistent` list on its own as proof the role runner is even running.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub persistent: Vec<RoleTickFailureEntry>,
+}
+
 /// `host.health` — host CPU/disk headroom plus the emitting binary's identity
 /// (version + build commit + build time) and uptime.
 /// Host-level: it references no repository, so it carries no visibility tag.
@@ -532,6 +584,17 @@ pub struct HostHealthRecord {
     /// backward-compatibility contract `active_sweep_ids` established.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub managed_repos: Vec<ManagedRepoEntry>,
+    /// This host's role-tick health (Issue #5022): mirrors `loom-daemon
+    /// health`'s `roles` section verdict inputs, carried through the
+    /// telemetry pipeline so a role dying on one host is observable
+    /// fleet-wide rather than only to an operator running `loom-daemon
+    /// health` locally on that host.
+    ///
+    /// `#[serde(default)]` so a record from a pre-#5022 daemon still decodes
+    /// (as the zero-value "no role ticks sampled" summary) rather than
+    /// failing the whole envelope.
+    #[serde(default)]
+    pub roles: RoleTickHealth,
 }
 
 /// One repository this host's daemon is currently managing (Issue #4976) —
@@ -682,6 +745,17 @@ mod tests {
                     visibility: RepoVisibility::Private,
                 },
             ],
+            roles: RoleTickHealth {
+                total: 12,
+                ok: 10,
+                persistent: vec![RoleTickFailureEntry {
+                    root: PathBuf::from("/repos/loom"),
+                    role: "judge".to_string(),
+                    failures: 2,
+                    last_at: ts(),
+                    detail: Some("no-token-pool".to_string()),
+                }],
+            },
         })
     }
 
@@ -906,6 +980,7 @@ mod tests {
             dispatch_halted: false,
             halt_reason: None,
             managed_repos: Vec::new(),
+            roles: RoleTickHealth::default(),
         });
         let value = serde_json::to_value(&record).unwrap();
         assert!(
@@ -999,6 +1074,7 @@ mod tests {
             dispatch_halted: false,
             halt_reason: None,
             managed_repos: Vec::new(),
+            roles: RoleTickHealth::default(),
         });
         let value = serde_json::to_value(&record).unwrap();
         assert!(
@@ -1036,5 +1112,91 @@ mod tests {
         let decoded: ManagedRepoEntry = serde_json::from_str(json).unwrap();
         assert_eq!(decoded.visibility, RepoVisibility::Private);
         assert_eq!(decoded.slug, "owner/repo");
+    }
+
+    // ------------------------------------------------------------------
+    // host.health role-tick health (#5022).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn host_health_serializes_role_tick_health_persistent_failures() {
+        let value = serde_json::to_value(host_health()).unwrap();
+        let roles = value.get("roles").unwrap();
+        assert_eq!(roles.get("total").and_then(serde_json::Value::as_u64), Some(12));
+        assert_eq!(roles.get("ok").and_then(serde_json::Value::as_u64), Some(10));
+        let persistent = roles
+            .get("persistent")
+            .and_then(serde_json::Value::as_array)
+            .unwrap();
+        assert_eq!(persistent.len(), 1);
+        assert_eq!(
+            persistent[0]
+                .get("role")
+                .and_then(serde_json::Value::as_str),
+            Some("judge")
+        );
+        assert_eq!(
+            persistent[0]
+                .get("detail")
+                .and_then(serde_json::Value::as_str),
+            Some("no-token-pool")
+        );
+    }
+
+    #[test]
+    fn host_health_omits_persistent_when_empty_but_still_carries_roles() {
+        // A `total: 0` (or all-ok) summary must still be sent — "no role
+        // ticks sampled" / "every tick ok" is meaningful information, not
+        // nothing to report — but its empty `persistent` list is omitted from
+        // the wire, mirroring `managed_repos`/`active_sweep_ids`.
+        let record = TelemetryRecord::HostHealth(HostHealthRecord {
+            captured_at: ts(),
+            daemon_version: "0.17.0".to_string(),
+            build_commit: "unknown".to_string(),
+            built_at: None,
+            uptime_sec: 1,
+            logical_cpus: 4,
+            cpu_idle_fraction: None,
+            load_per_core: None,
+            worktree_root_free_gb: None,
+            active_sweep_ids: Vec::new(),
+            dispatch_halted: false,
+            halt_reason: None,
+            managed_repos: Vec::new(),
+            roles: RoleTickHealth {
+                total: 5,
+                ok: 5,
+                persistent: Vec::new(),
+            },
+        });
+        let value = serde_json::to_value(&record).unwrap();
+        let roles = value.get("roles").unwrap();
+        assert_eq!(roles.get("total").and_then(serde_json::Value::as_u64), Some(5));
+        assert!(roles.get("persistent").is_none());
+        let decoded: TelemetryRecord = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn host_health_from_a_pre_5022_daemon_decodes_with_a_zero_value_roles_summary() {
+        // Backward compatibility: a record emitted by a daemon that predates
+        // role-tick health must decode with the zero-value ("nothing sampled")
+        // summary, never fail the whole envelope.
+        let json = r#"{
+            "kind": "host.health",
+            "captured_at": "2026-07-30T12:00:00Z",
+            "daemon_version": "0.16.0",
+            "uptime_sec": 86400,
+            "logical_cpus": 28
+        }"#;
+        let decoded: TelemetryRecord = serde_json::from_str(json).unwrap();
+        match decoded {
+            TelemetryRecord::HostHealth(r) => {
+                assert_eq!(r.roles, RoleTickHealth::default());
+                assert_eq!(r.roles.total, 0);
+                assert!(r.roles.persistent.is_empty());
+            }
+            other => panic!("expected HostHealth, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Role-tick health (`loom-daemon health`'s `roles` section) never left the
host: `HostHealthRecord` had no field for it, so a role dying on one host was
invisible fleet-wide except to an operator running `loom-daemon health`
locally on that host — the exact gap #5004 found during a 2026-08-03 Judge
outage that stayed green on every other signal for most of a day.

This is sub-issue 2 of 4 from the #5004 decomposition (gap 2 of 4).

## Changes

**Backend (`loom-daemon`)**
- `telemetry/mod.rs`: new `RoleTickHealth` / `RoleTickFailureEntry` wire
  types; `HostHealthRecord.roles` field (`#[serde(default)]`, backward
  compatible with pre-#5022 records).
- `observability/collector.rs`: `sample_role_tick_health` samples
  `role_tick_records()` and reuses `crate::health::summarize_role_ticks` (the
  same transient-vs-persistent classifier `loom-daemon health`'s `roles`
  section already computes) so the telemetry pipeline and the CLI can never
  disagree about which `(root, role)` pairs are persistently failing.
- `observability/otlp/mapping.rs`: three new unconditional gauges
  (`loom.host.roles_total_ticks`, `roles_ok_ticks`, `roles_persistent_failures`)
  — unconditional because a role-tick count of zero is a real known value
  (idle/disabled role runner), not an unmeasurable probe.
- `exporter.rs` / `otlp/mod.rs` / `sender.rs`: no logic changes — these
  forward the whole envelope/record already; just updated test fixtures.

**Dashboard backend (`dashboard/src`)**
- `redaction.ts`: added `roles` to `host.health`'s public-view field
  allowlist — it names a role and a local workspace path, never a repo,
  issue, branch, or operator, same reasoning as `dispatch_halted`/`halt_reason`.

**Dashboard frontend (`dashboard/web`)**
- `types.ts` / `parse.ts`: `RoleTickHealth`/`RoleTickFailure` types + parsing,
  following the existing "unknown != zero, never fabricate" contract.
- `fleet.ts`: a persistent role-tick failure now feeds `distressReason` (same
  priority tier as `dispatch_halted`), so a host with `roles: degraded` badges
  `degraded` and is visually distinguishable from a healthy host.
- `format.ts`: `roleTickSummaryText` (full, host-detail) / `roleTickCompactText`
  (compact, fleet-overview card) / `roleFailureLabel` (mirrors the daemon's
  own `RoleFailure::label()`).
- `views/hostDetail.ts` / `views/fleetOverview.ts`: render the summary/compact
  indicator.

**Docs**: `.loom/docs/telemetry-schema.md` documents the new `roles` field
alongside the rest of `host.health`.

## Test plan

- [x] Rust unit tests: `sample_role_tick_health` against a hand-built
  `RoleTickRecord` fixture with a persistent failure (and a self-recovered
  transient one, and an empty ring); an integration-level `sample_host_health`
  test through the real process-global ring.
- [x] OTLP mapping tests for the three new gauges, including the
  `total: 0` / no-metric-is-none-for-a-real-zero case.
- [x] Dashboard `parse.ts`/`fleet.ts`/`format.ts`/`hostDetail`/`fleetOverview`
  tests: parsing, degraded-status classification, and rendering, including
  the "roles: green" / "total: 0" edge cases from the issue's Test Plan.
- [x] `dashboard/test/redaction.test.ts`: `roles` survives public redaction
  unchanged.
- [x] `cargo test --lib --features otlp` (loom-daemon): full pass except two
  pre-existing, host-environment-dependent flakes unrelated to this diff
  (`daemon_install_state`/`worktree_reaper` tests that pass in isolation but
  race with a real `loom-daemon` process on this host under full-suite
  parallelism — confirmed pre-existing, not touched by this PR).
- [x] `npm test` / `npm run typecheck` in both `dashboard/web` and `dashboard`
  (backend Worker + frontend): all pass.
- [x] `cargo fmt --check` / `cargo clippy --lib --tests --features otlp -- -D warnings`: clean.

Closes #5022