### PR TITLE
config(loom): enable auditor on roleRunner.onIdle in the loom workspace only

### DIFF
--- a/.loom/config.json
+++ b/.loom/config.json
@@ -8,6 +8,9 @@
         "curator",
         "champion",
         "judge"
+      ],
+      "onIdle": [
+        "auditor"
       ]
     },
     "collisionDetection": {


### PR DESCRIPTION
## Summary
- Adds `auditor` to `autonomous.roleRunner.onIdle` in `.loom/config.json` (idle-edge path, not the fixed-interval `roles` list).
- Scoped to the loom repo only — `roleRunner` config is read per managed repo (`loom-daemon/src/role_runner.rs:1462`), so no other repo's config is affected. `defaults/config.json` has no `roleRunner` block, confirming this is a live per-repo edit, not a fleet-wide template change.

## Why loom only, and why onIdle
`auditor` doesn't generalize as written (#5040) — its build/launch instructions are Loom-specific and several managed repos are SPICE-simulation-heavy, which previously drove a worker to 1m loadavg 95 (#4903). The loom repo has 12 CI workflows, so the role's CI-aware step 0 short-circuits redundant build/test. `onIdle` (#4364) keeps auditor from competing with dispatch for tokens/CPU, and exercises the idle-edge path (currently unused fleet-wide).

## Test plan
- [x] `.loom/config.json` parses as valid JSON
- [x] Only `roleRunner.onIdle` was added; `roles` list unchanged
- [x] Confirmed `defaults/config.json` has no `roleRunner` block (no fleet-wide template touched)
- [ ] After merge, verify an idle-edge auditor tick appears in `.loom/logs/role-auditor.log` and `loom-daemon health`'s `roles` section (runtime verification, not verifiable from this PR alone — daemon re-reads config per tick, no restart required)

Closes #5046