### PR TITLE
fix(daemon): hold sweep dispatch to a workspace whose pre-flight advisory is tripped (#5030)

### DIFF
--- a/loom-daemon/src/sweep_registry/mod.rs
+++ b/loom-daemon/src/sweep_registry/mod.rs
@@ -503,6 +503,15 @@ pub struct SweepRegistry {
     /// [`Event::PreflightAdvisory`] fires only on a state-change transition,
     /// never every tick.
     preflight_advisory_tripped: bool,
+    /// Half-open recovery-probe clock for the dispatch breaker (Issue #5030).
+    /// While [`preflight_advisory_tripped`](Self::preflight_advisory_tripped) is
+    /// `true`, [`preflight_dispatch_gate`](Self::preflight_dispatch_gate) holds
+    /// new dispatch to this workspace except for one probe dispatch per
+    /// [`PreflightTripwireConfig::probe_cooldown`]; this records when the last
+    /// probe (or the first tick observing the trip) was let through. Cleared
+    /// back to `None` the moment the advisory un-trips, so a freshly re-tripped
+    /// advisory always waits a full cooldown before its first probe.
+    preflight_probe_last_at: Option<DateTime<Utc>>,
     /// Per-issue dispatch-backoff parameters (Issue #4485). `main.rs` /
     /// [`crate::workspace_pool::WorkspacePool`] set the resolved env > config >
     /// default value at provision time, mirroring
@@ -707,6 +716,7 @@ impl SweepRegistry {
             preflight_death_streak: 0,
             preflight_death_last_marker: None,
             preflight_advisory_tripped: false,
+            preflight_probe_last_at: None,
             dispatch_backoff_config: DispatchBackoffConfig::default(),
             dispatch_backoff: HashMap::new(),
             label_flip_log: HashMap::new(),
@@ -749,6 +759,7 @@ impl SweepRegistry {
             preflight_death_streak: 0,
             preflight_death_last_marker: None,
             preflight_advisory_tripped: false,
+            preflight_probe_last_at: None,
             dispatch_backoff_config: DispatchBackoffConfig::default(),
             dispatch_backoff: HashMap::new(),
             label_flip_log: HashMap::new(),

--- a/loom-daemon/src/sweep_registry/quarantine.rs
+++ b/loom-daemon/src/sweep_registry/quarantine.rs
@@ -118,6 +118,39 @@ pub const PREFLIGHT_TRIPWIRE_THRESHOLD_ENV: &str = "LOOM_PREFLIGHT_TRIPWIRE_THRE
 /// advisory trips (#4386).
 pub const DEFAULT_PREFLIGHT_TRIPWIRE_THRESHOLD: u32 = 3;
 
+/// Env var overriding the half-open probe cooldown, in seconds (Issue #5030).
+/// A zero/invalid value falls through to config/default.
+pub const PREFLIGHT_PROBE_COOLDOWN_ENV: &str = "LOOM_PREFLIGHT_PROBE_COOLDOWN_SECS";
+
+/// Default cooldown between recovery probe dispatches once the pre-flight
+/// advisory is tripped (Issue #5030). While tripped, the dispatch breaker holds
+/// new dispatch to the broken workspace but lets exactly one probe dispatch
+/// through per cooldown to test recovery (half-open) — since the advisory only
+/// clears after a dispatch *succeeds*, an unconditional hold would prevent the
+/// very dispatch needed to prove the break is fixed. 15 minutes matches
+/// [`DEFAULT_DISPATCH_BACKOFF_MAX_SECS`](crate::sweep_registry::DEFAULT_DISPATCH_BACKOFF_MAX_SECS),
+/// the ceiling of the per-issue backoff, so a still-broken workspace burns at
+/// most one ~1s pre-flight death per 15 minutes instead of one every tick.
+pub const DEFAULT_PREFLIGHT_PROBE_COOLDOWN_SECS: u64 = 900;
+
+/// The recovery-probe gate decision for one workspace's dispatch admission
+/// (Issue #5030), returned by
+/// [`SweepRegistry::preflight_dispatch_gate`](crate::sweep_registry::SweepRegistry::preflight_dispatch_gate).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreflightDispatchGate {
+    /// The advisory is not tripped — dispatch normally (the common case).
+    Open,
+    /// The advisory is tripped and the cooldown since the last probe has not
+    /// yet elapsed — hold all new dispatch to this workspace this tick.
+    Held,
+    /// The advisory is tripped but the cooldown has elapsed — let this tick's
+    /// dispatch through as a half-open recovery probe. A dispatch that reaches
+    /// `# CLAUDE_CLI_START` clears the advisory automatically (no operator
+    /// action); one that dies at pre-flight again re-holds until the next
+    /// cooldown.
+    Probe,
+}
+
 /// Resolved pre-flight-death tripwire parameters (Issue #4386), set on the
 /// registry at construction so [`SweepRegistry::reap_once`] can enforce it
 /// without a per-tick config read. Mirrors [`QuarantineConfig`]'s shape.
@@ -126,12 +159,15 @@ pub struct PreflightTripwireConfig {
     /// Consecutive cross-issue pre-flight deaths before the workspace
     /// advisory trips.
     pub threshold: u32,
+    /// Cooldown between half-open recovery probes once tripped (Issue #5030).
+    pub probe_cooldown: Duration,
 }
 
 impl Default for PreflightTripwireConfig {
     fn default() -> Self {
         Self {
             threshold: DEFAULT_PREFLIGHT_TRIPWIRE_THRESHOLD,
+            probe_cooldown: Duration::from_secs(DEFAULT_PREFLIGHT_PROBE_COOLDOWN_SECS),
         }
     }
 }
@@ -149,6 +185,18 @@ pub(crate) fn read_preflight_tripwire_file_threshold(repo_root: &Path) -> Option
         .and_then(|n| u32::try_from(n).ok())
 }
 
+/// Read `.loom/config.json → autonomous.workFinder.preflightTripwire.probeCooldownSecs`
+/// (Issue #5030), soft-failing to `None` — mirrors
+/// [`read_preflight_tripwire_file_threshold`].
+#[must_use]
+pub(crate) fn read_preflight_probe_cooldown_secs(repo_root: &Path) -> Option<u64> {
+    let effective = crate::config_resolver::resolve_effective_config(repo_root);
+    crate::config_resolver::get_path(&effective, "autonomous.workFinder.preflightTripwire")
+        .and_then(|c| c.get("probeCooldownSecs"))
+        .and_then(serde_json::Value::as_u64)
+        .filter(|&n| n > 0)
+}
+
 /// Resolve the full [`PreflightTripwireConfig`] for `repo_root` with
 /// precedence **env > config > default** (Issue #4386), mirroring
 /// [`resolve_quarantine_config`].
@@ -160,7 +208,16 @@ pub fn resolve_preflight_tripwire_config(repo_root: &Path) -> PreflightTripwireC
         .filter(|&n| n > 0)
         .or_else(|| read_preflight_tripwire_file_threshold(repo_root))
         .unwrap_or(DEFAULT_PREFLIGHT_TRIPWIRE_THRESHOLD);
-    PreflightTripwireConfig { threshold }
+    let probe_cooldown_secs = std::env::var(PREFLIGHT_PROBE_COOLDOWN_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .or_else(|| read_preflight_probe_cooldown_secs(repo_root))
+        .unwrap_or(DEFAULT_PREFLIGHT_PROBE_COOLDOWN_SECS);
+    PreflightTripwireConfig {
+        threshold,
+        probe_cooldown: Duration::from_secs(probe_cooldown_secs),
+    }
 }
 
 // ============================================================================
@@ -608,6 +665,13 @@ impl SweepRegistry {
             return;
         }
         self.preflight_advisory_tripped = should_trip;
+        if !should_trip {
+            // Advisory cleared (a dispatch reached CLI start): reset the
+            // half-open probe clock so if the workspace breaks again later, the
+            // breaker waits a full cooldown before its first recovery probe
+            // rather than re-probing off a stale timestamp (#5030).
+            self.preflight_probe_last_at = None;
+        }
         let marker = self.preflight_death_last_marker.clone().unwrap_or_default();
         let message = if should_trip {
             self.preflight_advisory_message(pool_exhausted_now, &marker)
@@ -639,6 +703,66 @@ impl SweepRegistry {
             marker,
             message,
         });
+    }
+
+    /// The dispatch breaker's admission decision for THIS workspace this tick
+    /// (Issue #5030) — the half-open recovery mechanism that keeps a broken
+    /// workspace from burning every dispatch slot on doomed ~1s pre-flight
+    /// deaths.
+    ///
+    /// # Why a breaker is needed here
+    ///
+    /// [`update_preflight_advisory`](Self::update_preflight_advisory) already
+    /// trips [`preflight_advisory_tripped`](Self::preflight_advisory_tripped)
+    /// after `threshold` consecutive claude-wrapper pre-flight deaths, but until
+    /// #5030 nothing in the dispatch-admission path read it: the work-finder
+    /// kept launching *different* queued issues into the same dead pre-flight
+    /// check, each dying instantly and freeing the slot for the next. This gate
+    /// lets the work-finder hold new dispatch to a tripped workspace.
+    ///
+    /// # Half-open recovery (no operator action)
+    ///
+    /// The advisory only clears after a dispatch *succeeds* (reaches
+    /// `# CLAUDE_CLI_START`, see [`reset_preflight_streak`](Self::reset_preflight_streak)),
+    /// so an unconditional hold would deadlock recovery — it would block the
+    /// very dispatch needed to prove the break is fixed. Instead this is a
+    /// half-open circuit breaker: while tripped it returns [`Held`] every tick
+    /// EXCEPT once per [`PreflightTripwireConfig::probe_cooldown`], when it
+    /// returns [`Probe`] to let one dispatch through. If that probe reaches CLI
+    /// start the advisory clears itself and dispatch resumes with no restart or
+    /// manual reset; if it dies at pre-flight again, the streak stays tripped
+    /// and the workspace is re-held until the next cooldown. The first tick that
+    /// observes a freshly-tripped advisory anchors the cooldown clock and holds,
+    /// so the tripping death is not immediately followed by another doomed
+    /// attempt — the first probe waits a full cooldown.
+    ///
+    /// `&mut self` because a [`Probe`] decision advances the cooldown clock.
+    ///
+    /// [`Held`]: PreflightDispatchGate::Held
+    /// [`Probe`]: PreflightDispatchGate::Probe
+    pub fn preflight_dispatch_gate(&mut self, now: DateTime<Utc>) -> PreflightDispatchGate {
+        if !self.preflight_advisory_tripped {
+            return PreflightDispatchGate::Open;
+        }
+        let cooldown = chrono::Duration::from_std(self.preflight_tripwire_config.probe_cooldown)
+            .unwrap_or_else(|_| {
+                chrono::Duration::seconds(DEFAULT_PREFLIGHT_PROBE_COOLDOWN_SECS as i64)
+            });
+        match self.preflight_probe_last_at {
+            None => {
+                // First tick observing the tripped advisory: anchor the clock
+                // and hold, so the first probe fires one full cooldown later.
+                self.preflight_probe_last_at = Some(now);
+                PreflightDispatchGate::Held
+            }
+            Some(last) if now.signed_duration_since(last) >= cooldown => {
+                // Cooldown elapsed: allow one probe tick through and re-anchor
+                // so the next probe is another cooldown away.
+                self.preflight_probe_last_at = Some(now);
+                PreflightDispatchGate::Probe
+            }
+            Some(_) => PreflightDispatchGate::Held,
+        }
     }
 
     /// Whether the live `.ranking` snapshot confirms zero healthy accounts
@@ -1425,6 +1549,151 @@ mod tests {
             } => assert_eq!(consecutive_deaths, 0),
             other => panic!("unexpected event: {other:?}"),
         }
+    }
+
+    /// Trip a fresh registry's pre-flight advisory via three consecutive
+    /// cross-issue pre-flight deaths (default threshold 3), returning it ready
+    /// for the #5030 dispatch-gate tests.
+    fn tripped_preflight_registry(dir: &Path) -> SweepRegistry {
+        let (mut registry, _record_log) = fixture_registry(dir);
+        for issue in [9401u32, 9402, 9403] {
+            insert_dead_running_with_log(
+                &mut registry,
+                issue,
+                0,
+                "unknown",
+                "# MCP_PREFLIGHT_FAILED\n",
+            );
+            registry.reap_once();
+        }
+        assert!(registry.preflight_advisory().0, "fixture must leave the advisory tripped");
+        registry
+    }
+
+    /// #5030: an untripped advisory never holds dispatch — the gate is `Open`.
+    #[test]
+    fn preflight_dispatch_gate_open_when_not_tripped() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+        assert!(!registry.preflight_advisory().0);
+        assert_eq!(
+            registry.preflight_dispatch_gate(Utc::now()),
+            PreflightDispatchGate::Open,
+            "a healthy workspace is never held by the pre-flight breaker"
+        );
+    }
+
+    /// #5030 (core state machine): once tripped the breaker holds every tick,
+    /// then lets exactly one probe through per cooldown (half-open), and holds
+    /// again immediately after each probe.
+    #[test]
+    fn preflight_dispatch_gate_holds_then_probes_once_per_cooldown() {
+        let dir = tempdir().unwrap();
+        let mut registry = tripped_preflight_registry(dir.path());
+        let cooldown = registry.preflight_tripwire_config().probe_cooldown;
+        let cooldown = chrono::Duration::from_std(cooldown).unwrap();
+
+        let t0 = Utc::now();
+        // First tick observing the trip anchors the clock and HOLDS — the
+        // tripping death is not immediately followed by another doomed attempt.
+        assert_eq!(registry.preflight_dispatch_gate(t0), PreflightDispatchGate::Held);
+        // Still within the cooldown: held every tick, zero probes.
+        assert_eq!(
+            registry.preflight_dispatch_gate(t0 + chrono::Duration::seconds(1)),
+            PreflightDispatchGate::Held
+        );
+        assert_eq!(
+            registry.preflight_dispatch_gate(t0 + cooldown - chrono::Duration::seconds(1)),
+            PreflightDispatchGate::Held,
+            "must not probe before a full cooldown elapses (respects backoff between probes)"
+        );
+        // Cooldown elapsed: exactly one probe is let through.
+        assert_eq!(
+            registry.preflight_dispatch_gate(t0 + cooldown),
+            PreflightDispatchGate::Probe,
+            "one probe dispatch is allowed once the cooldown elapses"
+        );
+        // Immediately re-held: the probe re-anchored the clock, so no spinning
+        // at full speed even though the advisory is still tripped.
+        assert_eq!(
+            registry.preflight_dispatch_gate(t0 + cooldown + chrono::Duration::seconds(1)),
+            PreflightDispatchGate::Held
+        );
+        // A second probe only after another full cooldown.
+        assert_eq!(
+            registry.preflight_dispatch_gate(t0 + cooldown + cooldown),
+            PreflightDispatchGate::Probe
+        );
+    }
+
+    /// #5030: recovery is automatic — a probe dispatch that reaches
+    /// `# CLAUDE_CLI_START` clears the advisory (no operator action), the gate
+    /// reopens, and a subsequent re-break waits a full cooldown before its first
+    /// probe (the probe clock was reset on clear, not left stale).
+    #[test]
+    fn preflight_dispatch_gate_reopens_on_recovery_and_resets_probe_clock() {
+        let dir = tempdir().unwrap();
+        let mut registry = tripped_preflight_registry(dir.path());
+        let cooldown =
+            chrono::Duration::from_std(registry.preflight_tripwire_config().probe_cooldown)
+                .unwrap();
+        let t0 = Utc::now();
+        assert_eq!(registry.preflight_dispatch_gate(t0), PreflightDispatchGate::Held);
+
+        // A dispatch reaches CLI start → streak resets, advisory clears.
+        insert_dead_running_with_log(
+            &mut registry,
+            9410,
+            0,
+            "unknown",
+            "# CLAUDE_CLI_START\nlater crash\n",
+        );
+        registry.reap_once();
+        assert!(!registry.preflight_advisory().0, "recovery clears the advisory automatically");
+        assert_eq!(
+            registry.preflight_dispatch_gate(t0 + chrono::Duration::seconds(5)),
+            PreflightDispatchGate::Open,
+            "cleared advisory reopens dispatch with no restart or manual reset"
+        );
+
+        // Re-break the workspace: the probe clock was reset on clear, so the
+        // first probe of the new trip waits a full cooldown from the re-trip
+        // (no stale-timestamp immediate probe).
+        for issue in [9411u32, 9412, 9413] {
+            insert_dead_running_with_log(
+                &mut registry,
+                issue,
+                0,
+                "unknown",
+                "# MCP_PREFLIGHT_FAILED\n",
+            );
+            registry.reap_once();
+        }
+        assert!(registry.preflight_advisory().0);
+        let t1 = t0 + chrono::Duration::seconds(10);
+        assert_eq!(
+            registry.preflight_dispatch_gate(t1),
+            PreflightDispatchGate::Held,
+            "a freshly re-tripped advisory anchors a new cooldown and holds first"
+        );
+        assert_eq!(registry.preflight_dispatch_gate(t1 + cooldown), PreflightDispatchGate::Probe);
+    }
+
+    /// #5030: env override of the probe cooldown is honored by
+    /// `resolve_preflight_tripwire_config` (precedence env > config > default).
+    #[test]
+    #[serial]
+    fn resolve_preflight_probe_cooldown_env_override() {
+        let dir = tempdir().unwrap();
+        // Default when unset.
+        std::env::remove_var(PREFLIGHT_PROBE_COOLDOWN_ENV);
+        let cfg = resolve_preflight_tripwire_config(dir.path());
+        assert_eq!(cfg.probe_cooldown, Duration::from_secs(DEFAULT_PREFLIGHT_PROBE_COOLDOWN_SECS));
+        // Env override wins.
+        std::env::set_var(PREFLIGHT_PROBE_COOLDOWN_ENV, "42");
+        let cfg = resolve_preflight_tripwire_config(dir.path());
+        assert_eq!(cfg.probe_cooldown, Duration::from_secs(42));
+        std::env::remove_var(PREFLIGHT_PROBE_COOLDOWN_ENV);
     }
 
     /// Edge case (#4386): a dead sweep whose log file is missing/unreadable

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -113,6 +113,7 @@ use crate::event_bus::EventBus;
 use crate::main_health_gate::{MainHealthState, WorkspaceHealthStates};
 use crate::sweep_registry::{
     DispatchBackoffError, LiveClaimDispatchError, OpenPrDispatchError, ParkedIssueDispatchError,
+    PreflightDispatchGate,
 };
 use crate::tokens::{token_pool_size, token_pool_size_at_dir};
 use crate::types::{Event, WorkFinderTickSummary};
@@ -1079,6 +1080,36 @@ pub fn dispatch_held_per_root_with_drain(
     dispatch_held_per_root(health_states, roots, suppress_dispatch_during_gate)
         .into_iter()
         .map(|h| h || draining)
+        .collect()
+}
+
+/// Fold a per-root claude-wrapper pre-flight-advisory hold (#5030) on top of the
+/// #3930 verified-red + #4084 gate-in-flight per-root holds.
+///
+/// `preflight_held` is a slice **parallel to `roots`**: `preflight_held[i] ==
+/// true` means root `i`'s pre-flight advisory is tripped AND its half-open
+/// breaker is currently in the "held" window (not a probe tick), so no new
+/// dispatch should go to that root this tick. The caller computes it from each
+/// root's own [`SweepRegistry::preflight_dispatch_gate`](crate::sweep_registry::SweepRegistry::preflight_dispatch_gate)
+/// — a broken workspace burns at most one ~1s pre-flight death per probe
+/// cooldown instead of one every tick.
+///
+/// The hold is strictly **per root**, matching the #3930 per-repo isolation
+/// contract: a workspace with a broken `.mcp.json` never halts dispatch to a
+/// healthy sibling repo. A missing entry (`preflight_held.len() < roots.len()`)
+/// defaults to *not held*. With an all-`false` slice the result is byte-for-byte
+/// [`dispatch_held_per_root`].
+#[must_use]
+pub fn dispatch_held_per_root_with_preflight(
+    health_states: &WorkspaceHealthStates,
+    roots: &[std::path::PathBuf],
+    suppress_dispatch_during_gate: bool,
+    preflight_held: &[bool],
+) -> Vec<bool> {
+    dispatch_held_per_root(health_states, roots, suppress_dispatch_during_gate)
+        .into_iter()
+        .enumerate()
+        .map(|(i, h)| h || preflight_held.get(i).copied().unwrap_or(false))
         .collect()
 }
 
@@ -2075,6 +2106,10 @@ pub fn spawn_multi_work_finder_task(
         ticker.tick().await;
         let mut was_halted = false;
         let mut was_pressured = false;
+        // Pre-flight-advisory hold transition state (#5030): log the distinct
+        // "held because pre-flight is broken" warning once per transition rather
+        // than every tick, mirroring `was_halted`.
+        let mut was_preflight_held_count: usize = 0;
         // Axis-visibility state (#4234) — see the single-workspace loop above
         // for the full rationale.
         let mut was_max_concurrent: Option<usize> = None;
@@ -2213,15 +2248,71 @@ pub fn spawn_multi_work_finder_task(
             // rather than OR'd into `halted` so its deferrals stay attributable.
             let saturation_held =
                 crate::admission_brake::global_observe(loadavg_1m, ncpu, chrono::Utc::now());
-            let halted: Vec<bool> = dispatch_held_per_root_with_drain(
+            // Per-root claude-wrapper pre-flight-advisory hold (#5030): consult
+            // each root's own SweepRegistry breaker. A workspace that has
+            // accumulated `threshold` consecutive pre-flight deaths (broken
+            // `.mcp.json`, dead token pool, ...) is held so the work-finder
+            // stops burning dispatch slots on doomed ~1s deaths, EXCEPT one
+            // half-open probe dispatch per cooldown to test recovery (which
+            // clears the advisory automatically on success — no operator
+            // action). Strictly per root: a broken workspace never holds a
+            // healthy sibling (the #3930 isolation contract).
+            let now_tick = chrono::Utc::now();
+            let mut preflight_probe_roots: Vec<std::path::PathBuf> = Vec::new();
+            let preflight_held: Vec<bool> = roots
+                .iter()
+                .map(|root| {
+                    let registry = pool.get_or_provision(root);
+                    let mut registry = registry
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    match registry.preflight_dispatch_gate(now_tick) {
+                        PreflightDispatchGate::Open => false,
+                        PreflightDispatchGate::Held => true,
+                        PreflightDispatchGate::Probe => {
+                            preflight_probe_roots.push(root.clone());
+                            false
+                        }
+                    }
+                })
+                .collect();
+            let halted: Vec<bool> = dispatch_held_per_root_with_preflight(
                 &health_states,
                 &roots,
                 suppress_dispatch_during_gate,
-                draining,
+                &preflight_held,
             )
             .into_iter()
-            .map(|h| h || breaker_suppressed)
+            .map(|h| h || draining || breaker_suppressed)
             .collect();
+            let preflight_held_count = preflight_held.iter().filter(|&&h| h).count();
+            // Distinguish a pre-flight-advisory hold from the main-health /
+            // gate-in-flight holds (#5030 AC4) so an operator can tell "held
+            // because pre-flight is broken" apart from "held because CI is red."
+            if preflight_held_count != was_preflight_held_count {
+                if preflight_held_count > 0 {
+                    log::warn!(
+                        "work_finder: {preflight_held_count} of {} repo(s) held — \
+                         claude-wrapper pre-flight advisory tripped (broken .mcp.json / dead token \
+                         pool); dispatch is suppressed except one probe per cooldown until a \
+                         dispatch reaches CLI start (#5030)",
+                        roots.len()
+                    );
+                } else {
+                    log::info!(
+                        "work_finder: pre-flight advisory cleared for all repos — dispatch \
+                         resuming (#5030)"
+                    );
+                }
+                was_preflight_held_count = preflight_held_count;
+            }
+            for probe_root in &preflight_probe_roots {
+                log::info!(
+                    "work_finder: pre-flight advisory recovery probe — allowing one dispatch to \
+                     {} to test recovery (#5030)",
+                    probe_root.display()
+                );
+            }
             let any_halted = halted.iter().any(|&h| h);
 
             let mut pairs: Vec<(GhWorkSource, RegistryDispatcher)> = roots
@@ -2237,6 +2328,7 @@ pub fn spawn_multi_work_finder_task(
                  healthy_tokens={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
                  configured_max={configured_max}, \
                  max_admissions_per_tick={max_admissions_per_tick}, any_halted={any_halted}, \
+                 preflight_held={preflight_held_count}, \
                  saturation_held={saturation_held}, \
                  observed_idle={}, workspaces={}, priorities={priorities:?})",
                 format_idle(idle),
@@ -5487,6 +5579,130 @@ exit 0
             vec![10],
             "sibling root with no gate in flight is unaffected"
         );
+    }
+
+    // ===================================================================
+    // Pre-flight-advisory dispatch hold (#5030)
+    // ===================================================================
+
+    #[test]
+    fn test_dispatch_held_per_root_with_preflight_holds_only_the_tripped_root() {
+        // A workspace whose pre-flight breaker is holding (broken .mcp.json)
+        // holds only its own root; a healthy sibling keeps dispatching — the
+        // #3930 per-repo isolation contract must survive the #5030 fold.
+        let states = WorkspaceHealthStates::new();
+        let root_a = std::path::PathBuf::from("/tmp/repo-a"); // pre-flight held
+        let root_b = std::path::PathBuf::from("/tmp/repo-b"); // healthy
+        let preflight_held = [true, false];
+        let held = dispatch_held_per_root_with_preflight(
+            &states,
+            &[root_a, root_b],
+            true,
+            &preflight_held,
+        );
+        assert_eq!(
+            held,
+            vec![true, false],
+            "only the tripped root is held; its healthy sibling keeps dispatching"
+        );
+    }
+
+    #[test]
+    fn test_dispatch_held_per_root_with_preflight_empty_slice_matches_per_root() {
+        // An all-false / missing pre-flight slice is byte-for-byte the plain
+        // per-root vector — the fold is a pure superset, never a regression of
+        // the #4084 / #3930 semantics.
+        let states = WorkspaceHealthStates::new();
+        let root_a = std::path::PathBuf::from("/tmp/repo-a");
+        let root_b = std::path::PathBuf::from("/tmp/repo-b");
+        states.get_or_create(&root_a).set_gate_in_flight(true);
+        states.get_or_create(&root_b).set_halted(true);
+        let roots = [root_a, root_b];
+        let plain = dispatch_held_per_root(&states, &roots, true);
+        let folded = dispatch_held_per_root_with_preflight(&states, &roots, true, &[]);
+        assert_eq!(plain, folded, "empty pre-flight slice ⇒ identical to dispatch_held_per_root");
+    }
+
+    #[test]
+    fn test_dispatch_held_per_root_with_preflight_composes_with_verified_red() {
+        // The pre-flight hold and the #3930 verified-red hold compose
+        // additively per root: root_a is held by pre-flight, root_b by a red
+        // main, root_c is healthy on both axes.
+        let states = WorkspaceHealthStates::new();
+        let root_a = std::path::PathBuf::from("/tmp/repo-a");
+        let root_b = std::path::PathBuf::from("/tmp/repo-b");
+        let root_c = std::path::PathBuf::from("/tmp/repo-c");
+        states.get_or_create(&root_b).set_halted(true);
+        let held = dispatch_held_per_root_with_preflight(
+            &states,
+            &[root_a, root_b, root_c],
+            true,
+            &[true, false, false],
+        );
+        assert_eq!(held, vec![true, true, false]);
+    }
+
+    #[test]
+    fn test_preflight_held_root_dispatches_zero_new_sweeps() {
+        // Regression (#5030): end-to-end through `tick_multi`, a workspace whose
+        // pre-flight advisory has tripped (its breaker is holding) dispatches
+        // ZERO new sweeps even with a full backlog, while its healthy sibling
+        // takes the shared slot — the burn-every-slot incident cannot recur.
+        // Mirrors `test_gate_in_flight_root_dispatches_zero_new_sweeps`.
+        let states = WorkspaceHealthStates::new();
+        let root_a = std::path::PathBuf::from("/tmp/repo-a"); // pre-flight held
+        let root_b = std::path::PathBuf::from("/tmp/repo-b"); // healthy
+        let halted =
+            dispatch_held_per_root_with_preflight(&states, &[root_a, root_b], true, &[true, false]);
+
+        let mut multi = vec![
+            (FakeSource::once((1..=5).map(issue).collect()), RecordingDispatcher::default()),
+            (FakeSource::once(vec![issue(10)]), RecordingDispatcher::default()),
+        ];
+        let report = tick_multi(&mut multi, &[], 10, &halted);
+
+        assert!(report.halted, "the pre-flight-held root marks the tick as halted");
+        assert_eq!(report.seen, 6, "both backlogs are still observed");
+        assert!(
+            multi[0].1.dispatched.is_empty(),
+            "a pre-flight-broken workspace dispatches zero new sweeps (no slot burn)"
+        );
+        assert_eq!(
+            multi[1].1.dispatched,
+            vec![10],
+            "the healthy sibling keeps dispatching against the shared budget"
+        );
+    }
+
+    #[test]
+    fn test_preflight_probe_tick_resumes_dispatch_to_recovering_root() {
+        // Under the half-open design, a probe tick reports the root as NOT held
+        // (`preflight_held=false` for that root), so `tick_multi` lets one
+        // dispatch through to test recovery — proving the breaker never blocks
+        // the very dispatch needed to prove the workspace is fixed.
+        let states = WorkspaceHealthStates::new();
+        let root_a = std::path::PathBuf::from("/tmp/repo-a"); // probing this tick
+        let root_b = std::path::PathBuf::from("/tmp/repo-b"); // healthy
+                                                              // A probe tick maps `PreflightDispatchGate::Probe` → not held.
+        let halted = dispatch_held_per_root_with_preflight(
+            &states,
+            &[root_a, root_b],
+            true,
+            &[false, false],
+        );
+
+        let mut multi = vec![
+            (FakeSource::once(vec![issue(1)]), RecordingDispatcher::default()),
+            (FakeSource::once(vec![issue(10)]), RecordingDispatcher::default()),
+        ];
+        let report = tick_multi(&mut multi, &[], 10, &halted);
+        assert!(!report.halted);
+        assert_eq!(
+            multi[0].1.dispatched,
+            vec![1],
+            "a probe tick lets one dispatch through to the recovering root"
+        );
+        assert_eq!(multi[1].1.dispatched, vec![10]);
     }
 
     // ===================================================================


### PR DESCRIPTION
Closes #5030

## Problem

The work-finder's per-root dispatch gate (`dispatch_held_per_root`) never consulted `SweepRegistry`'s existing pre-flight-death advisory (`preflight_advisory()`), so a workspace with a broken `.mcp.json` / dead token pool kept burning dispatch slots forever: with N queued issues, the work-finder launched *different* issues into the same dead claude-wrapper pre-flight check, each dying in ~1s and instantly freeing the slot for the next. On 2026-08-03 an 18-core host produced zero completed work for hours this way.

## Fix

A per-root, half-open dispatch breaker keyed off the already-tracked advisory.

- **`SweepRegistry::preflight_dispatch_gate(now) -> PreflightDispatchGate`** (`quarantine.rs`) returns `Open` / `Held` / `Probe`. While the advisory is tripped it holds new dispatch to that workspace, EXCEPT one probe dispatch per `probe_cooldown` (default 15m, matching the per-issue backoff ceiling; env `LOOM_PREFLIGHT_PROBE_COOLDOWN_SECS` / config `autonomous.workFinder.preflightTripwire.probeCooldownSecs`). The first tick observing a fresh trip anchors the cooldown and holds, so the tripping death is not immediately followed by another doomed attempt.
- **Automatic recovery, no operator action:** the advisory only clears after a dispatch *succeeds* (reaches `# CLAUDE_CLI_START`), so an unconditional hold would deadlock recovery. A successful probe clears the advisory automatically — dispatch resumes with no restart or manual reset. The probe clock resets on clear, so a later re-break waits a full cooldown before its first probe.
- **`dispatch_held_per_root_with_preflight`** (`work_finder.rs`) folds the per-root pre-flight hold onto the #3930 verified-red + #4084 gate-in-flight holds. Strictly per root — a broken workspace never halts a healthy sibling (the #3930 isolation contract).
- **Distinct visibility:** the work-finder logs a dedicated "held because pre-flight is broken" warning (distinguished from main-health / gate-in-flight), surfaces `preflight_held=` on the axis line, and logs each recovery probe.

Composes with the existing per-issue `DispatchBackoffConfig` without duplication: that backoff caps re-dispatch of the *same* issue and explicitly excludes pre-flight deaths, which is exactly why a *cross-issue, per-root* breaker was needed.

## Tests

- Gate state machine: `Open` when untripped; hold every tick then exactly one `Probe` per cooldown (never before); auto-recovery clears the advisory and reopens the gate; probe clock resets so a re-break waits a full cooldown.
- Env override of the probe cooldown (precedence env > config > default).
- Per-root isolation composition (pre-flight vs. verified-red vs. healthy).
- End-to-end `tick_multi` regression (mirrors `test_gate_in_flight_root_dispatches_zero_new_sweeps`): a pre-flight-held root dispatches **zero** new sweeps with a full backlog while its healthy sibling takes the shared slot; a probe tick lets one dispatch through to the recovering root.

Full suite: `sweep_registry::` 331 passed, `work_finder::` 143 passed, clippy clean.

Companion to #5023 (same escalation principle, `role_runner` tick loop); sub-issue of #5016.

🤖 Generated with [Claude Code](https://claude.com/claude-code)