### PR TITLE
feat(health): assess the review-side queue axes and flag review stalls

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1434,8 +1434,22 @@ Six sections, one line each (or the full structured payload with `--json`):
 | `dispatch` | in-flight vs dynamic cap, plus the last work-finder tick's dispatch/skip-reason summary | `DaemonStatusReport` + `work_finder::last_tick_summary()` |
 | `tokens` | healthy/total, exhausted count, `.ranking` staleness | `CapacityReport` + the resolved pool's `.ranking` mtime |
 | `roles` | **persistent** role-tick failures (transient ones are a count only) | `role_runner::role_tick_records()` |
-| `queues` | per-root ready (`loom:issue`) counts | `pipeline_snapshot` (`PipelineMetrics::HEALTH`) |
+| `queues` | per-root ready (`loom:issue`) counts **plus the review-side axes** (`loom:review-requested` / `loom:changes-requested` / `loom:pr`), and a per-repo *review stall* verdict | `pipeline_snapshot` (`PipelineMetrics::HEALTH`) |
 | `throughput` | merges across managed repos inside the window | `pipeline_snapshot` (`PipelineMetrics::HEALTH`) |
+
+#### `queues`: the review-stall rule (#5021)
+
+`queues` reports a repo **DEGRADED** ("REVIEW STALLED") when it is carrying at
+least `health::REVIEW_STALL_MIN_BACKLOG` (3) open `loom:review-requested` PRs
+**and** the window merged nothing at all. Neither half alone is a fault — a
+short review queue is normal, and a quiet window legitimately merges nothing
+(`throughput` treats zero merges as green for exactly that reason) — but the
+conjunction is a direct, cause-agnostic observation that review is not
+happening. It is evaluated **per repo**, so a repo with zero ready issues
+cannot be masked by the fleet-wide `total_ready` sum. An axis that was not
+observed (forge query failed, or the caller masked the metric off) is reported
+as `null`/`?`, never as `0`, and never produces a stall verdict in either
+direction.
 
 ### Liveness precedence: pgrep + pid-file first, launchd NEVER alone
 

--- a/loom-daemon/src/cli/health.rs
+++ b/loom-daemon/src/cli/health.rs
@@ -88,11 +88,13 @@ async fn collect(window: Duration) -> HealthReport {
     //    the same rule `status`'s client-side token probe follows.
     let (ranking_present, ranking_age_secs) = probe_ranking(status.as_ref());
 
-    // 4. The forge fan-out for queue depth + throughput. Only the two metrics
-    //    those sections need (#4761's `PipelineMetrics::HEALTH`), over the
-    //    requested window, across the roots the daemon reported. Skipped
-    //    entirely when the daemon is unreachable: without its root list there
-    //    is nothing to query, and the sections honestly report "not collected".
+    // 4. The forge fan-out for queue depth + review pipeline + throughput.
+    //    Only the metrics those sections actually read (#4761's
+    //    `PipelineMetrics::HEALTH`, widened by #5021 to carry the review-side
+    //    axes the `queues` verdict now consumes), over the requested window,
+    //    across the roots the daemon reported. Skipped entirely when the daemon
+    //    is unreachable: without its root list there is nothing to query, and
+    //    the sections honestly report "not collected".
     let pipeline = match &status {
         Some(report) => {
             let roots = report

--- a/loom-daemon/src/health.rs
+++ b/loom-daemon/src/health.rs
@@ -117,6 +117,24 @@ pub const WORK_FINDER_TICK_GRACE_INTERVALS: u64 = 2;
 /// it as "cannot compare" instead of as a real commit that never matches.
 const UNKNOWN_BUILD_COMMIT: &str = "unknown";
 
+/// How many open `loom:review-requested` PRs a repo must be carrying before a
+/// **zero-merge** window is read as a *review stall* rather than a quiet
+/// moment (Issue #5021).
+///
+/// The pair of conditions is the point. Either alone is ordinary: a repo can
+/// hold a few PRs awaiting review while Judge works through them, and an idle
+/// window legitimately merges nothing (which is exactly why
+/// [`assess_throughput`] treats zero merges as green). What is *not* ordinary
+/// is a review queue this deep with nothing coming out the far end — the
+/// direct, cause-agnostic observation of "review is not happening" that the
+/// 2026-08-03 fleet-wide Judge outage produced on every repo and that the
+/// `queued`-only assessment reported as green all day.
+///
+/// Three is the smallest backlog that cannot be explained by a single burst:
+/// one Builder wave lands one or two PRs per repo, so a third simultaneously
+/// unreviewed PR means at least one earlier PR was not picked up.
+pub const REVIEW_STALL_MIN_BACKLOG: usize = 3;
+
 // ============================================================================
 // Verdicts
 // ============================================================================
@@ -1072,9 +1090,56 @@ pub fn assess_roles(inputs: &HealthInputs) -> HealthSection {
     )
 }
 
+/// Add one optionally-observed count into a running total, **without** ever
+/// inventing a zero.
+///
+/// `None` on the input means "this metric was not observed for this repo" —
+/// the forge query failed, or the caller masked the metric off
+/// ([`crate::pipeline_snapshot::PipelineMetrics`]). Either way it must not be
+/// folded in as `0`, or an unobserved review queue would report as an empty
+/// one: the precise misreading Issue #5021 exists to prevent. The accumulator
+/// therefore stays `None` until at least one repo actually reports, and from
+/// then on sums only the repos that did.
+fn accumulate_observed(total: &mut Option<usize>, observed: Option<usize>) {
+    if let Some(n) = observed {
+        *total = Some(total.unwrap_or(0) + n);
+    }
+}
+
+/// Whether this repo's review pipeline looks *stalled*: at least
+/// [`REVIEW_STALL_MIN_BACKLOG`] PRs sitting in `loom:review-requested` while
+/// the window merged nothing at all.
+///
+/// Both inputs must be *observed* (`Some`) — an unobserved axis yields `false`
+/// ("cannot tell"), never a stall verdict and never a clean bill of health;
+/// the enclosing section reports the unobserved axis as `null`/`?` so the gap
+/// is visible rather than silently resolved either way.
+fn is_review_stalled(snap: &RepoPipelineSnapshot) -> bool {
+    matches!(
+        (snap.review_requested, snap.merged_24h),
+        (Some(backlog), Some(0)) if backlog >= REVIEW_STALL_MIN_BACKLOG
+    )
+}
+
 /// Assess the queue-depth section: per-root ready (dispatchable `loom:issue`,
 /// excluding park-labeled rows — see [`crate::pipeline_snapshot::RepoPipelineSnapshot::queued`])
-/// counts.
+/// counts, **plus** the review-side axes (`review_requested`,
+/// `changes_requested`, `approved`) that the same snapshot already carries.
+///
+/// The review axes are reported for their own sake and are also the input to a
+/// per-repo *review stall* check ([`is_review_stalled`]): a deep
+/// `loom:review-requested` backlog against a window that merged nothing is a
+/// direct, cause-agnostic observation that review is not happening. Before
+/// Issue #5021 those three fields were collected and discarded, so a fleet-wide
+/// Judge outage — which by construction moves `review_requested` and leaves
+/// `queued` untouched — read green here all day.
+///
+/// Verdict precedence when both a stall and a failed forge query are present:
+/// **stall wins** (`Degraded` over `Unknown`). Both are non-green and share an
+/// exit code, but a stall is a *known, actionable finding*, and burying it
+/// under the `Unknown` a single flaky `gh` call produces is the same masking
+/// this check exists to remove. The failed repos are still named in the
+/// summary either way.
 #[must_use]
 pub fn assess_queues(inputs: &HealthInputs) -> HealthSection {
     let Some(pipeline) = &inputs.pipeline else {
@@ -1092,6 +1157,10 @@ pub fn assess_queues(inputs: &HealthInputs) -> HealthSection {
     let mut parts: Vec<String> = Vec::with_capacity(pipeline.len());
     let mut total = 0_usize;
     let mut failed: Vec<String> = Vec::new();
+    let mut review_requested: Option<usize> = None;
+    let mut changes_requested: Option<usize> = None;
+    let mut approved: Option<usize> = None;
+    let mut stalled: Vec<String> = Vec::new();
     for snap in pipeline {
         let name = repo_label(&snap.root);
         match snap.queued {
@@ -1101,37 +1170,94 @@ pub fn assess_queues(inputs: &HealthInputs) -> HealthSection {
             }
             None => {
                 parts.push(format!("{name} ?"));
-                failed.push(name);
+                failed.push(name.clone());
             }
         }
+        accumulate_observed(&mut review_requested, snap.review_requested);
+        accumulate_observed(&mut changes_requested, snap.changes_requested);
+        accumulate_observed(&mut approved, snap.approved);
+        if is_review_stalled(snap) {
+            stalled.push(format!(
+                "{name} ({} awaiting review, 0 merged)",
+                snap.review_requested.unwrap_or(0)
+            ));
+        }
     }
-    let (verdict, summary) = if failed.is_empty() {
-        (
-            Verdict::Green,
-            format!("{total} ready across {} repo(s) ({})", pipeline.len(), parts.join(", ")),
-        )
-    } else {
-        (
-            Verdict::Unknown,
-            format!(
-                "{total}+ ready across {} repo(s) ({}); forge query FAILED for: {}",
-                pipeline.len(),
-                parts.join(", "),
-                failed.join(", ")
-            ),
-        )
+
+    // The review clause is appended only for axes some repo actually reported,
+    // so a caller that masked them off (or a total forge failure) renders the
+    // historical `queued`-only line instead of a fabricated "0 awaiting review".
+    let review_clause = {
+        let mut axes: Vec<String> = Vec::with_capacity(3);
+        if let Some(n) = review_requested {
+            axes.push(format!("{n} awaiting review"));
+        }
+        if let Some(n) = changes_requested {
+            axes.push(format!("{n} changes-requested"));
+        }
+        if let Some(n) = approved {
+            axes.push(format!("{n} approved"));
+        }
+        if axes.is_empty() {
+            String::new()
+        } else {
+            format!("; {}", axes.join(", "))
+        }
     };
+    let stall_clause = if stalled.is_empty() {
+        String::new()
+    } else {
+        format!("; REVIEW STALLED: {}", stalled.join(", "))
+    };
+    let failed_clause = if failed.is_empty() {
+        String::new()
+    } else {
+        format!("; forge query FAILED for: {}", failed.join(", "))
+    };
+
+    let verdict = if !stalled.is_empty() {
+        Verdict::Degraded
+    } else if failed.is_empty() {
+        Verdict::Green
+    } else {
+        Verdict::Unknown
+    };
+    let ready_prefix = if failed.is_empty() {
+        format!("{total} ready")
+    } else {
+        format!("{total}+ ready")
+    };
+    let summary = format!(
+        "{ready_prefix} across {} repo(s) ({}){review_clause}{stall_clause}{failed_clause}",
+        pipeline.len(),
+        parts.join(", ")
+    );
+
     HealthSection::new(
         "queues",
         verdict,
         summary,
         serde_json::json!({
             "total_ready": total,
+            "total_review_requested": review_requested,
+            "total_changes_requested": changes_requested,
+            "total_approved": approved,
+            "review_stall_min_backlog": REVIEW_STALL_MIN_BACKLOG,
+            "review_stalled": pipeline
+                .iter()
+                .filter(|s| is_review_stalled(s))
+                .map(|s| repo_label(&s.root))
+                .collect::<Vec<_>>(),
             "repos": pipeline
                 .iter()
                 .map(|s| serde_json::json!({
                     "root": s.root,
                     "ready": s.queued,
+                    "review_requested": s.review_requested,
+                    "changes_requested": s.changes_requested,
+                    "approved": s.approved,
+                    "merged": s.merged_24h,
+                    "review_stalled": is_review_stalled(s),
                     "error": s.error,
                 }))
                 .collect::<Vec<_>>(),
@@ -2386,6 +2512,176 @@ mod tests {
         }]);
         let section = assess_queues(&inputs);
         assert_eq!(section.verdict, Verdict::Unknown);
+        assert_eq!(assess(&inputs).exit_code(), EXIT_DEGRADED);
+    }
+
+    // ===================================================================
+    // Queues: the review-side axes (#5021)
+    // ===================================================================
+
+    /// One repo's snapshot with every axis observed — the fixture the review
+    /// tests vary a single field of.
+    fn review_snapshot(
+        name: &str,
+        queued: usize,
+        review_requested: usize,
+        merged: usize,
+    ) -> RepoPipelineSnapshot {
+        RepoPipelineSnapshot {
+            root: PathBuf::from(format!("/r/{name}")),
+            queued: Some(queued),
+            review_requested: Some(review_requested),
+            changes_requested: Some(0),
+            approved: Some(0),
+            merged_24h: Some(merged),
+            ..Default::default()
+        }
+    }
+
+    /// AC1: the section reports the three review-side axes, not just `queued`.
+    #[test]
+    fn queues_report_the_review_side_axes_per_repo() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = Some(vec![RepoPipelineSnapshot {
+            root: PathBuf::from("/r/loom"),
+            queued: Some(1),
+            review_requested: Some(2),
+            changes_requested: Some(1),
+            approved: Some(3),
+            merged_24h: Some(5),
+            ..Default::default()
+        }]);
+        let section = assess_queues(&inputs);
+
+        assert_eq!(section.verdict, Verdict::Green);
+        assert!(section.summary.contains("2 awaiting review"), "{}", section.summary);
+        assert!(section.summary.contains("1 changes-requested"), "{}", section.summary);
+        assert!(section.summary.contains("3 approved"), "{}", section.summary);
+
+        assert_eq!(section.detail["total_review_requested"], serde_json::json!(2));
+        assert_eq!(section.detail["total_changes_requested"], serde_json::json!(1));
+        assert_eq!(section.detail["total_approved"], serde_json::json!(3));
+        let repo = &section.detail["repos"][0];
+        assert_eq!(repo["review_requested"], serde_json::json!(2));
+        assert_eq!(repo["changes_requested"], serde_json::json!(1));
+        assert_eq!(repo["approved"], serde_json::json!(3));
+        assert_eq!(repo["review_stalled"], serde_json::json!(false));
+    }
+
+    /// AC2: a review backlog against a window that merged nothing is non-green
+    /// — the 2026-08-03 Judge-outage shape, reported without knowing the cause.
+    #[test]
+    fn a_review_backlog_with_no_merges_is_degraded() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = Some(vec![review_snapshot("loom", 1, REVIEW_STALL_MIN_BACKLOG, 0)]);
+        let section = assess_queues(&inputs);
+
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("REVIEW STALLED"), "{}", section.summary);
+        assert!(section.summary.contains("loom"), "{}", section.summary);
+        assert_eq!(section.detail["review_stalled"], serde_json::json!(["loom"]));
+        assert_eq!(assess(&inputs).exit_code(), EXIT_DEGRADED);
+    }
+
+    /// AC3 (the inverse): a flowing review pipeline stays green even with the
+    /// same backlog depth — the merge axis is what distinguishes them.
+    #[test]
+    fn a_review_backlog_that_is_still_merging_stays_green() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = Some(vec![review_snapshot("loom", 1, REVIEW_STALL_MIN_BACKLOG + 5, 2)]);
+        let section = assess_queues(&inputs);
+
+        assert_eq!(section.verdict, Verdict::Green);
+        assert!(!section.summary.contains("REVIEW STALLED"), "{}", section.summary);
+    }
+
+    /// A shallow backlog in a quiet window is *not* a stall — the same
+    /// cry-wolf rule `assess_throughput` follows for a zero-merge window.
+    #[test]
+    fn a_shallow_review_backlog_in_a_quiet_window_stays_green() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = Some(vec![review_snapshot("loom", 1, REVIEW_STALL_MIN_BACKLOG - 1, 0)]);
+        assert_eq!(assess_queues(&inputs).verdict, Verdict::Green);
+    }
+
+    /// Edge case: unobserved review axes must not be read as "zero backlog" —
+    /// they render as `null`, never `0`, and cannot produce a stall verdict.
+    #[test]
+    fn unobserved_review_axes_are_null_not_zero() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = Some(vec![RepoPipelineSnapshot {
+            root: PathBuf::from("/r/loom"),
+            queued: Some(1),
+            merged_24h: Some(0),
+            ..Default::default()
+        }]);
+        let section = assess_queues(&inputs);
+
+        assert_eq!(section.verdict, Verdict::Green);
+        assert_eq!(section.detail["total_review_requested"], serde_json::Value::Null);
+        assert_eq!(section.detail["total_changes_requested"], serde_json::Value::Null);
+        assert_eq!(section.detail["total_approved"], serde_json::Value::Null);
+        assert!(
+            !section.summary.contains("awaiting review"),
+            "an unobserved axis must not be summarized at all: {}",
+            section.summary
+        );
+    }
+
+    /// Edge case: a repo with **zero** ready issues but a stalled review queue
+    /// must still be caught — the all-repos-summed `total_ready` says 0 across
+    /// the fleet, which is exactly the "looks idle, is broken" masking #5004
+    /// reported.
+    #[test]
+    fn an_empty_ready_queue_does_not_mask_a_review_stall() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = Some(vec![
+            review_snapshot("anvil", 0, 0, 0),
+            review_snapshot("loom", 0, REVIEW_STALL_MIN_BACKLOG, 0),
+        ]);
+        let section = assess_queues(&inputs);
+
+        assert_eq!(section.detail["total_ready"], serde_json::json!(0));
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert_eq!(section.detail["review_stalled"], serde_json::json!(["loom"]));
+    }
+
+    /// A stall is a *known* finding and outranks the `Unknown` a single flaky
+    /// forge query produces — but the failed repo is still named.
+    #[test]
+    fn a_review_stall_outranks_a_failed_query_but_still_names_it() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = Some(vec![
+            RepoPipelineSnapshot {
+                root: PathBuf::from("/r/anvil"),
+                queued: None,
+                error: Some("rate limited".to_string()),
+                ..Default::default()
+            },
+            review_snapshot("loom", 2, REVIEW_STALL_MIN_BACKLOG, 0),
+        ]);
+        let section = assess_queues(&inputs);
+
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("REVIEW STALLED"), "{}", section.summary);
+        assert!(section.summary.contains("forge query FAILED for: anvil"), "{}", section.summary);
+    }
+
+    /// The whole-fleet shape of the 2026-08-03 outage: every repo idle on the
+    /// `queued` axis, nothing merging, PRs piling up awaiting review. The
+    /// pre-#5021 assessment reported this green.
+    #[test]
+    fn a_fleet_wide_judge_outage_is_not_green() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = Some(
+            (0..12)
+                .map(|i| review_snapshot(&format!("repo{i}"), 0, 4, 0))
+                .collect(),
+        );
+        let section = assess_queues(&inputs);
+
+        assert_ne!(section.verdict, Verdict::Green);
+        assert_eq!(section.detail["total_review_requested"], serde_json::json!(48));
         assert_eq!(assess(&inputs).exit_code(), EXIT_DEGRADED);
     }
 

--- a/loom-daemon/src/pipeline_snapshot.rs
+++ b/loom-daemon/src/pipeline_snapshot.rs
@@ -134,15 +134,23 @@ impl PipelineMetrics {
         merged: true,
     };
 
-    /// The two metrics `loom-daemon health` needs: queue depth and merge
-    /// throughput. Two `gh` calls per repo instead of six keeps the one-shot
-    /// health command inside its "< 5s typical" budget on a multi-repo fleet.
+    /// The metrics `loom-daemon health` needs: queue depth, the three
+    /// review-side axes, and merge throughput.
+    ///
+    /// `building` stays masked off — no health section reads it — so this is
+    /// five `gh` calls per repo rather than six. The three review axes were
+    /// masked off too until Issue #5021, which is *why* the `queues` section
+    /// could not see a Judge outage: the fields it needed were never fetched
+    /// on the CLI path. The extra calls are the cost of that visibility, and
+    /// they fan out per repo in parallel
+    /// ([`collect_pipeline_snapshots`]), so the wall-clock cost is three extra
+    /// sequential `gh` calls total, not three per repo.
     pub const HEALTH: Self = Self {
         queued: true,
         building: false,
-        review_requested: false,
-        changes_requested: false,
-        approved: false,
+        review_requested: true,
+        changes_requested: true,
+        approved: true,
         merged: true,
     };
 }
@@ -714,11 +722,14 @@ esac
         assert_eq!(source.merge_window, chrono::Duration::hours(24));
     }
 
-    /// The #4761 cost control: the HEALTH mask must issue exactly the two `gh`
-    /// calls it needs, not all six — the whole reason the mask exists.
+    /// The #4761 cost control, as widened by #5021: the HEALTH mask must issue
+    /// exactly the five `gh` calls the health sections read — queue depth, the
+    /// three review-side axes, and merge throughput — and must still skip
+    /// `building`, which no section consumes. The mask exists to keep the
+    /// one-shot command off the metrics nothing reads, not to be `ALL`.
     #[test]
     #[serial]
-    fn health_metrics_mask_fetches_only_queued_and_merged() {
+    fn health_metrics_mask_fetches_every_axis_the_sections_read_but_not_building() {
         let tmp = tempfile::tempdir().unwrap();
         let calls = tmp.path().join("calls.log");
         let gh = write_fake_gh(
@@ -733,15 +744,17 @@ esac
 
         assert_eq!(snap.queued, Some(1));
         assert_eq!(snap.merged_24h, Some(1));
-        assert_eq!(snap.building, None);
-        assert_eq!(snap.review_requested, None);
-        assert_eq!(snap.changes_requested, None);
-        assert_eq!(snap.approved, None);
+        assert_eq!(snap.review_requested, Some(1), "#5021: the review axis must be fetched");
+        assert_eq!(snap.changes_requested, Some(1));
+        assert_eq!(snap.approved, Some(1));
+        assert_eq!(snap.building, None, "no health section reads `building`");
         assert!(snap.is_complete());
 
         let log = std::fs::read_to_string(&calls).unwrap();
-        assert_eq!(log.lines().count(), 2, "exactly two gh calls, got:\n{log}");
+        assert_eq!(log.lines().count(), 5, "exactly five gh calls, got:\n{log}");
         assert!(log.contains("loom:issue"));
+        assert!(log.contains("loom:review-requested"));
+        assert!(log.contains("loom:changes-requested"));
         assert!(log.contains("--state merged"));
         assert!(!log.contains("loom:building"));
     }


### PR DESCRIPTION
## Summary

`assess_queues` (`loom-daemon/src/health.rs`) previously summed only `snap.queued` (`loom:issue`), discarding `review_requested` / `changes_requested` / `approved` — the one axis a review outage (e.g. a Judge outage) actually moves. Worse, `PipelineMetrics::HEALTH` masked those three metrics off entirely, so the CLI collector never fetched them at all.

- `assess_queues` now reports all three review axes (summary clause + per-repo `detail`) alongside the existing ready counts.
- New per-repo review-stall rule: `>= REVIEW_STALL_MIN_BACKLOG` (3) open `loom:review-requested` PRs with zero merges in the window is `Degraded`, evaluated per-repo so a repo with zero ready issues isn't masked by the fleet-wide `total_ready` sum.
- Unobserved axes (query failed, or metric masked off) accumulate as `null`, never `0`, and cannot produce a stall verdict in either direction.
- `PipelineMetrics::HEALTH` widened to fetch the three review axes (per-repo parallel fan-out, so wall-clock cost is only 3 extra sequential calls total).

This is gap 1 of 4 identified in #5004 (a 2026-08-03 Judge outage that stayed green on every routine signal for most of a day) — the cheapest fix with the highest yield since it needs no new telemetry plumbing, just consuming a field already collected.

## Test plan

- [x] `cargo test -p loom-daemon --lib health::` — 84 passed, including new fixtures covering: reporting all three axes, stall verdict on backlog+zero-merge, healthy-pipeline-stays-green inverse, shallow-backlog-in-quiet-window stays green, unobserved axes render `null` not `0`, empty-ready-queue doesn't mask a stall, stall outranks a failed-query `Unknown` (still names the failed repo), and the full fleet-wide-outage shape.
- [x] `cargo build -p loom-daemon` — clean.
- [x] `cargo clippy --package loom-daemon --package loom-api -- -D warnings ...` (CI's exact invocation) — clean.
- [x] `cargo fmt -p loom-daemon -- --check` — clean.

Closes #5021