### PR TITLE
feat(forge-helpers): add REST fallback for gh issue create

### DIFF
--- a/defaults/.claude/commands/loom/architect.md
+++ b/defaults/.claude/commands/loom/architect.md
@@ -174,6 +174,8 @@ When creating a proposal:
 
 > **Do not run concurrent Architects — serialize issue creation (#3707).** `gh issue create` returns a server-assigned number with no client-side coordination, so two Architects (or an Architect and a Curator-decomposition / Champion epic-phase run) filing issues at the same time in the same repo **race on issue numbers and cross-contaminate bodies**. Never place an issue-creating agent in a parallel wave; one issue-creating agent must finish its entire `gh issue create` burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the full invariant. Parallel **Builders** (implementing already-filed issues) stay safe — only issue *creation* must be serialized.
 
+> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`, or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+
 ### Duplicate Detection (CRITICAL)
 
 **BEFORE creating any issue, check for potential duplicates:**

--- a/defaults/.claude/commands/loom/auditor.md
+++ b/defaults/.claude/commands/loom/auditor.md
@@ -263,6 +263,10 @@ The label-specific dedup blocks later in this document (capability requests, bug
 reports, guard decisions) are concrete applications of this one rule — none of
 them is optional and none is an exception.
 
+> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST
+> fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`,
+> or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+
 ## When to Create Issues
 
 **Create issue if:**

--- a/defaults/.claude/commands/loom/builder-complexity.md
+++ b/defaults/.claude/commands/loom/builder-complexity.md
@@ -2,6 +2,11 @@
 
 This document covers complexity assessment, issue decomposition, and scope management for the Builder role. For the core builder workflow, see `builder.md`.
 
+> **`gh issue create` (used throughout this file's decomposition examples) fails
+> outright when GraphQL quota is exhausted.** REST fallback recipe (atomic
+> create+label): `.loom/docs/gh-issue-create-rest-fallback.md`, or
+> `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+
 ## Never Abandon Work
 
 **You must NEVER stop work on a claimed issue without creating a clear path forward.**

--- a/defaults/.claude/commands/loom/builder-pr.md
+++ b/defaults/.claude/commands/loom/builder-pr.md
@@ -828,6 +828,10 @@ Is the failure in YOUR changed files?
 
 If you want to track pre-existing issues for future cleanup:
 
+> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST
+> fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`,
+> or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+
 ```bash
 gh issue create --title "Tech debt: Migrate biome.json to v2 schema" --body "$(cat <<'EOF'
 ## Problem

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -319,6 +319,10 @@ If, during curation, you determine an issue is too large to be a single Builder 
 5. **Do not self-curate your own sub-issues in the same session.** A separate Curator pass (could be the same human-role agent in a later session, or a different agent) must independently review each sub-issue before it can earn `loom:curated`.
 6. **Serialize this `gh issue create` burst against any other issue-creating agent (#3707).** Do not run your sub-issue creation concurrently with another issue-creating agent (Architect / another Curator-decomposition / Champion epic-phase) in the same repo — concurrent `gh issue create` bursts race on server-assigned issue numbers and cross-contaminate bodies. One filer finishes its full burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the invariant.
 
+> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST
+> fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`,
+> or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+
 ### Why this matters
 
 A dedicated Curator pass after decomposition catches:

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -931,6 +931,10 @@ If feedback requires substantial work:
 4. Let Workers handle the complex refactoring
 5. Comment on PR explaining an issue was created
 
+> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST
+> fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`,
+> or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+
 **Example:**
 ```bash
 gh issue create --title "Refactor authentication system per PR #123 review" --body "$(cat <<'EOF'

--- a/defaults/.claude/commands/loom/hermit-patterns.md
+++ b/defaults/.claude/commands/loom/hermit-patterns.md
@@ -836,6 +836,11 @@ git log --all --format=%cd --date=short <file> | head -1
 
 ## Creating Removal Proposals - Full Templates
 
+> **`gh issue create` (used throughout the templates below) fails outright when
+> GraphQL quota is exhausted.** REST fallback recipe (atomic create+label):
+> `.loom/docs/gh-issue-create-rest-fallback.md`, or `forge_gh_create_issue_rl_safe`
+> in `lib/forge-helpers.sh` if scripting.
+
 ### Standalone Issue Template
 
 ```bash

--- a/defaults/.claude/commands/loom/hermit.md
+++ b/defaults/.claude/commands/loom/hermit.md
@@ -291,6 +291,10 @@ When you identify bloat, you have two options:
 
 > **Do not run concurrent Hermits — serialize issue creation (#3707).** `gh issue create` returns a server-assigned number with no client-side coordination, so two Hermits (or a Hermit and an Architect / Curator-decomposition / Champion epic-phase run) filing issues at the same time in the same repo **race on issue numbers and cross-contaminate bodies**. Never place an issue-creating agent in a parallel wave; one issue-creating agent must finish its entire `gh issue create` burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the full invariant.
 
+> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST
+> fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`,
+> or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+
 ### When to Create a New Issue vs Comment
 
 **Create New Issue:**

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -126,6 +126,11 @@ signature table plus ready-made wrappers
 `forge_gh_reopen_issue_rl_safe`, #4856) if you are scripting rather than
 running `gh` interactively.
 
+**This section covers labels/comments only** — `gh issue create` (used below
+under "Creating Follow-up Issues" and "Raising Concerns") is a separate
+GraphQL mutation with its own REST fallback: `.loom/docs/gh-issue-create-rest-fallback.md`
+(or `forge_gh_create_issue_rl_safe` in the same `lib/forge-helpers.sh`, #5047).
+
 ## Your Role
 
 **Your primary task is to evaluate PRs labeled `loom:review-requested` (green badges).**

--- a/defaults/docs/gh-issue-create-rest-fallback.md
+++ b/defaults/docs/gh-issue-create-rest-fallback.md
@@ -1,0 +1,100 @@
+# `gh issue create` REST fallback (GraphQL rate-limit exhaustion)
+
+`gh issue create` is a **GraphQL-backed mutation**. GitHub's GraphQL quota
+(5000/hr, shared across every agent + tool) and its REST quota are
+**independent** — the same fact `judge.md`'s "GraphQL Rate-Limit
+Exhaustion — REST Fallback for Labels/Comments" section and #4856's
+`forge_gh_comment_rl_safe` / `forge_gh_reopen_issue_rl_safe` /
+`forge_gh_swap_label_rl_safe` already rely on for labels, comments, and
+reopen. Before #5047, issue **creation** was the one filing mutation left
+uncovered: every role prompt that files issues (architect, auditor,
+builder-complexity, builder-pr, curator, doctor, hermit, hermit-patterns,
+judge) died outright when GraphQL exhausted, even though the REST pool
+typically sits nearly untouched (observed live: `core` 19/5000 used vs.
+`graphql` 1378/5000 used).
+
+This page is the **single source** for the fallback recipe — role prompts
+link here rather than repeating it. If the recipe needs to change, change it
+here (and in `forge_gh_create_issue_rl_safe`, its scripted equivalent), not
+in nine separate files.
+
+## The five-signature table
+
+A rejection whose text contains one of these (case-insensitive) is a rate
+limit, not a real failure — retry the same creation over REST instead of
+giving up:
+
+| Signature | Seen as |
+|---|---|
+| `api rate limit exceeded` | REST itself throttling (rare on the fallback path) |
+| `api rate limit already exceeded` | GraphQL: `GraphQL: API rate limit already exceeded for user ID …` |
+| `secondary rate limit` | either transport, burst throttling |
+| `abuse detection mechanism` | either transport, burst throttling |
+| `was submitted too quickly` | either transport, burst throttling |
+
+Anything else — auth failure, network error, a validation error (e.g. a
+nonexistent label) — is **not** a rate limit; report it and do not retry
+over REST.
+
+## The recipe: atomic create + label, never create-then-label
+
+**Labels must be applied in the same request as creation**, on both the
+primary and fallback paths. A create-then-label two-step doubles the request
+count (worse under the exact quota pressure this fallback exists for) and
+can half-fail, leaving an unlabeled issue behind.
+
+```bash
+# Primary path — unchanged, still try this first:
+gh issue create --repo "$NWO" --title "$TITLE" --body "$BODY" --label "$LABEL"
+
+# On a rate-limit rejection (see the signature table above), fall back to a
+# REST POST with labels in the SAME payload:
+jq -n --arg t "$TITLE" --arg b "$BODY" --arg labels "$LABEL" \
+  '{title: $t, body: $b, labels: ($labels | split(","))}' > payload.json
+gh api --method POST "repos/$NWO/issues" --input payload.json --jq '.html_url'
+```
+
+`--input payload.json` (a real file) also sidesteps the guard false positive
+where a heredoc body containing `>=` gets misclassified as a Bash redirect,
+and correctly handles a multi-line/markdown body — unlike `-f`/`--raw-field`,
+which does not expand `@file` and would post the literal string (the same
+`-f` vs. `-F` trap documented in `judge.md` for comments).
+
+## Scripted callers: `forge_gh_create_issue_rl_safe`
+
+If you are scripting rather than running `gh` interactively, use the
+ready-made wrapper in `lib/forge-helpers.sh` instead of hand-rolling the
+above:
+
+```bash
+source "$(dirname "${BASH_SOURCE[0]}")/lib/forge-helpers.sh"
+
+# forge_gh_create_issue_rl_safe NWO TITLE BODY [LABELS_CSV]
+url=$(forge_gh_create_issue_rl_safe "$NWO" "$TITLE" "$BODY" "loom:triage,bug")
+```
+
+It tries `gh issue create` first, falls back to the REST POST above on a
+rate-limit rejection (applying labels atomically either way), prints the
+created issue's URL on success, and propagates any non-rate-limit failure
+without attempting the REST call. GitHub-only, like the sibling `*_rl_safe`
+helpers — gate calls on `FORGE_TYPE == github` the same way callers already
+gate `forge_gh_comment_rl_safe` et al.
+
+## `loom-daemon forge issue create` does NOT get this fallback
+
+`loom-daemon forge issue <args…>` is a byte-identical passthrough to `gh
+issue <args…>` (see `loom-daemon/src/forge_cmd.rs`'s `gh_passthrough`) — it
+execs the real `gh` binary with the same arguments and inherits the same
+GraphQL cost, with **no** REST-fallback interception for `issue create`
+specifically (the passthrough is generic across every `gh issue` subcommand,
+not create-aware). It is not a safe alternative to reach for under GraphQL
+exhaustion. Use the recipe or helper above instead.
+
+## Serialize issue creation, fallback or not
+
+The REST fallback does not change the existing serialization requirement
+(#3707): `gh issue create` (and its REST equivalent) returns a
+server-assigned number with no client-side coordination, so concurrent
+issue-filing agents in the same repo still race on issue numbers and can
+cross-contaminate bodies. One issue-creating agent finishes its entire
+filing burst — REST fallback included — before the next starts.

--- a/defaults/scripts/lib/forge-helpers.sh
+++ b/defaults/scripts/lib/forge-helpers.sh
@@ -750,6 +750,11 @@ forge_pr_close_targets() {
 # already gated on `[[ "$FORGE_TYPE" == "github" ]]` by its caller, mirroring
 # the existing `_reset_partial_increment_labels` / `_auto_reconcile_stacked_children`
 # gating in merge-pr.sh, so no Gitea branch is needed here.
+#
+# #5047 extended this same table + fallback shape to issue *creation*
+# (`forge_gh_create_issue_rl_safe`, below) -- the one filing mutation #4856
+# left uncovered, since #4856 was scoped to labels/comments/reopen on
+# already-existing issues.
 is_rate_limit_error() {
   local text
   text=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
@@ -831,6 +836,72 @@ forge_gh_swap_label_rl_safe() {
     echo "gh issue edit (label swap) rate-limited on #$issue_num, and the REST fallback also failed: $out" >&2
     return 1
   fi
+  echo "$out" >&2
+  return 1
+}
+
+# Create an issue via `gh issue create`, falling back to a REST POST
+# (`repos/{nwo}/issues`) on a GraphQL rate-limit rejection (#5047). Labels are
+# applied ATOMICALLY in the same request on both paths -- `gh issue create
+# --label` on the primary path, the payload's `labels` array on the REST
+# fallback -- never a create-then-label two-step (that doubles the request
+# count and can half-fail, leaving an unlabeled issue behind).
+#
+# This is the single-sourced recipe referenced by the role prompts that file
+# issues (architect.md, auditor.md, builder-complexity.md, builder-pr.md,
+# curator.md, doctor.md, hermit.md, hermit-patterns.md, judge.md) -- update
+# this function, not each prompt, if the recipe needs to change.
+#
+# Usage: forge_gh_create_issue_rl_safe NWO TITLE BODY [LABELS_CSV]
+#   NWO         - "owner/repo"
+#   TITLE       - issue title
+#   BODY        - issue body (may be multi-line / markdown)
+#   LABELS_CSV  - optional comma-separated label list, e.g. "loom:triage,bug"
+#     (matches the `--label` flag's own comma-separated convention, so
+#     callers can pass the same string they'd otherwise give `gh issue
+#     create --label`)
+#
+# On success, prints the created issue's URL to stdout (matching `gh issue
+# create`'s own output) and returns 0. On failure, prints the error to
+# stderr and returns 1. GitHub-only, like the other `*_rl_safe` helpers above
+# -- callers gate on `FORGE_TYPE == github` before calling this.
+forge_gh_create_issue_rl_safe() {
+  local nwo="$1" title="$2" body="$3" labels_csv="${4:-}"
+  local -a label_args=()
+  local out
+
+  if [[ -n "$labels_csv" ]]; then
+    local IFS=','
+    local label
+    for label in $labels_csv; do
+      label_args+=(--label "$label")
+    done
+  fi
+
+  if out=$(gh issue create --repo "$nwo" --title "$title" --body "$body" "${label_args[@]}" 2>&1); then
+    printf '%s\n' "$out"
+    return 0
+  fi
+
+  if is_rate_limit_error "$out"; then
+    local payload_file rc=0 url
+    payload_file=$(mktemp)
+    if [[ -n "$labels_csv" ]]; then
+      jq -n --arg t "$title" --arg b "$body" --arg labels "$labels_csv" \
+        '{title: $t, body: $b, labels: ($labels | split(","))}' > "$payload_file"
+    else
+      jq -n --arg t "$title" --arg b "$body" '{title: $t, body: $b}' > "$payload_file"
+    fi
+    url=$(gh api --method POST "repos/$nwo/issues" --input "$payload_file" --jq '.html_url' 2>&1) || rc=$?
+    rm -f "$payload_file"
+    if [[ $rc -eq 0 ]]; then
+      printf '%s\n' "$url"
+      return 0
+    fi
+    echo "gh issue create rate-limited on \"$title\", and the REST fallback also failed: $url" >&2
+    return 1
+  fi
+
   echo "$out" >&2
   return 1
 }

--- a/defaults/scripts/tests/test-forge-helpers-rate-limit-fallback.sh
+++ b/defaults/scripts/tests/test-forge-helpers-rate-limit-fallback.sh
@@ -21,7 +21,11 @@
 #      when it works, fall back to the correct REST endpoint/method only on
 #      a rate-limit rejection, and propagate (not swallow) any OTHER
 #      failure without attempting a REST call.
-#   3. merge-pr.sh source wiring: the four mutating call sites this issue
+#   3. forge_gh_create_issue_rl_safe (#5047): same succeed/fallback/propagate
+#      shape as #2, PLUS an atomicity check -- the REST fallback's payload
+#      carries `labels` in the SAME POST as `title`/`body`, never a
+#      create-then-label two-step.
+#   4. merge-pr.sh source wiring: the four mutating call sites this issue
 #      is about actually route through the new wrappers.
 #
 # Usage:
@@ -249,6 +253,156 @@ _run_stubbed other-error forge_gh_swap_label_rl_safe "owner/repo" "7" "loom:buil
 assert_eq "1" "$rc" "forge_gh_swap_label_rl_safe: non-rate-limit failure propagates"
 
 rm -rf "$STUB_DIR"
+
+# --- 2.5. forge_gh_create_issue_rl_safe (#5047), with its own stubbed `gh` ---
+echo ""
+echo "Testing forge_gh_create_issue_rl_safe REST-fallback wrapper (#5047)..."
+
+CREATE_STUB_DIR=$(mktemp -d)
+CREATE_ARGV_LOG="$CREATE_STUB_DIR/argv.log"
+CREATE_MODE_FILE="$CREATE_STUB_DIR/mode.txt"
+CREATE_PAYLOAD_LOG="$CREATE_STUB_DIR/payload.log"
+export CREATE_ARGV_LOG CREATE_MODE_FILE CREATE_PAYLOAD_LOG
+
+# A `gh` stub whose behavior is driven by $CREATE_MODE_FILE:
+#   "ok"          - `gh issue create` succeeds immediately.
+#   "ratelimited" - `gh issue create` is rate-limited; the REST POST fallback
+#                   (`gh api --method POST repos/.../issues --input <file>`)
+#                   succeeds. The stub also copies the --input payload file's
+#                   contents to $CREATE_PAYLOAD_LOG so the test can assert
+#                   labels traveled in the SAME request body as title/body.
+#   "other-error" - `gh issue create` fails with an unrelated error; `gh api`
+#                   must NEVER be reached (recorded as a FAIL marker if it is).
+cat > "$CREATE_STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+mode="$(cat "$CREATE_MODE_FILE" 2>/dev/null || echo ok)"
+printf '%s\n' "$*" >> "$CREATE_ARGV_LOG"
+
+if [[ "$1" == "api" ]]; then
+  if [[ "$mode" == "ratelimited" ]]; then
+    prev=""
+    for a in "$@"; do
+      if [[ "$prev" == "--input" ]]; then
+        cat "$a" >> "$CREATE_PAYLOAD_LOG"
+      fi
+      prev="$a"
+    done
+    echo "https://github.com/owner/repo/issues/999"
+    exit 0
+  fi
+  echo "UNEXPECTED_REST_CALL" >> "$CREATE_ARGV_LOG"
+  exit 1
+fi
+
+case "$mode" in
+  ok)
+    echo "https://github.com/owner/repo/issues/42"
+    exit 0
+    ;;
+  ratelimited)
+    echo "GraphQL: API rate limit already exceeded for user ID 1" >&2
+    exit 1
+    ;;
+  other-error)
+    echo "HTTP 404: Not Found" >&2
+    exit 1
+    ;;
+esac
+STUB
+chmod +x "$CREATE_STUB_DIR/gh"
+
+_run_create_stubbed() {
+    local mode="$1"; shift
+    echo "$mode" > "$CREATE_MODE_FILE"
+    : > "$CREATE_ARGV_LOG"
+    : > "$CREATE_PAYLOAD_LOG"
+    PATH="$CREATE_STUB_DIR:$PATH" "$@"
+}
+
+# ok mode: primary `gh issue create` succeeds, labels passed as repeated
+# --label flags, no REST call at all.
+out=""
+rc=0
+out=$(_run_create_stubbed ok forge_gh_create_issue_rl_safe "owner/repo" "My Title" "My Body" "loom:triage,bug" 2>&1) || rc=$?
+assert_eq "0" "$rc" "forge_gh_create_issue_rl_safe: primary gh issue create succeeds -> no REST call"
+assert_eq "https://github.com/owner/repo/issues/42" "$out" "forge_gh_create_issue_rl_safe (ok mode) returns the created issue URL"
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- '--label loom:triage --label bug' "$CREATE_ARGV_LOG"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe passes each CSV label as its own --label flag"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe did not expand the labels CSV correctly"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! grep -q "^api " "$CREATE_ARGV_LOG"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe (ok mode) never calls gh api"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe (ok mode) unexpectedly called gh api"
+fi
+
+# ratelimited mode: falls back to a single atomic REST POST carrying title,
+# body, AND labels in one payload -- never a create-then-label two-step.
+out=""
+rc=0
+out=$(_run_create_stubbed ratelimited forge_gh_create_issue_rl_safe "owner/repo" "My Title" "My Body" "loom:triage,bug" 2>&1) || rc=$?
+assert_eq "0" "$rc" "forge_gh_create_issue_rl_safe: rate-limited primary call recovers via REST fallback"
+assert_eq "https://github.com/owner/repo/issues/999" "$out" "forge_gh_create_issue_rl_safe (ratelimited mode) returns the REST-created issue URL"
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q "^api --method POST repos/owner/repo/issues --input" "$CREATE_ARGV_LOG"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe REST fallback POSTs to the correct issues endpoint"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe REST fallback endpoint wrong or missing"
+fi
+api_call_count="$(grep -c '^api ' "$CREATE_ARGV_LOG" || true)"
+assert_eq "1" "$api_call_count" "forge_gh_create_issue_rl_safe REST fallback makes exactly ONE REST call (atomic, not create-then-label)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if jq -e '.title == "My Title" and .body == "My Body" and .labels == ["loom:triage","bug"]' \
+    "$CREATE_PAYLOAD_LOG" >/dev/null 2>&1; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe REST payload carries title+body+labels atomically"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe REST payload missing/malformed title|body|labels"
+    echo "    Payload: $(cat "$CREATE_PAYLOAD_LOG" 2>/dev/null)"
+fi
+
+# ratelimited mode, no labels: payload still valid JSON without a labels key
+# forced in (an empty/absent labels field, never a spurious create-then-label
+# follow-up call).
+out=""
+rc=0
+out=$(_run_create_stubbed ratelimited forge_gh_create_issue_rl_safe "owner/repo" "No Labels" "Body text" 2>&1) || rc=$?
+assert_eq "0" "$rc" "forge_gh_create_issue_rl_safe: REST fallback works with no labels argument"
+TESTS_RUN=$((TESTS_RUN + 1))
+if jq -e '.title == "No Labels" and .body == "Body text" and (has("labels") | not)' \
+    "$CREATE_PAYLOAD_LOG" >/dev/null 2>&1; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe omits labels from the payload when none given"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe payload wrong when no labels given"
+fi
+
+# other-error mode: propagate, never attempt the REST fallback.
+out=""
+rc=0
+out=$(_run_create_stubbed other-error forge_gh_create_issue_rl_safe "owner/repo" "My Title" "My Body" "loom:triage" 2>&1) || rc=$?
+assert_eq "1" "$rc" "forge_gh_create_issue_rl_safe: non-rate-limit failure propagates (not swallowed)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! grep -q "UNEXPECTED_REST_CALL" "$CREATE_ARGV_LOG"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe never retries over REST on a non-rate-limit failure"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe incorrectly retried over REST on a non-rate-limit failure"
+fi
+
+rm -rf "$CREATE_STUB_DIR"
 
 # --- 3. merge-pr.sh source wiring: the four #4856 call sites use the wrappers ---
 echo ""

--- a/loom-daemon/src/forge_cmd.rs
+++ b/loom-daemon/src/forge_cmd.rs
@@ -555,6 +555,17 @@ pub fn handle_auto_merge(pr: u32, method: &str) -> Result<()> {
 /// Sub-actions for `loom-daemon forge`.
 pub enum ForgeCmd {
     /// `forge issue <args…>` — passthrough to `gh issue` on GitHub.
+    ///
+    /// This is a generic, subcommand-agnostic passthrough: it does not parse
+    /// `args` to special-case `create` vs. `list`/`view`/`edit`. As a
+    /// consequence `forge issue create` is byte-identical to running `gh
+    /// issue create` directly and carries the same GraphQL cost — it does
+    /// **not** get the REST fallback documented in
+    /// `.loom/docs/gh-issue-create-rest-fallback.md` /
+    /// `forge_gh_create_issue_rl_safe` (#5047). Callers that need
+    /// exhausted-GraphQL resilience for issue creation should use that
+    /// shell recipe/helper directly rather than routing through this
+    /// passthrough.
     Issue(Vec<String>),
     /// `forge pr <args…>` — passthrough to `gh pr` on GitHub.
     Pr(Vec<String>),

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -630,6 +630,12 @@ enum Commands {
     /// (`merge-pr.sh`'s `forge_auto_merge`, or the `gh` read fallback) carries
     /// it. Forge config resolves from the canonical repo root (never a
     /// worktree CWD); see `forge_cmd.rs` for the full #4061 semantics.
+    ///
+    /// NOTE (#5047): the byte-identical passthrough means `forge issue
+    /// create` inherits `gh issue create`'s GraphQL cost with no REST
+    /// fallback of its own on exhaustion — see
+    /// `.loom/docs/gh-issue-create-rest-fallback.md` /
+    /// `forge_gh_create_issue_rl_safe` for the fallback path instead.
     Forge {
         #[command(subcommand)]
         action: ForgeAction,


### PR DESCRIPTION
## Summary
Nine role prompts (architect, auditor, builder-complexity, builder-pr, curator, doctor, hermit, hermit-patterns, judge) instruct agents to file issues with `gh issue create`, a GraphQL-backed mutation. Unlike labels/comments/reopen (#4856), issue *creation* had no documented REST fallback, so every filing role died outright on GraphQL exhaustion even though the REST pool typically sits nearly untouched. This adds a single-sourced fallback recipe + helper and points each role prompt at it.

## Changes
- `defaults/scripts/lib/forge-helpers.sh`: new `forge_gh_create_issue_rl_safe NWO TITLE BODY [LABELS_CSV]` — tries `gh issue create` first, falls back to a REST `POST repos/{nwo}/issues` on a rate-limit rejection (reusing the existing five-signature `is_rate_limit_error()` table), with labels applied **atomically** in the same payload on both paths (never a create-then-label two-step).
- `defaults/docs/gh-issue-create-rest-fallback.md` (new): the single-sourced recipe — signature table, atomic create+label shell snippet, the `forge_gh_create_issue_rl_safe` usage, and an explicit note that `loom-daemon forge issue create` does **not** get this fallback (its generic `gh` passthrough is not create-aware).
- `defaults/.claude/commands/loom/{architect,auditor,builder-complexity,builder-pr,curator,doctor,hermit,hermit-patterns,judge}.md`: one short pointer each to the new doc/helper, placed at each file's existing `gh issue create` guidance — no recipe duplication.
- `loom-daemon/src/forge_cmd.rs` + `src/main.rs`: doc comments clarifying `forge issue create` is a byte-identical `gh` passthrough with no REST-fallback interception, per the issue's last acceptance criterion.
- `defaults/scripts/tests/test-forge-helpers-rate-limit-fallback.sh`: extended with a dedicated stubbed-`gh` suite for `forge_gh_create_issue_rl_safe` (13 new assertions) covering the primary-succeeds path, the rate-limited REST fallback (including atomic label verification via the actual `--input` payload file contents and an exactly-one-REST-call assertion), the no-labels case, and non-rate-limit propagation.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| An agent can file an issue when the GraphQL pool is exhausted, following only what its role prompt says | ✅ | Each of the 9 role prompts now has a pointer to `.loom/docs/gh-issue-create-rest-fallback.md`, which contains the full recipe (signature table + shell snippet + helper usage) |
| The recipe is single-sourced, not copy-pasted into nine role files | ✅ | Recipe lives once in `defaults/docs/gh-issue-create-rest-fallback.md` / `forge_gh_create_issue_rl_safe`; role prompts carry only a 2-3 line pointer each |
| Labels are applied atomically with creation | ✅ | Primary path: `gh issue create --label` per label; REST fallback: single `jq`-built JSON payload with a `labels` array POSTed in one `gh api` call — verified by a test asserting exactly one REST call and payload contents |
| A test or documented check covers the exhausted-GraphQL path | ✅ | `test-forge-helpers-rate-limit-fallback.sh` (already CI-wired via `ci-wired.txt`) extended with `forge_gh_create_issue_rl_safe` coverage; all 40 assertions in the file pass |
| `loom-daemon forge issue`'s GraphQL passthrough is either given the same fallback or documented as not being one | ✅ | Documented (not given the fallback — it's a generic, subcommand-agnostic passthrough): doc comments in `forge_cmd.rs` and `main.rs`, plus a note in the new shared doc |

## Test Plan
- `bash defaults/scripts/tests/test-forge-helpers-rate-limit-fallback.sh` — 40/40 passed (0 failed), including the 13 new `forge_gh_create_issue_rl_safe` assertions
- `bash defaults/scripts/tests/test-forge-helpers.sh` — 39/39 passed (pre-existing suite, unaffected)
- `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — OK (no manifest change needed; extended an already-wired suite)
- `shellcheck defaults/scripts/lib/forge-helpers.sh` and the test file — no new warnings (only pre-existing SC2016 info notices elsewhere in the file)
- `bash -n` syntax check on both changed shell files — OK
- `cargo check`, `cargo clippy --quiet`, `cargo fmt -- --check` in `loom-daemon/` — clean
- Note: the repo's full `buildGate.command` (`cargo test --workspace --lib --bins` + the installer suite) could not complete in this session due to heavy host contention from other concurrent fleet agents (the process made 0% CPU progress over ~19 minutes); the scoped checks above cover the actual change surface, and the orchestrator's post-builder buildGate will re-run the full command independently.

Closes #5047