### PR TITLE
feat(daemon,codex): refuse a provable model/runtime mismatch before spawn (#5001 AC2/AC3)

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3713,6 +3713,20 @@ values are treated as unset at every tier (`--model ""` is never emitted). The
 resolved model and the tier that supplied it are recorded in the per-role log
 header: `==== loom-daemon role_runner: <ts> role=<role> model=<m> (source=<tier>) ====`.
 
+**A pinned model can still be the wrong provider family for the admitted
+runtime (#5028).** `runtimes.roles.<role> = "codex"` with no matching
+`autonomous.roleRunner.roleModels.<role>` override resolves the Claude-shaped
+default model above and forwards it to the Codex adapter, which 400s — before
+#5028 this retried identically, at full cost, on every tick forever. Runtime
+admission now resolves before the model, and a confidently-known
+Claude-vs-Codex mismatch is refused pre-spawn as `RoleTickOutcome::
+ModelRuntimeMismatch` instead of `Failure`: it never joins the generic failure
+tally, `loom-daemon health`'s `roles` section names the broken config key
+directly via the outcome's `detail()` (no spawn transcript needed), and the
+per-root log warns once on the edge and downgrades to `DEBUG` on repeat. Full
+mechanism and the `spawn-codex.sh`-side counterpart:
+[`runtime-adapters.md` § "Model/runtime mismatch refusal (#5028)"](runtime-adapters.md#model-runtime-mismatch-refusal-5028).
+
 `roles` restricts the dispatched subset (an explicit empty array runs none;
 unknown names are ignored with a warning). `intervalSecs` — both the env var
 and the config key — is a single override applied *uniformly* to every

--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -607,6 +607,63 @@ resolved model and names the tier that supplied it
 (`source=autonomous.roleRunner.roleModels.<role>`), so an operator can confirm the
 pin from the log alone.
 
+#### Model/runtime mismatch refusal (#5028)
+
+`roleModels` above gives an operator a *way* to configure a matching model, but
+before #5028 nothing ever verified the two axes actually agreed: the daemon
+resolved the model and the runtime independently and forwarded whatever it got.
+Set `runtimes.roles.judge = "codex"` with no `roleModels.judge` override, and
+the runner still resolved the Claude-shaped default (`sonnet`) and forwarded it
+verbatim to the Codex adapter, which 400s — the original #5001 outage,
+recurring verbatim for anyone who reaches for the runtime axis without the
+matching model one.
+
+`loom-daemon/src/sweep_registry/model.rs` now carries a narrow, fail-open
+classifier — `model_family` / `runtime_model_family` / `model_runtime_mismatch`
+— that answers exactly one question: are the admitted runtime and the resolved
+model **confidently-known, differing** provider families (Claude vs.
+OpenAI/Codex)? Only `claude` and `codex` runtimes, and only recognized
+Claude/OpenAI model names/aliases (`@effort` suffixes stripped first), are ever
+classified; every other runtime (`aider`, a tier-3/custom adapter) or unknown
+model name always falls through unrefused. This can only ever catch a launch
+that was already guaranteed to fail on the wire — never a launch that might
+have worked.
+
+The role runner (`ScriptRoleInvocationRunner::invoke`) now resolves runtime
+admission **before** the model — the runtime is a per-role input to the
+mismatch check — and if `model_runtime_mismatch` returns `Some(reason)`, the
+tick is refused as `RoleTickOutcome::ModelRuntimeMismatch` before any spawn:
+
+- A distinct outcome, deliberately never folded into the generic `Failure`
+  tally — same argument as `NoTokenPool` (#4642): this is a permanent config
+  conflict detected pre-spawn, not a transient invocation failure.
+- Its own `MODEL_RUNTIME_MISMATCH_SKIP_COUNT` counter
+  (`model_runtime_mismatch_skip_count()`).
+- A one-line operator-facing `detail()` — `"model/runtime mismatch: … (model
+  source=…); set autonomous.roleRunner.roleModels.<role> …"` — that
+  `record_role_tick` stores on the health ring, which `assess_roles` in
+  `health.rs` already renders verbatim: `loom-daemon health` now names the
+  broken config key directly, instead of an operator reading a spawn
+  transcript to find it (the original #5001 AC2).
+- Its own `RootTickLogAction::ModelMismatchEdge` / `ModelMismatchRepeat` pair
+  in the multi-workspace loop's per-root log dedup, tracked on a third state
+  map fully independent of the `Failure`/`RuntimeRejected` and `NoTokenPool`
+  axes — a misconfigured role warns once on the edge and logs at `DEBUG` on
+  repeat, never retrying at full WARN-noise cost forever (#5001 AC3). Because
+  the check runs before token selection and the CLI start, a misconfigured
+  role now costs a config read per tick instead of a token draw plus a full
+  session — and it self-heals the moment `roleModels.<role>` is corrected, with
+  no restart and no one-shot disable to clear.
+
+`defaults/scripts/spawn-codex.sh` carries an independent copy of the same
+refusal for every OTHER caller that reaches this adapter directly with no
+daemon preflight in front of it (sweep dispatch also pins models). After the
+model-selection block resolves an effective model (explicit `-m`/`--model` >
+`LOOM_MODEL` > `LOOM_CODEX_MODEL`), a Claude-shaped value (`opus`, `opusplan`,
+`sonnet`, `haiku`, `fable`, or `claude*`, `@effort` stripped) logs the same fix
+options and exits `78` (`EX_CONFIG`) before any auth work. Escape hatch:
+`LOOM_CODEX_MODEL_CHECK=0`.
+
 Daemon admission runs before any claim lock, forge mutation, account selection,
 log header, or child spawn. Successful sweep status and
 `sweep.global.dispatch` events include both `runtime` and `runtime_source`.

--- a/defaults/scripts/spawn-codex.sh
+++ b/defaults/scripts/spawn-codex.sh
@@ -163,6 +163,8 @@
 #   LOOM_CODEX_MODEL     Static per-adapter default model, used only when
 #                        neither an explicit flag nor LOOM_MODEL is present.
 #                        Unset by default (no `-m` emitted).
+#   LOOM_CODEX_MODEL_CHECK  Set to 0 to disable the Claude-shaped-model refusal
+#                        below (issue #5028). Default on (`1`).
 #   LOOM_EFFORT          Reasoning effort, mapped to
 #                        `-c model_reasoning_effort=<value>`. Skipped when an
 #                        explicit `-c model_reasoning_effort=` override is
@@ -460,6 +462,44 @@ elif [[ -n "$CODEX_DEFAULT_MODEL" ]]; then
     log_info "spawn-codex: model=$CODEX_DEFAULT_MODEL (from LOOM_CODEX_MODEL adapter default)"
 else
     log_info "spawn-codex: model=default"
+fi
+
+# --- Claude-shaped model refusal (issue #5028, follow-up to #5001 AC2/AC3) ---
+# The daemon-native role runner independently refuses this same conflict
+# (`loom-daemon/src/sweep_registry/model.rs::model_runtime_mismatch`) before
+# ever shelling out, but any OTHER caller that pins a model onto this runtime
+# (sweep dispatch, a hand-run `LOOM_RUNTIME=codex`) reaches this adapter
+# directly with no daemon preflight in front of it. Loom's logical Claude
+# tiers/aliases (`opus`, `opusplan`, `sonnet`, `haiku`, `fable`) and any
+# `claude*`-prefixed pinned ID are never valid on Codex's wire — the CLI 400s
+# on them. Catching it here, before any auth/dispatch work, means a
+# misconfigured caller fails fast and names the fix instead of burning an
+# entire session on a doomed spawn. Escape hatch: LOOM_CODEX_MODEL_CHECK=0
+# (e.g. if a future Codex model is genuinely named something like
+# "sonnet-mini").
+EFFECTIVE_MODEL=""
+if [[ "$HAS_MODEL_ARG" == "true" ]]; then
+    EFFECTIVE_MODEL="$EXPLICIT_MODEL"
+elif [[ -n "${LOOM_MODEL:-}" ]]; then
+    EFFECTIVE_MODEL="$LOOM_MODEL"
+elif [[ -n "$CODEX_DEFAULT_MODEL" ]]; then
+    EFFECTIVE_MODEL="$CODEX_DEFAULT_MODEL"
+fi
+if [[ -n "$EFFECTIVE_MODEL" && "${LOOM_CODEX_MODEL_CHECK:-1}" != "0" ]]; then
+    _model_base="${EFFECTIVE_MODEL%%@*}"
+    _model_key="$(printf '%s' "$_model_base" | tr '[:upper:]' '[:lower:]')"
+    case "$_model_key" in
+        opus | opusplan | sonnet | haiku | fable | claude*)
+            log_error "spawn-codex: refusing Claude-shaped model '$EFFECTIVE_MODEL' on the Codex runtime (#5028)."
+            log_error "This model/runtime combination is guaranteed to fail on the wire (HTTP 400)."
+            log_error "Fix one of:"
+            log_error "  - set autonomous.roleRunner.roleModels.<role> to a Codex-valid model in .loom/config.json"
+            log_error "  - set LOOM_MODEL / LOOM_CODEX_MODEL to a Codex-valid model for this invocation"
+            log_error "  - point this role/runtime binding back at Claude (unset runtimes.roles.<role> / LOOM_RUNTIME_<ROLE>)"
+            log_error "Escape hatch: LOOM_CODEX_MODEL_CHECK=0 (only if this really is a valid Codex model name)."
+            exit 78 # EX_CONFIG
+            ;;
+    esac
 fi
 
 # --- Effort selection ---

--- a/defaults/scripts/tests/test-spawn-codex.sh
+++ b/defaults/scripts/tests/test-spawn-codex.sh
@@ -331,6 +331,61 @@ assert_not_contains "model_reasoning_effort=high" "$out" \
     "an explicit -c model_reasoning_effort= wins over LOOM_EFFORT"
 
 # ============================================================
+# Section 3b: Claude-shaped model refusal (issue #5028)
+# ============================================================
+
+echo ""
+echo "Testing spawn-codex.sh Claude-shaped model refusal..."
+
+run_refusal() {
+    # usage: run_refusal [VAR=val ...] -- <args...>
+    local -a envs=()
+    while [[ $# -gt 0 && "$1" != "--" ]]; do envs+=("$1"); shift; done
+    shift || true
+    set +e
+    out="$(env -u CODEX_HOME -u LOOM_CODEX_HOME -u LOOM_CODEX_PROFILE \
+        -u LOOM_CODEX_SANDBOX -u LOOM_CODEX_NETWORK -u LOOM_MODEL \
+        -u LOOM_EFFORT -u LOOM_CODEX_MODEL \
+        LOOM_SWEEP_NICE=0 LOOM_SPAWN_NO_EXPORT=1 \
+        ${envs[@]+"${envs[@]}"} \
+        bash "$SPAWN_CODEX" "$@" 2>&1)"
+    REFUSAL_RC=$?
+    set -e
+    REFUSAL_OUT="$out"
+}
+
+for claude_model in opus opusplan sonnet haiku fable claude-opus-5 OPUS "sonnet@xhigh"; do
+    run_refusal -- -p x -m "$claude_model"
+    assert_eq "78" "$REFUSAL_RC" "explicit -m $claude_model exits 78 (EX_CONFIG)"
+    assert_contains "refusing Claude-shaped model" "$REFUSAL_OUT" \
+        "the refusal message names the problem for -m $claude_model"
+    assert_contains "autonomous.roleRunner.roleModels" "$REFUSAL_OUT" \
+        "the refusal names the config key to fix for -m $claude_model"
+done
+
+# The refusal fires identically via LOOM_MODEL and LOOM_CODEX_MODEL, not just -m.
+run_refusal LOOM_MODEL=sonnet -- -p x
+assert_eq "78" "$REFUSAL_RC" "LOOM_MODEL=sonnet exits 78"
+run_refusal LOOM_CODEX_MODEL=opus -- -p x
+assert_eq "78" "$REFUSAL_RC" "LOOM_CODEX_MODEL=opus exits 78"
+
+# No argv is ever assembled for a refused launch.
+run_refusal -- -p x -m sonnet
+assert_not_contains "would-exec" "$REFUSAL_OUT" \
+    "a refused launch never reaches argv assembly/dispatch"
+
+# Fail-open: Codex-valid and unrecognized model names are never refused.
+for ok_model in gpt-5-codex o3-mini gpt-4.1 mystery-model-9000; do
+    out="$(run_argv -- -p x -m "$ok_model")"
+    assert_contains "-m $ok_model" "$out" "a Codex/unrecognized model '$ok_model' is never refused"
+done
+
+# Escape hatch: with LOOM_CODEX_NO_EXEC=1 (argv-only mode), the refusal check
+# is bypassed entirely and the run proceeds to normal argv assembly.
+out="$(run_argv LOOM_CODEX_MODEL_CHECK=0 -- -p x -m sonnet)"
+assert_contains "-m sonnet" "$out" "LOOM_CODEX_MODEL_CHECK=0 disables the refusal"
+
+# ============================================================
 # Section 4: git-repo trust check (live-CLI behavior)
 # ============================================================
 

--- a/loom-daemon/src/role_runner.rs
+++ b/loom-daemon/src/role_runner.rs
@@ -154,6 +154,24 @@ pub fn no_token_pool_skip_count() -> u64 {
     NO_TOKEN_POOL_SKIP_COUNT.load(Ordering::Relaxed)
 }
 
+/// Process-wide count of ticks skipped with
+/// [`RoleTickOutcome::ModelRuntimeMismatch`] (#5028, follow-up to #5001 AC2/
+/// AC3) — a distinct, independently-attributable tally, deliberately never
+/// folded into the generic [`RoleTickOutcome::Failure`] count a real
+/// invocation failure increments, exactly like [`NO_TOKEN_POOL_SKIP_COUNT`]:
+/// this is a permanent config conflict, not a transient failure worth
+/// retrying identically forever.
+static MODEL_RUNTIME_MISMATCH_SKIP_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Total number of role-runner ticks skipped so far for a provable
+/// model/runtime mismatch (see [`RoleTickOutcome::ModelRuntimeMismatch`]).
+/// Exposed for tests and future status surfacing; the daemon does not reset
+/// this across its lifetime.
+#[must_use]
+pub fn model_runtime_mismatch_skip_count() -> u64 {
+    MODEL_RUNTIME_MISMATCH_SKIP_COUNT.load(Ordering::Relaxed)
+}
+
 /// One standalone support role this module knows how to dispatch: its name
 /// (used for config/env lookups and the per-role log file), the `/role`
 /// slash-command prompt passed to `claude -p`, and its default tick interval.
@@ -238,6 +256,16 @@ pub enum RoleTickOutcome {
     /// operator provisions a pool, not a transient failure worth retrying
     /// identically forever.
     NoTokenPool,
+    /// A provable model/runtime mismatch (#5028, follow-up to #5001 AC2/AC3):
+    /// the admitted runtime and the resolved model are confidently-known,
+    /// differing provider families (e.g. a Claude-shaped model resolved for a
+    /// role admitted onto the Codex runtime) — see
+    /// [`crate::sweep_registry::model_runtime_mismatch`]. A distinct variant,
+    /// deliberately never folded into the generic [`Self::Failure`] tally: it
+    /// is detected BEFORE any spawn, is a permanent config conflict rather
+    /// than a transient invocation failure, and self-heals the moment the
+    /// conflicting config is corrected (no restart, no one-shot disable).
+    ModelRuntimeMismatch(ModelRuntimeMismatch),
 }
 
 impl RoleTickOutcome {
@@ -245,6 +273,42 @@ impl RoleTickOutcome {
     #[must_use]
     pub fn is_success(&self) -> bool {
         matches!(self, Self::Success)
+    }
+}
+
+/// The detail carried by [`RoleTickOutcome::ModelRuntimeMismatch`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelRuntimeMismatch {
+    /// The role that was ticked (e.g. `"judge"`).
+    pub role: String,
+    /// The admitted runtime (e.g. `"codex"`).
+    pub runtime: String,
+    /// The model resolved by [`resolve_role_runner_model`] (or the test-only
+    /// `with_model` override) for this role.
+    pub model: String,
+    /// The config/env tier label [`resolve_role_runner_model`] attributes the
+    /// model to (e.g. `"default"`, `"autonomous.roleRunner.model"`), unchanged
+    /// from what a successful spawn's log header would have recorded.
+    pub model_source: String,
+    /// The [`crate::sweep_registry::model_runtime_mismatch`] reason string
+    /// naming the two conflicting families.
+    pub reason: String,
+}
+
+impl ModelRuntimeMismatch {
+    /// One-line, operator-facing detail. `record_role_tick` stores this
+    /// verbatim on the ring record, and `assess_roles` in `health.rs` already
+    /// renders a persistent failure's `detail` as-is — so `loom-daemon
+    /// health` names the broken config key without an operator reading a
+    /// spawn transcript (#5028 AC2).
+    #[must_use]
+    pub fn detail(&self) -> String {
+        format!(
+            "model/runtime mismatch: {} (model source={}); set \
+             autonomous.roleRunner.roleModels.{} to a model the {} runtime accepts, or point \
+             this role back at a Claude runtime",
+            self.reason, self.model_source, self.role, self.runtime
+        )
     }
 }
 
@@ -297,6 +361,11 @@ pub fn record_role_tick_at(
         // surface, and the persistent-vs-transient classifier will (correctly)
         // never clear it until a pool is provisioned.
         RoleTickOutcome::NoTokenPool => (false, Some("no-token-pool".to_string())),
+        // #5028: same reasoning as `NoTokenPool` — a permanent config
+        // conflict is exactly what a health check must surface, and the
+        // operator-facing `detail()` names the broken config key directly
+        // (AC2), so `assess_roles`'s verbatim rendering needs no special case.
+        RoleTickOutcome::ModelRuntimeMismatch(mismatch) => (false, Some(mismatch.detail())),
     };
     let mut ring = role_tick_ring()
         .lock()
@@ -447,14 +516,10 @@ impl RoleInvocationRunner for ScriptRoleInvocationRunner {
             NO_TOKEN_POOL_SKIP_COUNT.fetch_add(1, Ordering::Relaxed);
             return RoleTickOutcome::NoTokenPool;
         }
-        // Issue #4501: pin the child's model instead of inheriting the account's
-        // interactive CLI default (`fable` on the host that filed the issue,
-        // where every role child burned the most constrained quota tier and then
-        // died on "You've reached your Fable 5 limit").
-        let (model, model_source) = match &self.model {
-            Some(m) => (m.clone(), "override".to_string()),
-            None => resolve_role_runner_model(&self.workspace_root, role),
-        };
+        // Issue #5028 (follow-up to #5001 AC2/AC3): runtime admission now
+        // resolves BEFORE the model, because the runtime is a per-role INPUT
+        // to the model/runtime mismatch check just below — a Claude-shaped
+        // model can only be judged wrong once the admitted runtime is known.
         let admission = if self.spawn_bin.is_none() {
             match crate::runtime_admission::resolve_and_admit(&self.workspace_root, role, None) {
                 Ok(value) => Some(value),
@@ -463,6 +528,40 @@ impl RoleInvocationRunner for ScriptRoleInvocationRunner {
         } else {
             None
         };
+        // Issue #4501: pin the child's model instead of inheriting the account's
+        // interactive CLI default (`fable` on the host that filed the issue,
+        // where every role child burned the most constrained quota tier and then
+        // died on "You've reached your Fable 5 limit").
+        let (model, model_source) = match &self.model {
+            Some(m) => (m.clone(), "override".to_string()),
+            None => resolve_role_runner_model(&self.workspace_root, role),
+        };
+        // Issue #5028: refuse a launch whose resolved model is a provable
+        // conflict with the just-admitted runtime — e.g.
+        // `runtimes.roles.judge = "codex"` with no matching
+        // `autonomous.roleRunner.roleModels.judge` override still resolves the
+        // Claude-shaped default (`sonnet`), which the Codex adapter rejects
+        // with an HTTP 400. Detected here, before any spawn, so the role
+        // runner skips the doomed launch instead of burning a tick (and a
+        // token draw) on a guaranteed failure every time (#5001 AC2/AC3).
+        // Gated on `admission` being `Some` — tests that opt out of admission
+        // via `spawn_bin` have no resolved runtime to check against, and are
+        // unaffected (mirrors the token-pool preflight's `spawn_bin.is_none()`
+        // gate above).
+        if let Some(admitted) = &admission {
+            if let Some(reason) =
+                crate::sweep_registry::model_runtime_mismatch(&admitted.runtime, &model)
+            {
+                MODEL_RUNTIME_MISMATCH_SKIP_COUNT.fetch_add(1, Ordering::Relaxed);
+                return RoleTickOutcome::ModelRuntimeMismatch(ModelRuntimeMismatch {
+                    role: role.to_string(),
+                    runtime: admitted.runtime.clone(),
+                    model,
+                    model_source,
+                    reason,
+                });
+            }
+        }
         run_role_with_timeout(
             &script,
             &self.workspace_root,
@@ -1484,6 +1583,11 @@ pub fn spawn_multi_role_task(
         // is never conflated with (or silences the WARN for) a genuine
         // invocation failure — see `RootTickLogAction::is_no_token_pool`.
         let mut no_token_pool_roots: HashMap<PathBuf, bool> = HashMap::new();
+        // Per-root model/runtime-mismatch state (#5028), tracked completely
+        // independently of both `failing_roots` and `no_token_pool_roots` so a
+        // permanent config-conflict skip is never conflated with (or silences
+        // the WARN for) either — see `RootTickLogAction::is_model_mismatch`.
+        let mut model_mismatch_roots: HashMap<PathBuf, bool> = HashMap::new();
         // Disabled-root warn-once state (#4377): the per-tick disabled-skip
         // below is otherwise only a `debug!` — invisible at the default `info`
         // level, so a registered root left disabled gets zero diagnostics.
@@ -1611,6 +1715,7 @@ pub fn spawn_multi_role_task(
                         elapsed,
                         &mut failing_roots,
                         &mut no_token_pool_roots,
+                        &mut model_mismatch_roots,
                     ),
                     Err(e) => log::error!(
                         "role_runner: {} invocation task for {} panicked ({e}); continuing to the \
@@ -1672,6 +1777,12 @@ fn log_outcome(role: &str, outcome: &RoleTickOutcome, elapsed: Duration) {
                  .loom/docs/token-pool.md, #4642)"
             );
         }
+        RoleTickOutcome::ModelRuntimeMismatch(mismatch) => {
+            log::warn!(
+                "role_runner: {role} tick skipped after {elapsed:.1?} — {} (#5028)",
+                mismatch.detail()
+            );
+        }
     }
 }
 
@@ -1718,6 +1829,11 @@ fn log_outcome_for_root(role: &str, root: &Path, outcome: &RoleTickOutcome, elap
              .loom/docs/token-pool.md, #4642)",
             root.display()
         ),
+        RoleTickOutcome::ModelRuntimeMismatch(mismatch) => log::warn!(
+            "role_runner: {role} tick for {} skipped after {elapsed:.1?} — {} (#5028)",
+            root.display(),
+            mismatch.detail()
+        ),
     }
 }
 
@@ -1756,6 +1872,17 @@ enum RootTickLogAction {
     /// but tracked completely independently of the Failure/RuntimeRejected
     /// state.
     NoTokenPoolRepeat,
+    /// First tick with a model/runtime mismatch (edge into this state, #5028):
+    /// log at `WARN`. Distinct from [`Self::FailureEdge`] and
+    /// [`Self::NoTokenPoolEdge`] — a provable model/runtime conflict is a
+    /// permanent config state detected before any spawn, never tallied as an
+    /// invocation failure.
+    ModelMismatchEdge,
+    /// Repeat tick with a model/runtime mismatch (already warned, #5028):
+    /// downgrade to `DEBUG`, mirroring [`Self::FailureRepeat`] /
+    /// [`Self::NoTokenPoolRepeat`]'s dedup shape but tracked completely
+    /// independently of both.
+    ModelMismatchRepeat,
 }
 
 impl RootTickLogAction {
@@ -1774,6 +1901,15 @@ impl RootTickLogAction {
     fn is_no_token_pool(self) -> bool {
         matches!(self, Self::NoTokenPoolEdge | Self::NoTokenPoolRepeat)
     }
+
+    /// Whether this action should mark the root as model-mismatched for the
+    /// *next* tick's edge/repeat decision (#5028) — tracked independently of
+    /// both [`Self::is_failing`] and [`Self::is_no_token_pool`] so none of the
+    /// three axes bleed into each other's dedup state.
+    #[must_use]
+    fn is_model_mismatch(self) -> bool {
+        matches!(self, Self::ModelMismatchEdge | Self::ModelMismatchRepeat)
+    }
 }
 
 #[must_use]
@@ -1782,10 +1918,15 @@ fn classify_root_tick_log(
     elapsed: Duration,
     was_failing: bool,
     was_no_token_pool: bool,
+    was_model_mismatch: bool,
 ) -> RootTickLogAction {
     match outcome {
         RoleTickOutcome::NoTokenPool if was_no_token_pool => RootTickLogAction::NoTokenPoolRepeat,
         RoleTickOutcome::NoTokenPool => RootTickLogAction::NoTokenPoolEdge,
+        RoleTickOutcome::ModelRuntimeMismatch(_) if was_model_mismatch => {
+            RootTickLogAction::ModelMismatchRepeat
+        }
+        RoleTickOutcome::ModelRuntimeMismatch(_) => RootTickLogAction::ModelMismatchEdge,
         RoleTickOutcome::Failure(_) | RoleTickOutcome::RuntimeRejected(_) if was_failing => {
             RootTickLogAction::FailureRepeat
         }
@@ -1808,8 +1949,11 @@ fn classify_root_tick_log(
 /// *previous* tick for that root ended in [`RoleTickOutcome::Failure`] (or
 /// [`RoleTickOutcome::RuntimeRejected`]); `no_token_pool` tracks, per root and
 /// completely independently, whether the previous tick ended in
-/// [`RoleTickOutcome::NoTokenPool`] (#4642) — see [`RootTickLogAction`] for
-/// the per-transition logging rules.
+/// [`RoleTickOutcome::NoTokenPool`] (#4642); `model_mismatch` tracks, per root
+/// and completely independently of both, whether the previous tick ended in
+/// [`RoleTickOutcome::ModelRuntimeMismatch`] (#5028) — see [`RootTickLogAction`]
+/// for the per-transition logging rules.
+#[allow(clippy::too_many_arguments)]
 fn log_outcome_for_root_deduped(
     role: &str,
     root: &Path,
@@ -1817,6 +1961,7 @@ fn log_outcome_for_root_deduped(
     elapsed: Duration,
     failing: &mut HashMap<PathBuf, bool>,
     no_token_pool: &mut HashMap<PathBuf, bool>,
+    model_mismatch: &mut HashMap<PathBuf, bool>,
 ) {
     // Record the raw outcome BEFORE the log-dedup decision (#4761): the
     // edge/repeat dedup exists to keep the *log* quiet, but a health check needs
@@ -1825,11 +1970,19 @@ fn log_outcome_for_root_deduped(
     record_role_tick(role, root, outcome);
     let was_failing = failing.get(root).copied().unwrap_or(false);
     let was_no_token_pool = no_token_pool.get(root).copied().unwrap_or(false);
-    let action = classify_root_tick_log(outcome, elapsed, was_failing, was_no_token_pool);
+    let was_model_mismatch = model_mismatch.get(root).copied().unwrap_or(false);
+    let action = classify_root_tick_log(
+        outcome,
+        elapsed,
+        was_failing,
+        was_no_token_pool,
+        was_model_mismatch,
+    );
     let reason = match outcome {
         RoleTickOutcome::Failure(reason) => reason.as_str(),
         RoleTickOutcome::RuntimeRejected(rejection) => rejection.reason.as_str(),
         RoleTickOutcome::Success | RoleTickOutcome::NoTokenPool => "",
+        RoleTickOutcome::ModelRuntimeMismatch(_) => "",
     };
     match action {
         RootTickLogAction::Success => {
@@ -1898,9 +2051,32 @@ fn log_outcome_for_root_deduped(
                 root.display()
             );
         }
+        RootTickLogAction::ModelMismatchEdge => {
+            if let RoleTickOutcome::ModelRuntimeMismatch(mismatch) = outcome {
+                log::warn!(
+                    "role_runner: {role} tick for {} skipped after {elapsed:.1?} — {} (further \
+                     identical skips for this root are logged at DEBUG until the config is \
+                     corrected, #5028)",
+                    root.display(),
+                    mismatch.detail()
+                );
+            }
+        }
+        RootTickLogAction::ModelMismatchRepeat => {
+            if let RoleTickOutcome::ModelRuntimeMismatch(mismatch) = outcome {
+                log::debug!(
+                    "role_runner: {role} tick for {} skipped again after {elapsed:.1?} — repeat \
+                     of an already-logged model/runtime mismatch (see the mismatch-edge WARN \
+                     above, #5028): {}",
+                    root.display(),
+                    mismatch.detail()
+                );
+            }
+        }
     }
     failing.insert(root.to_path_buf(), action.is_failing());
     no_token_pool.insert(root.to_path_buf(), action.is_no_token_pool());
+    model_mismatch.insert(root.to_path_buf(), action.is_model_mismatch());
 }
 
 #[cfg(test)]
@@ -1960,7 +2136,16 @@ mod tests {
         // #4642: a per-repo token pool so the new pre-spawn token-pool check
         // does not short-circuit this test's runtime-admission scenario.
         fs::write(root.join(".loom/tokens/fake.token"), "sk-ant-oat01-fake").unwrap();
-        write_config(root, r#"{"runtimes":{"roles":{"curator":"codex"}}}"#);
+        // #5028: without a matching `roleModels.curator` override, curator
+        // admitted onto `codex` would resolve the Claude-shaped default model
+        // (`sonnet`) and now get refused as a `ModelRuntimeMismatch` BEFORE
+        // this test's runtime-admission/pinning scenario ever reaches the
+        // adapter — supplying the override keeps this test's scope on
+        // admission/pinning, not the (separately tested) mismatch refusal.
+        write_config(
+            root,
+            r#"{"runtimes":{"roles":{"curator":"codex"}},"autonomous":{"roleRunner":{"roleModels":{"curator":"gpt-5-codex"}}}}"#,
+        );
         fs::write(root.join(".loom/roles/curator.json"), r#"{"runtimeRequirements":["mcp"]}"#)
             .unwrap();
         fs::write(
@@ -2093,6 +2278,104 @@ mod tests {
             Some(v) => std::env::set_var("LOOM_SHARED_TOKENS_DIR", v),
             None => std::env::remove_var("LOOM_SHARED_TOKENS_DIR"),
         }
+    }
+
+    /// Shared fixture for the #5028 end-to-end mismatch tests: a workspace
+    /// admitted onto the `codex` runtime for `judge`, with a real per-repo
+    /// token pool (so the #4642 preflight does not short-circuit first) and a
+    /// fake `spawn-worker.sh` (the actual script `resolve_spawn_bin` resolves
+    /// and `invoke` runs — mirrors `mixed_runtime_role_launch_is_admitted_and_pinned_before_spawn`)
+    /// that writes a marker file if it is ever actually invoked — proving a
+    /// refused launch never reaches the spawn.
+    fn setup_codex_judge_fixture(root: &Path, config_extra: &str) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        for sub in [
+            ".loom/roles",
+            ".loom/runtimes",
+            ".loom/scripts",
+            ".loom/tokens",
+        ] {
+            fs::create_dir_all(root.join(sub)).unwrap();
+        }
+        fs::write(root.join(".loom/tokens/fake.token"), "sk-ant-oat01-fake").unwrap();
+        write_config(
+            root,
+            &format!(r#"{{"runtimes":{{"roles":{{"judge":"codex"}}}}{}}}"#, config_extra),
+        );
+        fs::write(root.join(".loom/roles/judge.json"), r#"{"runtimeRequirements":[]}"#).unwrap();
+        fs::write(
+            root.join(".loom/runtimes/codex.json"),
+            r#"{"runtime":"codex","capabilities":{}}"#,
+        )
+        .unwrap();
+        // Admission (`resolve_and_admit`) validates that the `codex` adapter
+        // file exists on disk before admitting the runtime at all — it is
+        // never actually exec'd in this fixture (that's `spawn-worker.sh`
+        // below), but its mere absence would itself refuse the launch with a
+        // `RuntimeRejected`, which is not what these tests are exercising.
+        let adapter = root.join(".loom/scripts/spawn-codex.sh");
+        fs::write(&adapter, "#!/bin/sh\nexit 0\n").unwrap();
+        fs::set_permissions(&adapter, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let marker = root.join("spawn-ran");
+        let worker = root.join(".loom/scripts/spawn-worker.sh");
+        fs::write(&worker, format!("#!/bin/sh\ntouch '{}'\nexit 0\n", marker.display())).unwrap();
+        fs::set_permissions(&worker, fs::Permissions::from_mode(0o755)).unwrap();
+        marker
+    }
+
+    /// Issue #5028 (#5001 AC2/AC3): `runtimes.roles.judge = "codex"` with NO
+    /// `autonomous.roleRunner.roleModels.judge` override resolves the
+    /// Claude-shaped default model (`sonnet`) for a role admitted onto Codex —
+    /// a provable, doomed launch. `invoke` must refuse it as
+    /// `ModelRuntimeMismatch` BEFORE the spawn, never create the adapter's
+    /// marker file, and increment the dedicated skip counter — never a bare
+    /// `Failure`/`RuntimeRejected`.
+    #[test]
+    #[serial]
+    fn test_invoke_refuses_a_provable_model_runtime_mismatch_before_spawning() {
+        let _env_guard = ClearedLoomRuntimeEnv::new();
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let marker = setup_codex_judge_fixture(root, "");
+
+        let before = model_runtime_mismatch_skip_count();
+        let mut runner = ScriptRoleInvocationRunner::new(root.to_path_buf())
+            .with_timeout(Duration::from_secs(5));
+        let outcome = runner.invoke("judge", "/loom:judge");
+
+        let RoleTickOutcome::ModelRuntimeMismatch(mismatch) = outcome else {
+            panic!("expected ModelRuntimeMismatch, got {outcome:?}");
+        };
+        assert_eq!(mismatch.role, "judge");
+        assert_eq!(mismatch.runtime, "codex");
+        assert_eq!(mismatch.model, "sonnet", "the unfixed Claude-shaped default");
+        assert!(!marker.exists(), "a doomed launch must never actually spawn the adapter");
+        assert_eq!(model_runtime_mismatch_skip_count(), before + 1);
+    }
+
+    /// Issue #5028: the SAME fixture with `roleModels.judge` pointed at a
+    /// Codex-valid model spawns successfully — proving the check is a
+    /// targeted refusal, not a blanket block on Judge-on-Codex, and that it
+    /// self-heals the moment the config is corrected (no restart needed).
+    #[test]
+    #[serial]
+    fn test_invoke_succeeds_once_role_models_supplies_a_matching_model() {
+        let _env_guard = ClearedLoomRuntimeEnv::new();
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let marker = setup_codex_judge_fixture(
+            root,
+            r#","autonomous":{"roleRunner":{"roleModels":{"judge":"gpt-5-codex"}}}"#,
+        );
+
+        let mut runner = ScriptRoleInvocationRunner::new(root.to_path_buf())
+            .with_timeout(Duration::from_secs(5));
+        let outcome = runner.invoke("judge", "/loom:judge");
+
+        assert_eq!(outcome, RoleTickOutcome::Success);
+        assert!(marker.exists(), "a matching model must let the launch actually spawn");
     }
 
     #[test]
@@ -3658,6 +3941,7 @@ mod tests {
                 &RoleTickOutcome::Failure("boom".into()),
                 NORMAL_TICK,
                 false,
+                false,
                 false
             ),
             RootTickLogAction::FailureEdge
@@ -3671,6 +3955,7 @@ mod tests {
                 &RoleTickOutcome::Failure("boom".into()),
                 NORMAL_TICK,
                 true,
+                false,
                 false
             ),
             RootTickLogAction::FailureRepeat
@@ -3680,7 +3965,7 @@ mod tests {
     #[test]
     fn test_classify_success_after_failure_is_recovery() {
         assert_eq!(
-            classify_root_tick_log(&RoleTickOutcome::Success, NORMAL_TICK, true, false),
+            classify_root_tick_log(&RoleTickOutcome::Success, NORMAL_TICK, true, false, false),
             RootTickLogAction::Recovered
         );
     }
@@ -3688,7 +3973,7 @@ mod tests {
     #[test]
     fn test_classify_steady_state_success_is_plain() {
         assert_eq!(
-            classify_root_tick_log(&RoleTickOutcome::Success, NORMAL_TICK, false, false),
+            classify_root_tick_log(&RoleTickOutcome::Success, NORMAL_TICK, false, false, false),
             RootTickLogAction::Success
         );
     }
@@ -3700,6 +3985,7 @@ mod tests {
                 &RoleTickOutcome::Success,
                 Duration::from_millis(100),
                 false,
+                false,
                 false
             ),
             RootTickLogAction::SuccessImplausiblyFast
@@ -3709,6 +3995,7 @@ mod tests {
                 &RoleTickOutcome::Success,
                 Duration::from_millis(100),
                 true,
+                false,
                 false
             ),
             RootTickLogAction::RecoveredImplausiblyFast
@@ -3720,7 +4007,7 @@ mod tests {
     #[test]
     fn test_classify_first_no_token_pool_is_edge() {
         assert_eq!(
-            classify_root_tick_log(&RoleTickOutcome::NoTokenPool, NORMAL_TICK, false, false),
+            classify_root_tick_log(&RoleTickOutcome::NoTokenPool, NORMAL_TICK, false, false, false),
             RootTickLogAction::NoTokenPoolEdge
         );
     }
@@ -3728,7 +4015,7 @@ mod tests {
     #[test]
     fn test_classify_repeat_no_token_pool_is_downgraded() {
         assert_eq!(
-            classify_root_tick_log(&RoleTickOutcome::NoTokenPool, NORMAL_TICK, false, true),
+            classify_root_tick_log(&RoleTickOutcome::NoTokenPool, NORMAL_TICK, false, true, false),
             RootTickLogAction::NoTokenPoolRepeat
         );
     }
@@ -3739,7 +4026,7 @@ mod tests {
         // no-token-pool skip demoted to `Repeat` just because `was_failing`
         // is true — the two conditions are tracked on separate axes.
         assert_eq!(
-            classify_root_tick_log(&RoleTickOutcome::NoTokenPool, NORMAL_TICK, true, false),
+            classify_root_tick_log(&RoleTickOutcome::NoTokenPool, NORMAL_TICK, true, false, false),
             RootTickLogAction::NoTokenPoolEdge
         );
     }
@@ -3756,12 +4043,72 @@ mod tests {
         assert!(!RootTickLogAction::FailureRepeat.is_no_token_pool());
     }
 
+    // ---- model/runtime mismatch classification (#5028) -----------------
+
+    fn mismatch_outcome() -> RoleTickOutcome {
+        RoleTickOutcome::ModelRuntimeMismatch(ModelRuntimeMismatch {
+            role: "judge".to_string(),
+            runtime: "codex".to_string(),
+            model: "sonnet".to_string(),
+            model_source: "default".to_string(),
+            reason: "runtime \"codex\" only accepts an OpenAI/Codex model but got \"sonnet\""
+                .to_string(),
+        })
+    }
+
+    #[test]
+    fn test_classify_first_model_mismatch_is_edge() {
+        assert_eq!(
+            classify_root_tick_log(&mismatch_outcome(), NORMAL_TICK, false, false, false),
+            RootTickLogAction::ModelMismatchEdge
+        );
+    }
+
+    #[test]
+    fn test_classify_repeat_model_mismatch_is_downgraded() {
+        assert_eq!(
+            classify_root_tick_log(&mismatch_outcome(), NORMAL_TICK, false, false, true),
+            RootTickLogAction::ModelMismatchRepeat
+        );
+    }
+
+    #[test]
+    fn test_classify_model_mismatch_is_independent_of_failing_and_no_token_pool_state() {
+        // A root previously `Failure`-failing OR previously no-token-pool must
+        // not have its model-mismatch skip demoted to `Repeat` just because
+        // one of the OTHER two axes is `true` — all three are tracked
+        // independently.
+        assert_eq!(
+            classify_root_tick_log(&mismatch_outcome(), NORMAL_TICK, true, false, false),
+            RootTickLogAction::ModelMismatchEdge
+        );
+        assert_eq!(
+            classify_root_tick_log(&mismatch_outcome(), NORMAL_TICK, false, true, false),
+            RootTickLogAction::ModelMismatchEdge
+        );
+    }
+
+    #[test]
+    fn test_root_tick_log_action_model_mismatch_is_not_failing_or_no_token_pool() {
+        // #5028: a model-mismatch skip must never contribute to the
+        // Failure/RuntimeRejected tally, nor to the NoTokenPool tally.
+        assert!(!RootTickLogAction::ModelMismatchEdge.is_failing());
+        assert!(!RootTickLogAction::ModelMismatchRepeat.is_failing());
+        assert!(!RootTickLogAction::ModelMismatchEdge.is_no_token_pool());
+        assert!(!RootTickLogAction::ModelMismatchRepeat.is_no_token_pool());
+        assert!(RootTickLogAction::ModelMismatchEdge.is_model_mismatch());
+        assert!(RootTickLogAction::ModelMismatchRepeat.is_model_mismatch());
+        assert!(!RootTickLogAction::FailureEdge.is_model_mismatch());
+        assert!(!RootTickLogAction::NoTokenPoolEdge.is_model_mismatch());
+    }
+
     #[test]
     #[serial(role_tick_ring)]
     fn test_log_outcome_for_root_deduped_tracks_failing_state_across_ticks() {
         let root = PathBuf::from("/tmp/does-not-need-to-exist-for-this-test");
         let mut failing: HashMap<PathBuf, bool> = HashMap::new();
         let mut no_token_pool: HashMap<PathBuf, bool> = HashMap::new();
+        let mut model_mismatch: HashMap<PathBuf, bool> = HashMap::new();
 
         // Tick 1: failure -> edge, marks failing.
         log_outcome_for_root_deduped(
@@ -3771,6 +4118,7 @@ mod tests {
             NORMAL_TICK,
             &mut failing,
             &mut no_token_pool,
+            &mut model_mismatch,
         );
         assert_eq!(failing.get(&root), Some(&true));
 
@@ -3785,6 +4133,7 @@ mod tests {
                 NORMAL_TICK,
                 &mut failing,
                 &mut no_token_pool,
+                &mut model_mismatch,
             );
             assert_eq!(failing.get(&root), Some(&true));
         }
@@ -3797,6 +4146,7 @@ mod tests {
             NORMAL_TICK,
             &mut failing,
             &mut no_token_pool,
+            &mut model_mismatch,
         );
         assert_eq!(failing.get(&root), Some(&false));
 
@@ -3808,6 +4158,7 @@ mod tests {
             NORMAL_TICK,
             &mut failing,
             &mut no_token_pool,
+            &mut model_mismatch,
         );
         assert_eq!(failing.get(&root), Some(&false));
     }
@@ -3821,6 +4172,7 @@ mod tests {
         let root_b = PathBuf::from("/tmp/root-b");
         let mut failing: HashMap<PathBuf, bool> = HashMap::new();
         let mut no_token_pool: HashMap<PathBuf, bool> = HashMap::new();
+        let mut model_mismatch: HashMap<PathBuf, bool> = HashMap::new();
 
         log_outcome_for_root_deduped(
             "curator",
@@ -3829,6 +4181,7 @@ mod tests {
             NORMAL_TICK,
             &mut failing,
             &mut no_token_pool,
+            &mut model_mismatch,
         );
         log_outcome_for_root_deduped(
             "curator",
@@ -3837,6 +4190,7 @@ mod tests {
             NORMAL_TICK,
             &mut failing,
             &mut no_token_pool,
+            &mut model_mismatch,
         );
 
         assert_eq!(failing.get(&root_a), Some(&true));
@@ -3852,6 +4206,7 @@ mod tests {
         let root = PathBuf::from("/tmp/does-not-need-to-exist-for-this-test-2");
         let mut failing: HashMap<PathBuf, bool> = HashMap::new();
         let mut no_token_pool: HashMap<PathBuf, bool> = HashMap::new();
+        let mut model_mismatch: HashMap<PathBuf, bool> = HashMap::new();
 
         log_outcome_for_root_deduped(
             "auditor",
@@ -3860,6 +4215,7 @@ mod tests {
             NORMAL_TICK,
             &mut failing,
             &mut no_token_pool,
+            &mut model_mismatch,
         );
         assert_eq!(no_token_pool.get(&root), Some(&true));
         assert_eq!(failing.get(&root), Some(&false));
@@ -3874,9 +4230,50 @@ mod tests {
             NORMAL_TICK,
             &mut failing,
             &mut no_token_pool,
+            &mut model_mismatch,
         );
         assert_eq!(failing.get(&root), Some(&true));
         assert_eq!(no_token_pool.get(&root), Some(&false));
+    }
+
+    #[test]
+    #[serial(role_tick_ring)]
+    fn test_log_outcome_for_root_deduped_model_mismatch_tracked_independently() {
+        // #5028: a ModelRuntimeMismatch tick must never mark `failing` or
+        // `no_token_pool` true, and must not itself be marked by either of
+        // those two axes — all three maps are independent even for the SAME
+        // root.
+        let root = PathBuf::from("/tmp/does-not-need-to-exist-for-this-test-3");
+        let mut failing: HashMap<PathBuf, bool> = HashMap::new();
+        let mut no_token_pool: HashMap<PathBuf, bool> = HashMap::new();
+        let mut model_mismatch: HashMap<PathBuf, bool> = HashMap::new();
+
+        log_outcome_for_root_deduped(
+            "judge",
+            &root,
+            &mismatch_outcome(),
+            NORMAL_TICK,
+            &mut failing,
+            &mut no_token_pool,
+            &mut model_mismatch,
+        );
+        assert_eq!(model_mismatch.get(&root), Some(&true));
+        assert_eq!(failing.get(&root), Some(&false));
+        assert_eq!(no_token_pool.get(&root), Some(&false));
+
+        // A subsequent real failure must still log as a fresh `FailureEdge`
+        // even though the root was just skipped for a model/runtime mismatch.
+        log_outcome_for_root_deduped(
+            "judge",
+            &root,
+            &RoleTickOutcome::Failure("boom".into()),
+            NORMAL_TICK,
+            &mut failing,
+            &mut no_token_pool,
+            &mut model_mismatch,
+        );
+        assert_eq!(failing.get(&root), Some(&true));
+        assert_eq!(model_mismatch.get(&root), Some(&false));
     }
 
     // ===================================================================
@@ -4008,6 +4405,7 @@ mod tests {
         reset_role_tick_ring();
         let mut failing = HashMap::new();
         let mut no_pool = HashMap::new();
+        let mut model_mismatch = HashMap::new();
         let root = PathBuf::from("/r/loom");
         for _ in 0..3 {
             log_outcome_for_root_deduped(
@@ -4017,10 +4415,31 @@ mod tests {
                 Duration::from_secs(30),
                 &mut failing,
                 &mut no_pool,
+                &mut model_mismatch,
             );
         }
         let records = role_tick_records();
         assert_eq!(records.len(), 3, "every tick is recorded, not just the fail edge");
         assert!(records.iter().all(|r| !r.ok));
+    }
+
+    /// #5028 AC2: a `ModelRuntimeMismatch` outcome records as NOT-ok with an
+    /// operator-facing `detail()` string that names the broken config key —
+    /// exactly what `assess_roles` in `health.rs` renders verbatim into
+    /// `loom-daemon health`, so an operator learns the fix without reading a
+    /// spawn transcript.
+    #[test]
+    #[serial(role_tick_ring)]
+    fn a_model_runtime_mismatch_records_its_operator_facing_detail() {
+        reset_role_tick_ring();
+        record_role_tick("judge", Path::new("/r/loom"), &mismatch_outcome());
+        let records = role_tick_records();
+        assert!(!records[0].ok);
+        let detail = records[0].detail.as_deref().unwrap();
+        assert!(
+            detail.contains("autonomous.roleRunner.roleModels.judge"),
+            "detail must name the broken config key: {detail}"
+        );
+        assert!(detail.contains("model/runtime mismatch"), "detail: {detail}");
     }
 }

--- a/loom-daemon/src/sweep_registry/model.rs
+++ b/loom-daemon/src/sweep_registry/model.rs
@@ -215,6 +215,102 @@ pub fn resolve_model_alias_from_config(config: &serde_json::Value, model: &str) 
 }
 
 // ----------------------------------------------------------------------------
+// Model/runtime family classification (#5028, follow-up to #5001 AC2/AC3)
+// ----------------------------------------------------------------------------
+//
+// A narrow, fail-open classifier — deliberately NOT the epic #4167 Phase 4
+// tier→ID table. It answers exactly one question: "is this model name
+// unambiguously the WRONG provider family for this runtime?" so a launch that
+// is already guaranteed to fail on the wire (a Claude-shaped model forwarded
+// to the Codex adapter, or vice versa) can be refused before a spawn instead
+// of discovered via an HTTP 400 deep inside a `claude`/`codex` session.
+//
+// Both sides must be confidently *known* to report a mismatch — an unknown
+// model name or an unrecognized runtime (aider, a tier-3/custom adapter) never
+// refuses a launch. This makes the classifier safe to run unconditionally on
+// every role tick: it can only ever catch a launch that was doomed anyway.
+
+/// The coarse provider family a model name belongs to, for the sole purpose of
+/// [`model_runtime_mismatch`]. Not a general model taxonomy — see the module
+/// note above.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelFamily {
+    /// Anthropic Claude models/aliases (`opus`, `opusplan`, `sonnet`, `haiku`,
+    /// `fable`, or any `claude*`-prefixed pinned ID).
+    Claude,
+    /// OpenAI / Codex models (`gpt*`, `o1*`, `o3*`, `o4*`, `codex*`).
+    OpenAi,
+}
+
+/// Classify a model name/alias into its [`ModelFamily`], stripping any
+/// `@effort` suffix first (`opus@xhigh` classifies identically to `opus`).
+/// Fail-open: returns `None` for anything not unambiguously recognized —
+/// a pinned third-party ID, a future alias, or an empty string are never
+/// misclassified into a false mismatch.
+#[must_use]
+pub fn model_family(model: &str) -> Option<ModelFamily> {
+    let base = model.split_once('@').map_or(model, |(base, _)| base);
+    let key = base.trim().to_ascii_lowercase();
+    if key.is_empty() {
+        return None;
+    }
+    if key.starts_with("claude")
+        || matches!(key.as_str(), "opus" | "opusplan" | "sonnet" | "haiku" | "fable")
+    {
+        return Some(ModelFamily::Claude);
+    }
+    if key.starts_with("gpt")
+        || key.starts_with("o1")
+        || key.starts_with("o3")
+        || key.starts_with("o4")
+        || key.starts_with("codex")
+    {
+        return Some(ModelFamily::OpenAi);
+    }
+    None
+}
+
+/// Classify a runtime name into the [`ModelFamily`] it accepts. Fail-open:
+/// only `claude` and `codex` (the two runtimes with an actual model-family
+/// constraint) resolve to `Some`; `aider`, a tier-3/custom runtime, or an
+/// unrecognized name always return `None` — such a runtime is never refused
+/// by this check.
+#[must_use]
+pub fn runtime_model_family(runtime: &str) -> Option<ModelFamily> {
+    match runtime.trim().to_ascii_lowercase().as_str() {
+        "claude" => Some(ModelFamily::Claude),
+        "codex" => Some(ModelFamily::OpenAi),
+        _ => None,
+    }
+}
+
+/// Issue #5028: `Some(<reason>)` only when `runtime` and `model` resolve to
+/// **known, differing** [`ModelFamily`] values — a launch guaranteed to 400 on
+/// the wire (a Claude-shaped model forwarded to the Codex adapter, or a
+/// Codex-shaped model forwarded to the Claude CLI). `None` in every other
+/// case, including either side being unrecognized — this can only ever refuse
+/// a launch that was already doomed, never a launch that might have worked.
+#[must_use]
+pub fn model_runtime_mismatch(runtime: &str, model: &str) -> Option<String> {
+    let runtime_family = runtime_model_family(runtime)?;
+    let model_family = model_family(model)?;
+    if runtime_family == model_family {
+        return None;
+    }
+    let (runtime_label, model_label) = match (runtime_family, model_family) {
+        (ModelFamily::Claude, ModelFamily::OpenAi) => ("Claude", "an OpenAI/Codex"),
+        (ModelFamily::OpenAi, ModelFamily::Claude) => ("Codex", "a Claude"),
+        // Unreachable — the `if` above already returned `None` for equal
+        // families, so only the two cross-family combinations above remain.
+        _ => ("this runtime's", "a mismatched"),
+    };
+    Some(format!(
+        "runtime {runtime:?} only accepts {runtime_label} models, but the resolved model \
+         {model:?} is {model_label} model"
+    ))
+}
+
+// ----------------------------------------------------------------------------
 // Model-cost A/B experiment (#3725) — daemon-native arm assignment (#4809)
 // ----------------------------------------------------------------------------
 
@@ -872,5 +968,95 @@ mod tests {
         }
         // And specifically the previously-broken rung is now gen-5.
         assert_eq!(generation_of(dir.path(), "opus"), 5);
+    }
+
+    // --- Issue #5028: model/runtime family classification ------------------
+
+    #[test]
+    fn model_family_classifies_claude_aliases_and_pinned_ids() {
+        for m in [
+            "opus",
+            "opusplan",
+            "sonnet",
+            "haiku",
+            "fable",
+            "claude-opus-5",
+            "CLAUDE-Sonnet-4-6",
+        ] {
+            assert_eq!(model_family(m), Some(ModelFamily::Claude), "{m} should classify as Claude");
+        }
+        // `@effort` suffixes are stripped before classification.
+        assert_eq!(model_family("opus@xhigh"), Some(ModelFamily::Claude));
+        assert_eq!(model_family("sonnet@low"), Some(ModelFamily::Claude));
+    }
+
+    #[test]
+    fn model_family_classifies_openai_aliases() {
+        for m in [
+            "gpt-5-codex",
+            "gpt-4.1",
+            "o1-mini",
+            "o3-mini",
+            "o4-mini",
+            "codex-mini-latest",
+        ] {
+            assert_eq!(model_family(m), Some(ModelFamily::OpenAi), "{m} should classify as OpenAI");
+        }
+        assert_eq!(model_family("gpt-5-codex@high"), Some(ModelFamily::OpenAi));
+    }
+
+    #[test]
+    fn model_family_fails_open_on_unknown_models() {
+        for m in ["mystery-model", "", "   ", "claude"] {
+            let result = model_family(m);
+            if m == "claude" {
+                // "claude" bare (no version) still starts with "claude" — a
+                // deliberately generous prefix match, since any pinned Claude
+                // ID is `claude-...`.
+                assert_eq!(result, Some(ModelFamily::Claude));
+            } else {
+                assert_eq!(result, None, "{m:?} must fail open (never a false mismatch)");
+            }
+        }
+    }
+
+    #[test]
+    fn runtime_model_family_only_recognizes_claude_and_codex() {
+        assert_eq!(runtime_model_family("claude"), Some(ModelFamily::Claude));
+        assert_eq!(runtime_model_family("CODEX"), Some(ModelFamily::OpenAi));
+        for rt in ["aider", "tier-3", "custom-runtime", "", "unknown"] {
+            assert_eq!(runtime_model_family(rt), None, "{rt:?} must never be refused");
+        }
+    }
+
+    #[test]
+    fn model_runtime_mismatch_only_on_a_provable_conflict() {
+        // The core #5001/#5028 scenario: Judge pinned to codex with no
+        // roleModels override still resolves the Claude-shaped default.
+        assert!(model_runtime_mismatch("codex", "sonnet").is_some());
+        assert!(model_runtime_mismatch("codex", "opus@xhigh").is_some());
+        assert!(model_runtime_mismatch("claude", "gpt-5-codex").is_some());
+
+        // A matching family is never a mismatch.
+        assert_eq!(model_runtime_mismatch("codex", "gpt-5-codex"), None);
+        assert_eq!(model_runtime_mismatch("claude", "sonnet"), None);
+        assert_eq!(model_runtime_mismatch("claude", "opus@xhigh"), None);
+
+        // Fail-open: an unrecognized runtime (aider, tier-3, custom) is never
+        // refused, regardless of the model.
+        assert_eq!(model_runtime_mismatch("aider", "sonnet"), None);
+        assert_eq!(model_runtime_mismatch("tier-3", "gpt-5-codex"), None);
+
+        // Fail-open: an unrecognized model is never refused, regardless of
+        // the runtime.
+        assert_eq!(model_runtime_mismatch("codex", "mystery-model"), None);
+        assert_eq!(model_runtime_mismatch("claude", "mystery-model"), None);
+    }
+
+    #[test]
+    fn model_runtime_mismatch_reason_names_both_sides() {
+        let reason = model_runtime_mismatch("codex", "sonnet").unwrap();
+        assert!(reason.contains("codex"), "reason must name the runtime: {reason}");
+        assert!(reason.contains("sonnet"), "reason must name the model: {reason}");
     }
 }


### PR DESCRIPTION
Closes #5028

## Summary

Follow-up to #5001 (closed by #5026, which shipped `roleModels` per-role
model overrides but left ACs 2-3 open). Without a matching
`autonomous.roleRunner.roleModels.<role>` override, a role admitted onto the
Codex runtime (`runtimes.roles.<role> = "codex"`) still resolved the
Claude-shaped default model (e.g. `sonnet`) and forwarded it to the Codex
adapter, which rejects it with an HTTP 400 — silently retried every tick,
forever, at full token/session cost, with no distinguishable health signal.

- **`loom-daemon/src/sweep_registry/model.rs`**: a narrow, fail-open
  `ModelFamily` classifier (`model_family` / `runtime_model_family` /
  `model_runtime_mismatch`) — refuses a launch only when both the runtime and
  the model are confidently-known, differing provider families. Unknown
  runtimes (aider, tier-3/custom) or unknown model names are never refused.
- **`loom-daemon/src/role_runner.rs`**: runtime admission now resolves
  *before* model resolution (the runtime is an input to the mismatch check).
  A provable mismatch short-circuits to a new `RoleTickOutcome::
  ModelRuntimeMismatch` before any spawn — its own skip counter, its own
  operator-facing `detail()` surfaced verbatim through the existing
  `loom-daemon health` roles section (AC2), and its own edge/repeat log-dedup
  axis, independent of `Failure`/`RuntimeRejected`/`NoTokenPool` (AC3: no
  full-cost retry loop; downgrades to `DEBUG` after the first warn).
- **`defaults/scripts/spawn-codex.sh`**: an independent copy of the same
  refusal (exit `78`/`EX_CONFIG`) for any caller that reaches this adapter
  directly with no daemon preflight in front of it (e.g. sweep dispatch).
  Escape hatch: `LOOM_CODEX_MODEL_CHECK=0`.
- Docs: `runtime-adapters.md` (full mechanism) + a pointer from
  `daemon-reference.md`'s role-runner section.

## Test plan

- [x] `cargo test -p loom-daemon --lib sweep_registry::model` — 27 passed
      (family classification, `@effort` stripping, fail-open cases)
- [x] `cargo test -p loom-daemon --lib role_runner` — 95 passed, including
      end-to-end fixtures asserting the refusal fires before the adapter's
      marker file is created, and that supplying a matching `roleModels`
      override lets the launch proceed
- [x] `defaults/scripts/tests/test-spawn-codex.sh` — new Section 3b
      (Claude-shaped model refusal) passes 27/32 new assertions; the
      remaining 5 fail-open/escape-hatch assertions hit a pre-existing,
      environment-only failure on this host (no Codex hook-trust profile
      provisioned — `provision-codex-hooks.sh` not run here) that reproduces
      identically against the unmodified base `spawn-codex.sh`, confirmed
      by running the same assertions against the pre-change script
- [x] `cargo build -p loom-daemon --lib` clean, `cargo fmt --check` clean,
      `cargo clippy --lib -- -D warnings` clean
