### PR TITLE
fix(dashboard): drop role-tick detail from the public host.health surface

### DIFF
--- a/.loom/docs/telemetry-schema.md
+++ b/.loom/docs/telemetry-schema.md
@@ -402,7 +402,18 @@ happens to run `loom-daemon health` locally on that one host.
   keeps the full path, but the public, unauthenticated view only ever gets each
   `root` truncated to its basename — mirroring the daemon's
   `RoleFailure::label()` and the frontend's `pathBasename`. `total`/`ok` and
-  each failure's `role`/`failures`/`last_at`/`detail` pass through unchanged.
+  each failure's `role`/`failures`/`last_at` pass through unchanged.
+- `detail` is **authenticated-only** (redaction class: **field, dropped for
+  public**; #5065). It is the free-form failure string the daemon's
+  `RoleTickOutcome::Failure` constructors build (`loom-daemon/src/
+  role_runner.rs`) — on the ordinary "role child exited non-zero" path it
+  interpolates the absolute `spawn-worker.sh` path plus up to
+  `MAX_OUTPUT_TAIL_BYTES` of the failing role child's own log tail, so it can
+  carry further absolute paths, repo slugs, issue numbers, or branch names.
+  Unlike `root` this has no basename-style truncation that makes it safe by
+  construction, so it is held behind the Access gate entirely rather than
+  redacted in place — same footing as `tokens.snapshot`'s `accounts`. The
+  authenticated `/api/*` surface still returns it in full.
   Enforced by `redactRoleTickHealth` in `dashboard/src/redaction.ts` (like
   `managed_repos`, `roles` is deliberately absent from the raw allowlist and
   only reaches a public response through that derivation).

--- a/dashboard/src/redaction.ts
+++ b/dashboard/src/redaction.ts
@@ -282,15 +282,26 @@ function pathBasename(root: string): string {
 
 /**
  * Redact one `host.health.roles` summary (#5022) for a public, unauthenticated
- * viewer. The counts (`total`/`ok`) and each persistent failure's non-path
- * detail (`role`/`failures`/`last_at`/`detail`) survive; every entry's `root`
- * — a full absolute filesystem workspace path whose home-directory segment
- * names the *operator* on the common macOS/Linux layout — is truncated to its
- * basename, exactly as the daemon's `RoleFailure::label()` and the frontend's
- * `pathBasename` already render it for display. Only the raw wire payload to
- * the public, unauthenticated API skipped that truncation; this closes it. The
+ * viewer. The counts (`total`/`ok`) and each persistent failure's `role`,
+ * `failures`, and `last_at` survive; every entry's `root` — a full absolute
+ * filesystem workspace path whose home-directory segment names the *operator*
+ * on the common macOS/Linux layout — is truncated to its basename, exactly as
+ * the daemon's `RoleFailure::label()` and the frontend's `pathBasename`
+ * already render it for display. Only the raw wire payload to the public,
+ * unauthenticated API skipped that truncation; this closes it. The
  * authenticated `/api/*` surface keeps the full path (this derivation runs on
  * the public path only).
+ *
+ * `detail` is deliberately dropped, not truncated (#5065): unlike `root`, it
+ * is not "non-path detail" — the daemon's own `RoleTickOutcome::Failure`
+ * constructors (`loom-daemon/src/role_runner.rs`) build it by interpolating
+ * an absolute `script.display()` path plus up to `MAX_OUTPUT_TAIL_BYTES` of
+ * the failing role child's own log tail, which can itself contain further
+ * absolute paths, repo slugs, issue numbers, or branch names. A free-form tail
+ * of another process's output cannot be shown safe by construction, so —
+ * unlike `root` — there is no basename-style truncation that makes it safe;
+ * it stays behind the Access gate, same footing as `tokens.snapshot`'s
+ * `accounts`. The authenticated `/api/*` surface still returns it unchanged.
  *
  * Like `redactManagedRepos`, a per-field pick (not a spread), so a future
  * field added to the `roles` schema is dropped from the public view by default
@@ -311,7 +322,7 @@ export function redactRoleTickHealth(roles: RoleTickHealthRow): Record<string, u
         if ("role" in row) entry.role = row.role;
         if ("failures" in row) entry.failures = row.failures;
         if ("last_at" in row) entry.last_at = row.last_at;
-        if ("detail" in row) entry.detail = row.detail;
+        // `detail` is intentionally NOT copied here — see the doc comment.
       }
       return entry;
     });

--- a/dashboard/test/redaction.test.ts
+++ b/dashboard/test/redaction.test.ts
@@ -267,13 +267,17 @@ describe("redactPayload — per-kind field allowlist", () => {
     expect(redactPayload("host.health", payload)).toEqual(payload);
   });
 
-  it("host.health: role-tick health (roles) survives redaction, but each persistent root is basenamed for the public view (#5022)", () => {
-    // The counts and each failure's role/detail survive (they describe the
-    // machine, not the work), but the workspace `root` is a full absolute
-    // filesystem path whose home-directory segment names the operator on the
-    // common macOS/Linux layout — so the public, unauthenticated surface only
-    // ever gets its basename, mirroring the daemon's `RoleFailure::label()`
-    // and the frontend's `pathBasename`.
+  it("host.health: role-tick health (roles) survives redaction, but each persistent root is basenamed and detail is dropped for the public view (#5022, #5065)", () => {
+    // The counts and each failure's role/failures/last_at survive (they
+    // describe the machine, not the work). The workspace `root` is a full
+    // absolute filesystem path whose home-directory segment names the
+    // operator on the common macOS/Linux layout — so the public,
+    // unauthenticated surface only ever gets its basename, mirroring the
+    // daemon's `RoleFailure::label()` and the frontend's `pathBasename`.
+    // `detail` is dropped entirely (#5065): it is a free-form failure string
+    // the daemon builds by interpolating another absolute path plus a log
+    // tail, so — unlike `root` — there is no basename-style truncation that
+    // makes it safe for the public surface.
     const payload = {
       kind: "host.health",
       captured_at: "2026-08-02T12:00:00Z",
@@ -313,7 +317,7 @@ describe("redactPayload — per-kind field allowlist", () => {
           role: "judge",
           failures: 2,
           last_at: "2026-08-02T11:59:00Z",
-          detail: "no-token-pool",
+          // NOTE: no `detail` key at all — dropped, not truncated.
         },
       ],
     });
@@ -321,6 +325,37 @@ describe("redactPayload — per-kind field allowlist", () => {
     // never reaches the public surface, in any field.
     expect(JSON.stringify(redacted)).not.toContain("/Users/alice");
     expect(JSON.stringify(redacted)).not.toContain("alice");
+  });
+
+  it("host.health: a realistic role-tick `detail` (absolute path + log tail) never reaches the public surface (#5065)", () => {
+    // The most common role-tick failure path (`RoleTickOutcome::Failure` in
+    // `loom-daemon/src/role_runner.rs` for a non-zero exit) builds `detail`
+    // by interpolating the absolute path to `spawn-worker.sh` plus a tail of
+    // the failing role child's own log output.
+    const payload = {
+      kind: "host.health",
+      captured_at: "2026-08-02T12:00:00Z",
+      daemon_version: "0.17.0",
+      roles: {
+        total: 1,
+        ok: 0,
+        persistent: [
+          {
+            root: "/Users/alice/GitHub/loom",
+            role: "judge",
+            failures: 1,
+            last_at: "2026-08-02T11:59:00Z",
+            detail:
+              "`/Users/alice/GitHub/loom/.loom/scripts/spawn-worker.sh` exited with exit status: 1: some log tail",
+          },
+        ],
+      },
+    };
+    const redacted = redactPayload("host.health", payload);
+    const serialized = JSON.stringify(redacted);
+    expect(serialized).not.toContain("alice");
+    expect(serialized).not.toContain("/Users/alice/GitHub/loom/.loom/scripts/spawn-worker.sh");
+    expect((redacted.roles as { persistent: Record<string, unknown>[] }).persistent[0]).not.toHaveProperty("detail");
   });
 
   it("host.health: no roles key at all when the payload carries no role-tick summary (#5022)", () => {
@@ -590,6 +625,42 @@ describe("redactFleetSnapshot", () => {
     const record = redactFleetSnapshot(snapshot, true).hosts["host-abc"]?.tokens?.record;
     expect(record).toEqual({ kind: "tokens.snapshot", accounts });
   });
+
+  it("keeps the full absolute root and detail in a role-tick failure for an authenticated viewer (#5065)", () => {
+    const roles = {
+      total: 1,
+      ok: 0,
+      persistent: [
+        {
+          root: "/Users/alice/GitHub/loom",
+          role: "judge",
+          failures: 1,
+          last_at: "2026-08-02T11:59:00Z",
+          detail: "`/Users/alice/GitHub/loom/.loom/scripts/spawn-worker.sh` exited with exit status: 1: log tail",
+        },
+      ],
+    };
+    const snapshot: FleetSnapshot = {
+      hosts: {
+        "host-abc": {
+          health: {
+            record: { kind: "host.health", uptime_sec: 100, roles },
+            updatedAt: "2026-07-30T12:00:00Z",
+          },
+        },
+      },
+      activeSweeps: [],
+    };
+
+    const authedRecord = redactFleetSnapshot(snapshot, true).hosts["host-abc"]?.health?.record;
+    expect(authedRecord).toEqual({ kind: "host.health", uptime_sec: 100, roles });
+
+    const publicRecord = redactFleetSnapshot(snapshot, false).hosts["host-abc"]?.health?.record;
+    const publicPersistent = (publicRecord?.roles as { persistent: Record<string, unknown>[] } | undefined)
+      ?.persistent;
+    expect(publicPersistent?.[0]).not.toHaveProperty("detail");
+    expect(JSON.stringify(publicRecord)).not.toContain("alice");
+  });
 });
 
 describe("redactManagedRepos", () => {
@@ -800,6 +871,47 @@ describe("GET /public/history vs GET /api/history — end-to-end redaction", () 
     expect(tokensRecord?.record).toMatchObject({ account_count: 1, exhausted_count: 0 });
     expect(tokensRecord?.record).not.toHaveProperty("accounts");
     expect(publicText).not.toContain("agent-1");
+  });
+
+  it("a role-tick failure's `detail` never reaches GET /public/history, but GET /api/history keeps it in full (#5065)", async () => {
+    // Mirrors the `root` basenaming case #5042 landed, for the sibling
+    // `detail` field: the common role-tick failure path builds `detail` by
+    // interpolating an absolute `spawn-worker.sh` path plus a log tail.
+    const roleTickDetail =
+      "`/Users/alice/GitHub/loom/.loom/scripts/spawn-worker.sh` exited with exit status: 1: some log tail";
+    await ingest([
+      hostHealthEnvelope({
+        roles: {
+          total: 1,
+          ok: 0,
+          persistent: [
+            {
+              root: "/Users/alice/GitHub/loom",
+              role: "judge",
+              failures: 1,
+              last_at: "2026-08-02T11:59:00Z",
+              detail: roleTickDetail,
+            },
+          ],
+        },
+      }),
+    ]);
+
+    const publicResponse = await callWorker(new Request("https://ingest.example/public/history"));
+    const publicText = await publicResponse.text();
+    expect(publicText).not.toContain("alice");
+    expect(publicText).not.toContain(roleTickDetail);
+    const publicBody = JSON.parse(publicText) as {
+      records: { kind: string; record: { roles?: { persistent?: Record<string, unknown>[] } } }[];
+    };
+    const publicHealth = publicBody.records.find((r) => r.kind === "host.health");
+    expect(publicHealth?.record.roles?.persistent?.[0]).not.toHaveProperty("detail");
+    expect(publicHealth?.record.roles?.persistent?.[0]).toMatchObject({ root: "loom", role: "judge" });
+
+    const authResponse = await callWorker(await authedRequest("https://ingest.example/api/history"));
+    const authText = await authResponse.text();
+    expect(authText).toContain(roleTickDetail);
+    expect(authText).toContain("/Users/alice/GitHub/loom");
   });
 
   it("the authenticated route still serves the full per-account token rows", async () => {


### PR DESCRIPTION
## Summary

`host.health.roles.persistent[].detail` was reaching the unauthenticated `/public/*` surface unmodified. On the common role-tick-failure path, the daemon builds `detail` by interpolating an absolute filesystem path (`spawn-worker.sh`'s location, which embeds the operator's home directory) plus up to 2048 bytes of the failing role child's own log tail — a free-form string that can additionally carry repo slugs, issue numbers, and branch names. This is a residual leak from #5042, which fixed the sibling `root` field but kept `detail` on the mistaken assumption it was "non-path detail".

## Changes

- `dashboard/src/redaction.ts`: `redactRoleTickHealth` no longer copies `detail` into the public projection (it still basenames `root` and passes through `role`/`failures`/`last_at` as before). Updated the function's doc comment to explain why `detail` cannot be redacted-in-place the way `root` is (no basename-style truncation makes a free-form log tail safe).
- `dashboard/test/redaction.test.ts`:
  - Updated the existing `redactRoleTickHealth` unit test to assert `detail` is absent (not merely unchanged) from the public projection.
  - Added a unit test with a realistic `detail` string (absolute path + operator username + log tail) asserting the serialized public response contains neither.
  - Added a `redactFleetSnapshot(snapshot, true)` unit test pinning that the authenticated surface still returns the full `root` and `detail` unchanged.
  - Added an end-to-end `GET /public/history` vs `GET /api/history` test (mirroring the `root` case #5042 landed) confirming the public route drops `detail` while the authenticated route keeps it.
- `.loom/docs/telemetry-schema.md`: documented `detail` as authenticated-only, alongside the existing `root`-basenaming note.

## Acceptance Criteria Verification

1. `redactRoleTickHealth` does not emit `detail` for a public viewer; `total`/`ok`/`role`/`failures`/`last_at`/basenamed `root` still do — verified by the updated unit test (`dashboard/test/redaction.test.ts`).
2. The authenticated `/api/*` surface is unchanged and still returns `detail` and the full `root` — verified by the new `redactFleetSnapshot(snapshot, true)` test.
3. A realistic `detail` (`` `/Users/alice/GitHub/loom/.loom/scripts/spawn-worker.sh` exited with exit status: 1: … ``) asserted absent from the *serialized* public response body (not just the field) — new unit test.
4. End-to-end `GET /public/history` case mirroring the `root` case #5042 landed — added.
5. `.loom/docs/telemetry-schema.md`'s `roles` section documents `detail` as authenticated-only.
6. `cd dashboard && CI=true npm run check:all` is green (backend: 10 files / 228 tests passed; web: 33 files / 463 tests passed).

## Test Plan

- [x] `cd dashboard && CI=true npm run check:all` — typecheck + full vitest suite for both the backend Worker and the web dashboard, all green.
- [x] Reviewed the diff for scope: only `dashboard/src/redaction.ts`, `dashboard/test/redaction.test.ts`, and `.loom/docs/telemetry-schema.md` are touched.

Closes #5065