### PR TITLE
fix(docs): unblock consumer install — rewrite runtime-adapters survey-orca link (#4988)

### DIFF
--- a/defaults/docs/runtime-adapters.md
+++ b/defaults/docs/runtime-adapters.md
@@ -860,7 +860,8 @@ collaboration:
 - **#4780** — tier-3 "generic passthrough" mechanism: `spawn-generic.sh`, the
   `defaults/runtimes/aider.json` worked example, and the capability-manifest
   gate this section documents. Adapted from a survey of
-  [stablyai/orca](https://github.com/stablyai/orca) (`.loom/docs/survey-orca-2026-07-31.md`,
+  [stablyai/orca](https://github.com/stablyai/orca)
+  ([survey-orca-2026-07-31.md](https://github.com/rjwalters/loom/blob/main/.loom/docs/survey-orca-2026-07-31.md),
   idea 5), filed from #4775.
 - [ADR-0012: Multi-Runtime Worker Support via a Runtime Adapter Contract](https://github.com/rjwalters/loom/blob/main/docs/adr/0012-runtime-adapter-contract.md).
 - Fork: https://github.com/gpeyton/loom · `AGENTS.md` standard: https://agents.md


### PR DESCRIPTION
## Summary

`install-loom.sh`'s `check-links` gate deterministically failed every consumer install from `main`, aborting at "Initialize Loom". Root-caused via a clean-room `loom-daemon init` to a temp repo.

**The 6 links cited in #4988 already resolve on current `main`:**
- `safehouse.md` and `token-pool.md` ship from `defaults/docs/` (they are NOT on `.loom-internal.list`), so `daemon-reference.md`/`fleet-comms.md` references to them resolve in the installed `.loom/docs/` tree. Rewriting those to GitHub URLs would have been wrong — the files are present locally and the intra-repo links are correct.
- `blame-issue.md` (codecast) and `runtime-adapters.md` (ADR-0012) already carry absolute GitHub URLs as of PR #4946.

**But the gate stayed red** because a 7th link of the same class surfaced after the issue was filed:

```
.loom/docs/runtime-adapters.md -> .loom/docs/survey-orca-2026-07-31.md
```

`survey-orca-2026-07-31.md` is a research artifact tracked only in the loom repo's own `.loom/docs/` — it is NOT in `defaults/docs/`, so it never ships to consumers. On the installed target the path is absent and `cmd_check_links` correctly flagged it dangling.

## Fix

Rewrite the backtick `.loom/docs/survey-orca-2026-07-31.md` reference in `defaults/docs/runtime-adapters.md` to an absolute `https://github.com/rjwalters/loom/blob/main/...` URL, matching the #4946 precedent.

Note: the backtick had to be removed (not merely wrapped in a markdown link like #4946 did for the `docs/research/` case) because `extract_link_targets`' backtick regex matches any `.loom/`-prefixed path regardless of surrounding markdown. The result is a plain markdown link the checker treats as external.

The `check-links` checker logic is left strict and unchanged — the gate still catches genuine packaging gaps (#4097).

## Verification

Clean-room `loom-daemon init` to a temp git repo, then `verify-install.sh check-links`:
- Before: `1 dangling link(s) found: .loom/docs/runtime-adapters.md -> .loom/docs/survey-orca-2026-07-31.md`
- After: `All intra-repo links resolve (94 file(s) checked)` (exit 0)

`scripts/check-docs-defaults-parity.sh` also passes.

## Residual nits (from the issue — cosmetic, not fixed here)

The issue noted two cosmetic rollback nits. They are out of scope for this doc fix and were not addressed:
1. Failure-path rollback leaves an untracked `.gitattributes` behind — install-path rollback concern, not a docs/link issue.
2. `verify-install.sh` warns about the legacy directory-walk fallback when `.loom/install-metadata.json` is absent. Observed in my bare `loom-daemon init` harness (which does not emit the manifest); the real `install-loom.sh` path DOES generate `.loom/manifest.json` (per the issue's own log), so this warning does not appear in a normal consumer install.

Closes #4988

🤖 Generated with [Claude Code](https://claude.com/claude-code)