### PR TITLE
fix(daemon): timestamp + workspace-scope the claude-wrapper preflight advisory

### DIFF
--- a/loom-daemon/src/cli/status.rs
+++ b/loom-daemon/src/cli/status.rs
@@ -756,6 +756,7 @@ pub(crate) mod status_client_tests {
             capacity_bound: false,
             preflight_advisory_active: false,
             preflight_advisory_message: None,
+            preflight_advisory_changed_at: None,
             configured_max: 5,
             per_token_concurrency: 2,
             dynamic_cap: 3,

--- a/loom-daemon/src/cli/status_render.rs
+++ b/loom-daemon/src/cli/status_render.rs
@@ -164,6 +164,13 @@ pub(crate) fn build_status_json_value(
         // silent-failure signature. `message` is `null` when not tripped.
         "preflight_advisory_active": report.preflight_advisory_active,
         "preflight_advisory_message": report.preflight_advisory_message,
+        // Freshness signal for the advisory above (Issue #5029): the wall-clock
+        // time of the most recent trip/clear transition, so a scripted
+        // consumer (like the human-readable renderer below) can distinguish a
+        // just-tripped warning from a stale one that predates a since-applied
+        // fix. `null` before the first transition this daemon process has
+        // observed.
+        "preflight_advisory_changed_at": report.preflight_advisory_changed_at,
         // Observability host-identity mismatch (#4830): non-null means this
         // host's ingest key is bound to a DIFFERENT host_id than the daemon
         // reports for itself, so its telemetry is being filed under the wrong
@@ -644,6 +651,44 @@ fn saturation_hold_note(report: &DaemonStatusReport, dispatch_cap: usize) -> Opt
     ))
 }
 
+/// Render the "as of" freshness suffix for the pre-flight advisory line
+/// (Issue #5029), e.g. `" (as of 12s ago, 2026-08-03T12:00:00Z)"` — empty
+/// string when no transition timestamp is available (an older daemon binary,
+/// or a state this process has not transitioned through yet), so pre-#5029
+/// output is unaffected byte-for-byte.
+fn format_preflight_advisory_freshness(changed_at: Option<DateTime<Utc>>) -> String {
+    match changed_at {
+        Some(ts) => {
+            let secs = (Utc::now() - ts).num_seconds().max(0);
+            format!(" (as of {secs}s ago, {ts})")
+        }
+        None => String::new(),
+    }
+}
+
+/// The claude-wrapper pre-flight-death tripwire warning line (#4386), with an
+/// "as of" freshness suffix appended (Issue #5029) — split out from
+/// [`print_status_human`] so the freshness text is unit-testable without
+/// capturing process stdout, mirroring [`render_admission_brake_line`].
+/// `None` when the advisory is not currently active (nothing to print) or the
+/// active flag is set with no message (defensive — should not happen in
+/// practice).
+fn render_preflight_advisory_line(report: &DaemonStatusReport) -> Option<String> {
+    if !report.preflight_advisory_active {
+        return None;
+    }
+    let msg = report.preflight_advisory_message.as_ref()?;
+    // Issue #5029: append the freshness indicator so a stale (already-cleared
+    // elsewhere, or long-since-tripped) warning is visibly distinguishable
+    // from a just-tripped one, rather than reading as a frozen count with no
+    // notion of time. The message itself already names the specific
+    // workspace it is scoped to (`preflight_advisory_message`).
+    Some(format!(
+        "{msg}{}",
+        format_preflight_advisory_freshness(report.preflight_advisory_changed_at)
+    ))
+}
+
 /// The standalone `Admission brake: …` status line (#4903), or `None` when no
 /// brake is registered (older daemon / never registered) — which renders
 /// nothing at all, the zero-behavior-change baseline the host breaker's line
@@ -745,10 +790,8 @@ pub(crate) fn print_status_human(
     // the "not capacity-bound … the limiter is work availability" line further
     // below is never the only diagnosis shown while this is tripped — see the
     // guard on that line.
-    if report.preflight_advisory_active {
-        if let Some(msg) = &report.preflight_advisory_message {
-            println!("\n{msg}");
-        }
+    if let Some(line) = render_preflight_advisory_line(report) {
+        println!("\n{line}");
     }
 
     // Observability host-identity mismatch (#4830): printed alongside the
@@ -2227,5 +2270,130 @@ mod admission_brake_render_tests {
         let older: DaemonStatusReport =
             serde_json::from_value(stripped).expect("pre-#4903 payload must still parse");
         assert!(older.admission_brake.is_none());
+    }
+}
+
+#[cfg(test)]
+mod preflight_advisory_render_tests {
+    //! Issue #5029: the pre-flight-death advisory (#4386) has no freshness
+    //! signal and is scoped to a single workspace with no way to tell which
+    //! one from the rendered text alone. These tests pin the display-only fix
+    //! — an "as of" freshness suffix on the human line, the timestamp on the
+    //! `--json` surface, and forward/backward wire compatibility — without
+    //! touching the trip/clear decision logic itself.
+    use super::{build_status_json_value, render_preflight_advisory_line};
+    use crate::cli::status::status_client_tests::sample_report;
+    use chrono::Utc;
+    use loom_daemon::self_update::SelfUpdateStatus;
+    use loom_daemon::types::DaemonStatusReport;
+
+    fn no_update() -> SelfUpdateStatus {
+        SelfUpdateStatus {
+            built_commit: "abc".to_string(),
+            source_commit: None,
+            update_available: None,
+        }
+    }
+
+    fn report_with(
+        active: bool,
+        message: Option<&str>,
+        changed_at: Option<chrono::DateTime<Utc>>,
+    ) -> DaemonStatusReport {
+        let mut r = sample_report();
+        r.preflight_advisory_active = active;
+        r.preflight_advisory_message = message.map(ToString::to_string);
+        r.preflight_advisory_changed_at = changed_at;
+        r
+    }
+
+    // ---- human surface -----------------------------------------------------
+
+    #[test]
+    fn active_advisory_renders_with_a_freshness_suffix() {
+        let ts = Utc::now() - chrono::Duration::seconds(42);
+        let report = report_with(
+            true,
+            Some("WARNING: last 3 dispatches died at claude-wrapper pre-flight (x) — check .mcp.json [workspace: /repos/loom]"),
+            Some(ts),
+        );
+        let line = render_preflight_advisory_line(&report).expect("active advisory renders a line");
+        assert!(line.contains("WARNING: last 3 dispatches"), "got: {line}");
+        assert!(
+            line.contains("workspace: /repos/loom"),
+            "the rendered line must name the scoped workspace: {line}"
+        );
+        assert!(
+            line.contains("as of") && line.contains("ago"),
+            "the rendered line must carry a freshness indicator: {line}"
+        );
+    }
+
+    #[test]
+    fn active_advisory_without_a_timestamp_renders_the_message_unchanged() {
+        // Forward-compat: an older daemon binary that never populated the new
+        // field must still render the bare message, not a "None"/error text.
+        let report = report_with(true, Some("WARNING: still dying"), None);
+        let line = render_preflight_advisory_line(&report).expect("line");
+        assert_eq!(line, "WARNING: still dying");
+    }
+
+    #[test]
+    fn inactive_advisory_renders_nothing() {
+        assert!(render_preflight_advisory_line(&report_with(false, None, None)).is_none());
+        // Defensive: `active` true with no message must not panic or fabricate
+        // a line — should not happen in practice, but stay silent rather than
+        // render a garbage string.
+        assert!(
+            render_preflight_advisory_line(&report_with(true, None, Some(Utc::now()))).is_none()
+        );
+    }
+
+    // ---- --json surface ----------------------------------------------------
+
+    #[test]
+    fn json_carries_the_advisory_timestamp() {
+        let ts = Utc::now() - chrono::Duration::seconds(7);
+        let value = build_status_json_value(
+            &report_with(true, Some("WARNING: x"), Some(ts)),
+            None,
+            &no_update(),
+            None,
+            None,
+        );
+        assert_eq!(value["preflight_advisory_active"], true);
+        assert!(value["preflight_advisory_changed_at"].is_string());
+    }
+
+    #[test]
+    fn json_advisory_timestamp_is_null_when_absent() {
+        let value = build_status_json_value(
+            &report_with(false, None, None),
+            None,
+            &no_update(),
+            None,
+            None,
+        );
+        assert!(value["preflight_advisory_changed_at"].is_null());
+    }
+
+    #[test]
+    fn advisory_timestamp_survives_a_wire_round_trip_and_older_payloads() {
+        let ts = Utc::now() - chrono::Duration::seconds(5);
+        let report = report_with(true, Some("WARNING: x"), Some(ts));
+        let json = serde_json::to_string(&report).expect("serialize");
+        let back: DaemonStatusReport = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.preflight_advisory_changed_at, report.preflight_advisory_changed_at);
+
+        // Forward-compat: an absent field (pre-#5029 daemon) parses as `None`,
+        // never a fabricated/default timestamp.
+        let mut stripped: serde_json::Value = serde_json::from_str(&json).expect("value");
+        stripped
+            .as_object_mut()
+            .expect("object")
+            .remove("preflight_advisory_changed_at");
+        let older: DaemonStatusReport =
+            serde_json::from_value(stripped).expect("pre-#5029 payload must still parse");
+        assert!(older.preflight_advisory_changed_at.is_none());
     }
 }

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1615,12 +1615,13 @@ pub fn build_daemon_status(
     // Claude-wrapper pre-flight-death tripwire (#4386), read from the
     // fallback/default workspace's own registry — mirrors the top-level
     // `main_health_gate_*` fields' fallback-root scoping above/below.
-    let (preflight_advisory_active, preflight_advisory_message) = {
+    let (preflight_advisory_active, preflight_advisory_message, preflight_advisory_changed_at) = {
         let registry = workspace_pool.get_or_provision(fallback_root);
         let sr = registry
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        sr.preflight_advisory()
+        let (active, message) = sr.preflight_advisory();
+        (active, message, sr.preflight_advisory_changed_at())
     };
     let capacity = crate::types::CapacityReport {
         ranking_present: ranking.is_some(),
@@ -1645,6 +1646,7 @@ pub fn build_daemon_status(
         capacity_bound,
         preflight_advisory_active,
         preflight_advisory_message,
+        preflight_advisory_changed_at,
         configured_max,
         per_token_concurrency,
         dynamic_cap,
@@ -5531,6 +5533,7 @@ exit 0
             capacity_bound: false,
             preflight_advisory_active: false,
             preflight_advisory_message: None,
+            preflight_advisory_changed_at: None,
             configured_max: 5,
             per_token_concurrency: 2,
             dynamic_cap: 3,

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -1182,6 +1182,7 @@ mod tests {
             capacity_bound: false,
             preflight_advisory_active: false,
             preflight_advisory_message: None,
+            preflight_advisory_changed_at: None,
             configured_max: 0,
             per_token_concurrency: 1,
             dynamic_cap: 0,

--- a/loom-daemon/src/sweep_registry/mod.rs
+++ b/loom-daemon/src/sweep_registry/mod.rs
@@ -512,6 +512,18 @@ pub struct SweepRegistry {
     /// back to `None` the moment the advisory un-trips, so a freshly re-tripped
     /// advisory always waits a full cooldown before its first probe.
     preflight_probe_last_at: Option<DateTime<Utc>>,
+    /// Wall-clock time of the most recent
+    /// [`preflight_advisory_tripped`](Self::preflight_advisory_tripped)
+    /// state-change transition (Issue #5029) — `None` until the first trip or
+    /// clear this process observes. Stamped exclusively inside
+    /// [`update_preflight_advisory`](Self::update_preflight_advisory)'s
+    /// existing state-change branch (never on an unrelated tick that leaves
+    /// `preflight_advisory_tripped` unchanged), so it is purely a display/
+    /// reporting addition — the trip/clear *decision* and
+    /// `preflight_death_streak` increment/reset semantics are untouched.
+    /// Lets `loom-daemon status` show "as of" freshness so a historical,
+    /// already-cleared tripped count is never mistaken for a live one.
+    preflight_advisory_changed_at: Option<DateTime<Utc>>,
     /// Per-issue dispatch-backoff parameters (Issue #4485). `main.rs` /
     /// [`crate::workspace_pool::WorkspacePool`] set the resolved env > config >
     /// default value at provision time, mirroring
@@ -717,6 +729,7 @@ impl SweepRegistry {
             preflight_death_last_marker: None,
             preflight_advisory_tripped: false,
             preflight_probe_last_at: None,
+            preflight_advisory_changed_at: None,
             dispatch_backoff_config: DispatchBackoffConfig::default(),
             dispatch_backoff: HashMap::new(),
             label_flip_log: HashMap::new(),
@@ -760,6 +773,7 @@ impl SweepRegistry {
             preflight_death_last_marker: None,
             preflight_advisory_tripped: false,
             preflight_probe_last_at: None,
+            preflight_advisory_changed_at: None,
             dispatch_backoff_config: DispatchBackoffConfig::default(),
             dispatch_backoff: HashMap::new(),
             label_flip_log: HashMap::new(),
@@ -863,6 +877,16 @@ impl SweepRegistry {
             .unwrap_or("unknown");
         let message = self.preflight_advisory_message(self.preflight_pool_exhausted_now(), marker);
         (true, Some(message))
+    }
+
+    /// Wall-clock time of the most recent trip/clear transition backing
+    /// [`preflight_advisory`](Self::preflight_advisory) (Issue #5029), or
+    /// `None` before the first transition this process has observed. Purely a
+    /// freshness signal for `DaemonStatusReport` / `loom-daemon status` — it
+    /// does not participate in the trip/clear decision itself.
+    #[must_use]
+    pub fn preflight_advisory_changed_at(&self) -> Option<DateTime<Utc>> {
+        self.preflight_advisory_changed_at
     }
 
     /// Current consecutive pre-flight-death streak (Issue #4386), for tests /

--- a/loom-daemon/src/sweep_registry/quarantine.rs
+++ b/loom-daemon/src/sweep_registry/quarantine.rs
@@ -672,6 +672,12 @@ impl SweepRegistry {
             // rather than re-probing off a stale timestamp (#5030).
             self.preflight_probe_last_at = None;
         }
+        // Issue #5029: stamp the transition instant purely for display —
+        // exactly this state-change branch, never an unrelated tick that
+        // leaves `should_trip == preflight_advisory_tripped` (the early
+        // return above), so this is a pure freshness signal alongside the
+        // unchanged trip/clear decision above.
+        self.preflight_advisory_changed_at = Some(Utc::now());
         let marker = self.preflight_death_last_marker.clone().unwrap_or_default();
         let message = if should_trip {
             self.preflight_advisory_message(pool_exhausted_now, &marker)
@@ -782,22 +788,29 @@ impl SweepRegistry {
     /// Render the operator-facing advisory message for the tripped state,
     /// naming the specific whole-pool-dead cause (Issue #4644) when
     /// `pool_exhausted_now` holds, else the ordinary #4386 streak wording.
+    ///
+    /// Issue #5029: always names `self.config.workspace_root` explicitly —
+    /// this registry's state (and hence this message) describes exactly ONE
+    /// workspace, never an aggregate across every managed repo, so an
+    /// operator reading "last N dispatches" alongside multiple registered
+    /// workspaces is never left guessing which repo it refers to.
     #[must_use]
     pub(crate) fn preflight_advisory_message(
         &self,
         pool_exhausted_now: bool,
         marker: &str,
     ) -> String {
+        let workspace = self.config.workspace_root.display();
         if pool_exhausted_now {
             format!(
                 "WARNING: token pool exhausted (0 healthy accounts) — every dispatch will die at \
                  token selection ({marker}); add accounts (`loom-daemon tokens bootstrap`) or wait \
-                 for the pool to recover before re-dispatching (#4644)"
+                 for the pool to recover before re-dispatching (#4644) [workspace: {workspace}]"
             )
         } else {
             format!(
                 "WARNING: last {} dispatches died at claude-wrapper pre-flight ({marker}) — check \
-                 .mcp.json",
+                 .mcp.json [workspace: {workspace}]",
                 self.preflight_death_streak
             )
         }
@@ -1513,6 +1526,12 @@ mod tests {
         let message = message.expect("advisory message present when tripped");
         assert!(message.contains("pre-flight"));
         assert!(message.contains("mcp.json"));
+        // AC (#5029): the message names the specific workspace it is scoped
+        // to, so an operator with multiple managed repos never has to guess.
+        assert!(
+            message.contains("workspace:"),
+            "message must name the scoped workspace: {message}"
+        );
 
         match sub.recv().await.unwrap() {
             Event::PreflightAdvisory {
@@ -1694,6 +1713,76 @@ mod tests {
         let cfg = resolve_preflight_tripwire_config(dir.path());
         assert_eq!(cfg.probe_cooldown, Duration::from_secs(42));
         std::env::remove_var(PREFLIGHT_PROBE_COOLDOWN_ENV);
+    }
+
+    /// AC (#5029): `preflight_advisory_changed_at` stamps the wall-clock
+    /// instant of a trip/clear *transition*, and does NOT move on an
+    /// unrelated tick that leaves the tripped state unchanged (a further
+    /// pre-flight death while already tripped) — a pure freshness signal
+    /// layered on top of the unchanged trip/clear decision logic.
+    #[test]
+    fn preflight_advisory_timestamp_updates_only_on_state_transition() {
+        let dir = tempdir().unwrap();
+        let (mut registry, _record_log) = fixture_registry(dir.path());
+
+        // No transition observed yet.
+        assert!(registry.preflight_advisory_changed_at().is_none());
+
+        // Two pre-flight deaths (different issues): below the default
+        // threshold of 3, so no transition yet.
+        for (issue, seq) in [(9201u32, 0u32), (9202, 0)] {
+            insert_dead_running_with_log(
+                &mut registry,
+                issue,
+                seq,
+                "unknown",
+                "# MCP_PREFLIGHT_FAILED\n",
+            );
+            registry.reap_once();
+        }
+        assert!(
+            registry.preflight_advisory_changed_at().is_none(),
+            "no state-change transition yet ⇒ no timestamp"
+        );
+
+        // A third consecutive pre-flight death trips the advisory — the
+        // FIRST state-change transition, so the timestamp is stamped.
+        insert_dead_running_with_log(&mut registry, 9203, 0, "unknown", "# MCP_PREFLIGHT_FAILED\n");
+        registry.reap_once();
+        assert!(registry.preflight_advisory().0);
+        let tripped_at = registry
+            .preflight_advisory_changed_at()
+            .expect("timestamp stamped on trip");
+
+        // A fourth consecutive pre-flight death (still tripped, an
+        // UNRELATED tick — `should_trip == preflight_advisory_tripped`
+        // already) must NOT move the timestamp.
+        insert_dead_running_with_log(&mut registry, 9204, 0, "unknown", "# MCP_PREFLIGHT_FAILED\n");
+        registry.reap_once();
+        assert_eq!(
+            registry.preflight_advisory_changed_at(),
+            Some(tripped_at),
+            "an unrelated tick that leaves the tripped state unchanged must not move the timestamp"
+        );
+
+        // A sweep whose log reaches `# CLAUDE_CLI_START` clears the advisory
+        // — the SECOND state-change transition, so the timestamp advances.
+        insert_dead_running_with_log(
+            &mut registry,
+            9205,
+            0,
+            "unknown",
+            "# CLAUDE_CLI_START\nsome later crash\n",
+        );
+        registry.reap_once();
+        assert!(!registry.preflight_advisory().0);
+        let cleared_at = registry
+            .preflight_advisory_changed_at()
+            .expect("timestamp stamped on clear");
+        assert!(
+            cleared_at >= tripped_at,
+            "the clear transition must stamp a timestamp at or after the trip transition"
+        );
     }
 
     /// Edge case (#4386): a dead sweep whose log file is missing/unreadable

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1012,6 +1012,16 @@ pub struct DaemonStatusReport {
     /// wire data compatible.
     #[serde(default)]
     pub preflight_advisory_message: Option<String>,
+    /// Wall-clock time of the most recent trip/clear transition backing
+    /// [`Self::preflight_advisory_active`] (Issue #5029) — `None` before the
+    /// first transition this daemon process has observed. Lets the status
+    /// renderer show an "as of" freshness indicator alongside the warning, so
+    /// a historical (already-cleared) tripped count is never mistaken for a
+    /// live one. Purely a display addition — carries no decision logic of its
+    /// own. `#[serde(default)]` keeps pre-#5029 wire data / older clients
+    /// compatible (an absent field parses as `None`).
+    #[serde(default)]
+    pub preflight_advisory_changed_at: Option<DateTime<Utc>>,
     /// Dynamic-cap input 3: **the** per-machine admission knob
     /// (`autonomous.workFinder.maxConcurrent` / `LOOM_WORK_FINDER_MAX_CONCURRENT`).
     /// Since #4512 this is the only *policy* term in the cap — the other two


### PR DESCRIPTION
## Summary

`SweepRegistry::preflight_advisory()` surfaces a boolean + message pair about
consecutive claude-wrapper pre-flight deaths, but had two display/reporting
gaps:

1. **No timestamp.** `preflight_death_streak` is a pure count with no
   associated time, so `loom-daemon status` kept printing a stale "WARNING:
   last 7 dispatches died..." even after the underlying fix landed and
   dispatch resumed normally — indistinguishable from a live warning.
2. **Scoped to one workspace with no label.** `ipc.rs` reads the advisory
   from the fallback/default workspace's own registry only, and the rendered
   message never named which workspace it described.

This is display/reporting only — the trip/clear *decision* logic in
`update_preflight_advisory` (quarantine.rs) and `preflight_death_streak`
increment/reset semantics are unchanged.

## Changes

- `sweep_registry/mod.rs`: new `preflight_advisory_changed_at: Option<DateTime<Utc>>`
  field + read-only accessor, threaded through both constructors.
- `sweep_registry/quarantine.rs`: `update_preflight_advisory` stamps
  `preflight_advisory_changed_at = Some(Utc::now())` inside its existing
  state-change branch only (never on an unrelated tick that leaves the
  tripped state unchanged). `preflight_advisory_message` now always names
  `self.config.workspace_root` explicitly (`[workspace: <root>]`), satisfying
  the AC's "OR the rendered message explicitly names the workspace it is
  scoped to" option.
- `types.rs`: `DaemonStatusReport.preflight_advisory_changed_at` (serde
  `#[serde(default)]` for wire compat).
- `ipc.rs`: status-report population reads the new accessor alongside the
  existing `preflight_advisory()` call.
- `cli/status_render.rs`: new `render_preflight_advisory_line` (extracted
  for testability, mirrors `render_admission_brake_line`) appends an "as of
  Ns ago, <timestamp>" freshness suffix on the human surface; the `--json`
  surface carries the raw timestamp.

## Test plan

- [x] `sweep_registry::quarantine::tests::preflight_advisory_timestamp_updates_only_on_state_transition` —
  asserts the timestamp is `None` before any transition, stamps on trip,
  does NOT move on a further death while already tripped (unrelated tick),
  and advances again on clear.
- [x] Extended `workspace_tripwire_trips_across_issues_resets_on_progress_and_dedups`
  to assert the message names the scoped workspace.
- [x] New `cli::status_render::preflight_advisory_render_tests` module: human
  line includes the freshness suffix and workspace scope, renders unchanged
  (no panic) when the timestamp is absent (pre-#5029 wire compat), stays
  silent when inactive, `--json` carries/nulls the timestamp correctly, and
  a full serialize/deserialize + stripped-field round trip.
- [x] `cargo test -p loom-daemon` (lib + bin): all pre-existing and new
  tests pass. The only failures observed (`tests/integration_basic.rs`
  terminal-pool tests timing out) are unrelated to this change (tmux/socket
  terminal creation, not touched by this diff) and reproduce under heavy
  concurrent host load from other builder worktrees running at the same
  time — pre-existing flakiness, not a regression from this PR.

Closes #5029