### PR TITLE
feat(claude-wrapper): warn when ~/.claude.json has no user-scope loom MCP registration

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -582,15 +582,22 @@ check_global_mcp_configs() {
     fi
 
     # Parse mcpServers from ~/.claude.json.
-    # Output one line per server: "name|command|args0"
-    # Falls through silently on malformed JSON or missing python3.
+    # First line is a presence sentinel: "__HAS_LOOM__=1" or "__HAS_LOOM__=0"
+    # (emitted whenever the file parses as JSON, regardless of whether any
+    # servers are configured), so we can detect a missing `loom` entry even
+    # when mcpServers is absent or empty — not just validate entries that
+    # already exist. Every subsequent line is one server: "name|command|args0"
+    # Falls through silently (no sentinel, no server lines) on malformed JSON
+    # or missing python3, preserving the prior warn-only, never-abort contract.
     local server_info
     server_info=$(python3 - "${global_config}" 2>/dev/null <<'PYEOF'
 import json, sys
 try:
     with open(sys.argv[1]) as f:
         cfg = json.load(f)
-    for name, srv in cfg.get('mcpServers', {}).items():
+    servers = cfg.get('mcpServers', {})
+    print(f"__HAS_LOOM__={1 if 'loom' in servers else 0}")
+    for name, srv in servers.items():
         command = srv.get('command', '')
         args = srv.get('args', [])
         args0 = args[0] if args else ''
@@ -601,6 +608,24 @@ PYEOF
 )
 
     if [[ -z "${server_info}" ]]; then
+        return 0
+    fi
+
+    # Presence check (acceptance criterion #1): warn — but never abort — when
+    # the machine-level `loom` MCP registration (#4230) is absent, instead of
+    # silently relying on a possibly-stale repo-local .mcp.json.
+    if [[ "${server_info}" == *$'\n'* ]]; then
+        local first_line="${server_info%%$'\n'*}"
+    else
+        local first_line="${server_info}"
+    fi
+    if [[ "${first_line}" == "__HAS_LOOM__=0" ]]; then
+        log_warn "⚠ No 'loom' entry in ~/.claude.json mcpServers — user-scope MCP registration (#4230) is missing"
+        log_warn "Fix: re-run scripts/install-loom.sh (or 'loom update') to register the machine-level 'loom' MCP server; see CLAUDE.md § MCP hooks"
+    fi
+    server_info="${server_info#*$'\n'}"
+
+    if [[ -z "${server_info}" || "${server_info}" == "__HAS_LOOM__="* ]]; then
         return 0
     fi
 

--- a/defaults/scripts/tests/test-mcp-config.sh
+++ b/defaults/scripts/tests/test-mcp-config.sh
@@ -866,7 +866,7 @@ JSON
         echo "RC=$?"
     ' _ "$WRAPPER" 2>&1)"
     assert_eq "RC=0" "$_out_no_file" \
-        "~/.claude.json missing entirely: no output, RC=0 (early-return regression check)"
+        "user .claude.json missing entirely: no output, RC=0 (early-return regression check)"
     rm -rf "$_home_no_file"
 else
     echo -e "  ${YELLOW}SKIP${NC}: check_global_mcp_configs presence tests (python3 not installed)"

--- a/defaults/scripts/tests/test-mcp-config.sh
+++ b/defaults/scripts/tests/test-mcp-config.sh
@@ -794,6 +794,85 @@ assert_eq "unusable" "$(_deps_unusable_rc "$_cls/emptydir/mcp-loom")" \
 rm -rf "$_cls"
 
 # ============================================================
+# Section 11: check_global_mcp_configs presence check (#5033)
+#
+# The function must warn when the user-scope `loom` MCP registration
+# (#4230) is absent from ~/.claude.json's mcpServers — not just validate
+# already-present entries' binary paths — while remaining warning-only
+# (never aborts, RC always 0).
+# ============================================================
+echo ""
+echo "Testing check_global_mcp_configs presence check (#5033)..."
+
+HAVE_PYTHON3=false
+command -v python3 >/dev/null 2>&1 && HAVE_PYTHON3=true
+
+if $HAVE_PYTHON3; then
+    # 11a. No mcpServers key at all (the robb-pro incident case) -> warns.
+    _home_missing_key="$(mktemp -d)"
+    cat >"$_home_missing_key/.claude.json" <<'JSON'
+{ "other": "stuff" }
+JSON
+    _out_missing_key="$(HOME="$_home_missing_key" CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1"
+        check_global_mcp_configs
+        echo "RC=$?"
+    ' _ "$WRAPPER" 2>&1)"
+    assert_contains "No 'loom' entry" "$_out_missing_key" \
+        "mcpServers key entirely absent: warns that the loom registration is missing"
+    assert_contains "install-loom.sh" "$_out_missing_key" \
+        "missing-registration warning names the install-loom.sh / loom update fix"
+    assert_contains "RC=0" "$_out_missing_key" \
+        "missing-registration check never aborts (warning-only contract preserved)"
+    rm -rf "$_home_missing_key"
+
+    # 11b. mcpServers present but no `loom` entry -> warns.
+    _home_no_loom="$(mktemp -d)"
+    cat >"$_home_no_loom/.claude.json" <<'JSON'
+{ "mcpServers": { "other": { "command": "cat", "args": [] } } }
+JSON
+    _out_no_loom="$(HOME="$_home_no_loom" CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1"
+        check_global_mcp_configs
+        echo "RC=$?"
+    ' _ "$WRAPPER" 2>&1)"
+    assert_contains "No 'loom' entry" "$_out_no_loom" \
+        "mcpServers present without a loom key: warns that the loom registration is missing"
+    assert_contains "RC=0" "$_out_no_loom" \
+        "mcpServers present without a loom key: check never aborts"
+    rm -rf "$_home_no_loom"
+
+    # 11c. mcpServers.loom present and healthy -> no presence warning.
+    _home_healthy="$(mktemp -d)"
+    cat >"$_home_healthy/.claude.json" <<JSON
+{ "mcpServers": { "loom": { "command": "$(command -v cat)", "args": [] } } }
+JSON
+    _out_healthy="$(HOME="$_home_healthy" CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1"
+        check_global_mcp_configs
+        echo "RC=$?"
+    ' _ "$WRAPPER" 2>&1)"
+    assert_not_contains "No 'loom' entry" "$_out_healthy" \
+        "healthy loom entry present: no presence warning"
+    assert_contains "RC=0" "$_out_healthy" \
+        "healthy loom entry present: check succeeds"
+    rm -rf "$_home_healthy"
+
+    # 11d. ~/.claude.json missing entirely -> unaffected (early return preserved).
+    _home_no_file="$(mktemp -d)"
+    _out_no_file="$(HOME="$_home_no_file" CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1"
+        check_global_mcp_configs
+        echo "RC=$?"
+    ' _ "$WRAPPER" 2>&1)"
+    assert_eq "RC=0" "$_out_no_file" \
+        "~/.claude.json missing entirely: no output, RC=0 (early-return regression check)"
+    rm -rf "$_home_no_file"
+else
+    echo -e "  ${YELLOW}SKIP${NC}: check_global_mcp_configs presence tests (python3 not installed)"
+fi
+
+# ============================================================
 # Summary
 # ============================================================
 echo ""


### PR DESCRIPTION
## Summary

- `check_global_mcp_configs` (`defaults/scripts/claude-wrapper.sh`) previously only validated the binary paths of `mcpServers` entries already present in `~/.claude.json` — it never checked that a `loom` key exists at all.
- On a machine with no user-scope `loom` MCP registration (the target state post-#4230), this left the gap completely silent: the pre-flight fell through to a possibly stale repo-local `.mcp.json` with no warning naming the actual problem.

## Changes

- `defaults/scripts/claude-wrapper.sh`: `check_global_mcp_configs` now emits a presence sentinel (`__HAS_LOOM__=0`/`1`) from the same Python parse pass used for entry validation, computed whenever `~/.claude.json` parses as JSON — regardless of whether `mcpServers` is missing entirely or present-but-empty.
  - When the `loom` key is absent, logs a warning naming the fix: re-run `scripts/install-loom.sh` (or `loom update`) to register the machine-level MCP server, per CLAUDE.md's MCP hooks section.
  - Remains warning-only — the function still always returns 0 (never aborts), consistent with its existing "global MCPs are outside Loom's control" contract.
  - The prior early-return path (`~/.claude.json` missing entirely) is unchanged.
- `defaults/scripts/tests/test-mcp-config.sh`: adds Section 8 covering the presence check — missing `mcpServers` key entirely, `mcpServers` present without a `loom` entry, `loom` present and healthy (no new warning), and `~/.claude.json` missing entirely (regression check for the early return).

## Acceptance Criteria Verification

- [x] `check_global_mcp_configs` asserts a `loom` key is present in `~/.claude.json`'s `mcpServers`, not just validating already-present entries' binary paths — verified via the presence sentinel added to the existing Python parse.
- [x] Absent `loom` key logs a clear, actionable warning naming `scripts/install-loom.sh` / `loom update` as the fix.
- [x] Remains warning-only — verified: `RC=0` in all manual test scenarios (missing key, present-without-loom, healthy, file-missing).
- [x] `resync-installed.sh`'s `.mcp.json`-is-out-of-scope stance is unchanged — no changes to `resync-installed.sh`; this check lives entirely in `claude-wrapper.sh`.

## Test Plan

- `bash defaults/scripts/tests/test-mcp-config.sh` — 61/61 pass (includes the 8 new assertions added for this issue).
- `shellcheck defaults/scripts/claude-wrapper.sh` — clean, no findings.
- Manual verification of all 5 scenarios by sourcing the function directly with a fake `HOME`:
  - No `mcpServers` key at all → warns, `RC=0`.
  - `mcpServers` present without a `loom` entry → warns, `RC=0`.
  - `mcpServers.loom` present and healthy → no presence warning, `RC=0`.
  - `mcpServers.loom` present with a bad binary path → existing per-entry warning still fires, `RC=0`.
  - `~/.claude.json` missing entirely → no output, `RC=0` (early-return path unaffected).

Closes #5033