### PR TITLE
fix(daemon): cap and ANSI-strip role-tick failure detail before it hits roles.summary

### DIFF
--- a/loom-daemon/src/health.rs
+++ b/loom-daemon/src/health.rs
@@ -68,6 +68,7 @@ use serde::Serialize;
 
 use crate::daemon_install_state::{InstallState, InstallStateReport};
 use crate::pipeline_snapshot::RepoPipelineSnapshot;
+use crate::script_helpers::log_filter::strip_ansi;
 use crate::types::{DaemonStatusReport, RoleTickRecord};
 
 // ============================================================================
@@ -470,6 +471,30 @@ pub struct RoleTickSummary {
 ///
 /// Records at or after `since` are considered; the rest are ignored. Both
 /// output lists are sorted by `(root, role)` for stable rendering.
+/// Max characters of a [`RoleFailure::detail`] retained in the **structured**
+/// (non-summary) health output (issue #5024). `RoleTickRecord.detail` is
+/// already ANSI-stripped and capped at the source by
+/// `role_runner::clean_and_cap_detail`, but [`summarize_role_ticks`] cleans
+/// it again here defensively — any future code path that lands a raw,
+/// ANSI-laden `RoleTickRecord` (a differently-sourced failure, a replayed
+/// record from an older binary, …) still cannot leak escapes or an unbounded
+/// blob into `health --json`'s `roles.persistent[].detail` field. Deliberately
+/// more generous than the tighter per-item cap folded into the one-line
+/// `roles.summary` string (see `assess_roles`'s `MAX_SUMMARY_DETAIL_CHARS`) —
+/// this is the fuller detail a `--json` consumer actually wants.
+const MAX_STRUCTURED_DETAIL_CHARS: usize = 1000;
+
+/// ANSI-strip and length-cap `detail` for storage in [`RoleFailure::detail`].
+fn clean_structured_detail(detail: &str) -> String {
+    let cleaned = strip_ansi(detail);
+    let cleaned = cleaned.trim();
+    if cleaned.chars().count() <= MAX_STRUCTURED_DETAIL_CHARS {
+        return cleaned.to_string();
+    }
+    let capped: String = cleaned.chars().take(MAX_STRUCTURED_DETAIL_CHARS).collect();
+    format!("{capped}… [truncated]")
+}
+
 #[must_use]
 pub fn summarize_role_ticks(records: &[RoleTickRecord], since: DateTime<Utc>) -> RoleTickSummary {
     // BTreeMap keyed by (root, role) so the output order is deterministic.
@@ -508,14 +533,18 @@ pub fn summarize_role_ticks(records: &[RoleTickRecord], since: DateTime<Utc>) ->
             .iter()
             .rev()
             .find(|r| !r.ok)
-            .and_then(|r| r.detail.clone());
+            .and_then(|r| r.detail.as_deref())
+            .map(clean_structured_detail);
         // Escalation streak (#5023): count the trailing run of consecutive
         // failures whose `detail` is byte-identical to the latest record's, from
         // newest backward. A success — or a failure carrying a *different*
         // detail — breaks the run, so this is `0` for a transient pair (latest
         // is a success) and resets to `0` the moment a persistent pair recovers.
         // Exact-string comparison is the deliberate basis (see
-        // `ROLE_TICK_ESCALATION_THRESHOLD`).
+        // `ROLE_TICK_ESCALATION_THRESHOLD`). Deliberately compares the *raw*
+        // record details rather than the cleaned/capped `detail` above (#5024):
+        // capping could make two genuinely different failures compare equal
+        // once truncated, inflating the streak.
         let consecutive_identical = if latest.ok {
             0
         } else {
@@ -1096,6 +1125,46 @@ pub fn assess_tokens(inputs: &HealthInputs) -> HealthSection {
     )
 }
 
+/// Max characters of a single failure's detail folded into the one-line
+/// `roles.summary` string (issue #5024). The full detail — already
+/// ANSI-stripped and capped at the source by
+/// `role_runner::clean_and_cap_detail` — still lives in the structured
+/// `persistent[].detail` field of the section's JSON payload; only the
+/// *summary line* gets this tighter cap so N simultaneously-failing
+/// `(root, role)` pairs cannot multiply the line's length (the 2026-08-03
+/// 12-repo outage produced a tens-of-kilobytes summary line before this fix).
+const MAX_SUMMARY_DETAIL_CHARS: usize = 60;
+
+/// Hard cap on the fully-assembled `roles.summary` line, applied after
+/// joining every persistent failure's (already-capped) detail. A second line
+/// of defense: even if a future code path folds many failures/details into
+/// one line without going through [`MAX_SUMMARY_DETAIL_CHARS`], the summary
+/// line itself still cannot grow unbounded.
+const MAX_ROLES_SUMMARY_LINE_CHARS: usize = 2000;
+
+/// ANSI-strip (defensive — the detail should already be clean from the
+/// source) and length-cap `detail` for inline use in the `roles.summary`
+/// line.
+fn summary_detail(detail: &str) -> String {
+    let cleaned = strip_ansi(detail);
+    let cleaned = cleaned.trim();
+    if cleaned.chars().count() <= MAX_SUMMARY_DETAIL_CHARS {
+        return cleaned.to_string();
+    }
+    let capped: String = cleaned.chars().take(MAX_SUMMARY_DETAIL_CHARS).collect();
+    format!("{capped}…")
+}
+
+/// Cap the fully-assembled `roles.summary` line length (see
+/// [`MAX_ROLES_SUMMARY_LINE_CHARS`]).
+fn cap_summary_line(line: String) -> String {
+    if line.chars().count() <= MAX_ROLES_SUMMARY_LINE_CHARS {
+        return line;
+    }
+    let capped: String = line.chars().take(MAX_ROLES_SUMMARY_LINE_CHARS).collect();
+    format!("{capped}… [truncated]")
+}
+
 /// Assess the role-tick section: only *persistent* failures surface; transient
 /// (self-recovered) ones are reported as a count so they are visible without
 /// being alarming.
@@ -1161,19 +1230,22 @@ pub fn assess_roles(inputs: &HealthInputs) -> HealthSection {
             .persistent
             .iter()
             .map(|f| {
-                let detail = f.detail.as_deref().unwrap_or("failed");
+                let detail = f
+                    .detail
+                    .as_deref()
+                    .map_or_else(|| "failed".to_string(), summary_detail);
                 format!("{} ({} ticks, {detail})", f.label(), f.failures)
             })
             .collect();
         (
             Verdict::Degraded,
-            format!(
+            cap_summary_line(format!(
                 "{}/{} ticks ok; {} PERSISTENT failure(s): {}{escalated_note}{transient_note}",
                 summary.ok,
                 summary.total,
                 summary.persistent.len(),
                 names.join(", ")
-            ),
+            )),
         )
     };
     HealthSection::new(
@@ -2569,7 +2641,8 @@ mod tests {
     // ------- Escalation on N consecutive identical failures (#5023) -------
 
     /// A failure record with an explicit `detail`, for the identical-vs-varying
-    /// tests (the plain `record` helper always uses `"boom"`).
+    /// escalation tests (#5023) and the summary-bounding tests (#5024) — the
+    /// plain `record` helper always uses `"boom"`.
     fn record_detail(role: &str, root: &str, ago_secs: i64, detail: &str) -> RoleTickRecord {
         RoleTickRecord {
             root: PathBuf::from(root),
@@ -2675,6 +2748,89 @@ mod tests {
         // The escalated subset is machine-readable for --json / dashboard
         // consumers (#5022 will export it externally).
         assert_eq!(section.detail["escalated"].as_array().map(Vec::len), Some(1));
+    }
+
+    // -- roles.summary bounding + ANSI cleanup (#5024) ----------------------
+
+    #[test]
+    fn roles_summary_line_stays_bounded_for_an_oversized_ansi_laden_detail() {
+        let mut inputs = healthy_inputs();
+        let noisy = format!("\x1b[31m{}\x1b[0m", "x".repeat(20_000));
+        inputs.status.as_mut().unwrap().role_tick_records =
+            vec![record_detail("curator", "/r/loom", 60, &noisy)];
+
+        let section = assess_roles(&inputs);
+
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(
+            section.summary.chars().count() <= MAX_ROLES_SUMMARY_LINE_CHARS + 100,
+            "summary line was not bounded: {} chars",
+            section.summary.chars().count()
+        );
+        assert!(
+            !section.summary.contains('\u{1b}'),
+            "summary line still contains a raw ANSI escape byte"
+        );
+    }
+
+    #[test]
+    fn roles_summary_line_does_not_multiply_with_many_simultaneous_failures() {
+        // The 2026-08-03 12-repo outage: every repo fails identically with a
+        // large detail. The summary line must stay bounded regardless of how
+        // many `(root, role)` pairs are failing at once.
+        let noisy = format!("\x1b[31m{}\x1b[0m", "boom ".repeat(2000));
+        let mut inputs = healthy_inputs();
+        inputs.status.as_mut().unwrap().role_tick_records = (0..12)
+            .map(|i| record_detail("curator", &format!("/r/repo{i}"), 60, &noisy))
+            .collect();
+
+        let section = assess_roles(&inputs);
+
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("12 PERSISTENT failure(s)"));
+        assert!(
+            section.summary.chars().count() <= MAX_ROLES_SUMMARY_LINE_CHARS + 100,
+            "summary line was not bounded across 12 failures: {} chars",
+            section.summary.chars().count()
+        );
+    }
+
+    #[test]
+    fn roles_structured_detail_still_carries_the_capped_cleaned_content() {
+        let mut inputs = healthy_inputs();
+        let noisy = format!("\x1b[31m{}\x1b[0m", "x".repeat(200));
+        inputs.status.as_mut().unwrap().role_tick_records =
+            vec![record_detail("curator", "/r/loom", 60, &noisy)];
+
+        let section = assess_roles(&inputs);
+
+        // The summary line is bounded/short...
+        assert!(section.summary.chars().count() < noisy.chars().count());
+        // ...but the structured `detail` field still carries the (ANSI-clean)
+        // failure content — moved out of the summary line, not dropped.
+        let structured_detail = section.detail["persistent"][0]["detail"]
+            .as_str()
+            .expect("persistent[0].detail should be a string");
+        assert!(structured_detail.contains('x'));
+        assert!(
+            !structured_detail.contains('\u{1b}'),
+            "structured detail should not carry raw ANSI escapes: {structured_detail:?}"
+        );
+    }
+
+    #[test]
+    fn roles_summary_detail_round_trips_short_clean_text_unchanged() {
+        let mut inputs = healthy_inputs();
+        inputs.status.as_mut().unwrap().role_tick_records = vec![record_detail(
+            "curator",
+            "/r/loom",
+            60,
+            "connection refused",
+        )];
+
+        let section = assess_roles(&inputs);
+
+        assert!(section.summary.contains("connection refused"));
     }
 
     // ===================================================================

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -83,6 +83,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 use std::time::{Duration, Instant};
 
+use crate::script_helpers::log_filter::strip_ansi;
 use crate::sweep_registry::{self, SweepRegistryConfig};
 use crate::types::RoleTickRecord;
 use crate::workspace_registry::{filter_missing_roots, WorkspaceRegistry};
@@ -119,6 +120,27 @@ const TERMINATE_GRACE: Duration = Duration::from_secs(5);
 
 /// Max bytes of captured invocation output retained in a failure log line.
 const MAX_OUTPUT_TAIL_BYTES: usize = 2048;
+
+/// Max characters of failure detail retained after ANSI-stripping and
+/// cleanup (issue #5024). Bounds `RoleTickOutcome::Failure`'s reason string —
+/// and therefore `RoleTickRecord.detail` — so a single failing invocation's
+/// raw log tail (which can still carry ANSI escapes, banners, and multi-line
+/// stderr even after [`MAX_OUTPUT_TAIL_BYTES`] truncation) cannot blow up the
+/// `roles.summary` health line downstream. See `health::assess_roles`, which
+/// folds every persistent failure's detail into one line.
+const MAX_FAILURE_DETAIL_CHARS: usize = 500;
+
+/// ANSI-strip and length-cap `text` for use as a `RoleTickOutcome::Failure`
+/// reason. Reuses [`strip_ansi`] rather than reimplementing ANSI stripping
+/// (issue #5024).
+fn clean_and_cap_detail(text: &str) -> String {
+    let cleaned = strip_ansi(text).trim().to_string();
+    if cleaned.chars().count() <= MAX_FAILURE_DETAIL_CHARS {
+        return cleaned;
+    }
+    let capped: String = cleaned.chars().take(MAX_FAILURE_DETAIL_CHARS).collect();
+    format!("{capped}… [truncated]")
+}
 
 /// A `Success` outcome faster than this is implausible for a real
 /// `claude -p "/<role>"` session — starting the process, authenticating, and
@@ -766,7 +788,7 @@ fn run_role_with_timeout(
         match child.try_wait() {
             Ok(Some(status)) if status.success() => return RoleTickOutcome::Success,
             Ok(Some(status)) => {
-                let tail = tail_of_file(&log_path);
+                let tail = clean_and_cap_detail(&tail_of_file(&log_path));
                 return RoleTickOutcome::Failure(format!(
                     "`{}` exited with {status}: {tail}",
                     script.display()
@@ -2089,6 +2111,35 @@ mod tests {
     fn write_config(root: &Path, contents: &str) {
         fs::create_dir_all(root.join(".loom")).unwrap();
         fs::write(root.join(".loom").join("config.json"), contents).unwrap();
+    }
+
+    // -- clean_and_cap_detail (#5024) ---------------------------------------
+
+    #[test]
+    fn clean_and_cap_detail_strips_ansi_and_trims() {
+        let raw = "\x1b[31merror:\x1b[0m something failed\n";
+        assert_eq!(clean_and_cap_detail(raw), "error: something failed");
+    }
+
+    #[test]
+    fn clean_and_cap_detail_round_trips_short_clean_text_unchanged() {
+        let raw = "exit code 1: connection refused";
+        assert_eq!(clean_and_cap_detail(raw), raw);
+    }
+
+    #[test]
+    fn clean_and_cap_detail_caps_oversized_text() {
+        let raw = "x".repeat(MAX_FAILURE_DETAIL_CHARS * 4);
+        let cleaned = clean_and_cap_detail(&raw);
+        // Capped body + a short "… [truncated]" marker — bound generously
+        // above MAX_FAILURE_DETAIL_CHARS so the assertion doesn't hardcode
+        // the marker's exact byte/char width.
+        assert!(
+            cleaned.chars().count() <= MAX_FAILURE_DETAIL_CHARS + 32,
+            "cleaned detail was not capped: {} chars",
+            cleaned.chars().count()
+        );
+        assert!(cleaned.ends_with("[truncated]"));
     }
 
     /// RAII guard that clears the ambient `LOOM_RUNTIME` env var for the


### PR DESCRIPTION
## Summary

Role-runner invocation failures embedded the raw `claude-wrapper` log tail
(ANSI escapes, banners, full stderr) verbatim as the failure reason. That
string became `RoleTickRecord.detail`, and `health::assess_roles` folded
every persistent failure's detail straight into the one-line `roles.summary`
string. During the 2026-08-03 12-repo outage the `roles` summary alone was
tens of kilobytes and truncated mid-escape-sequence — this closes gap 4/4 of
the #5004 decomposition.

## Changes

- `loom-daemon/src/role_runner.rs`: added `clean_and_cap_detail`, which
  reuses the existing `strip_ansi` helper (`script_helpers/log_filter.rs`)
  and caps failure detail to 500 chars. Applied it to the exit-status branch
  that builds `RoleTickOutcome::Failure` from `tail_of_file(&log_path)`.
- `loom-daemon/src/health.rs`:
  - `summarize_role_ticks` now defensively re-cleans/caps each `RoleFailure`'s
    structured `detail` (1000 chars) independent of the source, so `health
    --json`'s `roles.persistent[].detail` field can never carry raw ANSI or
    an unbounded blob even if a future code path bypasses the source-level
    cleaning.
  - `assess_roles` caps each failure's contribution to the one-line
    `roles.summary` string to 60 chars (`MAX_SUMMARY_DETAIL_CHARS`) and adds
    a 2000-char hard cap on the fully-assembled line
    (`MAX_ROLES_SUMMARY_LINE_CHARS`) as a second line of defense — the
    `{ok}/{total} ticks ok; {N} PERSISTENT failure(s): {names}` format is
    unchanged, only the per-failure free-text detail is capped/cleaned.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `roles.summary` stays a single bounded line regardless of how many repos are failing or how large their log tails are | ✅ | New tests `roles_summary_line_stays_bounded_for_an_oversized_ansi_laden_detail` (20k-char ANSI-laden detail) and `roles_summary_line_does_not_multiply_with_many_simultaneous_failures` (12 simultaneously-failing repos, mirroring the outage) both assert the summary stays under `MAX_ROLES_SUMMARY_LINE_CHARS` |
| Raw per-failure detail is ANSI-stripped and length-capped before being stored in `RoleTickRecord.detail` / surfaced in the structured `detail` field — not dropped, just moved out of the summary line | ✅ | `role_runner::clean_and_cap_detail` cleans at the source; `health::clean_structured_detail` re-cleans defensively for the structured field. New test `roles_structured_detail_still_carries_the_capped_cleaned_content` asserts the structured `persistent[0].detail` still contains the (ANSI-clean) content |
| `{ok}/{total} ticks ok; {N} PERSISTENT failure(s): {names}` summary format is preserved for the *names* list; only per-failure free-text detail is capped/cleaned | ✅ | Format string unchanged in `assess_roles`; existing tests `only_persistent_failures_make_the_roles_section_degraded` and `a_failure_that_is_still_the_latest_record_is_persistent` still pass unmodified |

## Test Plan

- `cargo test --lib -- health:: role_runner::` — 170 passed, 0 failed (includes 3 new `clean_and_cap_detail` unit tests in `role_runner.rs` and 4 new tests in `health.rs`: oversized/ANSI-laden bounding, many-simultaneous-failures bounding, structured-detail retention, and short/clean round-trip)
- `cargo check --lib` — clean
- `cargo clippy --lib -- -D warnings` — clean
- `cargo fmt -- --check` — clean
- Edge cases covered: short/clean detail round-trips unchanged (`roles_summary_detail_round_trips_short_clean_text_unchanged`, `clean_and_cap_detail_round_trips_short_clean_text_unchanged`); 12 simultaneous persistent failures don't multiply the summary length

Closes #5024