### PR TITLE
fix(claude-wrapper): abort on stale-bundle rebuild failure + npm ci self-repair for an unusable node_modules

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -27,6 +27,13 @@
 #   LOOM_AUTH_CACHE_TTL    - Auth cache TTL in seconds (default: 120)
 #   LOOM_AUTH_CACHE_STALE_LOCK_THRESHOLD - Stale lock cleanup threshold in seconds (default: 90)
 #   LOOM_AUTH_CACHE_LOCK_WAIT - Max time to wait for lock holder in seconds (default: 60)
+#   LOOM_NODE_BIN          - Absolute path to `node` for the MCP pre-flight
+#                            (issue #5032). Optional: the pre-flight resolves
+#                            node/npm from an ordered explicit candidate list
+#                            (PATH, then /opt/homebrew/bin, /usr/local/bin, …)
+#                            because launchd jobs and `ssh host 'cmd'` shells
+#                            never source the login profile.
+#   LOOM_NPM_BIN           - Absolute path to `npm`, same resolution rules.
 #   LOOM_MODEL             - Model to pass as `claude --model <value>` (issue
 #                            #3477). An explicit `--model` in the wrapper args
 #                            always wins. The flag is appended once before the
@@ -453,10 +460,19 @@ for name, srv in servers.items():
     # is startable but lacks recent fixes (a smoke test passes on it silently).
     # Rebuild before the smoke test. This mirrors the predicate in
     # scripts/setup-mcp.sh (the one-shot .mcp.json generator) exactly so the two
-    # gates cannot drift (issue #4043). Rebuild failure on an otherwise-startable
-    # bundle is non-fatal — fall through to the smoke test below.
-    local mcp_src
-    mcp_src="$(dirname "$(dirname "${mcp_entry}")")/src"
+    # gates cannot drift (issue #4043).
+    #
+    # Rebuild failure here is FATAL for this candidate (#5032). The original
+    # design treated it as non-fatal ("an otherwise-startable bundle") and fell
+    # through to the smoke test below — but that assumption does not survive an
+    # actual rebuild failure: a bundle that cannot be rebuilt from its own
+    # sources is not otherwise-startable, and the smoke test then runs against
+    # the same known-broken dist and is guaranteed to fail. Aborting instead
+    # matches the missing-entry-point path above and lets check_mcp_server fall
+    # back to the next candidate immediately with an actionable message.
+    local mcp_src mcp_pkg_dir
+    mcp_pkg_dir="$(dirname "$(dirname "${mcp_entry}")")"
+    mcp_src="${mcp_pkg_dir}/src"
     if [[ -d "${mcp_src}" ]] && \
        [[ -n "$(find "${mcp_src}" -type f -newer "${mcp_entry}" -print -quit 2>/dev/null)" ]]; then
         log_warn "MCP bundle is stale (src newer than dist) - rebuilding: ${mcp_entry}"
@@ -464,14 +480,21 @@ for name, srv in servers.items():
             # Rebuild succeeded and already re-verified the smoke test.
             return 0
         fi
-        log_warn "MCP rebuild for stale bundle failed - continuing with existing bundle"
+        log_error "MCP rebuild for stale bundle failed - aborting this candidate (${mcp_config})"
+        log_error "Repair manually: cd ${mcp_pkg_dir} && npm ci && npm run build"
+        return 1
     fi
 
     # Smoke test: start MCP server and verify it emits the startup message
     # The MCP server writes "Loom MCP server running on stdio" to stderr on success.
     # Use a short timeout - we just need to see the startup message.
-    local mcp_stderr
-    mcp_stderr=$(timeout 5 node "${mcp_entry}" </dev/null 2>&1 || true)
+    # `node` is resolved via explicit candidate paths, not a bare PATH lookup:
+    # a non-login ssh session / launchd job never sources the login profile, so
+    # /opt/homebrew/bin is not on PATH (#5032, same reasoning as #4875).
+    local mcp_stderr node_bin
+    node_bin="$(_locate_node_tool node)" || node_bin="node"
+    [[ -n "${node_bin}" ]] || node_bin="node"
+    mcp_stderr=$(timeout 5 "${node_bin}" "${mcp_entry}" </dev/null 2>&1 || true)
 
     if echo "${mcp_stderr}" | grep -qi "running on stdio"; then
         log_info "MCP server health check passed (${mcp_config})"
@@ -614,7 +637,143 @@ PYEOF
     return 0  # Always succeed — this is a warning-only check
 }
 
-# Attempt to rebuild the MCP server and re-verify
+# Ordered explicit candidate directories for the node toolchain (#5032).
+# claude-wrapper.sh runs from launchd jobs and `ssh host 'cmd'` non-login
+# shells that never source the login profile, so /opt/homebrew/bin (Apple
+# Silicon Homebrew) et al are NOT on PATH and a bare `command -v npm` lookup
+# fails even on a host where npm is perfectly well installed. Mirrors the
+# explicit-candidate-list pattern lib/locate-daemon-bin.sh established for the
+# same class of bug (#4875) rather than inventing a second approach.
+_LOOM_NODE_TOOL_DIRS=(
+    /opt/homebrew/bin
+    /usr/local/bin
+    /usr/bin
+    /opt/local/bin
+    /snap/bin
+)
+
+# _locate_node_tool <node|npm> -> echoes an absolute path, or nothing (rc 1).
+# Precedence: $LOOM_NODE_BIN / $LOOM_NPM_BIN override -> PATH -> the explicit
+# candidate list above -> nvm-style versioned installs (newest first).
+_locate_node_tool() {
+    local tool="$1"
+    local override=""
+    case "${tool}" in
+        node) override="${LOOM_NODE_BIN:-}" ;;
+        npm)  override="${LOOM_NPM_BIN:-}" ;;
+    esac
+
+    if [[ -n "${override}" && -x "${override}" ]]; then
+        echo "${override}"
+        return 0
+    fi
+
+    if command -v "${tool}" >/dev/null 2>&1; then
+        command -v "${tool}"
+        return 0
+    fi
+
+    local dir candidate
+    for dir in "${_LOOM_NODE_TOOL_DIRS[@]}" "${HOME}/.local/bin" "${HOME}/.volta/bin"; do
+        candidate="${dir}/${tool}"
+        if [[ -x "${candidate}" ]]; then
+            echo "${candidate}"
+            return 0
+        fi
+    done
+
+    local nvm_root="${NVM_DIR:-${HOME}/.nvm}"
+    if [[ -d "${nvm_root}/versions/node" ]]; then
+        while IFS= read -r candidate; do
+            [[ -z "${candidate}" ]] && continue
+            if [[ -x "${candidate}" ]]; then
+                echo "${candidate}"
+                return 0
+            fi
+        done < <(ls -1d "${nvm_root}"/versions/node/*/bin/"${tool}" 2>/dev/null | sort -r)
+    fi
+
+    return 1
+}
+
+# Render the search list for a "tool not found" error message. Mirrors
+# _locate_node_tool's precedence exactly, kept side by side so the two cannot
+# drift (same discipline as loom_daemon_bin_search_paths).
+_node_tool_search_paths() {
+    local tool="$1"
+    case "${tool}" in
+        node) echo "\$LOOM_NODE_BIN" ;;
+        npm)  echo "\$LOOM_NPM_BIN" ;;
+    esac
+    echo "${tool} on \$PATH"
+    local dir
+    for dir in "${_LOOM_NODE_TOOL_DIRS[@]}" "${HOME}/.local/bin" "${HOME}/.volta/bin"; do
+        echo "${dir}/${tool}"
+    done
+    echo "${NVM_DIR:-${HOME}/.nvm}/versions/node/*/bin/${tool}"
+}
+
+# True (rc 0) when <pkg_dir>/node_modules is missing, empty, or a broken
+# half-install — i.e. mechanically repairable by `npm ci` rather than a genuine
+# build-source error (#5032).
+#
+# "Broken half-install" is the robb-pro root cause: node_modules existed and
+# was non-empty, but node_modules/@modelcontextprotocol/sdk was an EMPTY
+# directory, so `npm run build` died with MODULE_NOT_FOUND exactly like a real
+# source error. Checking that every declared dependency resolves to a directory
+# containing its own package.json catches that case; a `require` failure for a
+# dependency the package never declared is correctly NOT treated as repairable.
+_mcp_node_modules_unusable() {
+    local pkg_dir="$1"
+    local node_modules="${pkg_dir}/node_modules"
+
+    if [[ ! -d "${node_modules}" ]]; then
+        return 0
+    fi
+    if [[ -z "$(ls -A "${node_modules}" 2>/dev/null)" ]]; then
+        return 0
+    fi
+
+    # `timeout` is not present on a bare macOS install; degrade to a direct
+    # call rather than losing the half-install detection entirely.
+    local -a _py=()
+    if command -v timeout >/dev/null 2>&1; then
+        _py=(timeout 10 "${LOOM_PYTHON}")
+    else
+        _py=("${LOOM_PYTHON}")
+    fi
+
+    local deps
+    deps=$("${_py[@]}" -c "
+import json, sys
+try:
+    with open('${pkg_dir}/package.json') as f:
+        cfg = json.load(f)
+except Exception:
+    sys.exit(0)
+for section in ('dependencies', 'devDependencies'):
+    for name in (cfg.get(section) or {}):
+        print(name)
+" 2>/dev/null || echo "")
+
+    local dep
+    while IFS= read -r dep; do
+        [[ -z "${dep}" ]] && continue
+        if [[ ! -f "${node_modules}/${dep}/package.json" ]]; then
+            return 0
+        fi
+    done <<< "${deps}"
+
+    return 1
+}
+
+# Attempt to rebuild the MCP server and re-verify.
+#
+# Before `npm run build`, self-repair a missing/empty/half-installed
+# node_modules with `npm ci` when a package-lock.json is present (#5032) —
+# without it the two very different failures (unusable dependency tree vs.
+# genuine build-source error) are indistinguishable at the call site and both
+# needed an operator to run `npm ci` by hand.
 _try_mcp_rebuild() {
     local mcp_entry="$1"
 
@@ -628,13 +787,54 @@ _try_mcp_rebuild() {
         return 1
     fi
 
+    local npm_bin node_bin node_dir
+    npm_bin="$(_locate_node_tool npm)" || npm_bin=""
+    if [[ -z "${npm_bin}" ]]; then
+        log_error "npm not found - cannot rebuild the MCP bundle at ${mcp_dir}"
+        log_error "Searched: $(_node_tool_search_paths npm | tr '\n' ' ')"
+        log_error "Set \$LOOM_NPM_BIN to an absolute npm path, or install node."
+        return 1
+    fi
+    # npm's own shim execs `node`; a minimal PATH breaks it even once npm
+    # itself is resolved, so put the resolved node's directory on PATH for the
+    # build subshells.
+    node_bin="$(_locate_node_tool node)" || node_bin=""
+    node_dir=""
+    [[ -n "${node_bin}" ]] && node_dir="$(dirname "${node_bin}")"
+
     log_info "Attempting MCP server rebuild in ${mcp_dir}..."
 
+    # Self-repair: an unusable dependency tree plus a lockfile is mechanically
+    # fixable — run `npm ci` first. Without a lockfile `npm ci` cannot run at
+    # all, so fall straight through to the build and let it report the error.
+    if _mcp_node_modules_unusable "${mcp_dir}"; then
+        if [[ -f "${mcp_dir}/package-lock.json" ]]; then
+            log_warn "MCP node_modules missing/incomplete in ${mcp_dir} - running 'npm ci' (self-repair)"
+            if ( set -o pipefail
+                 cd "${mcp_dir}" && PATH="${node_dir:+${node_dir}:}${PATH}" \
+                     "${npm_bin}" ci 2>&1 | tail -5 ) >&2; then
+                log_info "npm ci completed - dependency tree repaired"
+            else
+                # No network / corrupted lockfile / registry auth failure.
+                # Abort loudly: `npm run build` on the same broken tree would
+                # only produce a confusing MODULE_NOT_FOUND.
+                log_error "npm ci failed in ${mcp_dir} - cannot repair the MCP dependency tree"
+                log_error "Repair manually: cd ${mcp_dir} && npm ci && npm run build"
+                return 1
+            fi
+        else
+            log_warn "MCP node_modules missing/incomplete in ${mcp_dir} but no package-lock.json - cannot self-repair with 'npm ci'"
+        fi
+    fi
+
     # Run npm build (suppressing verbose output)
-    if (cd "${mcp_dir}" && npm run build 2>&1 | tail -5) >&2; then
+    if ( set -o pipefail
+         cd "${mcp_dir}" && PATH="${node_dir:+${node_dir}:}${PATH}" \
+             "${npm_bin}" run build 2>&1 | tail -5 ) >&2; then
         log_info "MCP rebuild completed"
     else
         log_error "MCP rebuild failed"
+        log_error "Repair manually: cd ${mcp_dir} && npm ci && npm run build"
         return 1
     fi
 
@@ -645,7 +845,8 @@ _try_mcp_rebuild() {
     fi
 
     local mcp_stderr
-    mcp_stderr=$(timeout 5 node "${mcp_entry}" </dev/null 2>&1 || true)
+    [[ -n "${node_bin}" ]] || node_bin="node"
+    mcp_stderr=$(timeout 5 "${node_bin}" "${mcp_entry}" </dev/null 2>&1 || true)
 
     if echo "${mcp_stderr}" | grep -qi "running on stdio"; then
         log_info "MCP server health check passed after rebuild"

--- a/defaults/scripts/tests/test-mcp-config.sh
+++ b/defaults/scripts/tests/test-mcp-config.sh
@@ -473,6 +473,327 @@ else
 fi
 
 # ============================================================
+# Section 8: stale-bundle rebuild — abort on failure + npm ci self-repair (#5032)
+#
+# Before #5032 a failed rebuild on the STALE-bundle path was swallowed
+# ("continuing with existing bundle") and fell through to a smoke test against
+# the very same known-broken dist — guaranteed to fail, with no actionable
+# message. And _try_mcp_rebuild only ever ran `npm run build`, so a
+# missing/half-installed node_modules (the robb-pro root cause: an EMPTY
+# node_modules/@modelcontextprotocol/sdk directory) was indistinguishable from
+# a genuine build-source error and needed an operator to run `npm ci` by hand.
+# ============================================================
+echo ""
+echo "Testing stale-bundle rebuild abort + npm ci self-repair (#5032)..."
+
+# A dist stub that announces itself on stderr. If the smoke test ever runs, the
+# marker shows up in the captured wrapper output — that is how the tests below
+# assert "did NOT fall through to the smoke test".
+_write_broken_dist() {
+    local dir="$1" # e.g. .../mcp-loom
+    mkdir -p "$dir/dist"
+    cat >"$dir/dist/index.js" <<'JS'
+process.stderr.write("SMOKE_TEST_RAN: bundle is broken\n");
+process.exit(1);
+JS
+}
+
+# npm stub: records every invocation and simulates ci/build outcomes.
+# Driven by marker files in $NPM_STUB_DIR so each fixture can pick a behavior
+# without regenerating the script.
+_write_npm_stub() {
+    local stub="$1"
+    mkdir -p "$(dirname "$stub")"
+    cat >"$stub" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >>"${NPM_STUB_LOG}"
+case "${1:-}" in
+    ci)
+        if [[ -f "${NPM_STUB_DIR}/ci-fails" ]]; then
+            echo "npm ERR! network request to https://registry.npmjs.org failed" >&2
+            exit 1
+        fi
+        mkdir -p node_modules/@modelcontextprotocol/sdk node_modules/typescript
+        echo '{"name":"@modelcontextprotocol/sdk","version":"1.0.0"}' \
+            >node_modules/@modelcontextprotocol/sdk/package.json
+        echo '{"name":"typescript","version":"5.0.0"}' \
+            >node_modules/typescript/package.json
+        exit 0
+        ;;
+    run)
+        if [[ -f "${NPM_STUB_DIR}/build-fails" ]]; then
+            echo "src/index.ts(1,1): error TS1005: build source error" >&2
+            exit 1
+        fi
+        if [[ ! -f node_modules/@modelcontextprotocol/sdk/package.json ]]; then
+            echo "Error: Cannot find module '@modelcontextprotocol/sdk' (MODULE_NOT_FOUND)" >&2
+            exit 1
+        fi
+        mkdir -p dist
+        printf 'process.stderr.write("Loom MCP server running on stdio\\n");\n' >dist/index.js
+        exit 0
+        ;;
+esac
+exit 0
+STUB
+    chmod +x "$stub"
+}
+
+# Build an isolated candidate workspace with a STALE bundle (src newer than
+# dist) and a package.json declaring one runtime + one dev dependency.
+# $2 selects the node_modules state: complete | empty-shell | absent
+# $3 = "lock" to drop a package-lock.json alongside.
+_seed_stale_mcp_ws() {
+    local ws="$1" deps_state="$2" lock="${3:-}"
+    local pkg="$ws/mcp-loom"
+    mkdir -p "$pkg/src"
+    _write_broken_dist "$pkg"
+    cat >"$pkg/package.json" <<'JSON'
+{
+  "name": "mcp-loom",
+  "version": "1.0.0",
+  "dependencies": { "@modelcontextprotocol/sdk": "^1.0.0" },
+  "devDependencies": { "typescript": "^5.0.0" }
+}
+JSON
+    [[ "$lock" == "lock" ]] && echo '{"lockfileVersion":3}' >"$pkg/package-lock.json"
+    case "$deps_state" in
+        complete)
+            mkdir -p "$pkg/node_modules/@modelcontextprotocol/sdk" "$pkg/node_modules/typescript"
+            echo '{"name":"@modelcontextprotocol/sdk"}' \
+                >"$pkg/node_modules/@modelcontextprotocol/sdk/package.json"
+            echo '{"name":"typescript"}' >"$pkg/node_modules/typescript/package.json"
+            ;;
+        empty-shell)
+            # The robb-pro shape: node_modules exists and is non-empty, but the
+            # sdk package directory is an empty husk.
+            mkdir -p "$pkg/node_modules/@modelcontextprotocol/sdk" "$pkg/node_modules/typescript"
+            echo '{"name":"typescript"}' >"$pkg/node_modules/typescript/package.json"
+            ;;
+        absent) : ;;
+    esac
+    cat >"$ws/.mcp.json" <<JSON
+{ "mcpServers": { "loom": { "command": "node", "args": ["$pkg/dist/index.js"] } } }
+JSON
+    # Force staleness deterministically (no sleep): dist in 2020, src in 2025.
+    touch -t 202001010000 "$pkg/dist/index.js"
+    : >"$pkg/src/index.ts"
+    touch -t 202501010000 "$pkg/src/index.ts"
+}
+
+# Run _check_mcp_candidate against a workspace with the npm stub wired in.
+# The rc is captured with `|| rc=$?` because the wrapper sets `set -e` when
+# sourced — a bare failing call would kill the harness before the RC echo.
+_run_check_candidate() {
+    local ws="$1" stub_dir="$2"
+    NPM_STUB_DIR="$stub_dir" NPM_STUB_LOG="$stub_dir/npm-calls.log" \
+    LOOM_NPM_BIN="$stub_dir/npm" LOOM_WORKSPACE="$ws" CLAUDE_WRAPPER_SOURCE_ONLY=1 \
+        bash -c '
+            source "$1"
+            rc=0
+            _check_mcp_candidate "$2" || rc=$?
+            echo "RC=$rc"
+        ' _ "$WRAPPER" "$ws" 2>&1 || true
+}
+
+if $HAVE_NODE; then
+    # --- 8a. Stale bundle, healthy deps, genuine build-source failure ---------
+    _s8a="$(mktemp -d)"
+    _seed_stale_mcp_ws "$_s8a/ws" complete lock
+    _write_npm_stub "$_s8a/stub/npm"
+    : >"$_s8a/stub/npm-calls.log"
+    : >"$_s8a/stub/build-fails"
+    _out8a="$(_run_check_candidate "$_s8a/ws" "$_s8a/stub")"
+    _log8a="$(cat "$_s8a/stub/npm-calls.log")"
+
+    assert_contains "RC=1" "$_out8a" \
+        "8a: stale bundle + failed rebuild aborts the candidate (rc 1, #5032)"
+    assert_contains "aborting this candidate" "$_out8a" \
+        "8a: abort message replaces 'continuing with existing bundle' (#5032)"
+    assert_contains "Repair manually" "$_out8a" \
+        "8a: abort message names the repair command (#5032)"
+    assert_not_contains "continuing with existing bundle" "$_out8a" \
+        "8a: the swallow-and-continue branch is gone (#5032)"
+    assert_not_contains "SMOKE_TEST_RAN" "$_out8a" \
+        "8a: does NOT fall through to a smoke test against the broken bundle (#5032)"
+    assert_contains "run build" "$_log8a" \
+        "8a: npm run build was attempted"
+    assert_not_contains "ci" "$_log8a" \
+        "8a: npm ci is NOT run when node_modules is complete (not a repairable case)"
+    rm -rf "$_s8a"
+
+    # --- 8b. Stale bundle, empty-shell dependency + lockfile -> npm ci repair --
+    _s8b="$(mktemp -d)"
+    _seed_stale_mcp_ws "$_s8b/ws" empty-shell lock
+    _write_npm_stub "$_s8b/stub/npm"
+    : >"$_s8b/stub/npm-calls.log"
+    _out8b="$(_run_check_candidate "$_s8b/ws" "$_s8b/stub")"
+    _log8b="$(cat "$_s8b/stub/npm-calls.log")"
+
+    assert_contains "ci" "$_log8b" \
+        "8b: empty node_modules package + package-lock.json triggers npm ci (#5032)"
+    assert_contains "run build" "$_log8b" \
+        "8b: npm run build still runs after the npm ci repair (#5032)"
+    assert_contains "RC=0" "$_out8b" \
+        "8b: candidate becomes healthy after self-repair, no operator action (#5032)"
+    assert_contains "self-repair" "$_out8b" \
+        "8b: the self-repair attempt is logged"
+    rm -rf "$_s8b"
+
+    # --- 8b2. node_modules entirely absent + lockfile -> npm ci repair --------
+    _s8b2="$(mktemp -d)"
+    _seed_stale_mcp_ws "$_s8b2/ws" absent lock
+    _write_npm_stub "$_s8b2/stub/npm"
+    : >"$_s8b2/stub/npm-calls.log"
+    _out8b2="$(_run_check_candidate "$_s8b2/ws" "$_s8b2/stub")"
+    assert_contains "ci" "$(cat "$_s8b2/stub/npm-calls.log")" \
+        "8b2: missing node_modules + package-lock.json triggers npm ci (#5032)"
+    assert_contains "RC=0" "$_out8b2" \
+        "8b2: candidate healthy after repairing a missing node_modules (#5032)"
+    rm -rf "$_s8b2"
+
+    # --- 8c. npm ci itself fails (no network) -> abort, no fall-through -------
+    _s8c="$(mktemp -d)"
+    _seed_stale_mcp_ws "$_s8c/ws" empty-shell lock
+    _write_npm_stub "$_s8c/stub/npm"
+    : >"$_s8c/stub/npm-calls.log"
+    : >"$_s8c/stub/ci-fails"
+    _out8c="$(_run_check_candidate "$_s8c/ws" "$_s8c/stub")"
+    _log8c="$(cat "$_s8c/stub/npm-calls.log")"
+
+    assert_contains "RC=1" "$_out8c" \
+        "8c: failed npm ci aborts the candidate (#5032)"
+    assert_contains "npm ci failed" "$_out8c" \
+        "8c: failed npm ci produces an actionable error (#5032)"
+    assert_contains "Repair manually" "$_out8c" \
+        "8c: failed npm ci names the repair command (#5032)"
+    assert_not_contains "SMOKE_TEST_RAN" "$_out8c" \
+        "8c: failed npm ci does NOT fall through to the smoke test (#5032)"
+    assert_not_contains "run build" "$_log8c" \
+        "8c: failed npm ci short-circuits before npm run build (#5032)"
+    rm -rf "$_s8c"
+
+    # --- 8d. No lockfile: cannot self-repair, but still aborts actionably ----
+    _s8d="$(mktemp -d)"
+    _seed_stale_mcp_ws "$_s8d/ws" empty-shell   # no lockfile
+    _write_npm_stub "$_s8d/stub/npm"
+    : >"$_s8d/stub/npm-calls.log"
+    _out8d="$(_run_check_candidate "$_s8d/ws" "$_s8d/stub")"
+    _log8d="$(cat "$_s8d/stub/npm-calls.log")"
+    assert_not_contains "ci" "$_log8d" \
+        "8d: no package-lock.json -> npm ci is not attempted (#5032)"
+    assert_contains "no package-lock.json" "$_out8d" \
+        "8d: the un-repairable case is explained in the log (#5032)"
+    assert_contains "RC=1" "$_out8d" \
+        "8d: un-repairable stale bundle still aborts rather than falling through (#5032)"
+    rm -rf "$_s8d"
+
+    # --- 8e. Missing entry point (regression guard: behavior UNCHANGED) ------
+    # The sibling path already returned 1 on rebuild failure and 0 on success.
+    _s8e="$(mktemp -d)"
+    _seed_stale_mcp_ws "$_s8e/ws" complete lock
+    rm -f "$_s8e/ws/mcp-loom/dist/index.js"   # entry point missing, not stale
+    _write_npm_stub "$_s8e/stub/npm"
+    : >"$_s8e/stub/npm-calls.log"
+    _out8e_ok="$(_run_check_candidate "$_s8e/ws" "$_s8e/stub")"
+    assert_contains "RC=0" "$_out8e_ok" \
+        "8e: missing entry point + successful rebuild still returns 0 (unchanged)"
+    assert_contains "MCP entry point missing" "$_out8e_ok" \
+        "8e: missing entry point still logs its own warning (unchanged)"
+
+    rm -f "$_s8e/ws/mcp-loom/dist/index.js"
+    : >"$_s8e/stub/build-fails"
+    _out8e_fail="$(_run_check_candidate "$_s8e/ws" "$_s8e/stub")"
+    assert_contains "RC=1" "$_out8e_fail" \
+        "8e: missing entry point + failed rebuild still returns 1 (unchanged)"
+    rm -rf "$_s8e"
+else
+    echo -e "  ${YELLOW}SKIP${NC}: stale-bundle rebuild tests (node not installed)"
+fi
+
+# ============================================================
+# Section 9: node/npm resolution without a login PATH (#5032)
+#
+# claude-wrapper runs from launchd / `ssh host 'cmd'` non-login shells that
+# never source the login profile, so /opt/homebrew/bin is not on PATH. The
+# rebuild path must resolve npm/node from an ordered explicit candidate list
+# (the lib/locate-daemon-bin.sh pattern from #4875), not a bare PATH lookup.
+# ============================================================
+echo ""
+echo "Testing node/npm resolution with a minimal PATH (#5032)..."
+
+_BASH_BIN="$(command -v bash)"
+
+_locate_node_tool_in_env() {
+    # $1 = tool, remaining args = env assignments.
+    # `bash` is invoked by absolute path so the assignments may narrow $PATH.
+    local tool="$1"; shift
+    env "$@" CLAUDE_WRAPPER_SOURCE_ONLY=1 "$_BASH_BIN" -c '
+        source "$1" >/dev/null 2>&1
+        _locate_node_tool "$2" || true
+    ' _ "$WRAPPER" "$tool" 2>/dev/null || true
+}
+
+_fake_node="$(mktemp -d)/node"
+mkdir -p "$(dirname "$_fake_node")"
+printf '#!/usr/bin/env bash\necho fake\n' >"$_fake_node"
+chmod +x "$_fake_node"
+assert_eq "$_fake_node" "$(_locate_node_tool_in_env node "LOOM_NODE_BIN=$_fake_node")" \
+    "LOOM_NODE_BIN override wins over PATH (#5032)"
+assert_eq "$_fake_node" "$(_locate_node_tool_in_env npm "LOOM_NPM_BIN=$_fake_node")" \
+    "LOOM_NPM_BIN override wins over PATH (#5032)"
+rm -rf "$(dirname "$_fake_node")"
+
+if $HAVE_NODE; then
+    _real_node="$(command -v node)"
+    _real_node_dir="$(dirname "$_real_node")"
+    case "$_real_node_dir" in
+        # node lives in a candidate dir that a non-login shell's default
+        # PATH (/usr/bin:/bin) does NOT include — exactly the #5032 scenario.
+        /opt/homebrew/bin|/usr/local/bin|/opt/local/bin|/snap/bin)
+            assert_eq "$_real_node" \
+                "$(_locate_node_tool_in_env node 'PATH=/usr/bin:/bin')" \
+                "node resolves from the explicit candidate list under a non-login PATH (#5032)"
+            ;;
+        *)
+            echo -e "  ${YELLOW}SKIP${NC}: minimal-PATH node resolution (node is already on the non-login PATH: $_real_node_dir)"
+            ;;
+    esac
+else
+    echo -e "  ${YELLOW}SKIP${NC}: minimal-PATH node resolution (node not installed)"
+fi
+
+# ============================================================
+# Section 10: _mcp_node_modules_unusable classification (#5032)
+# ============================================================
+echo ""
+echo "Testing _mcp_node_modules_unusable classification (#5032)..."
+
+_deps_unusable_rc() {
+    CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1" >/dev/null 2>&1
+        if _mcp_node_modules_unusable "$2"; then echo "unusable"; else echo "ok"; fi
+    ' _ "$WRAPPER" "$1" 2>/dev/null
+}
+
+_cls="$(mktemp -d)"
+for _state in complete empty-shell absent; do
+    mkdir -p "$_cls/$_state"
+    _seed_stale_mcp_ws "$_cls/$_state" "$_state" lock
+done
+assert_eq "ok" "$(_deps_unusable_rc "$_cls/complete/mcp-loom")" \
+    "complete node_modules is usable (a build failure there is a real source error)"
+assert_eq "unusable" "$(_deps_unusable_rc "$_cls/empty-shell/mcp-loom")" \
+    "an EMPTY dependency directory is classified unusable (robb-pro root cause, #5032)"
+assert_eq "unusable" "$(_deps_unusable_rc "$_cls/absent/mcp-loom")" \
+    "a missing node_modules is classified unusable (#5032)"
+mkdir -p "$_cls/emptydir/mcp-loom/node_modules"
+cp "$_cls/complete/mcp-loom/package.json" "$_cls/emptydir/mcp-loom/package.json"
+assert_eq "unusable" "$(_deps_unusable_rc "$_cls/emptydir/mcp-loom")" \
+    "a completely empty node_modules directory is classified unusable (#5032)"
+rm -rf "$_cls"
+
+# ============================================================
 # Summary
 # ============================================================
 echo ""


### PR DESCRIPTION
Closes #5032

## Problem

`_check_mcp_candidate`'s STALE-bundle branch treated a failed `_try_mcp_rebuild` as non-fatal (`log_warn "MCP rebuild for stale bundle failed - continuing with existing bundle"`) and fell through to a smoke test against the very same known-broken `dist` — guaranteed to fail, with no actionable message. The comment justified it as "rebuild failure on an otherwise-startable bundle," but a bundle that cannot be rebuilt from its own sources is not otherwise-startable. The sibling missing-entry-point branch already did the right thing (`return 1`).

Separately, `_try_mcp_rebuild` only ever ran `npm run build`. It never looked at `node_modules`, so a half-installed dependency tree (the robb-pro root cause: `mcp-loom/node_modules/@modelcontextprotocol/sdk` was an **empty directory**) and a genuine build-source error were indistinguishable — both `MODULE_NOT_FOUND`, both needing an operator to run `cd mcp-loom && npm ci && npm run build` by hand while every dispatch died at `preflight-mcp-failed`.

## Changes (`defaults/scripts/claude-wrapper.sh`)

1. **Abort on stale-bundle rebuild failure** — `_check_mcp_candidate` now `return 1`s with `"MCP rebuild for stale bundle failed - aborting this candidate"` plus a `Repair manually: cd <pkg> && npm ci && npm run build` line, instead of falling through to the doomed smoke test. `check_mcp_server` then moves to the next candidate immediately, exactly as it does for the missing-entry-point case. The missing-entry-point branch itself is **untouched**.
2. **`npm ci` self-repair** — new `_mcp_node_modules_unusable()` classifies the mechanically-repairable case: `node_modules` absent, completely empty, or containing a declared dependency (from `dependencies` + `devDependencies`) whose directory has no `package.json` — that last check is what catches the empty-husk shape. When it fires **and** a `package-lock.json` exists, `_try_mcp_rebuild` runs `npm ci` before `npm run build`. A complete tree is left alone, so a real source error is still reported as a source error.
3. **Explicit npm/node path resolution** — new `_locate_node_tool()` / `_node_tool_search_paths()` mirror the ordered-candidate pattern `lib/locate-daemon-bin.sh` established for #4875: `$LOOM_NODE_BIN`/`$LOOM_NPM_BIN` → `$PATH` → `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `/opt/local/bin`, `/snap/bin`, `~/.local/bin`, `~/.volta/bin` → nvm-style versioned installs. The resolved node's directory is prepended to `PATH` for the build subshells (npm's own shim execs `node`), and both smoke tests now use the resolved node. "npm not found" prints the full search list.
4. **Failed `npm ci` aborts** — no network / corrupt lockfile short-circuits before `npm run build` with `"npm ci failed in <dir> - cannot repair the MCP dependency tree"` + the repair command. `npm run build` failure also gained the repair-command line.
5. Both npm invocations run under an explicit `set -o pipefail` subshell so a `| tail -5` can never mask the real exit status regardless of the caller's shell options.

## Test plan

`defaults/scripts/tests/test-mcp-config.sh` (already CI-wired) gains sections 8–10 — 84/84 pass locally, `shellcheck --severity=warning` clean:

- **8a** stale + complete deps + build failure → rc 1, "aborting this candidate", repair command named, **no** `SMOKE_TEST_RAN` marker (proves no fall-through), `npm ci` not attempted.
- **8b / 8b2** stale + empty package dir (robb-pro shape) / absent `node_modules`, with lockfile → `npm ci` runs, then `npm run build`, candidate healthy (rc 0), no operator action.
- **8c** `npm ci` fails → rc 1, "npm ci failed", repair command named, `npm run build` never reached, no smoke test.
- **8d** unusable deps but no lockfile → no `npm ci`, explained in the log, still aborts.
- **8e** regression guard: missing entry point + successful rebuild still rc 0; + failed rebuild still rc 1.
- **9** `LOOM_NODE_BIN`/`LOOM_NPM_BIN` override wins; node resolves from the explicit list under a non-login `PATH=/usr/bin:/bin`.
- **10** `_mcp_node_modules_unusable` classification: complete → usable; empty husk / absent / empty dir → unusable.

**Manual verification** — reproduced the robb-pro sequence on a scratch copy of the real `mcp-loom` (empty `node_modules/@modelcontextprotocol/sdk`, 2020-dated `dist/index.js`, `src/` newer), run under `env -i` with **node and npm off `PATH`**:

```
[WARN] MCP bundle is stale (src newer than dist) - rebuilding: .../dist/index.js
[INFO] Attempting MCP server rebuild in .../mcp-loom...
[WARN] MCP node_modules missing/incomplete in .../mcp-loom - running 'npm ci' (self-repair)
[INFO] npm ci completed - dependency tree repaired
[INFO] MCP rebuild completed
[INFO] MCP server health check passed after rebuild
RC=0
```

Also ran `test-spawn-claude.sh` (the other claude-wrapper suite): 160/168, with the same 8 `#4233` niceness/taskpolicy failures on unmodified `main` — pre-existing and environmental (the ambient sweep env leaks `LOOM_SWEEP_CLAIM_OWNED` into the fixtures), untouched by this PR.

## Notes / deviations

- Line numbers matched the issue exactly; no drift.
- Tests went into the existing `defaults/scripts/tests/test-mcp-config.sh` (already the home of the claude-wrapper MCP pre-flight tests and already in `ci-wired.txt`) rather than a new file.
- Two new optional env vars (`LOOM_NODE_BIN`, `LOOM_NPM_BIN`) are documented in the wrapper's header block.
- Out of scope, worth a follow-up: under a truly minimal macOS `PATH=/usr/bin:/bin`, `timeout` does not exist at all, so the pre-existing `timeout 10 python3` entry-point extraction fails and the whole pre-flight degrades to a #4230-style skip. Not a new risk (skip, not failure), but the same non-login-PATH failure class. `_mcp_node_modules_unusable` already degrades gracefully when `timeout` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
