### PR TITLE
feat(daemon-update): fetch + verify prebuilt release artifacts instead of rebuilding

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -4896,7 +4896,119 @@ manually rebuilt the Rust binary, reprovisioned it, and restarted the process.
 ./.loom/scripts/cli/loom-daemon-update.sh --force       # rebuild + provision + restart even if already up to date
 ./.loom/scripts/cli/loom-daemon-update.sh --no-restart  # rebuild + provision only; leave the running daemon untouched
 ./.loom/scripts/cli/loom-daemon-update.sh --relaunch    # launchd only: after a refused restart, re-render the plist + relaunch under supervision (preserves the live plist's LOOM_* env)
+./.loom/scripts/cli/loom-daemon-update.sh --fetch        # REQUIRE a verified release artifact (never silently fall back to a source build); exit 1 if none resolves
+./.loom/scripts/cli/loom-daemon-update.sh --no-fetch     # never consider release artifacts; always build from local source (pre-#5020 behavior)
 ```
+
+#### Artifact-based self-update (epic #4990 Phase 3, #5020)
+
+By default the script now **prefers a prebuilt GitHub Release artifact over a
+local `cargo build --release`**, so a CPU-saturated host — or one with no Rust
+toolchain installed at all — converges onto the latest release without ever
+compiling. This is the consumer side of the release artifacts published by
+Phase 1 (#5003) and signed by Phase 2 (#5011).
+
+**Precedence (three-state, `FETCH_MODE`)**
+
+| Mode | How to select | Behavior |
+|------|---------------|----------|
+| `auto` (**default**) | — | Prefer a verified artifact when one resolves; **softly** fall back to the source build otherwise |
+| `force` | `--fetch` / `LOOM_DAEMON_UPDATE_FETCH=1` | Require an artifact; **exit 1** rather than silently building from source |
+| `off` | `--no-fetch` / `LOOM_DAEMON_UPDATE_FETCH=0` | Never fetch; always build from local source |
+
+An artifact is used only when the latest release's version is **strictly newer**
+than the installed daemon's (an *equal* version wins only under an explicit
+`--fetch`; plain `--force` keeps meaning "rebuild this checkout"), the host's
+platform maps to one of the release target triples
+(`aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`),
+and that release actually publishes `loom-daemon-<target>` **and** its
+`.sha256`. Everything else — an unrecognized platform, no `gh` CLI, no Releases
+(a fork), an unreachable or rate-limited GitHub API, a release with no artifact
+for this platform — is a **soft** fallback to the existing source-build path, so
+dev machines, canaries, and forks behave exactly as before.
+
+**Verification (epic design principle 2: checksum always, signature when present)**
+
+- **Checksum — unconditional.** The downloaded binary is compared against the
+  release's `.sha256`. A mismatch **aborts the whole update (exit 1)** and leaves
+  the running daemon untouched; it is never downgraded to a source-build fallback,
+  because a mismatch is tamper/corruption evidence, not a resolution failure.
+- **Signature — only when present, and never blocking by its absence.**
+  - macOS: verified in-binary via `codesign --verify --strict`. "Not signed at
+    all" (a release built without the Developer ID secrets) is an expected
+    **soft-skip**; "signed but verification fails" is treated as tamper evidence
+    and **aborts (exit 1)**.
+  - Linux: the detached `loom-daemon-<target>.sig` (published only when the
+    release was built with a cosign key) is verified with `cosign verify-blob`.
+    If `cosign` is missing, or no public key is resolvable, the script emits a
+    **loud skip** and proceeds — no cosign public key is distributed with this
+    repo yet. Point `LOOM_DAEMON_UPDATE_COSIGN_PUBKEY` at a key (or commit one at
+    `.loom/cosign.pub` / `defaults/cosign.pub`) to turn that skip into real
+    verification. A resolvable key plus a failing verification **aborts (exit 1)**.
+
+**Provisioning and restart are unchanged.** A verified artifact goes through the
+*same* `provision_machine_daemon()` seam as a freshly compiled binary (no parallel
+provisioning logic), and the same supervised launchd/systemd/pid-file restart
+tiers (#4054/#4950). Two artifact-specific adjustments:
+
+- **Post-provision verification** uses `verify_destination_artifact()` instead of
+  the source path's embedded-commit compare (a release's commit is unrelated to
+  the local checkout's HEAD). It asserts the destination's full `--version` string
+  equals the verified artifact's — the same string `provision_machine_daemon()`'s
+  version-equality short-circuit compares, so a silent no-op roll still exits `5`.
+- **Signing is skipped** for fetched binaries, and `sign_daemon_binary()` now
+  refuses to re-sign any binary that already carries a certificate-backed
+  signature (`codesign -dvvv` reports an `Authority=`). Without that guard, the
+  belt-and-braces ad-hoc re-sign inside `provision_machine_daemon()` would
+  silently *downgrade* a Developer ID-signed release artifact to ad-hoc on every
+  provision. A locally built binary is always ad-hoc, so this changes nothing for
+  the source path.
+
+**Interaction with the autonomous loop's staleness check (worth knowing).** The
+loop's own staleness signal is still *embedded commit vs. local source HEAD*. On a
+host whose checkout is **ahead of the latest release** (the usual state for a
+development host), a newly published release therefore costs one extra roll: the
+artifact is fetched and installed first, then the next tick still sees the
+installed release commit ≠ local HEAD and rebuilds from source, superseding it.
+That is deliberate, converges (the source build's version equals the release's, so
+no artifact wins afterwards — there is no ping-pong), and is the right trade on the
+hosts this exists for: a saturated host reaches the release *immediately* instead
+of waiting out the up-to-6h build-stampede deferral, and a host with no Rust
+toolchain simply stays on the release (its source-build attempt fails as retryable
+and never displaces it). Hosts that want only source builds can set
+`LOOM_DAEMON_UPDATE_FETCH=0`.
+
+**Still requires a source checkout.** This phase changes *what gets installed*,
+not the script's entry conditions: `loom-daemon/Cargo.toml` must still exist (the
+script also uses the checkout to resolve `origin`'s `owner/repo` slug). Removing
+that requirement for binary-only installs is out of scope here.
+
+Concretely, artifact resolution runs *after* the ff-first sync with
+`origin/<default-branch>` (#4330), so a checkout that hard-aborts that sync
+(genuine divergence, unmanaged dirty tracked files) still exits `2` before any
+artifact is considered — pass `--allow-stale` to skip the sync entirely and go
+straight to resolution, or fix the checkout. This is unchanged pre-existing
+behavior, not something the fetch path introduces, but it does mean "no Rust
+toolchain" is not the same as "no git checkout hygiene".
+
+**Extra environment variables** (all optional; the first three are primarily test
+seams):
+
+| Variable | Purpose |
+|----------|---------|
+| `LOOM_DAEMON_UPDATE_FETCH` | `1`/`true`/`yes` ⇒ force (`--fetch`); `0`/`false`/`no` ⇒ off (`--no-fetch`); unset ⇒ auto |
+| `LOOM_DAEMON_UPDATE_GH_REPO` | Override the `owner/repo` slug used for release resolution (default: parsed from the `origin` remote) |
+| `LOOM_DAEMON_UPDATE_TARGET` | Override the detected release target triple |
+| `LOOM_DAEMON_UPDATE_COSIGN_PUBKEY` | Path to the cosign public key used to verify a Linux `.sig` |
+
+**No new daemon config keys.** The autonomous self-update loop
+(`autonomous.autoUpdate.*`) needs no change and passes no fetch flag: it invokes
+`loom-daemon-update.sh --no-restart` and inherits the `auto` default, which is
+exactly the unattended behavior it wants (prefer an artifact, degrade to a
+rebuild). It deliberately does **not** pass `--fetch`, since that would turn a
+transient GitHub API hiccup into a failed roll. The existing exit-code contract is
+unchanged: a checksum/signature failure maps to exit `1` (retryable, same bucket
+as a failed `cargo build`), so `classify_exit` needs no new cases.
 
 **Launchd refused-restart fallback (`--relaunch`, exit 6, #4118)**: on the
 FIRST roll onto a #4077-capable binary the *running* (old) daemon has no
@@ -4997,8 +5109,10 @@ Self-update: built from ab12cd3 — UPDATE AVAILABLE (source checkout HEAD is de
 ```
 
 `loom-daemon-update.sh` requires an actual Loom source checkout
-(`loom-daemon/Cargo.toml` must exist) — it rebuilds from source and refuses to
-run against a binary-only / release-tarball install.
+(`loom-daemon/Cargo.toml` must exist) and refuses to run against a binary-only /
+release-tarball install — even when it ends up installing a prebuilt release
+artifact rather than rebuilding (see
+[Artifact-based self-update](#artifact-based-self-update-epic-4990-phase-3-5020)).
 
 ### Autonomous self-update loop (#4055)
 

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -32,9 +32,19 @@
 # entirely) for deliberate use (bisecting, testing a local patch) — see below.
 #
 # It:
-#   - detects whether the resolved binary is stale vs. the local source tree,
+#   - detects whether the resolved binary is stale vs. the local source tree
+#     (or, in artifact-fetch mode, vs. the latest GitHub Release — see below),
+#   - Artifact-fetch mode (Epic #4990 Phase 3, #5020, ON by default, opt out
+#     with --no-fetch): resolves the latest GitHub Release with version >=
+#     the installed daemon and, when that release publishes an artifact for
+#     this host's platform, downloads + verifies it (checksum unconditional,
+#     signature when present) INSTEAD of rebuilding from source — a
+#     saturated host with no Rust toolchain converges on a release alone.
+#     Resolution failure of any kind (unrecognized platform, no `gh` CLI, no
+#     Releases yet, API unreachable, no artifact for this platform) SOFTLY
+#     falls back to the rebuild path below (--fetch instead hard-fails).
 #   - rebuilds (`cargo build --release`) in loom-daemon/ when stale (or
-#     --force),
+#     --force) AND no artifact was fetched,
 #   - provisions the fresh binary to wherever the resolved binary lives
 #     (LOOM_DAEMON_BIN override, else the machine-level ~/.local/bin install
 #     via scripts/install/provision-daemon.sh, matching #3922's convention),
@@ -127,9 +137,30 @@
 #   ./.loom/scripts/cli/loom-daemon-update.sh --relaunch    Launchd/systemd only: after a refused restart, re-render the plist/unit and relaunch under supervision (SIGTERMs the daemon so sweep children reparent; preserves the live LOOM_* env)
 #   ./.loom/scripts/cli/loom-daemon-update.sh --allow-stale Skip the default ff-first sync with origin/<default-branch> and build the current (possibly stale) checkout as-is (#4330) — for deliberate use: bisecting, testing a local patch
 #   ./.loom/scripts/cli/loom-daemon-update.sh --auto-resolve-safe-abort  When the ff-only sync would otherwise hard-abort (#4330), auto-perform the fix IF the blocking state classifies as safe (#4951): content-identical diverged commits with an otherwise-CLEAN working tree (`git reset --hard origin/<default-branch>`), or dirty tracked files that are ALL Loom-managed installed copies (`git checkout --` them + re-run resync-installed.sh). Any other cause (genuine content divergence, any unmanaged dirty file, or a dirty tracked file co-existing with the content-identical divergence) still hard-aborts unchanged — this flag never widens what's classified as safe, only whether the safe cases are printed (default) or performed
+#   ./.loom/scripts/cli/loom-daemon-update.sh --fetch        Artifact-fetch mode (Epic #4990 Phase 3, #5020): REQUIRE a verified GitHub Release artifact for this host's platform (resolve latest Release >= installed version, download, verify checksum unconditionally + signature when present, provision) instead of `cargo build --release`; hard-fails (exit 1) rather than silently falling back to a source build when no matching artifact resolves. Same as LOOM_DAEMON_UPDATE_FETCH=1.
+#   ./.loom/scripts/cli/loom-daemon-update.sh --no-fetch      Disable artifact-fetch mode entirely; always use the local source-build path (pre-#5020 behavior). Same as LOOM_DAEMON_UPDATE_FETCH=0.
 #   ./.loom/scripts/cli/loom-daemon-update.sh --help
 #
 # Environment:
+#   LOOM_DAEMON_UPDATE_FETCH  Artifact-fetch precedence (Epic #4990 Phase 3,
+#                          #5020): 1/true/yes forces it (same as --fetch,
+#                          hard-fails without a matching artifact); 0/false/no
+#                          disables it (same as --no-fetch); unset (default)
+#                          is "auto" — prefer a verified artifact when one
+#                          resolves, else soft-fall-back to the source build.
+#   LOOM_DAEMON_UPDATE_GH_REPO  Override the "owner/repo" slug used to
+#                          resolve GitHub Releases (else parsed from the
+#                          `origin` git remote).
+#   LOOM_DAEMON_UPDATE_TARGET  Override the release target triple this host
+#                          resolves to (else auto-detected from `uname -s -m`,
+#                          e.g. aarch64-apple-darwin) — mainly for tests.
+#   LOOM_DAEMON_UPDATE_COSIGN_PUBKEY  Path to the cosign public key used to
+#                          verify a Linux release's detached `.sig` (else a
+#                          conventional checked-in `.loom/cosign.pub` /
+#                          `defaults/cosign.pub` if present). No key is
+#                          committed to this repo as of Phase 2 (#5011), so
+#                          by default a present `.sig` is a LOUD SKIP, not a
+#                          block — see verify_artifact_signature.
 #   LOOM_DAEMON_BIN       Path to the loom-daemon binary (else auto-detected,
 #                          same resolution as loom-daemon-start.sh). When set,
 #                          the fresh binary is provisioned directly to this
@@ -204,7 +235,13 @@
 #      installed copies — by default these still
 #      exit 1 but the abort message names the exact safe command; pass
 #      --auto-resolve-safe-abort to have the script perform it instead (exit
-#      0 on success). Any other cause still hard-aborts unchanged.
+#      0 on success). Any other cause still hard-aborts unchanged. Also used
+#      by artifact-fetch mode (#5020) for: a checksum mismatch on a
+#      downloaded artifact (unconditional — leaves the running daemon
+#      untouched), a signature-verification failure on a PRESENT signature
+#      (distinct from "unsigned", which is not an error), and --fetch given
+#      with no matching release artifact resolvable (refuses to silently
+#      fall back to a source build).
 #   3  (--check only) update available
 #   4  build verification FAILED: the freshly-built binary's embedded commit
 #      does not match the source HEAD it was built from. This is a BUILD-SYSTEM
@@ -315,6 +352,347 @@ locate_daemon_bin() { loom_locate_daemon_bin "$1"; }
 # "loom-daemon 0.15.0 (commit ab12cd3, built 2026-07-26T12:00:00Z)" -> ab12cd3
 extract_commit() {
     echo "$1" | grep -oE 'commit [0-9a-f]+' | head -n1 | awk '{print $2}'
+}
+
+# Extract the semver from `loom-daemon --version` output, e.g.
+# "loom-daemon 0.15.0 (commit ab12cd3, ...)" -> 0.15.0
+extract_version() {
+    echo "$1" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1
+}
+
+# =====================================================================
+# Artifact-fetch mode (Epic #4990 Phase 3, #5020)
+# =====================================================================
+#
+# Phase 1 (#5003) and Phase 2 (#5011/#5018) publish, on every GitHub Release,
+# `loom-daemon-<target>` + `<...>.sha256` for every fleet target triple
+# (`aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`,
+# `aarch64-unknown-linux-gnu`), plus an OPTIONAL Linux-only `<...>.sig`
+# (detached cosign signature) when a cosign key secret was configured for
+# that release. macOS artifacts are signed IN PLACE (embedded Developer ID
+# signature, no separate asset) when the signing secrets were configured;
+# there is no way to tell from the filename alone whether a given release's
+# macOS asset is signed.
+#
+# This section resolves the latest Release with version >= the currently
+# installed daemon, downloads the artifact for the host's own platform +
+# its checksum (and signature, when present), and verifies both:
+#   - checksum: UNCONDITIONAL. A mismatch hard-aborts the whole update
+#     (exit 1) and leaves the running daemon untouched -- this is a
+#     tamper/corruption signal, never a soft-fallback condition.
+#   - signature: verified ONLY when present. macOS: `codesign --verify
+#     --strict` against the downloaded binary (distinguishes "not signed"
+#     -- expected, soft-skip -- from "signed but verification failed" --
+#     abort). Linux: detached `.sig` via `cosign verify-blob`, only when
+#     both `cosign` and a public key are resolvable; otherwise a LOUD skip
+#     (never a block) per the epic's design principle 2. Absence of a
+#     signature never blocks the update.
+#
+# Any OTHER resolution failure (unrecognized host platform, no `gh` CLI, no
+# Releases yet, GitHub API unreachable/rate-limited, no artifact published
+# for this platform) is a SOFT fallback to the existing local
+# `cargo build --release` path below -- never a hard error -- unless the
+# operator forced `--fetch` (see FETCH_MODE handling near the arg parser).
+
+# detect_target_triple -- echo this host's release target triple, or "" for
+# an unrecognized platform (e.g. x86_64 macOS, which the release matrix does
+# not build for as of Phase 1). Overridable via LOOM_DAEMON_UPDATE_TARGET
+# (tests, or a host whose uname doesn't match the expected values).
+detect_target_triple() {
+    local os arch
+    os="$(uname -s 2>/dev/null || echo unknown)"
+    arch="$(uname -m 2>/dev/null || echo unknown)"
+    case "$os" in
+        Darwin)
+            case "$arch" in
+                arm64|aarch64) echo "aarch64-apple-darwin" ;;
+                *) echo "" ;;
+            esac
+            ;;
+        Linux)
+            case "$arch" in
+                aarch64|arm64) echo "aarch64-unknown-linux-gnu" ;;
+                x86_64|amd64)  echo "x86_64-unknown-linux-gnu" ;;
+                *) echo "" ;;
+            esac
+            ;;
+        *) echo "" ;;
+    esac
+}
+
+# resolve_gh_repo_slug -- echo "owner/repo" parsed from the `origin` remote
+# (git@github.com:, https://github.com/, and ssh://git@github.com/ forms),
+# or "" when it cannot be resolved. Overridable via
+# LOOM_DAEMON_UPDATE_GH_REPO.
+resolve_gh_repo_slug() {
+    local remote_url slug
+    remote_url="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)"
+    [[ -z "$remote_url" ]] && { echo ""; return 0; }
+    case "$remote_url" in
+        git@github.com:*)
+            slug="${remote_url#git@github.com:}"
+            echo "${slug%.git}"
+            ;;
+        https://github.com/*|http://github.com/*)
+            echo "$remote_url" | sed -E 's#^https?://github\.com/##; s/\.git$//'
+            ;;
+        ssh://git@github.com/*)
+            echo "$remote_url" | sed -E 's#^ssh://git@github\.com/##; s/\.git$//'
+            ;;
+        *) echo "" ;;
+    esac
+}
+
+# semver_compare <a> <b> -- echoes -1, 0, or 1 for a<b, a==b, a>b. Compares
+# up to 3 dot-separated numeric components (non-numeric suffixes are
+# stripped defensively); missing components default to 0.
+semver_compare() {
+    local v1="${1:-0.0.0}" v2="${2:-0.0.0}"
+    local oldifs="$IFS"
+    IFS='.'
+    # shellcheck disable=SC2206
+    local -a a=($v1) b=($v2)
+    IFS="$oldifs"
+    local i ai bi
+    for i in 0 1 2; do
+        ai="${a[i]:-0}"; ai="${ai//[!0-9]/}"; ai="${ai:-0}"
+        bi="${b[i]:-0}"; bi="${bi//[!0-9]/}"; bi="${bi:-0}"
+        if (( 10#$ai < 10#$bi )); then echo -1; return 0; fi
+        if (( 10#$ai > 10#$bi )); then echo 1; return 0; fi
+    done
+    echo 0
+}
+
+# fetch_resolve_latest -- read-only resolution (no downloads): resolve the
+# latest GitHub Release + confirm it has an artifact for this host's target.
+# Sets FETCH_REPO_SLUG, FETCH_TARGET, FETCH_LATEST_TAG, FETCH_LATEST_VERSION,
+# FETCH_RESOLVE_OK, and (on failure) FETCH_RESOLVE_REASON. Returns 0/1
+# matching FETCH_RESOLVE_OK so callers can `if fetch_resolve_latest; then`.
+FETCH_REPO_SLUG=""
+FETCH_TARGET=""
+FETCH_LATEST_TAG=""
+FETCH_LATEST_VERSION=""
+# shellcheck disable=SC2034  # set for API completeness; callers use the function's own return code instead
+FETCH_RESOLVE_OK=false
+FETCH_RESOLVE_REASON=""
+fetch_resolve_latest() {
+    FETCH_RESOLVE_OK=false
+    FETCH_RESOLVE_REASON=""
+
+    FETCH_TARGET="${LOOM_DAEMON_UPDATE_TARGET:-$(detect_target_triple)}"
+    if [[ -z "$FETCH_TARGET" ]]; then
+        FETCH_RESOLVE_REASON="unrecognized host platform ($(uname -s 2>/dev/null || echo '?')/$(uname -m 2>/dev/null || echo '?')) -- no release target-triple mapping"
+        return 1
+    fi
+
+    if ! command -v gh >/dev/null 2>&1; then
+        FETCH_RESOLVE_REASON="'gh' CLI not found on PATH"
+        return 1
+    fi
+
+    FETCH_REPO_SLUG="${LOOM_DAEMON_UPDATE_GH_REPO:-$(resolve_gh_repo_slug)}"
+    if [[ -z "$FETCH_REPO_SLUG" ]]; then
+        FETCH_RESOLVE_REASON="could not resolve owner/repo from git remote 'origin' (set LOOM_DAEMON_UPDATE_GH_REPO to override)"
+        return 1
+    fi
+
+    local tag
+    if ! tag=$(gh release view --json tagName -R "$FETCH_REPO_SLUG" --jq '.tagName' 2>/dev/null) || [[ -z "$tag" ]]; then
+        FETCH_RESOLVE_REASON="'gh release view' found no latest release for $FETCH_REPO_SLUG (no Releases yet, an unreachable/rate-limited API, or an auth failure)"
+        return 1
+    fi
+    FETCH_LATEST_TAG="$tag"
+    FETCH_LATEST_VERSION="$(extract_version "$tag")"
+    if [[ -z "$FETCH_LATEST_VERSION" ]]; then
+        FETCH_RESOLVE_REASON="could not parse a semver version out of release tag '$tag'"
+        return 1
+    fi
+
+    local assets bin_name sha_name
+    assets="$(gh release view --json assets -R "$FETCH_REPO_SLUG" --jq '.assets[].name' 2>/dev/null || true)"
+    bin_name="loom-daemon-${FETCH_TARGET}"
+    sha_name="${bin_name}.sha256"
+    if ! grep -qxF "$bin_name" <<<"$assets" || ! grep -qxF "$sha_name" <<<"$assets"; then
+        FETCH_RESOLVE_REASON="release $tag has no artifact for target $FETCH_TARGET (checked for $bin_name + $sha_name)"
+        return 1
+    fi
+
+    # shellcheck disable=SC2034  # set for API completeness; callers use the function's own return code instead
+    FETCH_RESOLVE_OK=true
+    return 0
+}
+
+# resolve_cosign_pubkey -- echo a resolvable cosign public key path, or "".
+# No public key is committed to this repo as of Phase 2 (#5011) -- this is
+# deliberately best-effort: LOOM_DAEMON_UPDATE_COSIGN_PUBKEY (env) first,
+# else a conventional checked-in path if one is ever added. An empty result
+# means "signature present but unverifiable" -- a loud skip, never a block
+# (see verify_artifact_signature).
+resolve_cosign_pubkey() {
+    if [[ -n "${LOOM_DAEMON_UPDATE_COSIGN_PUBKEY:-}" && -r "${LOOM_DAEMON_UPDATE_COSIGN_PUBKEY}" ]]; then
+        echo "$LOOM_DAEMON_UPDATE_COSIGN_PUBKEY"
+        return 0
+    fi
+    local candidate
+    for candidate in "$REPO_ROOT/.loom/cosign.pub" "$REPO_ROOT/defaults/cosign.pub"; do
+        [[ -r "$candidate" ]] && { echo "$candidate"; return 0; }
+    done
+    echo ""
+}
+
+# verify_artifact_checksum <bin_path> <sha256_path> -- unconditional
+# checksum verification. The `.sha256` format is `shasum -a 256` /
+# `sha256sum` output (`<hex>  <filename>`), so the hex digest is always the
+# first field.
+verify_artifact_checksum() {
+    local bin_path="$1" sha_path="$2" expected actual
+    expected="$(awk 'NR==1{print $1}' "$sha_path" 2>/dev/null)"
+    [[ -n "$expected" ]] || return 1
+    if command -v shasum >/dev/null 2>&1; then
+        actual="$(shasum -a 256 "$bin_path" | awk '{print $1}')"
+    elif command -v sha256sum >/dev/null 2>&1; then
+        actual="$(sha256sum "$bin_path" | awk '{print $1}')"
+    else
+        err "Neither 'shasum' nor 'sha256sum' is available -- cannot verify the artifact checksum."
+        return 1
+    fi
+    [[ "$expected" == "$actual" ]]
+}
+
+# verify_artifact_signature <target> <bin_path> <sig_path-or-empty> --
+# signature verification, present-only (absence always passes). Distinguishes
+# "not signed" (expected/allowed, soft-skip) from "signed but verification
+# failed" (tamper evidence, hard-fail) per the epic's design principle 2.
+verify_artifact_signature() {
+    local target="$1" bin_path="$2" sig_path="$3"
+    case "$target" in
+        *-apple-darwin)
+            if ! command -v codesign >/dev/null 2>&1; then
+                warn "'codesign' not available -- skipping macOS signature verification (best-effort; checksum already verified)."
+                return 0
+            fi
+            local desc
+            desc="$(codesign -dv "$bin_path" 2>&1 || true)"
+            if grep -q 'code object is not signed at all' <<<"$desc"; then
+                warn "Downloaded artifact is unsigned (no Developer ID secrets were configured for this release) -- proceeding without signature verification, per design (checksum is unconditional; signature is optional)."
+                return 0
+            fi
+            if codesign --verify --strict "$bin_path" 2>/dev/null; then
+                ok "macOS codesign verification passed for $(basename "$bin_path")."
+                return 0
+            fi
+            err "macOS codesign verification FAILED for $(basename "$bin_path") -- an embedded signature is present but invalid. This is NOT the 'unsigned' case; treating as tamper evidence."
+            return 1
+            ;;
+        *-linux-*)
+            if [[ -z "$sig_path" ]]; then
+                # No .sig asset published for this release (cosign secret was
+                # not configured for it) -- absence never blocks, by design.
+                return 0
+            fi
+            if ! command -v cosign >/dev/null 2>&1; then
+                warn "A detached signature ($(basename "$sig_path")) is present for this release but 'cosign' is not installed -- SKIPPING verification (loud skip, not a block; checksum already verified)."
+                return 0
+            fi
+            local pubkey
+            pubkey="$(resolve_cosign_pubkey)"
+            if [[ -z "$pubkey" ]]; then
+                warn "A detached signature ($(basename "$sig_path")) is present but no cosign public key is resolvable (set LOOM_DAEMON_UPDATE_COSIGN_PUBKEY) -- SKIPPING verification (loud skip, not a block; checksum already verified)."
+                return 0
+            fi
+            if cosign verify-blob --key "$pubkey" --signature "$sig_path" "$bin_path" >/dev/null 2>&1; then
+                ok "cosign signature verification passed for $(basename "$bin_path")."
+                return 0
+            fi
+            err "cosign signature verification FAILED for $(basename "$bin_path") against $(basename "$sig_path") using key $pubkey."
+            return 1
+            ;;
+        *) return 0 ;;
+    esac
+}
+
+# Temp dirs created by fetch_and_verify_artifact, cleaned up on any exit
+# (including the hard-abort `exit 1` calls it makes on a verification
+# failure) so a checksum-mismatch abort never leaves the unverified artifact
+# lying around.
+_LOOM_FETCH_TMPDIRS=()
+_cleanup_fetch_tmpdirs() {
+    local d
+    for d in ${_LOOM_FETCH_TMPDIRS[@]+"${_LOOM_FETCH_TMPDIRS[@]}"}; do
+        rm -rf "$d" 2>/dev/null || true
+    done
+}
+trap _cleanup_fetch_tmpdirs EXIT
+
+# fetch_and_verify_artifact -- download loom-daemon-<ARTIFACT_TARGET> +
+# its .sha256 (required) + its .sig (best-effort) for ARTIFACT_TAG from
+# FETCH_REPO_SLUG, verify checksum (unconditional) and signature (when
+# present), and set ARTIFACT_BIN (path to the verified binary),
+# ARTIFACT_VERSION_OUTPUT (its full `--version` string, the post-provision
+# identity) and ARTIFACT_COMMIT (its embedded commit, when resolvable) on
+# success.
+#
+# A checksum or signature-verification FAILURE hard-aborts the whole script
+# (exit 1) -- these are tamper/corruption signals, never soft-fallback
+# conditions (AC2/AC3). A DOWNLOAD failure (network blip, asset renamed
+# server-side after fetch_resolve_latest checked) instead returns 1 so the
+# caller can decide -- in practice this script has already committed to
+# ARTIFACT_MODE by the time this runs, so the caller also aborts, but the
+# distinction keeps this function's contract composable.
+fetch_and_verify_artifact() {
+    local tmpdir bin_name sha_name sig_name bin_path sha_path sig_path=""
+    tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/loom-daemon-fetch.XXXXXX" 2>/dev/null)" || {
+        err "Could not create a temp dir for the artifact download."
+        return 1
+    }
+    _LOOM_FETCH_TMPDIRS+=("$tmpdir")
+
+    bin_name="loom-daemon-${ARTIFACT_TARGET}"
+    sha_name="${bin_name}.sha256"
+    sig_name="${bin_name}.sig"
+
+    echo "Downloading ${bin_name} + ${sha_name} from ${FETCH_REPO_SLUG}@${ARTIFACT_TAG}..."
+    if ! gh release download "$ARTIFACT_TAG" -R "$FETCH_REPO_SLUG" \
+            -p "$bin_name" -p "$sha_name" -D "$tmpdir" --clobber >/dev/null 2>&1; then
+        err "Failed to download release assets (${bin_name}, ${sha_name}) for ${ARTIFACT_TAG} from ${FETCH_REPO_SLUG}."
+        return 1
+    fi
+    bin_path="$tmpdir/$bin_name"
+    sha_path="$tmpdir/$sha_name"
+    if [[ ! -f "$bin_path" || ! -f "$sha_path" ]]; then
+        err "Download reported success but expected files are missing under $tmpdir."
+        return 1
+    fi
+    chmod 755 "$bin_path" 2>/dev/null || true
+
+    # ---- checksum: unconditional ----
+    if ! verify_artifact_checksum "$bin_path" "$sha_path"; then
+        err "Checksum verification FAILED for $bin_name -- the downloaded artifact does not match its published $sha_name."
+        err "Aborting the update; the running daemon (if any) is left untouched."
+        exit 1
+    fi
+    ok "Checksum verified: $bin_name matches $sha_name."
+
+    # ---- signature: best-effort download (may not exist), verify when present ----
+    if gh release download "$ARTIFACT_TAG" -R "$FETCH_REPO_SLUG" \
+            -p "$sig_name" -D "$tmpdir" --clobber >/dev/null 2>&1 \
+        && [[ -f "$tmpdir/$sig_name" ]]; then
+        sig_path="$tmpdir/$sig_name"
+    fi
+    if ! verify_artifact_signature "$ARTIFACT_TARGET" "$bin_path" "$sig_path"; then
+        err "Signature verification FAILED for $bin_name (see above)."
+        err "Aborting the update; the running daemon (if any) is left untouched."
+        exit 1
+    fi
+
+    ARTIFACT_BIN="$bin_path"
+    # Captured from the VERIFIED download, before provisioning: the identity
+    # verify_destination_artifact() asserts against afterwards (see its own
+    # doc comment for why the full --version string, not the commit or a
+    # byte checksum, is the right identity here).
+    ARTIFACT_VERSION_OUTPUT="$("$bin_path" --version 2>/dev/null || true)"
+    ARTIFACT_COMMIT="$(extract_commit "$ARTIFACT_VERSION_OUTPUT")"
+    return 0
 }
 
 # ---------- stale `loom-*` entry-point check (#4079 hardening, #4557) ---------
@@ -511,6 +889,11 @@ warn_stale_entry_points() {
 # and from a provisioning soft-failure. Skipped only when the source HEAD is
 # unknown (a tarball build with no .git), where there is nothing to compare
 # against. Relies on $SOURCE_COMMIT being resolved (it is, before any build).
+#
+# SOURCE-BUILD PATH ONLY. The artifact-fetch path (#5020) uses
+# verify_destination_artifact() below instead: a fetched release's commit has
+# nothing to do with the local checkout's HEAD, so this function's whole
+# premise does not apply there.
 verify_destination_binary() {
     local dest="$1"
     if [[ "$SOURCE_COMMIT" == "unknown" ]]; then
@@ -532,6 +915,49 @@ verify_destination_binary() {
     ok "Post-provision verification: destination binary at $dest embeds source HEAD commit ($dest_commit)."
 }
 
+# verify_destination_artifact <dest_path> — the artifact-fetch (#5020)
+# counterpart of verify_destination_binary above, closing the SAME "reports
+# success while shipping nothing" hole for a fetched release binary. Exits 5
+# on mismatch, identically.
+#
+# Why a different identity than the source path's embedded-commit compare:
+#   - A fetched release artifact's commit is the RELEASE's commit, unrelated to
+#     the local checkout's HEAD — comparing against $SOURCE_COMMIT would fail
+#     on every successful artifact roll.
+#   - A byte/checksum compare of the destination is NOT usable either:
+#     provision_machine_daemon() calls sign_daemon_binary() on the DESTINATION,
+#     which (on Darwin, for a genuinely unsigned artifact) ad-hoc re-signs it
+#     in place and therefore changes its bytes vs. the verified download.
+# So the identity used here is the artifact's own full `--version` STRING
+# (version + commit + build timestamp), which is stable across a re-sign and
+# is exactly the same string provision_machine_daemon()'s own version-equality
+# short-circuit compares — so this assertion also proves that short-circuit
+# did not silently no-op a real roll.
+#
+# $ARTIFACT_VERSION_OUTPUT is captured from the VERIFIED download before
+# provisioning. It is empty only if the artifact refused to report a version,
+# in which case there is nothing to compare against and we skip loudly rather
+# than invent a comparison.
+verify_destination_artifact() {
+    local dest="$1"
+    if [[ -z "${ARTIFACT_VERSION_OUTPUT:-}" ]]; then
+        warn "Fetched artifact reported no --version output — skipping post-provision verification (checksum/signature were already verified pre-provision)."
+        return 0
+    fi
+    if [[ -z "$dest" || ! -x "$dest" ]]; then
+        err "Post-provision verification FAILED: provisioning reported success but no executable binary was found at the destination ('${dest:-<unknown>}')."
+        exit 5
+    fi
+    local dest_version
+    dest_version=$("$dest" --version 2>/dev/null || true)
+    if [[ "$dest_version" != "$ARTIFACT_VERSION_OUTPUT" ]]; then
+        err "Post-provision verification FAILED: destination binary at $dest reports '${dest_version:-<none>}' but the fetched release artifact reports '$ARTIFACT_VERSION_OUTPUT'."
+        err "Provisioning reported success yet the destination is NOT the freshly-fetched binary — a silent no-op roll. Refusing to report success."
+        exit 5
+    fi
+    ok "Post-provision verification: destination binary at $dest is the fetched release artifact ($dest_version)."
+}
+
 # ---------- args ----------
 DRY_RUN=false
 FORCE=false
@@ -540,7 +966,14 @@ NO_RESTART=false
 RELAUNCH=false
 ALLOW_STALE=false
 AUTO_RESOLVE_SAFE_ABORT=false
+# FETCH_MODE: auto (default -- prefer a verified release artifact when one
+# resolves, else soft-fall-back to the source build), force (--fetch --
+# require an artifact, hard-fail rather than silently building from source),
+# or off (--no-fetch -- always build from source, the pre-#5020 behavior).
+FETCH_MODE="auto"
 [[ "${LOOM_DAEMON_UPDATE_RELAUNCH:-}" =~ ^(1|true|yes)$ ]] && RELAUNCH=true
+[[ "${LOOM_DAEMON_UPDATE_FETCH:-}" =~ ^(0|false|no)$ ]] && FETCH_MODE="off"
+[[ "${LOOM_DAEMON_UPDATE_FETCH:-}" =~ ^(1|true|yes)$ ]] && FETCH_MODE="force"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --help|-h) show_help; exit 0 ;;
@@ -551,6 +984,8 @@ while [[ $# -gt 0 ]]; do
         --relaunch) RELAUNCH=true; shift ;;
         --allow-stale) ALLOW_STALE=true; shift ;;
         --auto-resolve-safe-abort) AUTO_RESOLVE_SAFE_ABORT=true; shift ;;
+        --fetch) FETCH_MODE="force"; shift ;;
+        --no-fetch) FETCH_MODE="off"; shift ;;
         *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
     esac
 done
@@ -928,10 +1363,12 @@ fi
 DAEMON_BIN=$(locate_daemon_bin "$REPO_ROOT")
 
 INSTALLED_COMMIT="unknown"
+INSTALLED_VERSION=""
 if [[ -n "$DAEMON_BIN" && -x "$DAEMON_BIN" ]]; then
     installed_version_output=$("$DAEMON_BIN" --version 2>/dev/null || true)
     extracted=$(extract_commit "$installed_version_output")
     [[ -n "$extracted" ]] && INSTALLED_COMMIT="$extracted"
+    INSTALLED_VERSION=$(extract_version "$installed_version_output")
 fi
 
 SOURCE_COMMIT=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")
@@ -955,6 +1392,47 @@ elif [[ "$INSTALLED_COMMIT" == "unknown" || "$SOURCE_COMMIT" == "unknown" ]]; th
     UPDATE_NEEDED=true
 elif [[ "$INSTALLED_COMMIT" != "$SOURCE_COMMIT" ]]; then
     UPDATE_NEEDED=true
+fi
+
+# ---------- artifact-fetch resolution (Epic #4990 Phase 3, #5020) ----------
+# Read-only resolution (no downloads yet — see fetch_and_verify_artifact()
+# for the actual download/verify, which only runs once we're past --check
+# and --dry-run below). When a newer release resolves for this host's
+# platform, it takes precedence over the source-commit comparison above:
+# ARTIFACT_MODE=true and UPDATE_NEEDED is forced true, regardless of what
+# the local source tree looks like. Any resolution failure softly falls back
+# to the source-commit-based UPDATE_NEEDED computed above — UNLESS the
+# operator forced --fetch, checked further below once we know UPDATE_NEEDED.
+ARTIFACT_MODE=false
+ARTIFACT_TAG=""
+ARTIFACT_VERSION=""
+ARTIFACT_TARGET=""
+ARTIFACT_BIN=""
+ARTIFACT_COMMIT=""
+ARTIFACT_VERSION_OUTPUT=""
+ARTIFACT_FALLBACK_REASON=""
+if [[ "$FETCH_MODE" != "off" ]]; then
+    if fetch_resolve_latest; then
+        FETCH_VERSION_CMP="$(semver_compare "$FETCH_LATEST_VERSION" "${INSTALLED_VERSION:-0.0.0}")"
+        # Strictly newer wins. An EQUAL version only wins under an explicit
+        # --fetch: `--force` alone keeps its established meaning ("rebuild this
+        # checkout even though it isn't stale"), which an operator running it
+        # inside a source tree would be surprised to see silently turn into a
+        # release download.
+        if [[ "$FETCH_VERSION_CMP" == "1" ]] || { [[ "$FETCH_VERSION_CMP" == "0" ]] && [[ "$FETCH_MODE" == "force" ]]; }; then
+            ARTIFACT_MODE=true
+            ARTIFACT_TAG="$FETCH_LATEST_TAG"
+            ARTIFACT_VERSION="$FETCH_LATEST_VERSION"
+            ARTIFACT_TARGET="$FETCH_TARGET"
+            UPDATE_NEEDED=true
+            echo "Release artifact available: ${ARTIFACT_TAG} (target ${ARTIFACT_TARGET}) — preferring fetch over a local rebuild."
+        else
+            echo "Latest release ${FETCH_LATEST_TAG} (${FETCH_LATEST_VERSION}) is not newer than the installed version (${INSTALLED_VERSION:-unknown}) — nothing to fetch; falling back to the local source-tree comparison."
+        fi
+    else
+        ARTIFACT_FALLBACK_REASON="$FETCH_RESOLVE_REASON"
+        warn "Artifact-fetch: ${ARTIFACT_FALLBACK_REASON} — falling back to the local source-build path."
+    fi
 fi
 
 # Advisory only, and deliberately placed here so it is reported on EVERY path —
@@ -1013,6 +1491,16 @@ idle_shutdown_notice() {
 # duplicating the call at each of this script's several exit points.
 print_final_installed_line() {
     local commit="$1"
+    # Artifact-fetch mode (#5020): the installed binary is a RELEASE build, so
+    # comparing its commit against origin/<default-branch>'s tip is the wrong
+    # currency claim — a released commit is normally BEHIND the branch tip and
+    # saying "does NOT match" about it would be actively misleading. Report the
+    # release identity instead.
+    if [[ "${ARTIFACT_MODE:-false}" == "true" ]]; then
+        echo "Installed: release ${ARTIFACT_TAG} (${ARTIFACT_VERSION}${commit:+, commit ${commit}}) for target ${ARTIFACT_TARGET} — fetched artifact, checksum verified"
+        idle_shutdown_notice
+        return 0
+    fi
     if [[ -z "$DEFAULT_BRANCH" || "$ORIGIN_COMMIT" == "unknown" ]]; then
         echo "Installed: ${commit} (currency vs origin/<default-branch> unknown — unresolvable or unreachable)"
     elif [[ "$commit" == "$ORIGIN_COMMIT" ]]; then
@@ -1395,7 +1883,11 @@ describe_manager() {
 if [[ "$CHECK_ONLY" == "true" ]]; then
     describe_manager
     if [[ "$UPDATE_NEEDED" == "true" ]]; then
-        warn "Update available (installed=${INSTALLED_COMMIT}, source=${SOURCE_COMMIT})."
+        if [[ "$ARTIFACT_MODE" == "true" ]]; then
+            warn "Update available via release artifact ${ARTIFACT_TAG} (installed=${INSTALLED_VERSION:-unknown}, latest=${ARTIFACT_VERSION}, target=${ARTIFACT_TARGET})."
+        else
+            warn "Update available (installed=${INSTALLED_COMMIT}, source=${SOURCE_COMMIT})."
+        fi
         exit 3
     fi
     ok "loom-daemon binary is already up to date with source HEAD (${SOURCE_COMMIT})."
@@ -1424,6 +1916,15 @@ if [[ "$UPDATE_NEEDED" == "false" ]]; then
     exit 0
 fi
 
+# An update IS needed at this point. --fetch (or LOOM_DAEMON_UPDATE_FETCH=1)
+# means "I know a release artifact should exist; don't silently fall back to
+# building from source" — refuse rather than mask a resolution failure.
+if [[ "$FETCH_MODE" == "force" && "$ARTIFACT_MODE" != "true" ]]; then
+    err "--fetch (or LOOM_DAEMON_UPDATE_FETCH=1) was given but no usable release artifact was resolved${ARTIFACT_FALLBACK_REASON:+ (${ARTIFACT_FALLBACK_REASON})}."
+    err "Refusing to silently fall back to a source build; re-run without --fetch to allow that, or resolve the cause above."
+    exit 1
+fi
+
 # ---------- resolve the restart plan up front (read-only; safe for --dry-run) ----------
 # WAS_RUNNING + DAEMON_MANAGER were resolved above (launchd checked ahead of the
 # pid file). The flags below are only consulted for the pid-file/nohup restart
@@ -1443,12 +1944,19 @@ PROVISION_TARGET="${LOOM_DAEMON_BIN:-$DEST_DIR/loom-daemon}"
 
 if [[ "$DRY_RUN" == "true" ]]; then
     echo
-    if [[ "$ALLOW_STALE" == "true" ]]; then
-        echo "[dry-run] --allow-stale given: would build the current checkout as-is (no fetch/ff-merge)."
-    elif [[ -n "$DEFAULT_BRANCH" && "$ORIGIN_BEHIND_COUNT" -gt 0 ]]; then
-        echo "[dry-run] Plan includes fast-forwarding local ${DEFAULT_BRANCH} to origin/${DEFAULT_BRANCH} (${ORIGIN_BEHIND_COUNT} commit(s) behind) before building; would abort instead of building stale if the ff-merge cannot apply."
+    if [[ "$ARTIFACT_MODE" == "true" ]]; then
+        echo "[dry-run] Would fetch + verify release artifact ${ARTIFACT_TAG} (target ${ARTIFACT_TARGET}) from ${FETCH_REPO_SLUG} — checksum unconditional, signature verified when present. No 'cargo build' would run."
+    else
+        if [[ "$ALLOW_STALE" == "true" ]]; then
+            echo "[dry-run] --allow-stale given: would build the current checkout as-is (no fetch/ff-merge)."
+        elif [[ -n "$DEFAULT_BRANCH" && "$ORIGIN_BEHIND_COUNT" -gt 0 ]]; then
+            echo "[dry-run] Plan includes fast-forwarding local ${DEFAULT_BRANCH} to origin/${DEFAULT_BRANCH} (${ORIGIN_BEHIND_COUNT} commit(s) behind) before building; would abort instead of building stale if the ff-merge cannot apply."
+        fi
+        if [[ -n "$ARTIFACT_FALLBACK_REASON" ]]; then
+            echo "[dry-run] Artifact-fetch was not used: ${ARTIFACT_FALLBACK_REASON}."
+        fi
+        echo "[dry-run] Would run: (cd $DAEMON_DIR && cargo build --release)"
     fi
-    echo "[dry-run] Would run: (cd $DAEMON_DIR && cargo build --release)"
     echo "[dry-run] Would provision the fresh binary to: $PROVISION_TARGET"
     if [[ "$NO_RESTART" == "true" ]]; then
         echo "[dry-run] --no-restart given: would leave the running daemon (if any) untouched."
@@ -1464,94 +1972,119 @@ if [[ "$DRY_RUN" == "true" ]]; then
     exit 0
 fi
 
-# ---------- rebuild ----------
-# Non-interactive SSH sessions (the fleet remote-update path, #4695) don't
-# source a login shell's profile, so a rustup-installed cargo living at the
-# default `~/.cargo/bin` is invisible to `command -v cargo` even though it IS
-# installed. Fall back the same way loom-daemon-start.sh's resolve_plist_path()
-# already does for launchd/systemd's non-login-shell PATH: prefer sourcing
-# rustup's own `~/.cargo/env` (the canonical PATH-setup snippet rustup
-# writes), then fall back to prepending `~/.cargo/bin` directly if that
-# script isn't present but the binary still is (e.g. a non-rustup or
-# partially-cleaned install), then finally fall back to the FULL shared
-# canonical PATH superset (lib/canonical-daemon-path.sh, #4831 — the same set
-# resolve_plist_path() renders and fleet add-worker's provisioning uses) in
-# case `cargo` was installed via Homebrew or another non-rustup path this
-# script doesn't special-case.
-if ! command -v cargo >/dev/null 2>&1; then
-    if [[ -f "$HOME/.cargo/env" ]]; then
-        # shellcheck disable=SC1091
-        source "$HOME/.cargo/env"
-    elif [[ -x "$HOME/.cargo/bin/cargo" ]]; then
-        export PATH="$HOME/.cargo/bin:$PATH"
+# ---------- rebuild (source) OR fetch (artifact, Epic #4990 Phase 3, #5020) ----------
+if [[ "$ARTIFACT_MODE" == "true" ]]; then
+    echo
+    echo "Fetching loom-daemon release artifact ${ARTIFACT_TAG} (target ${ARTIFACT_TARGET}) from ${FETCH_REPO_SLUG}..."
+    # fetch_and_verify_artifact() exits 1 directly on a checksum or
+    # signature-verification failure (AC2/AC3 — a hard abort, not a
+    # fallback); a `return 1` here means a DOWNLOAD-layer failure instead
+    # (network blip, or an asset that vanished between resolve and
+    # download), which is likewise fatal at this point since the script has
+    # already committed to ARTIFACT_MODE.
+    if ! fetch_and_verify_artifact; then
+        err "Artifact download failed (see above) — the running daemon (if any) was left untouched."
+        exit 1
     fi
-fi
-if ! command -v cargo >/dev/null 2>&1; then
-    _LOOM_CANONICAL_PATH_LIB="$SCRIPT_DIR/../lib/canonical-daemon-path.sh"
-    if [[ -r "$_LOOM_CANONICAL_PATH_LIB" ]]; then
-        # shellcheck source=../lib/canonical-daemon-path.sh
-        source "$_LOOM_CANONICAL_PATH_LIB"
-        if declare -F canonical_daemon_path >/dev/null 2>&1; then
-            export PATH="$(canonical_daemon_path):$PATH"
+    NEW_BIN="$ARTIFACT_BIN"
+    BUILT_COMMIT="$ARTIFACT_COMMIT"
+    # NOTE: the source path's exit-4 "build verification" (built commit ==
+    # source HEAD) deliberately has NO artifact-mode equivalent — it guards a
+    # build.rs staleness defect that cannot exist for a binary this host did
+    # not compile. The artifact's integrity was instead established by the
+    # unconditional checksum + present-signature verification above, and its
+    # arrival at the destination is asserted post-provision by
+    # verify_destination_artifact().
+    ok "Fetched + verified: $NEW_BIN (release ${ARTIFACT_TAG}${BUILT_COMMIT:+, commit $BUILT_COMMIT})"
+else
+    # Non-interactive SSH sessions (the fleet remote-update path, #4695) don't
+    # source a login shell's profile, so a rustup-installed cargo living at the
+    # default `~/.cargo/bin` is invisible to `command -v cargo` even though it IS
+    # installed. Fall back the same way loom-daemon-start.sh's resolve_plist_path()
+    # already does for launchd/systemd's non-login-shell PATH: prefer sourcing
+    # rustup's own `~/.cargo/env` (the canonical PATH-setup snippet rustup
+    # writes), then fall back to prepending `~/.cargo/bin` directly if that
+    # script isn't present but the binary still is (e.g. a non-rustup or
+    # partially-cleaned install), then finally fall back to the FULL shared
+    # canonical PATH superset (lib/canonical-daemon-path.sh, #4831 — the same set
+    # resolve_plist_path() renders and fleet add-worker's provisioning uses) in
+    # case `cargo` was installed via Homebrew or another non-rustup path this
+    # script doesn't special-case.
+    if ! command -v cargo >/dev/null 2>&1; then
+        if [[ -f "$HOME/.cargo/env" ]]; then
+            # shellcheck disable=SC1091
+            source "$HOME/.cargo/env"
+        elif [[ -x "$HOME/.cargo/bin/cargo" ]]; then
+            export PATH="$HOME/.cargo/bin:$PATH"
         fi
     fi
-fi
-if ! command -v cargo >/dev/null 2>&1; then
-    err "cargo not found on PATH (checked \$HOME/.cargo/bin and the shared canonical PATH too, see lib/canonical-daemon-path.sh) — cannot rebuild loom-daemon. Install Rust via rustup: https://rustup.rs"
-    exit 1
-fi
-
-echo
-echo "Rebuilding loom-daemon (cargo build --release)..."
-if ! (cd "$DAEMON_DIR" && cargo build --release); then
-    err "cargo build --release failed — the running daemon (if any) was left untouched."
-    exit 1
-fi
-
-NEW_BIN=""
-for candidate in \
-    "$DAEMON_DIR/target/release/loom-daemon" \
-    "$REPO_ROOT/target/release/loom-daemon"; do
-    # `cargo build --release` run from loom-daemon/ writes to that crate's own
-    # target/ when loom-daemon is a standalone crate, but to the WORKSPACE
-    # root's target/ when it is a member of a Cargo workspace (this repo's
-    # actual layout: root Cargo.toml -> [workspace] members = [...,
-    # "loom-daemon"]). Check both, matching locate_daemon_bin()'s candidate
-    # order above.
-    if [[ -x "$candidate" ]]; then
-        NEW_BIN="$candidate"
-        break
+    if ! command -v cargo >/dev/null 2>&1; then
+        _LOOM_CANONICAL_PATH_LIB="$SCRIPT_DIR/../lib/canonical-daemon-path.sh"
+        if [[ -r "$_LOOM_CANONICAL_PATH_LIB" ]]; then
+            # shellcheck source=../lib/canonical-daemon-path.sh
+            source "$_LOOM_CANONICAL_PATH_LIB"
+            if declare -F canonical_daemon_path >/dev/null 2>&1; then
+                export PATH="$(canonical_daemon_path):$PATH"
+            fi
+        fi
     fi
-done
-if [[ -z "$NEW_BIN" ]]; then
-    err "Build did not produce an executable at $DAEMON_DIR/target/release/loom-daemon or $REPO_ROOT/target/release/loom-daemon"
-    exit 1
-fi
-ok "Build succeeded: $NEW_BIN"
+    if ! command -v cargo >/dev/null 2>&1; then
+        err "cargo not found on PATH (checked \$HOME/.cargo/bin and the shared canonical PATH too, see lib/canonical-daemon-path.sh) — cannot rebuild loom-daemon. Install Rust via rustup: https://rustup.rs"
+        exit 1
+    fi
 
-# ---------- verify the freshly-built binary embeds the expected commit ----------
-# A rebuild can succeed (exit 0) yet bake in a STALE LOOM_DAEMON_GIT_COMMIT — the
-# exact hazard this script exists to close (a build.rs watch-set bug that lets
-# `--version` report the old commit). Provisioning such a binary would "report
-# success while shipping nothing" and, worse, turn any auto-update loop that
-# trusts the baked commit into an infinite rebuild-still-stale retry. So assert
-# the built commit == source HEAD BEFORE provisioning. On mismatch, fail loudly
-# and do NOT provision: this is a build-system defect that retrying cannot fix,
-# distinct from the compile failure handled above (#4053).
-BUILT_VERSION_OUTPUT=$("$NEW_BIN" --version 2>/dev/null || true)
-BUILT_COMMIT=$(extract_commit "$BUILT_VERSION_OUTPUT")
-if [[ "$SOURCE_COMMIT" == "unknown" ]]; then
-    warn "Source HEAD is unknown (no .git?) — skipping built-commit verification (tarball build)."
-elif [[ -z "$BUILT_COMMIT" ]]; then
-    err "Build verification FAILED: the freshly-built binary reports no commit in --version output ('${BUILT_VERSION_OUTPUT:-<empty>}')."
-    err "Refusing to provision a binary that cannot prove what it was built from. This is a build-system defect, not a compile failure."
-    exit 4
-elif [[ "$BUILT_COMMIT" != "$SOURCE_COMMIT" ]]; then
-    err "Build verification FAILED: the freshly-built binary embeds commit '$BUILT_COMMIT' but source HEAD is '$SOURCE_COMMIT'."
-    err "A successful build produced a binary stamped with the WRONG commit (a stale baked-in commit — e.g. a build.rs watch-set bug). Retrying will not fix it; refusing to provision (#4053)."
-    exit 4
-else
-    ok "Build verification: freshly-built binary embeds source HEAD commit ($BUILT_COMMIT)."
+    echo
+    echo "Rebuilding loom-daemon (cargo build --release)..."
+    if ! (cd "$DAEMON_DIR" && cargo build --release); then
+        err "cargo build --release failed — the running daemon (if any) was left untouched."
+        exit 1
+    fi
+
+    NEW_BIN=""
+    for candidate in \
+        "$DAEMON_DIR/target/release/loom-daemon" \
+        "$REPO_ROOT/target/release/loom-daemon"; do
+        # `cargo build --release` run from loom-daemon/ writes to that crate's own
+        # target/ when loom-daemon is a standalone crate, but to the WORKSPACE
+        # root's target/ when it is a member of a Cargo workspace (this repo's
+        # actual layout: root Cargo.toml -> [workspace] members = [...,
+        # "loom-daemon"]). Check both, matching locate_daemon_bin()'s candidate
+        # order above.
+        if [[ -x "$candidate" ]]; then
+            NEW_BIN="$candidate"
+            break
+        fi
+    done
+    if [[ -z "$NEW_BIN" ]]; then
+        err "Build did not produce an executable at $DAEMON_DIR/target/release/loom-daemon or $REPO_ROOT/target/release/loom-daemon"
+        exit 1
+    fi
+    ok "Build succeeded: $NEW_BIN"
+
+    # ---------- verify the freshly-built binary embeds the expected commit ----------
+    # A rebuild can succeed (exit 0) yet bake in a STALE LOOM_DAEMON_GIT_COMMIT — the
+    # exact hazard this script exists to close (a build.rs watch-set bug that lets
+    # `--version` report the old commit). Provisioning such a binary would "report
+    # success while shipping nothing" and, worse, turn any auto-update loop that
+    # trusts the baked commit into an infinite rebuild-still-stale retry. So assert
+    # the built commit == source HEAD BEFORE provisioning. On mismatch, fail loudly
+    # and do NOT provision: this is a build-system defect that retrying cannot fix,
+    # distinct from the compile failure handled above (#4053).
+    BUILT_VERSION_OUTPUT=$("$NEW_BIN" --version 2>/dev/null || true)
+    BUILT_COMMIT=$(extract_commit "$BUILT_VERSION_OUTPUT")
+    if [[ "$SOURCE_COMMIT" == "unknown" ]]; then
+        warn "Source HEAD is unknown (no .git?) — skipping built-commit verification (tarball build)."
+    elif [[ -z "$BUILT_COMMIT" ]]; then
+        err "Build verification FAILED: the freshly-built binary reports no commit in --version output ('${BUILT_VERSION_OUTPUT:-<empty>}')."
+        err "Refusing to provision a binary that cannot prove what it was built from. This is a build-system defect, not a compile failure."
+        exit 4
+    elif [[ "$BUILT_COMMIT" != "$SOURCE_COMMIT" ]]; then
+        err "Build verification FAILED: the freshly-built binary embeds commit '$BUILT_COMMIT' but source HEAD is '$SOURCE_COMMIT'."
+        err "A successful build produced a binary stamped with the WRONG commit (a stale baked-in commit — e.g. a build.rs watch-set bug). Retrying will not fix it; refusing to provision (#4053)."
+        exit 4
+    else
+        ok "Build verification: freshly-built binary embeds source HEAD commit ($BUILT_COMMIT)."
+    fi
 fi
 
 # ---------- sign (Darwin-only, best-effort, non-fatal, #4016) ----------
@@ -1562,11 +2095,20 @@ fi
 # survive a rebuild (see sign_daemon_binary's own doc comment in
 # scripts/install/provision-daemon.sh and .loom/docs/daemon-reference.md); it
 # only pins a human-legible identifier in place of the rustc metadata hash.
+#
+# Skipped in artifact-fetch mode (#5020): a fetched macOS artifact may
+# already carry a REAL Developer ID signature (Phase 2, #5011/#5018) —
+# force-resigning it here (or via provision_machine_daemon's own
+# belt-and-braces call below) would silently downgrade that to an ad-hoc
+# signature. sign_daemon_binary() itself now guards against that (skips any
+# binary that already carries a certificate-backed signature), but skip the
+# direct call entirely here too: there is nothing useful for it to do to an
+# already-signed or genuinely-unsigned fetched artifact.
 # shellcheck disable=SC1091
 if [[ -r "$REPO_ROOT/scripts/install/provision-daemon.sh" ]]; then
     source "$REPO_ROOT/scripts/install/provision-daemon.sh"
 fi
-if declare -F sign_daemon_binary >/dev/null 2>&1; then
+if [[ "$ARTIFACT_MODE" != "true" ]] && declare -F sign_daemon_binary >/dev/null 2>&1; then
     sign_daemon_binary "$NEW_BIN"
 fi
 
@@ -1583,8 +2125,12 @@ if [[ -n "${LOOM_DAEMON_BIN:-}" ]]; then
         exit 1
     fi
     # This override path has the same "shipped nothing" hazard as the
-    # machine-level path — verify the destination is the freshly-built binary.
-    verify_destination_binary "$dest"
+    # machine-level path — verify the destination is the freshly-built/fetched binary.
+    if [[ "$ARTIFACT_MODE" == "true" ]]; then
+        verify_destination_artifact "$dest"
+    else
+        verify_destination_binary "$dest"
+    fi
 else
     if declare -F provision_machine_daemon >/dev/null 2>&1; then
         # Hard-fail on provisioning failure: a soft warn here (the pre-#4053
@@ -1598,7 +2144,11 @@ else
         # the version-equality short-circuit) — verify that destination is the
         # expected build so the short-circuit can no longer produce a silent
         # no-op on a real roll (#4053).
-        verify_destination_binary "${PROVISIONED_DAEMON_BIN:-}"
+        if [[ "$ARTIFACT_MODE" == "true" ]]; then
+            verify_destination_artifact "${PROVISIONED_DAEMON_BIN:-}"
+        else
+            verify_destination_binary "${PROVISIONED_DAEMON_BIN:-}"
+        fi
     else
         warn "scripts/install/provision-daemon.sh not found/sourceable — skipping machine-level provisioning."
         warn "Freshly-built binary: $NEW_BIN (set LOOM_DAEMON_BIN=$NEW_BIN to use it directly)"

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -651,6 +651,178 @@ EOF
     chmod +x "$path"
 }
 
+# Writes a fake `gh` at $1 for the artifact-fetch tests (Epic #4990 Phase 3,
+# #5020). Understands exactly the invocations loom-daemon-update.sh's
+# fetch_resolve_latest() / fetch_and_verify_artifact() make:
+#   gh release view --json tagName  -R <slug> --jq '.tagName'         -> $2
+#   gh release view --json assets   -R <slug> --jq '.assets[].name'   -> `ls $3`
+#   gh release download <tag> -R <slug> -p <name> [-p <name> ...] -D <dir> --clobber
+#       -> copies each matching file from $3 into <dir>; exits 1 if NONE of
+#          the -p patterns matched anything under $3 (mirrors real gh's
+#          "no assets match" failure for a required download).
+write_fake_gh() {
+    local path="$1" tag="$2" assets_dir="$3"
+    cat > "$path" <<FAKEGH
+#!/usr/bin/env bash
+ASSETS_DIR="$assets_dir"
+TAG_VAL="$tag"
+FAKEGH
+    cat >> "$path" <<'FAKEGH'
+if [[ "${1:-}" == "release" && "${2:-}" == "view" ]]; then
+    shift 2
+    fields=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --json) fields="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+    case "$fields" in
+        tagName) echo "$TAG_VAL"; exit 0 ;;
+        assets)  ls "$ASSETS_DIR" 2>/dev/null; exit 0 ;;
+        *) exit 1 ;;
+    esac
+fi
+if [[ "${1:-}" == "release" && "${2:-}" == "download" ]]; then
+    shift 2
+    shift # drop the <tag> positional arg
+    dest="."
+    patterns=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -p) patterns+=("$2"); shift 2 ;;
+            -D) dest="$2"; shift 2 ;;
+            -R) shift 2 ;;
+            --clobber) shift ;;
+            *) shift ;;
+        esac
+    done
+    mkdir -p "$dest"
+    copied=0
+    for pat in "${patterns[@]}"; do
+        for f in "$ASSETS_DIR"/$pat; do
+            [[ -e "$f" ]] || continue
+            cp "$f" "$dest/"
+            copied=1
+        done
+    done
+    [[ "$copied" -eq 1 ]] && exit 0 || exit 1
+fi
+echo "fake gh: unsupported invocation: $*" >&2
+exit 1
+FAKEGH
+    chmod +x "$path"
+}
+
+# Writes a fake "release artifact" binary at $1 reporting version $2 / commit
+# $3 on --version, otherwise behaving like write_fake_daemon (rejects unknown
+# subcommands, loops forever on a normal run) — standing in for a downloaded
+# `loom-daemon-<target>` asset. A parameterized-version sibling of
+# write_fake_daemon (which hardcodes 0.15.0), needed so a fetched artifact can
+# report a version NEWER than the installed daemon's.
+write_fake_artifact_daemon() {
+    local path="$1" version="$2" commit="$3"
+    cat > "$path" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--version" ]]; then
+    echo "loom-daemon ${version} (commit ${commit}, built 2026-08-03T00:00:00Z)"
+    exit 0
+fi
+if [[ "\${1:-}" == "calibrate" ]]; then
+    exit 1
+fi
+if [[ -n "\${1:-}" && "\${1:-}" != -* ]]; then
+    echo "fake loom-daemon: unsupported subcommand: \$*" >&2
+    exit 1
+fi
+while true; do sleep 1; done
+EOF
+    chmod +x "$path"
+}
+
+# sha256_of <path> — portable checksum in `.sha256`-file format
+# (`<hex>  <basename>`), matching the release workflow's own
+# `shasum -a 256`/`sha256sum` output.
+sha256_of() {
+    local path="$1" base
+    base="$(basename "$path")"
+    if command -v shasum >/dev/null 2>&1; then
+        (cd "$(dirname "$path")" && shasum -a 256 "$base")
+    else
+        (cd "$(dirname "$path")" && sha256sum "$base")
+    fi
+}
+
+# Writes a fake `gh` at $1 whose every `release view` fails — standing in for
+# the "GitHub API unreachable / rate-limited / unauthenticated" case that must
+# SOFTLY fall back to the local source build (AC4), never hard-fail.
+write_fake_gh_unreachable() {
+    local path="$1"
+    cat > "$path" <<'FAKEGH'
+#!/usr/bin/env bash
+echo "gh: failed to fetch release: dial tcp: lookup api.github.com: no such host" >&2
+exit 1
+FAKEGH
+    chmod +x "$path"
+}
+
+# Writes a fake `codesign` at $1 emulating one of three macOS states, so the
+# darwin signature branch of verify_artifact_signature() is testable on ANY
+# host (including a Linux CI runner, which has no codesign at all):
+#   unsigned    -- `-dv` reports "code object is not signed at all" (expected
+#                  for a release built with no Developer ID secrets: soft-skip)
+#   signed-ok   -- `-dv` reports an Authority, `--verify` succeeds
+#   signed-bad  -- `-dv` reports an Authority, `--verify` FAILS (tamper
+#                  evidence: must abort, NOT be confused with "unsigned")
+write_fake_codesign() {
+    local path="$1" mode="$2"
+    cat > "$path" <<FAKECS
+#!/usr/bin/env bash
+MODE="$mode"
+FAKECS
+    cat >> "$path" <<'FAKECS'
+target="${!#}"
+if [[ "${1:-}" == "-dv" || "${1:-}" == "-dvvv" ]]; then
+    if [[ "$MODE" == "unsigned" ]]; then
+        echo "$target: code object is not signed at all" >&2
+        exit 1
+    fi
+    {
+        echo "Executable=$target"
+        echo "Identifier=com.rjwalters.loom-daemon"
+        echo "Authority=Developer ID Application: Test Authority (TESTTEAM)"
+    } >&2
+    exit 0
+fi
+if [[ "${1:-}" == "--verify" ]]; then
+    [[ "$MODE" == "signed-ok" ]] && exit 0
+    echo "$target: invalid signature (code or signature have been modified)" >&2
+    exit 1
+fi
+exit 0
+FAKECS
+    chmod +x "$path"
+}
+
+# Writes a fake `cosign` at $1 whose `verify-blob` exits $2 — the Linux
+# detached-signature branch of verify_artifact_signature().
+write_fake_cosign() {
+    local path="$1" rc="$2"
+    cat > "$path" <<FAKECOSIGN
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "verify-blob" ]]; then
+    if [[ "$rc" -eq 0 ]]; then
+        echo "Verified OK" >&2
+        exit 0
+    fi
+    echo "Error: failed to verify signature" >&2
+    exit 1
+fi
+exit 0
+FAKECOSIGN
+    chmod +x "$path"
+}
+
 MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
 BASE_WORKDIR="$(mktemp -d)"
@@ -3290,6 +3462,708 @@ else
     TESTS_PASSED=$((TESTS_PASSED + 1))
     echo -e "${GREEN}✓${NC} content-identical branch never claims a reset --hard while the tree is dirty"
 fi
+
+# ============================================================
+# Artifact-fetch mode (Epic #4990 Phase 3, #5020): resolve the latest GitHub
+# Release, download + verify its artifact for this host's platform, and
+# provision it INSTEAD of a local `cargo build --release`. Every test below
+# pins LOOM_DAEMON_UPDATE_GH_REPO (bypassing git-remote parsing) and
+# LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" (a Linux target, so no
+# codesign/cosign tooling is needed to exercise the core resolve/download/
+# verify/provision flow — signature verification for that target is a
+# soft-skip whenever no `.sig` asset is published, exactly test A's fixture).
+# ============================================================
+
+# ------------------------------------------------------------
+# A. Successful artifact update: a newer release with a matching-platform
+#    artifact is fetched, checksum-verified, and provisioned — WITHOUT ever
+#    invoking `cargo build` (no fake cargo is placed on PATH for this test at
+#    all, so a fallback to the source-build path would fail loudly rather
+#    than silently succeed).
+# ------------------------------------------------------------
+WA="$BASE_WORKDIR/w-fetch-a"
+new_fixture "$WA"
+write_fake_daemon "$WA/installed-loom-daemon" "oldc0mm" "$WA/marker"
+
+WA_ASSETS="$WA/gh-assets"
+mkdir -p "$WA_ASSETS"
+WA_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WA_ASSETS/$WA_BIN_NAME" "0.16.0" "artifac1"
+sha256_of "$WA_ASSETS/$WA_BIN_NAME" > "$WA_ASSETS/$WA_BIN_NAME.sha256"
+
+WA_FAKEBIN="$WA/fakebin"
+mkdir -p "$WA_FAKEBIN"
+write_fake_gh "$WA_FAKEBIN/gh" "v0.16.0" "$WA_ASSETS"
+
+outA=$( cd "$WA" && PATH="$WA_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WA/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcA=$(echo "$outA" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcA" "artifact-fetch: successful update exits 0"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outA" | grep -q 'Rebuilding loom-daemon (cargo build'; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} artifact-fetch: successful update never invokes 'cargo build' (AC1)"
+    echo "  output: $outA"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} artifact-fetch: successful update never invokes 'cargo build' (AC1)"
+fi
+
+installedA_version="$("$WA/installed-loom-daemon" --version 2>/dev/null)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$installedA_version" | grep -q 'commit artifac1'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} artifact-fetch: the fetched+verified artifact was provisioned to the destination"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} artifact-fetch: the fetched+verified artifact was provisioned to the destination"
+    echo "  --version: $installedA_version"
+fi
+
+# ------------------------------------------------------------
+# B. Checksum-mismatch abort: a tampered/corrupted checksum aborts the WHOLE
+#    update (exit 1) and leaves the running (destination) daemon untouched —
+#    never a soft fallback to a source build (AC2).
+# ------------------------------------------------------------
+WB="$BASE_WORKDIR/w-fetch-b"
+new_fixture "$WB"
+write_fake_daemon "$WB/installed-loom-daemon" "oldc0mm" "$WB/marker"
+installedB_before="$("$WB/installed-loom-daemon" --version 2>/dev/null)"
+
+WB_ASSETS="$WB/gh-assets"
+mkdir -p "$WB_ASSETS"
+WB_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WB_ASSETS/$WB_BIN_NAME" "0.16.0" "artifac2"
+# Deliberately WRONG checksum (does not match the binary written above).
+echo "0000000000000000000000000000000000000000000000000000000000000000  ${WB_BIN_NAME}" > "$WB_ASSETS/$WB_BIN_NAME.sha256"
+
+WB_FAKEBIN="$WB/fakebin"
+mkdir -p "$WB_FAKEBIN"
+write_fake_gh "$WB_FAKEBIN/gh" "v0.16.0" "$WB_ASSETS"
+
+outB=$( cd "$WB" && PATH="$WB_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WB/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcB=$(echo "$outB" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "1" "$rcB" "artifact-fetch: checksum mismatch aborts the update (exit 1)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outB" | grep -q 'Checksum verification FAILED'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} artifact-fetch: checksum-mismatch failure is reported explicitly"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} artifact-fetch: checksum-mismatch failure is reported explicitly"
+    echo "  output: $outB"
+fi
+
+installedB_after="$("$WB/installed-loom-daemon" --version 2>/dev/null)"
+assert_eq "$installedB_before" "$installedB_after" "artifact-fetch: checksum mismatch leaves the destination binary untouched"
+
+# ------------------------------------------------------------
+# C. Missing-artifact fallback: the resolved release has no artifact
+#    published for this host's platform (a real, but incomplete, release) —
+#    softly falls back to the existing local source-build path and still
+#    completes the update end-to-end (AC4).
+# ------------------------------------------------------------
+WC="$BASE_WORKDIR/w-fetch-c"
+new_fixture "$WC"
+HEADC="$(cd "$WC" && git rev-parse --short HEAD)"
+write_fake_daemon "$WC/installed-loom-daemon" "deadbee" "$WC/marker"
+NEW_FAKE_C="$WC/new-fake-daemon"
+write_fake_daemon "$NEW_FAKE_C" "$HEADC" "$WC/new-marker"
+
+# A release exists (newer than installed) but publishes NO assets at all for
+# this target — fetch_resolve_latest must reject it (no matching bin/sha256)
+# and the caller must fall back, not hard-fail.
+WC_ASSETS="$WC/gh-assets"
+mkdir -p "$WC_ASSETS"
+echo "unrelated-file" > "$WC_ASSETS/README.txt"
+
+WC_FAKEBIN="$WC/fakebin"
+mkdir -p "$WC_FAKEBIN"
+write_fake_gh "$WC_FAKEBIN/gh" "v0.20.0" "$WC_ASSETS"
+write_fake_cargo "$WC_FAKEBIN/cargo"
+
+outC=$( cd "$WC" && PATH="$WC_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WC/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    NEW_FAKE_BIN_SRC="$NEW_FAKE_C" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcC=$(echo "$outC" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcC" "artifact-fetch: missing-artifact fallback still completes the update (exit 0)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outC" | grep -q 'Artifact-fetch:.*falling back to the local source-build path'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} artifact-fetch: a resolution failure is reported as a soft fallback"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} artifact-fetch: a resolution failure is reported as a soft fallback"
+    echo "  output: $outC"
+fi
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outC" | grep -q 'Rebuilding loom-daemon (cargo build'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} artifact-fetch: missing-artifact fallback actually rebuilds from source"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} artifact-fetch: missing-artifact fallback actually rebuilds from source"
+    echo "  output: $outC"
+fi
+
+installedC_version="$("$WC/installed-loom-daemon" --version 2>/dev/null)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$installedC_version" | grep -q "commit ${HEADC}"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} artifact-fetch: the source-build fallback provisioned the freshly-built binary"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} artifact-fetch: the source-build fallback provisioned the freshly-built binary"
+    echo "  --version: $installedC_version"
+fi
+
+# ------------------------------------------------------------
+# D. --no-fetch disables artifact-fetch mode entirely, even when a matching
+#    release artifact IS available — restores the pre-#5020 always-build
+#    behavior.
+# ------------------------------------------------------------
+WD="$BASE_WORKDIR/w-fetch-d"
+new_fixture "$WD"
+HEADD="$(cd "$WD" && git rev-parse --short HEAD)"
+write_fake_daemon "$WD/installed-loom-daemon" "deadbee" "$WD/marker"
+NEW_FAKE_D="$WD/new-fake-daemon"
+write_fake_daemon "$NEW_FAKE_D" "$HEADD" "$WD/new-marker"
+
+WD_ASSETS="$WD/gh-assets"
+mkdir -p "$WD_ASSETS"
+WD_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WD_ASSETS/$WD_BIN_NAME" "0.16.0" "artifac4"
+sha256_of "$WD_ASSETS/$WD_BIN_NAME" > "$WD_ASSETS/$WD_BIN_NAME.sha256"
+
+WD_FAKEBIN="$WD/fakebin"
+mkdir -p "$WD_FAKEBIN"
+write_fake_gh "$WD_FAKEBIN/gh" "v0.16.0" "$WD_ASSETS"
+write_fake_cargo "$WD_FAKEBIN/cargo"
+
+outD=$( cd "$WD" && PATH="$WD_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WD/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    NEW_FAKE_BIN_SRC="$NEW_FAKE_D" \
+    bash "$UPDATE_SCRIPT" --no-restart --no-fetch 2>&1; echo "EXIT=$?" )
+rcD=$(echo "$outD" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcD" "--no-fetch: update still completes (exit 0)"
+
+installedD_version="$("$WD/installed-loom-daemon" --version 2>/dev/null)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$installedD_version" | grep -q "commit ${HEADD}"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --no-fetch: rebuilds from source even though a release artifact was available"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --no-fetch: rebuilds from source even though a release artifact was available"
+    echo "  --version: $installedD_version"
+fi
+
+# ------------------------------------------------------------
+# E. --fetch (forced) hard-fails rather than silently falling back to a
+#    source build when no matching artifact resolves.
+# ------------------------------------------------------------
+WE="$BASE_WORKDIR/w-fetch-e"
+new_fixture "$WE"
+write_fake_daemon "$WE/installed-loom-daemon" "deadbee" "$WE/marker"
+
+WE_ASSETS="$WE/gh-assets"
+mkdir -p "$WE_ASSETS"
+echo "unrelated-file" > "$WE_ASSETS/README.txt"
+
+WE_FAKEBIN="$WE/fakebin"
+mkdir -p "$WE_FAKEBIN"
+write_fake_gh "$WE_FAKEBIN/gh" "v0.20.0" "$WE_ASSETS"
+write_fake_cargo "$WE_FAKEBIN/cargo"
+
+outE=$( cd "$WE" && PATH="$WE_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WE/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    bash "$UPDATE_SCRIPT" --no-restart --fetch 2>&1; echo "EXIT=$?" )
+rcE=$(echo "$outE" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "1" "$rcE" "--fetch: refuses to silently fall back to a source build (exit 1)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outE" | grep -q 'Rebuilding loom-daemon (cargo build'; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --fetch: never falls back to 'cargo build' on a forced-fetch failure"
+    echo "  output: $outE"
+else
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --fetch: never falls back to 'cargo build' on a forced-fetch failure"
+fi
+
+# ------------------------------------------------------------
+# F. GitHub API unreachable/rate-limited during release resolution: every
+#    `gh release view` fails. This must be a SOFT fallback to the local
+#    source build (AC4) — never a hard failure of the whole update.
+# ------------------------------------------------------------
+WF="$BASE_WORKDIR/w-fetch-f"
+new_fixture "$WF"
+HEADF="$(cd "$WF" && git rev-parse --short HEAD)"
+write_fake_daemon "$WF/installed-loom-daemon" "deadbee" "$WF/marker"
+NEW_FAKE_F="$WF/new-fake-daemon"
+write_fake_daemon "$NEW_FAKE_F" "$HEADF" "$WF/new-marker"
+
+WF_FAKEBIN="$WF/fakebin"
+mkdir -p "$WF_FAKEBIN"
+write_fake_gh_unreachable "$WF_FAKEBIN/gh"
+write_fake_cargo "$WF_FAKEBIN/cargo"
+
+outF=$( cd "$WF" && PATH="$WF_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WF/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    NEW_FAKE_BIN_SRC="$NEW_FAKE_F" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcF=$(echo "$outF" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcF" "artifact-fetch: an unreachable GitHub API falls back to the source build (exit 0)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outF" | grep -q 'Artifact-fetch:.*falling back to the local source-build path'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} artifact-fetch: an unreachable GitHub API is reported as a soft fallback"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} artifact-fetch: an unreachable GitHub API is reported as a soft fallback"
+    echo "  output: $outF"
+fi
+
+installedF_version="$("$WF/installed-loom-daemon" --version 2>/dev/null)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$installedF_version" | grep -q "commit ${HEADF}"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} artifact-fetch: the API-failure fallback still provisioned a freshly-built binary"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} artifact-fetch: the API-failure fallback still provisioned a freshly-built binary"
+    echo "  --version: $installedF_version"
+fi
+
+# ------------------------------------------------------------
+# G. Already at the latest release: the resolved release's version equals the
+#    installed daemon's AND the local source commit matches too — the
+#    existing up-to-date no-op contract must hold (exit 0, no download, no
+#    build, destination untouched).
+# ------------------------------------------------------------
+WG="$BASE_WORKDIR/w-fetch-g"
+new_fixture "$WG"
+HEADG="$(cd "$WG" && git rev-parse --short HEAD)"
+write_fake_daemon "$WG/installed-loom-daemon" "$HEADG" "$WG/marker"
+
+WG_ASSETS="$WG/gh-assets"
+mkdir -p "$WG_ASSETS"
+WG_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WG_ASSETS/$WG_BIN_NAME" "0.15.0" "shouldnt"
+sha256_of "$WG_ASSETS/$WG_BIN_NAME" > "$WG_ASSETS/$WG_BIN_NAME.sha256"
+
+WG_FAKEBIN="$WG/fakebin"
+mkdir -p "$WG_FAKEBIN"
+# write_fake_daemon reports version 0.15.0, so tag v0.15.0 is NOT newer.
+write_fake_gh "$WG_FAKEBIN/gh" "v0.15.0" "$WG_ASSETS"
+
+outG=$( cd "$WG" && PATH="$WG_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WG/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcG=$(echo "$outG" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcG" "artifact-fetch: already at the latest release is a no-op (exit 0)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outG" | grep -q 'is not newer than the installed version'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} artifact-fetch: an equal-version release is reported as nothing to fetch"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} artifact-fetch: an equal-version release is reported as nothing to fetch"
+    echo "  output: $outG"
+fi
+
+installedG_version="$("$WG/installed-loom-daemon" --version 2>/dev/null)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$installedG_version" | grep -q "commit ${HEADG}" && ! echo "$outG" | grep -q 'Downloading '; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} artifact-fetch: the up-to-date no-op downloads nothing and leaves the binary untouched"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} artifact-fetch: the up-to-date no-op downloads nothing and leaves the binary untouched"
+    echo "  output: $outG"
+fi
+
+# ------------------------------------------------------------
+# H. --check regression: reports the available RELEASE artifact (exit 3) and
+#    writes nothing.
+# ------------------------------------------------------------
+WH="$BASE_WORKDIR/w-fetch-h"
+new_fixture "$WH"
+write_fake_daemon "$WH/installed-loom-daemon" "oldc0mm" "$WH/marker"
+installedH_before="$("$WH/installed-loom-daemon" --version 2>/dev/null)"
+
+WH_ASSETS="$WH/gh-assets"
+mkdir -p "$WH_ASSETS"
+WH_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WH_ASSETS/$WH_BIN_NAME" "0.16.0" "artifac8"
+sha256_of "$WH_ASSETS/$WH_BIN_NAME" > "$WH_ASSETS/$WH_BIN_NAME.sha256"
+
+WH_FAKEBIN="$WH/fakebin"
+mkdir -p "$WH_FAKEBIN"
+write_fake_gh "$WH_FAKEBIN/gh" "v0.16.0" "$WH_ASSETS"
+
+outH=$( cd "$WH" && PATH="$WH_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WH/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    bash "$UPDATE_SCRIPT" --check 2>&1; echo "EXIT=$?" )
+rcH=$(echo "$outH" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "3" "$rcH" "--check: an available release artifact still reports 'update available' (exit 3)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outH" | grep -q 'Update available via release artifact v0.16.0'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --check: names the release artifact it would fetch"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --check: names the release artifact it would fetch"
+    echo "  output: $outH"
+fi
+
+installedH_after="$("$WH/installed-loom-daemon" --version 2>/dev/null)"
+assert_eq "$installedH_before" "$installedH_after" "--check: writes nothing even when an artifact is available"
+
+# ------------------------------------------------------------
+# I. --dry-run regression: describes the fetch it WOULD perform, never runs
+#    cargo, and leaves the destination untouched.
+# ------------------------------------------------------------
+WI="$BASE_WORKDIR/w-fetch-i"
+new_fixture "$WI"
+write_fake_daemon "$WI/installed-loom-daemon" "oldc0mm" "$WI/marker"
+installedI_before="$("$WI/installed-loom-daemon" --version 2>/dev/null)"
+
+WI_ASSETS="$WI/gh-assets"
+mkdir -p "$WI_ASSETS"
+WI_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WI_ASSETS/$WI_BIN_NAME" "0.16.0" "artifac9"
+sha256_of "$WI_ASSETS/$WI_BIN_NAME" > "$WI_ASSETS/$WI_BIN_NAME.sha256"
+
+WI_FAKEBIN="$WI/fakebin"
+mkdir -p "$WI_FAKEBIN"
+write_fake_gh "$WI_FAKEBIN/gh" "v0.16.0" "$WI_ASSETS"
+
+outI=$( cd "$WI" && PATH="$WI_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WI/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    bash "$UPDATE_SCRIPT" --dry-run 2>&1; echo "EXIT=$?" )
+rcI=$(echo "$outI" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcI" "--dry-run: exits 0 with an artifact available"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outI" | grep -q '\[dry-run\] Would fetch + verify release artifact v0.16.0' \
+    && ! echo "$outI" | grep -q '\[dry-run\] Would run: (cd .* cargo build'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --dry-run: describes the artifact fetch instead of a cargo build"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --dry-run: describes the artifact fetch instead of a cargo build"
+    echo "  output: $outI"
+fi
+
+installedI_after="$("$WI/installed-loom-daemon" --version 2>/dev/null)"
+assert_eq "$installedI_before" "$installedI_after" "--dry-run: leaves the destination binary untouched in artifact mode"
+
+# ------------------------------------------------------------
+# J. Linux detached signature PRESENT, cosign + a public key both resolvable,
+#    verification SUCCEEDS -> the update proceeds and says so (AC3).
+# ------------------------------------------------------------
+WJ="$BASE_WORKDIR/w-fetch-j"
+new_fixture "$WJ"
+write_fake_daemon "$WJ/installed-loom-daemon" "oldc0mm" "$WJ/marker"
+
+WJ_ASSETS="$WJ/gh-assets"
+mkdir -p "$WJ_ASSETS"
+WJ_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WJ_ASSETS/$WJ_BIN_NAME" "0.16.0" "sigokc0"
+sha256_of "$WJ_ASSETS/$WJ_BIN_NAME" > "$WJ_ASSETS/$WJ_BIN_NAME.sha256"
+echo "fake-detached-signature" > "$WJ_ASSETS/$WJ_BIN_NAME.sig"
+echo "-----BEGIN PUBLIC KEY-----fake-----END PUBLIC KEY-----" > "$WJ/cosign.pub"
+
+WJ_FAKEBIN="$WJ/fakebin"
+mkdir -p "$WJ_FAKEBIN"
+write_fake_gh "$WJ_FAKEBIN/gh" "v0.16.0" "$WJ_ASSETS"
+write_fake_cosign "$WJ_FAKEBIN/cosign" 0
+
+outJ=$( cd "$WJ" && PATH="$WJ_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WJ/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    LOOM_DAEMON_UPDATE_COSIGN_PUBKEY="$WJ/cosign.pub" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcJ=$(echo "$outJ" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcJ" "signature present + cosign verifies: update proceeds (exit 0)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outJ" | grep -q 'cosign signature verification passed'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} signature present: cosign verification actually ran and passed"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} signature present: cosign verification actually ran and passed"
+    echo "  output: $outJ"
+fi
+
+installedJ_version="$("$WJ/installed-loom-daemon" --version 2>/dev/null)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$installedJ_version" | grep -q 'commit sigokc0'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} signature present + verified: the artifact was provisioned"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} signature present + verified: the artifact was provisioned"
+    echo "  --version: $installedJ_version"
+fi
+
+# ------------------------------------------------------------
+# K. Linux detached signature PRESENT but cosign verification FAILS -> abort
+#    (exit 1), destination untouched. A present-but-invalid signature is
+#    tamper evidence, never a soft skip.
+# ------------------------------------------------------------
+WK="$BASE_WORKDIR/w-fetch-k"
+new_fixture "$WK"
+write_fake_daemon "$WK/installed-loom-daemon" "oldc0mm" "$WK/marker"
+installedK_before="$("$WK/installed-loom-daemon" --version 2>/dev/null)"
+
+WK_ASSETS="$WK/gh-assets"
+mkdir -p "$WK_ASSETS"
+WK_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WK_ASSETS/$WK_BIN_NAME" "0.16.0" "sigbadc"
+sha256_of "$WK_ASSETS/$WK_BIN_NAME" > "$WK_ASSETS/$WK_BIN_NAME.sha256"
+echo "tampered-detached-signature" > "$WK_ASSETS/$WK_BIN_NAME.sig"
+echo "-----BEGIN PUBLIC KEY-----fake-----END PUBLIC KEY-----" > "$WK/cosign.pub"
+
+WK_FAKEBIN="$WK/fakebin"
+mkdir -p "$WK_FAKEBIN"
+write_fake_gh "$WK_FAKEBIN/gh" "v0.16.0" "$WK_ASSETS"
+write_fake_cosign "$WK_FAKEBIN/cosign" 1
+write_fake_cargo "$WK_FAKEBIN/cargo"
+
+outK=$( cd "$WK" && PATH="$WK_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WK/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    LOOM_DAEMON_UPDATE_COSIGN_PUBKEY="$WK/cosign.pub" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcK=$(echo "$outK" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "1" "$rcK" "signature present but INVALID: aborts the update (exit 1)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outK" | grep -q 'cosign signature verification FAILED' \
+    && ! echo "$outK" | grep -q 'Rebuilding loom-daemon (cargo build'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} signature present but INVALID: never degrades to a source-build fallback"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} signature present but INVALID: never degrades to a source-build fallback"
+    echo "  output: $outK"
+fi
+
+installedK_after="$("$WK/installed-loom-daemon" --version 2>/dev/null)"
+assert_eq "$installedK_before" "$installedK_after" "signature-verification failure leaves the destination binary untouched"
+
+# ------------------------------------------------------------
+# L. Linux detached signature PRESENT but no cosign public key is resolvable
+#    -> LOUD SKIP, update still proceeds (AC3: an unverifiable-but-optional
+#    signature never blocks; the checksum already passed).
+# ------------------------------------------------------------
+WL="$BASE_WORKDIR/w-fetch-l"
+new_fixture "$WL"
+write_fake_daemon "$WL/installed-loom-daemon" "oldc0mm" "$WL/marker"
+
+WL_ASSETS="$WL/gh-assets"
+mkdir -p "$WL_ASSETS"
+WL_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WL_ASSETS/$WL_BIN_NAME" "0.16.0" "nokeyc0"
+sha256_of "$WL_ASSETS/$WL_BIN_NAME" > "$WL_ASSETS/$WL_BIN_NAME.sha256"
+echo "fake-detached-signature" > "$WL_ASSETS/$WL_BIN_NAME.sig"
+
+WL_FAKEBIN="$WL/fakebin"
+mkdir -p "$WL_FAKEBIN"
+write_fake_gh "$WL_FAKEBIN/gh" "v0.16.0" "$WL_ASSETS"
+write_fake_cosign "$WL_FAKEBIN/cosign" 0
+
+outL=$( cd "$WL" && PATH="$WL_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WL/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcL=$(echo "$outL" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcL" "signature present, no public key: loud skip, update still proceeds (exit 0)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outL" | grep -q 'no cosign public key is resolvable.*SKIPPING verification'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} signature present, no public key: the skip is LOUD, not silent"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} signature present, no public key: the skip is LOUD, not silent"
+    echo "  output: $outL"
+fi
+
+installedL_version="$("$WL/installed-loom-daemon" --version 2>/dev/null)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$installedL_version" | grep -q 'commit nokeyc0'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} signature present, no public key: the artifact was still provisioned"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} signature present, no public key: the artifact was still provisioned"
+    echo "  --version: $installedL_version"
+fi
+
+# ------------------------------------------------------------
+# M. macOS target, artifact UNSIGNED (no Developer ID secrets were configured
+#    for that release) -> soft-skip, update proceeds. This is the case that
+#    must NOT be confused with tamper evidence.
+# ------------------------------------------------------------
+WM="$BASE_WORKDIR/w-fetch-m"
+new_fixture "$WM"
+write_fake_daemon "$WM/installed-loom-daemon" "oldc0mm" "$WM/marker"
+
+WM_ASSETS="$WM/gh-assets"
+mkdir -p "$WM_ASSETS"
+WM_BIN_NAME="loom-daemon-aarch64-apple-darwin"
+write_fake_artifact_daemon "$WM_ASSETS/$WM_BIN_NAME" "0.16.0" "unsignd"
+sha256_of "$WM_ASSETS/$WM_BIN_NAME" > "$WM_ASSETS/$WM_BIN_NAME.sha256"
+
+WM_FAKEBIN="$WM/fakebin"
+mkdir -p "$WM_FAKEBIN"
+write_fake_gh "$WM_FAKEBIN/gh" "v0.16.0" "$WM_ASSETS"
+write_fake_codesign "$WM_FAKEBIN/codesign" unsigned
+
+outM=$( cd "$WM" && PATH="$WM_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WM/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="aarch64-apple-darwin" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcM=$(echo "$outM" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcM" "macOS artifact unsigned: soft-skip, update proceeds (exit 0)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outM" | grep -q 'Downloaded artifact is unsigned'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} macOS artifact unsigned: reported as 'unsigned', not as a verification failure"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} macOS artifact unsigned: reported as 'unsigned', not as a verification failure"
+    echo "  output: $outM"
+fi
+
+installedM_version="$("$WM/installed-loom-daemon" --version 2>/dev/null)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$installedM_version" | grep -q 'commit unsignd'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} macOS artifact unsigned: still provisioned (absence never blocks)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} macOS artifact unsigned: still provisioned (absence never blocks)"
+    echo "  --version: $installedM_version"
+fi
+
+# ------------------------------------------------------------
+# N. macOS target, artifact SIGNED and codesign verification succeeds ->
+#    proceeds, reporting the verification.
+# ------------------------------------------------------------
+WN="$BASE_WORKDIR/w-fetch-n"
+new_fixture "$WN"
+write_fake_daemon "$WN/installed-loom-daemon" "oldc0mm" "$WN/marker"
+
+WN_ASSETS="$WN/gh-assets"
+mkdir -p "$WN_ASSETS"
+WN_BIN_NAME="loom-daemon-aarch64-apple-darwin"
+write_fake_artifact_daemon "$WN_ASSETS/$WN_BIN_NAME" "0.16.0" "csignok"
+sha256_of "$WN_ASSETS/$WN_BIN_NAME" > "$WN_ASSETS/$WN_BIN_NAME.sha256"
+
+WN_FAKEBIN="$WN/fakebin"
+mkdir -p "$WN_FAKEBIN"
+write_fake_gh "$WN_FAKEBIN/gh" "v0.16.0" "$WN_ASSETS"
+write_fake_codesign "$WN_FAKEBIN/codesign" signed-ok
+
+outN=$( cd "$WN" && PATH="$WN_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WN/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="aarch64-apple-darwin" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcN=$(echo "$outN" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcN" "macOS artifact signed + verified: update proceeds (exit 0)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outN" | grep -q 'macOS codesign verification passed'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} macOS artifact signed: codesign verification actually ran and passed"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} macOS artifact signed: codesign verification actually ran and passed"
+    echo "  output: $outN"
+fi
+
+# ------------------------------------------------------------
+# O. macOS target, artifact SIGNED but codesign verification FAILS -> abort
+#    (exit 1), destination untouched. Distinct from the "unsigned" case in M.
+# ------------------------------------------------------------
+WO="$BASE_WORKDIR/w-fetch-o"
+new_fixture "$WO"
+write_fake_daemon "$WO/installed-loom-daemon" "oldc0mm" "$WO/marker"
+installedO_before="$("$WO/installed-loom-daemon" --version 2>/dev/null)"
+
+WO_ASSETS="$WO/gh-assets"
+mkdir -p "$WO_ASSETS"
+WO_BIN_NAME="loom-daemon-aarch64-apple-darwin"
+write_fake_artifact_daemon "$WO_ASSETS/$WO_BIN_NAME" "0.16.0" "csignbad"
+sha256_of "$WO_ASSETS/$WO_BIN_NAME" > "$WO_ASSETS/$WO_BIN_NAME.sha256"
+
+WO_FAKEBIN="$WO/fakebin"
+mkdir -p "$WO_FAKEBIN"
+write_fake_gh "$WO_FAKEBIN/gh" "v0.16.0" "$WO_ASSETS"
+write_fake_codesign "$WO_FAKEBIN/codesign" signed-bad
+write_fake_cargo "$WO_FAKEBIN/cargo"
+
+outO=$( cd "$WO" && PATH="$WO_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WO/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="aarch64-apple-darwin" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcO=$(echo "$outO" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "1" "$rcO" "macOS artifact signed but INVALID: aborts the update (exit 1)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outO" | grep -q 'codesign verification FAILED' \
+    && ! echo "$outO" | grep -q 'Rebuilding loom-daemon (cargo build'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} macOS signed-but-invalid: treated as tamper evidence, no source-build fallback"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} macOS signed-but-invalid: treated as tamper evidence, no source-build fallback"
+    echo "  output: $outO"
+fi
+
+installedO_after="$("$WO/installed-loom-daemon" --version 2>/dev/null)"
+assert_eq "$installedO_before" "$installedO_after" "macOS signed-but-invalid leaves the destination binary untouched"
 
 # ============================================================
 # 25. Launchd-sandbox guards (#4078): the whole suite exercises the REAL

--- a/loom-daemon/src/auto_update.rs
+++ b/loom-daemon/src/auto_update.rs
@@ -555,6 +555,24 @@ impl DrainTrigger for IpcDrainTrigger {
 /// [`LOW_PRIORITY_NICE`] via a `pre_exec` `setpriority(2)` — inherited by
 /// `cargo`/`rustc`, so a rebuild forced past gate 4's deadline yields CPU to
 /// the in-flight sweeps rather than stampeding them.
+///
+/// # Artifact-fetch precedence (Epic #4990 Phase 3, #5020)
+///
+/// No flag is passed here to select fetch-vs-build: `loom-daemon-update.sh`
+/// prefers a verified GitHub Release artifact for the host's platform
+/// automatically (default "auto" precedence, opt-out via `--no-fetch` /
+/// `LOOM_DAEMON_UPDATE_FETCH=0`) whenever one resolves, and softly falls back
+/// to this same `cargo build --release` path otherwise — so a saturated host
+/// with no Rust toolchain converges on a release alone (AC1) with *zero*
+/// daemon-side awareness required. This call site deliberately does not opt
+/// in with `--fetch` (which would hard-fail instead of falling back): the
+/// auto-updater's whole purpose is unattended convergence, and a resolution
+/// hiccup (an unreachable GitHub API, a release missing this platform's
+/// artifact) must degrade to the existing rebuild path, not go Terminal.
+/// The exit-code contract above is UNCHANGED by the fetch path: a checksum
+/// or signature-verification failure on a resolved artifact maps to exit `1`
+/// (Retryable, same bucket as a `cargo build` failure — plausibly transient,
+/// e.g. a network blip), so `classify_exit` below needs no new cases.
 fn run_update_script(
     script: &Path,
     cwd: &Path,

--- a/scripts/install/provision-daemon.sh
+++ b/scripts/install/provision-daemon.sh
@@ -130,6 +130,23 @@ sign_daemon_binary() {
   [[ "$(uname -s 2>/dev/null)" == "Darwin" ]] || return 0
   command -v codesign >/dev/null 2>&1 || return 0
 
+  # Epic #4990 Phase 3 (#5020): never force-resign a binary that already
+  # carries a REAL, certificate-backed signature -- e.g. a fetched release
+  # artifact signed in CI with the project's Developer ID (Phase 2,
+  # #5011/#5018). `codesign -f` below UNCONDITIONALLY REPLACES whatever
+  # signature is present, and an ad-hoc re-sign has no certificate chain, so
+  # forcing it here would silently downgrade a Developer ID signature to
+  # ad-hoc on every provision -- exactly the Gatekeeper regression Phase 2
+  # exists to avoid. `codesign -dvvv` prints an `Authority=` line only for a
+  # certificate-backed signature; a LOCALLY BUILT binary (the pre-#4990 case
+  # this function was originally written for) never has one -- cargo's own
+  # linker-applied signature is always ad-hoc -- so this check is a no-op for
+  # that path and changes nothing there.
+  if codesign -dvvv "$bin" 2>&1 | grep -q '^Authority='; then
+    _pmd_ok "already signed with a real certificate (not re-signing): $bin"
+    return 0
+  fi
+
   local identity
   identity="$(_pmd_resolve_codesign_identity)"
 

--- a/tests/install/test-provision-daemon.sh
+++ b/tests/install/test-provision-daemon.sh
@@ -433,6 +433,47 @@ rc15=$?
 assert_eq "gate accepts a real compiled binary without the bypass" "0" "$rc15"
 assert_eq "real binary is installed at dest" "1" "$( [[ -x "$DEST15/loom-daemon" ]] && echo 1 || echo 0 )"
 
+# ---------- test 16: certificate-signed binaries are never force-resigned
+# (#5020, epic #4990 Phase 3) — a FETCHED release artifact carries a real
+# Developer ID signature (Phase 2, #5011/#5018), and `codesign -f` would
+# unconditionally REPLACE it with an ad-hoc signature that has no certificate
+# chain. sign_daemon_binary must detect the existing Authority and skip.
+# ---------------------------------------------------------------------------
+FAKE_SIGNED_DIR="$WORKDIR/fake-signed-bin"
+mkdir -p "$FAKE_SIGNED_DIR"
+cat > "$FAKE_SIGNED_DIR/uname" <<'EOF'
+#!/usr/bin/env bash
+echo "Darwin"
+EOF
+chmod +x "$FAKE_SIGNED_DIR/uname"
+CODESIGN_SIGNED_ARGS_FILE="$WORKDIR/codesign-args-signed.txt"
+# `-dvvv` reports a certificate-backed signature (Authority on stderr, exactly
+# where real codesign prints it); ANY other invocation records its argv so the
+# assertion below can prove no re-signing was attempted.
+cat > "$FAKE_SIGNED_DIR/codesign" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "-dvvv" ]]; then
+  echo "Identifier=com.rjwalters.loom-daemon" >&2
+  echo "Authority=Developer ID Application: Test Authority (TESTTEAM)" >&2
+  exit 0
+fi
+echo "\$@" >> "$CODESIGN_SIGNED_ARGS_FILE"
+exit 0
+EOF
+chmod +x "$FAKE_SIGNED_DIR/codesign"
+
+SRC16="$WORKDIR/src16/loom-daemon"
+mkdir -p "$WORKDIR/src16"
+make_fake_bin "$SRC16" "0.17.0"
+DEST16="$WORKDIR/dest16"
+out16=$(PATH="$FAKE_SIGNED_DIR:$PATH" LOOM_DAEMON_BIN_DIR="$DEST16" provision_machine_daemon "$SRC16" 2>&1)
+rc16=$?
+assert_eq "already-signed: provision returns 0" "0" "$rc16"
+assert_eq "already-signed: binary is still provisioned" "1" "$( [[ -x "$DEST16/loom-daemon" ]] && echo 1 || echo 0 )"
+assert_contains "already-signed: says it is not re-signing" "$out16" "already signed with a real certificate"
+assert_eq "already-signed: codesign -f is NEVER invoked (no ad-hoc downgrade)" "0" \
+  "$( [[ -s "$CODESIGN_SIGNED_ARGS_FILE" ]] && echo 1 || echo 0 )"
+
 # ---------- summary ----------
 echo ""
 echo "-----------------------------------------"


### PR DESCRIPTION
## Summary

Teaches the update path to consume the release artifacts published by epic #4990 Phase 1 (#5003) and signed by Phase 2 (#5011/#5018), instead of always rebuilding from source.

`loom-daemon-update.sh` now **prefers a prebuilt GitHub Release artifact over a local `cargo build --release`**, so a CPU-saturated host — or one with no Rust toolchain installed at all — converges onto the latest release without ever compiling.

## Changes

**Resolution + precedence (three-state `FETCH_MODE`)**

| Mode | Selected by | Behavior |
|------|-------------|----------|
| `auto` (**default**) | — | Prefer a verified artifact when one resolves; **softly** fall back to the source build otherwise |
| `force` | `--fetch` / `LOOM_DAEMON_UPDATE_FETCH=1` | Require an artifact; **exit 1** rather than silently building from source |
| `off` | `--no-fetch` / `LOOM_DAEMON_UPDATE_FETCH=0` | Never fetch; pre-#5020 behavior |

An artifact wins only when the latest release is **strictly newer** than the installed daemon (an *equal* version wins only under an explicit `--fetch`, so plain `--force` keeps meaning "rebuild this checkout"), the host maps to a release target triple, and the release publishes both `loom-daemon-<target>` **and** its `.sha256`. Every other outcome — unrecognized platform, no `gh` CLI, no Releases (a fork), an unreachable/rate-limited API, no artifact for this platform — is a **soft** fallback, never a hard error.

**Verification** (epic design principle 2: checksum always, signature when present)

- **Checksum is unconditional.** A mismatch aborts the update (exit 1) and leaves the running daemon untouched. It is never downgraded to a fallback — a mismatch is tamper/corruption evidence, not a resolution failure.
- **Signature is verified only when present**, and its absence never blocks.
  - macOS: `codesign --verify --strict` in-binary, distinguishing "not signed at all" (expected **soft-skip**) from "signed but invalid" (**abort**).
  - Linux: the detached `.sig` via `cosign verify-blob`. Since no cosign public key is distributed with this repo yet, a missing `cosign` binary or unresolvable key is a **loud skip** rather than a block; `LOOM_DAEMON_UPDATE_COSIGN_PUBKEY` (or a committed `.loom/cosign.pub` / `defaults/cosign.pub`) turns it into real verification. See "Follow-up" below.

**Provisioning and restart are reused unchanged** — same `provision_machine_daemon()` seam, same supervised launchd/systemd/pid-file restart tiers (#4054/#4950). Two artifact-specific adjustments:

- `verify_destination_artifact()` replaces the source path's embedded-commit compare (a release's commit is unrelated to the local checkout's HEAD). It asserts the destination's full `--version` string equals the verified artifact's — the same string `provision_machine_daemon()`'s version-equality short-circuit compares — so a silent no-op roll still exits `5`.
- `sign_daemon_binary()` now **skips any binary already carrying a certificate-backed signature** (`codesign -dvvv` reports `Authority=`). Without this, the belt-and-braces ad-hoc re-sign inside `provision_machine_daemon()` would silently **downgrade** a Developer ID-signed release artifact to ad-hoc on every provision — exactly the Gatekeeper regression Phase 2 exists to avoid. A locally built binary is always ad-hoc, so the source path is unaffected. This is the only functional change to `provision-daemon.sh`; its structure and the `provision_machine_daemon()` seam are otherwise untouched.

**No new daemon config keys.** `auto_update.rs` passes no fetch flag and inherits the `auto` default, which is exactly the unattended behavior it wants (prefer an artifact, degrade to a rebuild). It deliberately does **not** pass `--fetch`, since that would turn a transient GitHub API hiccup into a failed roll. The exit-code contract is unchanged — a checksum/signature failure maps to exit `1` (Retryable, same bucket as a failed `cargo build`) — so `classify_exit` needs no new cases. The change there is a doc comment recording that reasoning.

## Acceptance Criteria Verification

| AC | Status | Evidence |
|----|--------|----------|
| Saturated host with no Rust toolchain converges via artifact fetch — no `cargo build` | Met | Test A runs with **no cargo on PATH at all** and asserts the output never contains `Rebuilding loom-daemon (cargo build` |
| Checksum unconditional; mismatch aborts, running daemon untouched | Met | Test B: exit 1 + destination binary byte-identical before/after |
| Signature verified when present; absence does not block | Met | Tests J/K/L (cosign verifies / invalid aborts / no pubkey = loud skip) and M/N/O (macOS unsigned soft-skip / signed verified / signed-invalid aborts) |
| Clean fallback when no matching artifact, or the API call fails | Met | Test C (no artifact for this platform) and Test F (API unreachable) both exit 0 having rebuilt from source |
| Restart supervised per #4054/#4950, reusing existing tiers unchanged | Met | Zero changes to the restart tiers; artifact mode joins the pipeline before the shared provision step |
| `provision_machine_daemon()` reused as the sole provisioning seam | Met | No parallel provisioning logic added; artifact mode calls the same seam |
| Test coverage for fetch / mismatch / fallback / signature states | Met | 15 new cases (A–O) in `test-loom-daemon-update.sh` + 1 in `test-provision-daemon.sh` |
| Test files gain fixtures for the new fetch path | Met | New fakes: `write_fake_gh`, `write_fake_gh_unreachable`, `write_fake_artifact_daemon`, `write_fake_codesign`, `sha256_of` |

Regression ACs from the Test Plan — `--allow-stale`, `--check`, `--dry-run`, `--force` — all still behave as documented (Tests G/H/I cover `--check` and `--dry-run` *in artifact mode* specifically; the pre-existing cases for all four still pass).

## Test Plan

- `bash defaults/scripts/tests/test-loom-daemon-update.sh` → **205 passed, 0 failed** (was 160 before; +45 assertions across 15 new cases). Includes the suite's own guard that the real `~/.local/bin/loom-daemon` is byte-identical before/after.
- `bash tests/install/test-provision-daemon.sh` → **44 passed, 0 failed** (+4 assertions, incl. "codesign -f is NEVER invoked" on an already-certificate-signed binary).
- `cargo check -p loom-daemon` → clean. `cargo fmt --check -p loom-daemon` → clean.
- `shellcheck -S warning` on all four changed shell files → only pre-existing SC2034s on unchanged lines; no new findings.

The macOS/Linux signature branches are exercised via a fake `codesign`/`cosign` on PATH, so all six signature states are testable on any host (including a Linux CI runner with no `codesign` at all).

## Notes / Follow-up

- **Cosign public-key distribution** is still unresolved from Phase 2 — no key is committed anywhere. Per the issue's explicit deferral to builder judgment, the Linux `.sig` path ships as soft-skip-if-unresolvable rather than blocking the whole feature. Making that verification mandatory needs a key-distribution decision; filed as a fast-follow.
- **Artifact resolution runs *after* the ff-first sync with `origin/<default-branch>` (#4330)**, so a checkout that hard-aborts that sync still exits `2` before any artifact is considered (`--allow-stale` skips the sync and goes straight to resolution). This is unchanged pre-existing behavior, not something the fetch path introduces, but it is now documented explicitly since "no Rust toolchain" is not the same as "no git checkout hygiene".
- On a host whose checkout is **ahead of the latest release** (the usual dev-host state), a newly published release costs one extra roll: the artifact installs first, then the next tick sees the release commit ≠ local HEAD and rebuilds from source, superseding it. This converges (the source build's version equals the release's, so no artifact wins afterwards — no ping-pong) and is the right trade for the hosts this exists for. Documented in the daemon reference.

Closes #5020
