### PR TITLE
Judge fallback-queue dedup via marker

### DIFF
--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -688,9 +688,11 @@ Pre-Iteration Environment Check (gh repo view)
                     ↓
                 Search for unlabeled open PRs
                     ↓
-                    ├─→ Found? → Check for loom:fallback-evaluated marker
-                    │     │        with matching head SHA
-                    │     ├─→ Found (no new commits)? → Skip to next unlabeled PR
+                    ├─→ Found? → Walk the list in order; for each candidate check
+                    │     │        for a loom:fallback-evaluated marker whose SHA
+                    │     │        matches that PR's current head SHA
+                    │     ├─→ Found (no new commits)? → Skip it, try the next
+                    │     │        unlabeled PR (exit iteration if none remain)
                     │     └─→ Not found, or SHA differs? → Evaluate and post comment
                     │              (with updated marker ending)
                     │
@@ -723,27 +725,51 @@ if [ "$LABELED_PRS" -gt 0 ]; then
 else
   echo "No loom:review-requested PRs found, checking unlabeled PRs..."
 
-  # 2. Check fallback queue (cached — see "Cached Forge Reads")
-  UNLABELED_PR=$("$GH_READ" pr list --state=open --limit 500 --json number,labels \
-    --jq '.[] | select(([.labels[].name | select(startswith("loom:"))] | length) == 0) | .number' \
-    | head -n 1)
+  # 2. Check fallback queue (cached — see "Cached Forge Reads"). Keep the WHOLE
+  #    candidate list, not just the head of it: a PR that was already evaluated
+  #    at its current head SHA is skipped, and the walk below moves on to the
+  #    next candidate rather than exiting and claiming "no work".
+  UNLABELED_PRS=$("$GH_READ" pr list --state=open --limit 500 --json number,labels \
+    --jq '.[] | select(([.labels[].name | select(startswith("loom:"))] | length) == 0) | .number')
+
+  # 3. Walk the candidates in order; stop at the first one with no prior
+  #    fallback-evaluated marker for its current head SHA (dedup).
+  UNLABELED_PR=""
+  CURRENT_HEAD_SHA=""
+  for CANDIDATE in $UNLABELED_PRS; do
+    CANDIDATE_HEAD_SHA=$(gh pr view "$CANDIDATE" --json headRefOid --jq '.headRefOid')
+
+    # Extract the most recent loom:fallback-evaluated marker from PR comments.
+    # `--paginate` is REQUIRED: without it `gh api` returns only the first page
+    # (default per_page=30, oldest-first), so on a long-lived PR (#4972 already
+    # had 129 comments when this dedup was added) a marker posted near the end
+    # of the history would never be seen and the dedup would silently never
+    # engage — the exact bug this check exists to prevent. Same pitfall the
+    # Stale `loom:reviewing` Claim Check documents above; with `--jq`,
+    # `--paginate` re-runs the filter per page and concatenates the per-page
+    # output, which is what `tail -n 1` (most-recent-marker-wins) consumes —
+    # pages arrive oldest-first, so the last line is the newest marker.
+    # Extraction is `jq`-only on purpose: `grep -oP` (PCRE lookaround) is a
+    # GNU-only flag that stock BSD/macOS grep rejects outright
+    # (`grep: invalid option -- P`), and a Judge running under an alternate
+    # runtime would degrade silently to "no marker found" — i.e. back to
+    # re-evaluating every pass. jq's regex engine is the same everywhere.
+    # `capture` emits nothing (no error) for a body without the marker.
+    PRIOR_MARKER_SHA=$(gh api "repos/{owner}/{repo}/issues/$CANDIDATE/comments" --paginate \
+      --jq '.[] | (.body // "") | capture("<!-- loom:fallback-evaluated sha=(?<sha>[0-9a-f]+) -->") | .sha' \
+      | tail -n 1)
+
+    if [ -n "$PRIOR_MARKER_SHA" ] && [ "$CANDIDATE_HEAD_SHA" = "$PRIOR_MARKER_SHA" ]; then
+      echo "Skipping unlabeled PR #$CANDIDATE: already evaluated in fallback mode (head SHA unchanged since last evaluation) — trying the next unlabeled PR"
+      continue
+    fi
+
+    UNLABELED_PR="$CANDIDATE"
+    CURRENT_HEAD_SHA="$CANDIDATE_HEAD_SHA"
+    break
+  done
 
   if [ -n "$UNLABELED_PR" ]; then
-    # 3. Check for prior fallback-evaluated marker (dedup) before evaluating
-    CURRENT_HEAD_SHA=$(gh pr view $UNLABELED_PR --json headRefOid --jq '.headRefOid')
-    
-    # Extract the most recent loom:fallback-evaluated marker from PR comments
-    # Filter comments containing the marker, extract SHA values, and take the most recent
-    PRIOR_MARKER_SHA=$(gh api "repos/{owner}/{repo}/issues/$UNLABELED_PR/comments" \
-      | jq -r '.[] | select(.body | contains("<!-- loom:fallback-evaluated sha=")) | .body' \
-      | grep -oP '(?<=<!-- loom:fallback-evaluated sha=)[a-f0-9]+(?= -->)' \
-      | tail -n 1)
-    
-    if [ "$CURRENT_HEAD_SHA" = "$PRIOR_MARKER_SHA" ] && [ -n "$PRIOR_MARKER_SHA" ]; then
-        echo "Skipping unlabeled PR #$UNLABELED_PR: already evaluated in fallback mode (head SHA unchanged since last evaluation)"
-        exit 0
-    fi
-    
     echo "Evaluating unlabeled PR #$UNLABELED_PR (fallback mode)"
 
     # Check out and evaluate the PR (worktree-aware — see "PR Branch Isolation")
@@ -756,8 +782,14 @@ else
     fi
     # ... run checks, evaluate code ...
 
-    # Provide feedback but DO NOT add workflow labels
-    gh pr comment $UNLABELED_PR --body "$(cat <<'EOF'
+    # Provide feedback but DO NOT add workflow labels.
+    # NOTE: this heredoc is deliberately UNQUOTED (`<<EOF`, not `<<'EOF'`) so
+    # $CURRENT_HEAD_SHA expands into the marker. With a quoted delimiter the
+    # marker would post the literal string "sha=$CURRENT_HEAD_SHA", which can
+    # never equal a real head SHA — the dedup read above would then match
+    # nothing and every pass would re-evaluate. Keep any other `$` or backticks
+    # out of this body, or escape them.
+    gh pr comment $UNLABELED_PR --body "$(cat <<EOF
 Code evaluation feedback...
 
 Note: This PR was evaluated in fallback mode (no loom:review-requested label).
@@ -767,7 +799,9 @@ Consider adding loom:review-requested if you want it in the evaluation queue.
 EOF
 )"
   else
-    echo "No work available - both queues empty"
+    # Reached either because the fallback queue was empty, or because every
+    # unlabeled PR in it was already evaluated at its current head SHA.
+    echo "No work available - both queues empty (every unlabeled PR, if any, was already evaluated at its current head SHA)"
     exit 0
   fi
 fi

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -688,8 +688,11 @@ Pre-Iteration Environment Check (gh repo view)
                     ↓
                 Search for unlabeled open PRs
                     ↓
-                    ├─→ Found? → Evaluate but leave labels unchanged
-                    │              (external/manual PR, no workflow labels)
+                    ├─→ Found? → Check for loom:fallback-evaluated marker
+                    │     │        with matching head SHA
+                    │     ├─→ Found (no new commits)? → Skip to next unlabeled PR
+                    │     └─→ Not found, or SHA differs? → Evaluate and post comment
+                    │              (with updated marker ending)
                     │
                     └─→ None found → No work available, exit iteration
 ```
@@ -726,6 +729,21 @@ else
     | head -n 1)
 
   if [ -n "$UNLABELED_PR" ]; then
+    # 3. Check for prior fallback-evaluated marker (dedup) before evaluating
+    CURRENT_HEAD_SHA=$(gh pr view $UNLABELED_PR --json headRefOid --jq '.headRefOid')
+    
+    # Extract the most recent loom:fallback-evaluated marker from PR comments
+    # Filter comments containing the marker, extract SHA values, and take the most recent
+    PRIOR_MARKER_SHA=$(gh api "repos/{owner}/{repo}/issues/$UNLABELED_PR/comments" \
+      | jq -r '.[] | select(.body | contains("<!-- loom:fallback-evaluated sha=")) | .body' \
+      | grep -oP '(?<=<!-- loom:fallback-evaluated sha=)[a-f0-9]+(?= -->)' \
+      | tail -n 1)
+    
+    if [ "$CURRENT_HEAD_SHA" = "$PRIOR_MARKER_SHA" ] && [ -n "$PRIOR_MARKER_SHA" ]; then
+        echo "Skipping unlabeled PR #$UNLABELED_PR: already evaluated in fallback mode (head SHA unchanged since last evaluation)"
+        exit 0
+    fi
+    
     echo "Evaluating unlabeled PR #$UNLABELED_PR (fallback mode)"
 
     # Check out and evaluate the PR (worktree-aware — see "PR Branch Isolation")
@@ -744,6 +762,8 @@ Code evaluation feedback...
 
 Note: This PR was evaluated in fallback mode (no loom:review-requested label).
 Consider adding loom:review-requested if you want it in the evaluation queue.
+
+<!-- loom:fallback-evaluated sha=$CURRENT_HEAD_SHA -->
 EOF
 )"
   else


### PR DESCRIPTION
## Summary

Adds a machine-readable marker (`<!-- loom:fallback-evaluated sha=<head-sha> -->`) to fallback-mode evaluation comments so subsequent Judge passes can detect already-evaluated unlabeled PRs and skip re-review when the head SHA has not changed.

This prevents unbounded duplicate-comment growth on PRs (like #4972 with 129+ comments) that remain open and unchanged since the last fallback-mode pass, while still re-evaluating when new commits are pushed (SHA differs).

## Changes

- **Decision tree**: Updated to show marker-check step before evaluating fallback-queue PRs
- **Example workflow**: Added SHA extraction and marker-check logic before evaluation
- **Comment template**: Appends `<!-- loom:fallback-evaluated sha=$CURRENT_HEAD_SHA -->` marker to fallback evaluation comments
- **Installed copy**: Also updated `.claude/commands/loom/judge.md` for immediate Judge instance pickup

## Edge Cases Handled

1. **Multiple prior markers with different SHAs**: Takes the most recent marker's SHA using `tail -n 1`
2. **PR transitions from unlabeled to loom:review-requested mid-flight**: Normal-path evaluation takes over (fallback path is only entered when labeled queue is empty)
3. **New commits pushed to PR**: Head SHA differs from marker SHA, so PR is re-evaluated with fresh comment

## Out of Scope

Cleanup of PR #4972's existing 129 duplicate comments is explicitly out of scope — only stops future growth. Comment cleanup would require iterative comment deletion via the API and is a separate maintenance task, not part of preventing future accumulation.

Closes #4989