### PR TITLE
fix(scripts): make sync-labels.sh additive by default, gate deletion behind --prune-defaults

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3874,8 +3874,10 @@ a repo with no `loom:*` labels cannot hold a queue — a Curator that tries to a
 call, this needs **no checkout of the target repo**: run
 `sync-labels.sh --repo OWNER/NAME` from a workspace that already has an
 authoritative `.github/labels.yml` (labels.yml is read locally; only the target
-moves). Preview first — `--repo` points the default-label *deletions* at a repo
-you are not standing in, so a typo'd NWO is worth catching:
+moves). This is additive by default (#5066) — it only creates/updates the Loom
+labels and never touches GitHub's default labels (`bug`, `enhancement`, etc.),
+so it is safe to run against a repo that predates Loom without first previewing.
+Preview anyway if in doubt:
 
 ```bash
 # From a checkout whose .github/labels.yml is the source of truth (e.g. loom):
@@ -3890,14 +3892,21 @@ done
 
 `--dry-run` is deliberately forge-free (it reports intent from labels.yml alone
 and makes zero `gh` calls), so it also validates the parse and the NWO offline.
-Because that means a dry run cannot tell a typo'd NWO apart from a repo that
-really exists, the **real** run preflights the named target with `gh repo view`
-before deleting anything and aborts if it is missing or read-only (#4524) —
-nothing is deleted when the preflight fails. `--repo` is GitHub-only — an
-explicitly configured Gitea forge rejects it, whether that comes from
-`LOOM_FORGE_TYPE=gitea` or `forge.type: gitea` in any config tier. For a Gitea
-root, run `sync-labels.sh` from a checkout of that repo so the Gitea helpers can
-resolve a base URL and token.
+`--repo` is GitHub-only — an explicitly configured Gitea forge rejects it,
+whether that comes from `LOOM_FORGE_TYPE=gitea` or `forge.type: gitea` in any
+config tier. For a Gitea root, run `sync-labels.sh` from a checkout of that
+repo so the Gitea helpers can resolve a base URL and token.
+
+If a genuinely greenfield repo also needs GitHub's default labels cleared, add
+`--prune-defaults` (the old, pre-#5066 unconditional-deletion behavior). Because
+`--repo` points that deletion at a repo you are not standing in, a typo'd NWO is
+worth catching first — pair it with `--dry-run`, which for `--prune-defaults`
+additionally performs a read-only in-use lookup so the preview flags which
+default labels are still attached to an issue/PR. The **real** `--prune-defaults`
+run preflights the named target with `gh repo view` before deleting anything and
+aborts if it is missing or read-only (#4524); it then skips (with a warning
+listing the affected issue/PR numbers) any default label still in use, unless
+`--force` is also given.
 
 **3. Refresh a stale install.** A root installed before the machine-level daemon
 model carries a committed file-copy of `.loom/` that **shadows** the machine

--- a/defaults/scripts/sync-labels.sh
+++ b/defaults/scripts/sync-labels.sh
@@ -2,16 +2,23 @@
 # Sync workflow labels from .github/labels.yml onto the forge.
 #
 # Creates (or updates) the Loom coordination labels defined in
-# .github/labels.yml and removes GitHub's noisy default labels. Run this
-# after a Quick / files-only install to create the labels the label-based
-# workflow depends on — a Quick install ships .github/labels.yml but does
-# NOT create the labels on the forge (see issue #3582).
+# .github/labels.yml. Run this after a Quick / files-only install to create
+# the labels the label-based workflow depends on — a Quick install ships
+# .github/labels.yml but does NOT create the labels on the forge (see issue
+# #3582).
+#
+# By default this is ADDITIVE ONLY (#5066): it never touches GitHub's default
+# labels (bug, documentation, duplicate, enhancement, good first issue, help
+# wanted, invalid, question, wontfix). Deleting those is destructive to
+# pre-existing repo data — it silently strips the label from every issue/PR
+# carrying it — so it requires the explicit --prune-defaults opt-in below.
 #
 # Supports both GitHub (via the gh CLI) and Gitea (via the forge API).
 #
 # Usage:
 #   .loom/scripts/sync-labels.sh [--] [WORKTREE_PATH]
 #   .loom/scripts/sync-labels.sh --repo OWNER/NAME [--dry-run] [--] [WORKTREE_PATH]
+#   .loom/scripts/sync-labels.sh --prune-defaults [--force] [--dry-run] [--] [WORKTREE_PATH]
 #
 #   WORKTREE_PATH  Directory containing .github/labels.yml and a git remote.
 #                  Defaults to the current directory. `--` ends option parsing,
@@ -29,11 +36,21 @@
 # --repo bypasses repository *resolution* (the target is named, not inferred
 # from a git remote) and is GitHub-only — an explicitly configured Gitea forge
 # (LOOM_FORGE_TYPE or forge.type in the resolved config) rejects it. Pair it
-# with --dry-run first: --repo makes the default-label deletions land on a repo
-# you are not standing in, so a typo'd NWO is worth previewing. A real (non
-# dry-run) --repo sync additionally preflights the named target with
-# `gh repo view` before deleting anything (#4524), because a dry run is
+# with --dry-run first: --repo makes any --prune-defaults deletions land on a
+# repo you are not standing in, so a typo'd NWO is worth previewing. A real
+# (non dry-run) --repo sync additionally preflights the named target with
+# `gh repo view` before mutating anything (#4524), because a bare dry run is
 # deliberately forge-free and so cannot tell a typo apart from a real repo.
+#
+# --prune-defaults (#5066) opts into the old (pre-#5066) unconditional
+# behavior of deleting GitHub's default labels — intended for a genuinely
+# greenfield repo where clearing those defaults is wanted. Before deleting a
+# default label that is still attached to at least one issue/PR, the script
+# either warns and skips it (no --force) or deletes it anyway after warning
+# (--force) — it never deletes an in-use label silently. Combined with
+# --dry-run, --prune-defaults reports which default labels are currently in
+# use (a read-only forge query) without deleting anything; a bare --dry-run
+# (no --prune-defaults) stays completely forge-free, as before.
 #
 # This is the installed-tree counterpart of the source-only
 # scripts/install/sync-labels.sh. It is self-contained apart from the
@@ -47,10 +64,14 @@ usage() {
   cat <<'EOF'
 Usage: sync-labels.sh [--] [WORKTREE_PATH]
        sync-labels.sh --repo OWNER/NAME [--dry-run] [--] [WORKTREE_PATH]
+       sync-labels.sh --prune-defaults [--force] [--dry-run] [--] [WORKTREE_PATH]
 
 Sync Loom workflow labels from .github/labels.yml onto the forge (GitHub or
-Gitea). Creates missing labels, updates existing ones to match labels.yml,
-and removes GitHub's default labels.
+Gitea). Creates missing labels and updates existing ones to match
+labels.yml. Additive by default — GitHub's default labels (bug,
+documentation, duplicate, enhancement, good first issue, help wanted,
+invalid, question, wontfix) are left untouched unless --prune-defaults is
+given.
 
 Arguments:
   WORKTREE_PATH     Directory containing .github/labels.yml (default: .)
@@ -61,6 +82,14 @@ Options:
                     WORKTREE_PATH's git remote. labels.yml is still read from
                     WORKTREE_PATH, so no checkout of the target is needed.
                     GitHub-only (uses the gh CLI).
+      --prune-defaults
+                    Opt in to deleting GitHub's default labels (the pre-#5066
+                    behavior). A default label still attached to any issue/PR
+                    is skipped with a warning listing the affected numbers,
+                    unless --force is also given.
+      --force       Combined with --prune-defaults, delete an in-use default
+                    label anyway (after warning). No effect without
+                    --prune-defaults.
       --dry-run     Print the label operations that would run and exit without
                     calling the forge. Recommended before a --repo run.
       --            End of options: every remaining argument is positional, so
@@ -72,6 +101,8 @@ EOF
 WORKTREE_PATH="."
 REPO_OVERRIDE=""
 DRY_RUN=0
+PRUNE_DEFAULTS=0
+FORCE_PRUNE=0
 POSITIONAL_SEEN=0
 # Set by `--`: from that point on every remaining argument is positional, even
 # one that starts with `-`. Without this the `--)` case below was a no-op shift
@@ -121,6 +152,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dry-run)
       DRY_RUN=1
+      shift
+      ;;
+    --prune-defaults)
+      PRUNE_DEFAULTS=1
+      shift
+      ;;
+    --force)
+      FORCE_PRUNE=1
       shift
       ;;
     --)
@@ -274,6 +313,56 @@ github_delete_label() {
   fi
 }
 
+# Numbers (one per line) of open+closed issues/PRs currently carrying `label`
+# on GitHub. GitHub's REST /issues endpoint returns both issues and pull
+# requests (PRs are "issues" in that API), so a single query covers both —
+# no separate /pulls call needed. Capped at 100 results (the max page size);
+# callers only need "is this in use" plus a representative sample, not an
+# exhaustive audit. Best-effort: any API failure (bad REPO, no access, rate
+# limit) is treated as "no known usage" rather than blocking the caller,
+# matching this script's existing warn-don't-block posture on delete
+# failures — an in-use check that can't run must never itself become the
+# reason a label silently fails to sync.
+github_label_usage() {
+  local label="$1"
+  gh api "repos/${REPO}/issues" \
+    -f state=all -f per_page=100 -f "labels=${label}" \
+    --jq '.[].number' 2>/dev/null || true
+}
+
+# Format a newline-separated list of issue/PR numbers as "#1 #2 #3", noting
+# when the list was truncated at github_label_usage's 100-result cap.
+join_usage_numbers() {
+  local numbers="$1" count list
+  count=$(printf '%s\n' "$numbers" | grep -c . || true)
+  list=$(printf '%s\n' "$numbers" | sed '/^$/d; s/^/#/' | paste -sd' ' -)
+  if [[ "$count" -ge 100 ]]; then
+    printf '%s (100+ shown, there may be more)' "$list"
+  else
+    printf '%s' "$list"
+  fi
+}
+
+# Delete a default label unless it is currently in use, in which case skip it
+# (warn) or delete it anyway (warn, then delete) depending on FORCE_PRUNE.
+# Never deletes an in-use label silently.
+github_maybe_delete_label() {
+  local label="$1"
+  local usage_numbers usage_list
+  usage_numbers="$(github_label_usage "$label")"
+  if [[ -n "$usage_numbers" ]]; then
+    usage_list="$(join_usage_numbers "$usage_numbers")"
+    if [[ "$FORCE_PRUNE" -eq 1 ]]; then
+      warning "Deleting in-use default label '$label' (--force): affects issue/PR $usage_list"
+      github_delete_label "$label"
+    else
+      warning "Refusing to delete in-use default label '$label': affects issue/PR $usage_list (pass --force to delete anyway)"
+    fi
+  else
+    github_delete_label "$label"
+  fi
+}
+
 github_sync_label() {
   local name="$1" description="$2" color="$3"
 
@@ -342,6 +431,50 @@ gitea_delete_label() {
     else
       warning "Could not delete label '$label'"
     fi
+  fi
+}
+
+# Gitea counterpart of github_label_usage: numbers (one per line) of
+# open+closed issues/PRs currently carrying `label`. Gitea's issues endpoint
+# filters by numeric label ID (not name) and, with type=all, includes both
+# issues and pull requests. Best-effort, same as the GitHub version: any
+# lookup failure (label not found, API error) reports "no known usage"
+# rather than blocking the caller.
+gitea_label_usage() {
+  local label="$1"
+  local label_id body
+  label_id=$(gitea_label_id "$label")
+  [[ -z "$label_id" ]] && return 0
+  body=$(gitea_api GET "repos/${FORGE_OWNER}/${FORGE_REPO}/issues?labels=${label_id}&state=all&type=all" 2>/dev/null) || return 0
+  echo "$body" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for item in data:
+    n = item.get('number')
+    if n is not None:
+        print(n)
+" 2>/dev/null || true
+}
+
+# Delete a default label unless it is currently in use, in which case skip it
+# (warn) or delete it anyway (warn, then delete) depending on FORCE_PRUNE.
+gitea_maybe_delete_label() {
+  local label="$1"
+  local usage_numbers usage_list
+  usage_numbers="$(gitea_label_usage "$label")"
+  if [[ -n "$usage_numbers" ]]; then
+    usage_list="$(join_usage_numbers "$usage_numbers")"
+    if [[ "$FORCE_PRUNE" -eq 1 ]]; then
+      warning "Deleting in-use default label '$label' (--force): affects issue/PR $usage_list"
+      gitea_delete_label "$label"
+    else
+      warning "Refusing to delete in-use default label '$label': affects issue/PR $usage_list (pass --force to delete anyway)"
+    fi
+  else
+    gitea_delete_label "$label"
   fi
 }
 
@@ -431,16 +564,43 @@ if [[ -n "$REPO_OVERRIDE" && "$DRY_RUN" -eq 0 ]]; then
   repo_override_preflight
 fi
 
-info "Removing default labels..."
-for label in "${DEFAULT_LABELS[@]}"; do
+# Additive by default (#5066): deleting GitHub's default labels is
+# destructive to pre-existing repo data (it strips the label from every
+# issue/PR carrying it), so it only happens with the explicit --prune-defaults
+# opt-in below.
+if [[ "$PRUNE_DEFAULTS" -eq 1 ]]; then
+  info "Pruning default labels (--prune-defaults)..."
+  for label in "${DEFAULT_LABELS[@]}"; do
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      # Unlike the bare-dry-run path below, --prune-defaults + --dry-run DOES
+      # contact the forge here: a read-only in-use lookup, so the preview can
+      # flag exactly which deletions would be skipped/need --force, per #5066's
+      # acceptance criteria. A bare --dry-run (no --prune-defaults) never
+      # reaches this branch at all, so it stays completely forge-free.
+      usage_numbers=""
+      if [[ "$FORGE_TYPE" == "github" ]]; then
+        usage_numbers="$(github_label_usage "$label")"
+      elif [[ "$FORGE_TYPE" == "gitea" ]]; then
+        usage_numbers="$(gitea_label_usage "$label")"
+      fi
+      if [[ -n "$usage_numbers" ]]; then
+        info "[dry-run] would delete default label: $label (IN USE: $(join_usage_numbers "$usage_numbers") — would be skipped without --force)"
+      else
+        info "[dry-run] would delete default label: $label"
+      fi
+    elif [[ "$FORGE_TYPE" == "github" ]]; then
+      github_maybe_delete_label "$label"
+    elif [[ "$FORGE_TYPE" == "gitea" ]]; then
+      gitea_maybe_delete_label "$label"
+    fi
+  done
+else
   if [[ "$DRY_RUN" -eq 1 ]]; then
-    info "[dry-run] would delete default label: $label"
-  elif [[ "$FORGE_TYPE" == "github" ]]; then
-    github_delete_label "$label"
-  elif [[ "$FORGE_TYPE" == "gitea" ]]; then
-    gitea_delete_label "$label"
+    info "[dry-run] would leave default labels untouched (pass --prune-defaults to remove them): ${DEFAULT_LABELS[*]}"
+  else
+    info "Leaving default labels untouched (pass --prune-defaults to remove them): ${DEFAULT_LABELS[*]}"
   fi
-done
+fi
 
 # Sync Loom workflow labels
 info "Syncing Loom workflow labels..."

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -59,6 +59,7 @@ test-install-full-reinstall-no-target-mutation.sh
 test-install-pr-markers.sh
 test-install-source-guard.sh
 test-install-stash-scope.sh
+test-install-sync-labels.sh
 test-judge-fanout-experiment.sh
 test-locate-daemon-bin.sh
 test-loom-daemon-launchd-plist.sh

--- a/defaults/scripts/tests/test-install-sync-labels.sh
+++ b/defaults/scripts/tests/test-install-sync-labels.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# test-install-sync-labels.sh - Unit tests for the source-only
+# scripts/install/sync-labels.sh's --prune-defaults / --force flags (#5066).
+#
+# scripts/install/sync-labels.sh is the pre-install/bootstrap counterpart of
+# defaults/scripts/sync-labels.sh (used before .loom/ exists on a target, and
+# from a checked-out loom source tree) — it has its own DEFAULT_LABELS
+# deletion loop, independently maintained from the installed-tree copy
+# (whose own coverage lives in test-sync-labels-repo-flag.sh). #5066 made
+# default-label deletion opt-in on BOTH copies; this suite proves that this
+# copy holds the same invariants:
+#   1. A bare run creates/updates Loom labels and deletes nothing.
+#   2. --prune-defaults restores the pre-#5066 unconditional deletion.
+#   3. A default label still attached to an issue/PR is skipped (warned, with
+#      the affected numbers) unless --force is also given.
+#
+# This is a black-box test: the script is a full CLI, so we stub `gh` on
+# PATH, run the real script as a subprocess against a scratch git repo (a
+# real git remote is required — unlike the installed-tree copy, this script
+# has no --repo override to bypass remote-based resolution), and assert on
+# exit codes, stdout/stderr, and the recorded `gh` argv log.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-install-sync-labels.sh
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$TEST_DIR/../../.." && pwd)"
+SLS="$REPO_ROOT/scripts/install/sync-labels.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Unexpected substring: '$needle'"
+        echo "    In: '$haystack'"
+    fi
+}
+
+if [[ ! -x "$SLS" ]]; then
+    echo -e "${RED}FATAL${NC}: $SLS not found or not executable" >&2
+    exit 2
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP" 2>/dev/null || true' EXIT
+
+STUB_DIR="$TMP/stub"
+mkdir -p "$STUB_DIR"
+
+# --- Stub gh on PATH ---------------------------------------------------------
+# Same contract as test-sync-labels-repo-flag.sh's stub:
+#   gh label list ...           -> exit 0 (script takes the `create` branch)
+#   gh label create|edit|delete -> exit 0
+#   gh api repos/.../issues -f labels=<L> ... -> echoes
+#       $LOOM_TEST_GH_USAGE_NUMBERS (one number per line) when <L> matches
+#       $LOOM_TEST_GH_USAGE_LABEL, otherwise empty (label not in use).
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${LOOM_TEST_GH_LOG:?stub gh: LOOM_TEST_GH_LOG not set}"
+
+case "$1" in
+  label)
+    case "$2" in
+      list)   exit 0 ;;
+      create|edit|delete) exit 0 ;;
+    esac
+    echo "stub gh: unhandled label args: $*" >&2
+    exit 3
+    ;;
+  api)
+    label=""
+    prev=""
+    for arg in "$@"; do
+      if [[ "$prev" == "-f" && "$arg" == labels=* ]]; then
+        label="${arg#labels=}"
+      fi
+      prev="$arg"
+    done
+    if [[ -n "$label" && "$label" == "${LOOM_TEST_GH_USAGE_LABEL:-}" ]]; then
+      printf '%s\n' "${LOOM_TEST_GH_USAGE_NUMBERS:-}" | sed '/^$/d'
+    fi
+    exit 0
+    ;;
+esac
+echo "stub gh: unhandled args: $*" >&2
+exit 3
+STUB
+chmod +x "$STUB_DIR/gh"
+
+# --- Scratch git repo ---------------------------------------------------------
+# Unlike the installed-tree copy, scripts/install/sync-labels.sh has no --repo
+# override — it always resolves the target from `git config remote.origin.url`
+# via forge-detect.sh's detect_forge_and_repo. A real (if fake-remote) git repo
+# is therefore required, not just a directory.
+SRC="$TMP/src"
+mkdir -p "$SRC/.github"
+git -C "$TMP" init -q "$SRC" 2>/dev/null || git init -q "$SRC"
+git -C "$SRC" remote add origin "https://github.com/octocat/hello-world.git"
+cat > "$SRC/.github/labels.yml" <<'EOF'
+# BEGIN LOOM LABELS
+- name: loom:issue
+  description: "Approved and ready for a Builder"
+  color: "3B82F6"
+- name: loom:pr
+  description: "Approved pull request"
+  color: "10B981"
+# END LOOM LABELS
+EOF
+
+GH_LOG="$TMP/gh.log"
+
+# run_sls [--] <script args...>
+# Sets: RC, OUT (merged stdout+stderr), LOG (recorded gh argv lines).
+RC=0
+OUT=""
+LOG=""
+run_sls() {
+    : > "$GH_LOG"
+    OUT="$(
+        PATH="$STUB_DIR:$PATH" \
+        LOOM_TEST_GH_LOG="$GH_LOG" \
+        LOOM_TEST_GH_USAGE_LABEL="${LOOM_TEST_GH_USAGE_LABEL:-}" \
+        LOOM_TEST_GH_USAGE_NUMBERS="${LOOM_TEST_GH_USAGE_NUMBERS:-}" \
+        bash "$SLS" "$@" 2>&1
+    )"
+    RC=$?
+    LOG="$(cat "$GH_LOG")"
+}
+
+echo ""
+echo "=== Additive by default: no deletion without --prune-defaults (#5066) ==="
+
+run_sls "$SRC"
+assert_eq "0" "$RC" "a bare run against the scratch repo exits 0"
+assert_contains "$OUT" "Target repository: octocat/hello-world (github)" \
+    "the target repo resolves from the git remote, unchanged"
+assert_not_contains "$LOG" "label delete" \
+    "a bare run performs no default-label deletion"
+assert_contains "$OUT" "Leaving default labels untouched" \
+    "a bare run explains that default labels were left alone"
+assert_contains "$LOG" "label create loom:issue -R octocat/hello-world" \
+    "a bare run still creates/updates the Loom labels"
+assert_contains "$OUT" "Synced 2 labels" \
+    "both labels.yml entries were synced"
+
+echo ""
+echo "=== --prune-defaults restores the old (pre-#5066) deletion behavior ==="
+
+run_sls --prune-defaults "$SRC"
+assert_eq "0" "$RC" "--prune-defaults run exits 0"
+assert_contains "$OUT" "Pruning default labels (--prune-defaults)..." \
+    "--prune-defaults announces that it is pruning"
+assert_contains "$LOG" "label delete bug -R octocat/hello-world" \
+    "--prune-defaults deletes GitHub's default labels"
+assert_contains "$LOG" "label delete wontfix -R octocat/hello-world" \
+    "--prune-defaults deletes every default label, not just the first"
+
+echo ""
+echo "=== --prune-defaults skips an in-use default label unless --force ==="
+
+LOOM_TEST_GH_USAGE_LABEL="bug" LOOM_TEST_GH_USAGE_NUMBERS=$'1\n2' \
+    run_sls --prune-defaults "$SRC"
+assert_eq "0" "$RC" "an in-use default label does not fail the whole run"
+assert_contains "$OUT" "Refusing to delete in-use default label 'bug'" \
+    "the in-use label is refused, not silently deleted"
+assert_contains "$OUT" "#1 #2" \
+    "the refusal names the affected issue/PR numbers"
+assert_not_contains "$LOG" "label delete bug " \
+    "the in-use label is NOT deleted without --force"
+assert_contains "$LOG" "label delete wontfix -R octocat/hello-world" \
+    "an unrelated, unused default label is still deleted normally"
+
+LOOM_TEST_GH_USAGE_LABEL="bug" LOOM_TEST_GH_USAGE_NUMBERS=$'1\n2' \
+    run_sls --prune-defaults --force "$SRC"
+assert_eq "0" "$RC" "--force run exits 0"
+assert_contains "$OUT" "Deleting in-use default label 'bug' (--force)" \
+    "--force warns before deleting an in-use label"
+assert_contains "$LOG" "label delete bug -R octocat/hello-world" \
+    "--force actually deletes the in-use label"
+
+echo ""
+echo "=== --prune-defaults / --force are no-ops without the other flag combos ==="
+
+run_sls --force "$SRC"
+assert_eq "0" "$RC" "--force without --prune-defaults exits 0"
+assert_not_contains "$LOG" "label delete" \
+    "--force alone (no --prune-defaults) still performs no deletion"
+
+echo ""
+echo "=== Argument parsing ==="
+
+run_sls --bogus "$SRC"
+assert_eq "2" "$RC" "unknown option exits 2"
+assert_contains "$OUT" "Unknown option: --bogus" "unknown option is named"
+
+run_sls "$SRC" extra
+assert_eq "2" "$RC" "a second positional argument exits 2"
+assert_contains "$OUT" "Unexpected extra argument: extra" \
+    "the extra positional is named"
+
+echo ""
+echo "────────────────────────────────"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/defaults/scripts/tests/test-sync-labels-repo-flag.sh
+++ b/defaults/scripts/tests/test-sync-labels-repo-flag.sh
@@ -129,6 +129,11 @@ mkdir -p "$STUB_DIR"
 #                         (simulating "no resolvable remote here")
 #   gh label list ...  -> echoes nothing (script takes the `create` branch)
 #   gh label create|edit|delete ... -> exit 0
+#   gh api repos/.../issues -f labels=<L> ... -> the #5066 in-use lookup made
+#                         by github_label_usage/github_maybe_delete_label.
+#                         Echoes $LOOM_TEST_GH_USAGE_NUMBERS (one number per
+#                         line) when <L> matches $LOOM_TEST_GH_USAGE_LABEL,
+#                         otherwise empty (label not in use).
 cat > "$STUB_DIR/gh" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "${LOOM_TEST_GH_LOG:?stub gh: LOOM_TEST_GH_LOG not set}"
@@ -159,6 +164,23 @@ case "$1" in
     esac
     echo "stub gh: unhandled label args: $*" >&2
     exit 3
+    ;;
+  api)
+    # Find the -f labels=<value> argument by argv POSITION, not by splitting
+    # the space-joined log — a label value with spaces ("good first issue")
+    # must survive intact.
+    label=""
+    prev=""
+    for arg in "$@"; do
+      if [[ "$prev" == "-f" && "$arg" == labels=* ]]; then
+        label="${arg#labels=}"
+      fi
+      prev="$arg"
+    done
+    if [[ -n "$label" && "$label" == "${LOOM_TEST_GH_USAGE_LABEL:-}" ]]; then
+      printf '%s\n' "${LOOM_TEST_GH_USAGE_NUMBERS:-}" | sed '/^$/d'
+    fi
+    exit 0
     ;;
 esac
 echo "stub gh: unhandled args: $*" >&2
@@ -248,6 +270,8 @@ run_sls() {
         LOOM_CONFIG_DEFAULTS_FILE="" \
         REPO_ROOT="$repo_root" \
         LOOM_FORGE_TYPE="${LOOM_FORGE_TYPE_OVERRIDE:-}" \
+        LOOM_TEST_GH_USAGE_LABEL="${LOOM_TEST_GH_USAGE_LABEL:-}" \
+        LOOM_TEST_GH_USAGE_NUMBERS="${LOOM_TEST_GH_USAGE_NUMBERS:-}" \
         bash "$SLS" "$@" 2>&1
     )"
     RC=$?
@@ -269,8 +293,12 @@ assert_contains "$OUT" "Target repository: octocat/hello-world (github)" \
 # the preflight below is a different call (it NAMES the target).
 assert_not_contains "$LOG" "repo view --json nameWithOwner --jq" \
     "--repo never resolves the NWO from the forge (forge_get_repo_nwo short-circuited)"
-assert_contains "$LOG" "label delete bug -R octocat/hello-world" \
-    "default-label deletion targets the override NWO"
+# Additive by default (#5066): no --prune-defaults, so no default-label
+# deletion happens even when --repo names an explicit target.
+assert_not_contains "$LOG" "label delete" \
+    "bare --repo run performs no default-label deletion (additive by default)"
+assert_contains "$OUT" "Leaving default labels untouched" \
+    "bare --repo run explains why nothing was deleted"
 assert_contains "$LOG" "label create loom:issue -R octocat/hello-world" \
     "label create targets the override NWO"
 assert_contains "$OUT" "Synced 2 labels" \
@@ -305,8 +333,10 @@ echo "=== --dry-run is forge-free ==="
 run_sls -- --repo octocat/hello-world --dry-run
 assert_eq "0" "$RC" "--repo --dry-run exits 0"
 assert_eq "" "$LOG" "--dry-run makes ZERO gh calls"
-assert_contains "$OUT" "[dry-run] would delete default label: bug" \
-    "--dry-run reports the default-label deletions it would make"
+assert_contains "$OUT" "[dry-run] would leave default labels untouched" \
+    "--dry-run (no --prune-defaults) reports that default labels are left alone"
+assert_not_contains "$OUT" "[dry-run] would delete default label" \
+    "--dry-run without --prune-defaults never previews a deletion"
 assert_contains "$OUT" "[dry-run] would create or update label: loom:issue" \
     "--dry-run reports the labels it would sync"
 assert_contains "$OUT" "Dry run complete: 2 labels would be synced to octocat/hello-world" \
@@ -519,7 +549,7 @@ run_sls --repo-view " " -- --repo octocat/hello-world
 assert_eq "0" "$RC" "an indeterminate permission does not block the sync"
 assert_contains "$OUT" "Could not determine your permission" \
     "an indeterminate permission is warned about"
-assert_contains "$LOG" "label delete bug -R octocat/hello-world" \
+assert_contains "$LOG" "label create loom:issue -R octocat/hello-world" \
     "the sync proceeds once existence is proven"
 
 # The preflight is real-run only: --dry-run must stay forge-free.
@@ -535,6 +565,94 @@ assert_eq "0" "$RC" "--help exits 0"
 assert_contains "$OUT" "--repo OWNER/NAME" "--help documents --repo"
 assert_contains "$OUT" "--dry-run" "--help documents --dry-run"
 assert_contains "$OUT" "End of options" "--help documents the -- terminator (#4524)"
+assert_contains "$OUT" "--prune-defaults" "--help documents --prune-defaults (#5066)"
+assert_contains "$OUT" "--force" "--help documents --force (#5066)"
+
+echo ""
+echo "=== Additive by default: no deletion without --prune-defaults (#5066) ==="
+
+# A bare run (no --repo, no --prune-defaults) against the locally-resolved
+# repo must create/update Loom labels and touch none of GitHub's defaults —
+# the core regression this issue exists to prevent.
+run_sls --nwo owner/from-remote --
+assert_not_contains "$LOG" "label delete" \
+    "a bare run performs no default-label deletion"
+assert_contains "$OUT" "Leaving default labels untouched" \
+    "a bare run explains that default labels were left alone"
+assert_contains "$LOG" "label create loom:issue -R owner/from-remote" \
+    "a bare run still creates/updates the Loom labels"
+
+# Same, but --repo (a real forge round-trip location, not just the resolved
+# path) confirms the additive default holds there too.
+run_sls -- --repo octocat/hello-world
+assert_not_contains "$LOG" "label delete" \
+    "a bare --repo run performs no default-label deletion"
+
+echo ""
+echo "=== --prune-defaults restores the old (pre-#5066) deletion behavior ==="
+
+run_sls -- --repo octocat/hello-world --prune-defaults
+assert_eq "0" "$RC" "--prune-defaults run exits 0"
+assert_contains "$OUT" "Pruning default labels (--prune-defaults)..." \
+    "--prune-defaults announces that it is pruning"
+assert_contains "$LOG" "label delete bug -R octocat/hello-world" \
+    "--prune-defaults deletes GitHub's default labels (unused label, no in-use guard triggered)"
+assert_contains "$LOG" "label delete wontfix -R octocat/hello-world" \
+    "--prune-defaults deletes every default label, not just the first"
+assert_contains "$LOG" "label create loom:issue -R octocat/hello-world" \
+    "--prune-defaults still creates/updates the Loom labels"
+
+echo ""
+echo "=== --prune-defaults skips an in-use default label unless --force ==="
+
+# 'bug' is reported in use on issues #1 and #2; every other default label is
+# reported unused (LOOM_TEST_GH_USAGE_LABEL only matches one label per run).
+LOOM_TEST_GH_USAGE_LABEL="bug" LOOM_TEST_GH_USAGE_NUMBERS=$'1\n2' \
+    run_sls -- --repo octocat/hello-world --prune-defaults
+assert_eq "0" "$RC" "an in-use default label does not fail the whole run"
+assert_contains "$OUT" "Refusing to delete in-use default label 'bug'" \
+    "the in-use label is refused, not silently deleted"
+assert_contains "$OUT" "#1 #2" \
+    "the refusal names the affected issue/PR numbers"
+assert_contains "$OUT" "pass --force to delete anyway" \
+    "the refusal names the escape hatch"
+assert_not_contains "$LOG" "label delete bug " \
+    "the in-use label is NOT deleted without --force"
+assert_contains "$LOG" "label delete wontfix -R octocat/hello-world" \
+    "an unrelated, unused default label is still deleted normally"
+
+# --force overrides the refusal, but still warns first.
+LOOM_TEST_GH_USAGE_LABEL="bug" LOOM_TEST_GH_USAGE_NUMBERS=$'1\n2' \
+    run_sls -- --repo octocat/hello-world --prune-defaults --force
+assert_eq "0" "$RC" "--force run exits 0"
+assert_contains "$OUT" "Deleting in-use default label 'bug' (--force)" \
+    "--force warns before deleting an in-use label"
+assert_contains "$OUT" "#1 #2" \
+    "the --force warning still names the affected issue/PR numbers"
+assert_contains "$LOG" "label delete bug -R octocat/hello-world" \
+    "--force actually deletes the in-use label"
+
+echo ""
+echo "=== --prune-defaults --dry-run flags in-use deletions (#5066) ==="
+
+# Unlike a bare --dry-run (forge-free), --dry-run combined with
+# --prune-defaults performs a READ-ONLY in-use lookup so the preview can flag
+# which deletions would be skipped without --force.
+LOOM_TEST_GH_USAGE_LABEL="bug" LOOM_TEST_GH_USAGE_NUMBERS=$'1\n2' \
+    run_sls -- --repo octocat/hello-world --prune-defaults --dry-run
+assert_eq "0" "$RC" "--prune-defaults --dry-run exits 0"
+assert_contains "$OUT" "[dry-run] would delete default label: bug (IN USE: #1 #2" \
+    "the dry-run preview flags the in-use default label"
+assert_contains "$OUT" "[dry-run] would delete default label: wontfix" \
+    "the dry-run preview lists an unused default label plainly"
+assert_not_contains "$OUT" "would delete default label: wontfix (IN USE" \
+    "the dry-run preview does not flag an unused label as in-use"
+assert_not_contains "$LOG" "label delete" \
+    "--prune-defaults --dry-run never actually deletes anything"
+assert_not_contains "$LOG" "label create" \
+    "--prune-defaults --dry-run never actually creates/updates anything"
+assert_contains "$LOG" "api repos/octocat/hello-world/issues" \
+    "--prune-defaults --dry-run DOES make a read-only in-use lookup (unlike a bare --dry-run)"
 
 echo ""
 echo "=== Installed-tree parity (.loom/scripts is a symlinked dir) ==="

--- a/scripts/install/sync-labels.sh
+++ b/scripts/install/sync-labels.sh
@@ -2,10 +2,70 @@
 # Sync workflow labels from .github/labels.yml
 #
 # Supports both GitHub (via gh CLI) and Gitea (via API).
+#
+# Additive by default (#5066): creates/updates the Loom labels from
+# .github/labels.yml and never touches GitHub's default labels (bug,
+# documentation, duplicate, enhancement, good first issue, help wanted,
+# invalid, question, wontfix) unless --prune-defaults is passed. Deleting
+# those is destructive to pre-existing repo data — it silently strips the
+# label from every issue/PR carrying it. A default label still in use is
+# skipped (with a warning naming the affected issue/PR numbers) unless
+# --force is also given.
+#
+# Usage:
+#   sync-labels.sh [--prune-defaults] [--force] [--] [WORKTREE_PATH]
+#
+# This is the source-only counterpart of the installed-tree
+# defaults/scripts/sync-labels.sh (which additionally supports --repo and
+# --dry-run). Keep --prune-defaults/--force behavior in parity between the
+# two when editing either.
 
 set -euo pipefail
 
-WORKTREE_PATH="${1:-.}"
+WORKTREE_PATH="."
+PRUNE_DEFAULTS=0
+FORCE_PRUNE=0
+POSITIONAL_SEEN=0
+POSITIONAL_ONLY=0
+
+take_positional() {
+  if [[ "$POSITIONAL_SEEN" -eq 1 ]]; then
+    echo "Unexpected extra argument: $1" >&2
+    exit 2
+  fi
+  WORKTREE_PATH="$1"
+  POSITIONAL_SEEN=1
+}
+
+while [[ $# -gt 0 ]]; do
+  if [[ "$POSITIONAL_ONLY" -eq 1 ]]; then
+    take_positional "$1"
+    shift
+    continue
+  fi
+  case "$1" in
+    --prune-defaults)
+      PRUNE_DEFAULTS=1
+      shift
+      ;;
+    --force)
+      FORCE_PRUNE=1
+      shift
+      ;;
+    --)
+      POSITIONAL_ONLY=1
+      shift
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      exit 2
+      ;;
+    *)
+      take_positional "$1"
+      shift
+      ;;
+  esac
+done
 
 # Source forge detection helper
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -71,6 +131,50 @@ github_delete_label() {
     info "Deleted default label: $label"
   elif ! echo "$output" | grep -qi "not found\|404"; then
     warning "Could not delete label '$label': $output"
+  fi
+}
+
+# Numbers (one per line) of open+closed issues/PRs currently carrying
+# `label`. GitHub's REST /issues endpoint returns both issues and pull
+# requests, so one query covers both. Capped at 100 results (max page size).
+# Best-effort: any API failure is treated as "no known usage" rather than
+# blocking the caller.
+github_label_usage() {
+  local label="$1"
+  gh api "repos/${REPO}/issues" \
+    -f state=all -f per_page=100 -f "labels=${label}" \
+    --jq '.[].number' 2>/dev/null || true
+}
+
+# Format a newline-separated list of issue/PR numbers as "#1 #2 #3", noting
+# when the list was truncated at github_label_usage's 100-result cap.
+join_usage_numbers() {
+  local numbers="$1" count list
+  count=$(printf '%s\n' "$numbers" | grep -c . || true)
+  list=$(printf '%s\n' "$numbers" | sed '/^$/d; s/^/#/' | paste -sd' ' -)
+  if [[ "$count" -ge 100 ]]; then
+    printf '%s (100+ shown, there may be more)' "$list"
+  else
+    printf '%s' "$list"
+  fi
+}
+
+# Delete a default label unless it is currently in use, in which case skip it
+# (warn) or delete it anyway (warn, then delete) depending on FORCE_PRUNE.
+github_maybe_delete_label() {
+  local label="$1"
+  local usage_numbers usage_list
+  usage_numbers="$(github_label_usage "$label")"
+  if [[ -n "$usage_numbers" ]]; then
+    usage_list="$(join_usage_numbers "$usage_numbers")"
+    if [[ "$FORCE_PRUNE" -eq 1 ]]; then
+      warning "Deleting in-use default label '$label' (--force): affects issue/PR $usage_list"
+      github_delete_label "$label"
+    else
+      warning "Refusing to delete in-use default label '$label': affects issue/PR $usage_list (pass --force to delete anyway)"
+    fi
+  else
+    github_delete_label "$label"
   fi
 }
 
@@ -142,6 +246,67 @@ for l in data:
   fi
 }
 
+# Numbers (one per line) of open+closed issues/PRs currently carrying
+# `label`. Gitea's issues endpoint filters by numeric label ID (not name)
+# and, with type=all, includes both issues and pull requests. Best-effort:
+# any lookup failure reports "no known usage" rather than blocking the
+# caller.
+gitea_label_usage() {
+  local label="$1"
+  local response body http_code label_id
+
+  response=$(gitea_api GET "/repos/${FORGE_OWNER}/${FORGE_REPO}/labels")
+  http_code=$(echo "$response" | tail -1)
+  body=$(echo "$response" | sed '$d')
+  [[ "$http_code" == "200" ]] || return 0
+
+  label_id=$(echo "$body" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for l in data:
+    if l['name'] == '$label':
+        print(l['id'])
+        break
+" 2>/dev/null || echo "")
+  [[ -n "$label_id" ]] || return 0
+
+  response=$(gitea_api GET "/repos/${FORGE_OWNER}/${FORGE_REPO}/issues?labels=${label_id}&state=all&type=all")
+  http_code=$(echo "$response" | tail -1)
+  body=$(echo "$response" | sed '$d')
+  [[ "$http_code" == "200" ]] || return 0
+
+  echo "$body" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for item in data:
+    n = item.get('number')
+    if n is not None:
+        print(n)
+" 2>/dev/null || true
+}
+
+# Delete a default label unless it is currently in use, in which case skip it
+# (warn) or delete it anyway (warn, then delete) depending on FORCE_PRUNE.
+gitea_maybe_delete_label() {
+  local label="$1"
+  local usage_numbers usage_list
+  usage_numbers="$(gitea_label_usage "$label")"
+  if [[ -n "$usage_numbers" ]]; then
+    usage_list="$(join_usage_numbers "$usage_numbers")"
+    if [[ "$FORCE_PRUNE" -eq 1 ]]; then
+      warning "Deleting in-use default label '$label' (--force): affects issue/PR $usage_list"
+      gitea_delete_label "$label"
+    else
+      warning "Refusing to delete in-use default label '$label': affects issue/PR $usage_list (pass --force to delete anyway)"
+    fi
+  else
+    gitea_delete_label "$label"
+  fi
+}
+
 gitea_sync_label() {
   local name="$1" description="$2" color="$3"
 
@@ -206,14 +371,22 @@ DEFAULT_LABELS=(
   "wontfix"
 )
 
-info "Removing default labels..."
-for label in "${DEFAULT_LABELS[@]}"; do
-  if [[ "$FORGE_TYPE" == "github" ]]; then
-    github_delete_label "$label"
-  elif [[ "$FORGE_TYPE" == "gitea" ]]; then
-    gitea_delete_label "$label"
-  fi
-done
+# Additive by default (#5066): deleting GitHub's default labels is
+# destructive to pre-existing repo data (it strips the label from every
+# issue/PR carrying it), so it only happens with the explicit --prune-defaults
+# opt-in.
+if [[ "$PRUNE_DEFAULTS" -eq 1 ]]; then
+  info "Pruning default labels (--prune-defaults)..."
+  for label in "${DEFAULT_LABELS[@]}"; do
+    if [[ "$FORGE_TYPE" == "github" ]]; then
+      github_maybe_delete_label "$label"
+    elif [[ "$FORGE_TYPE" == "gitea" ]]; then
+      gitea_maybe_delete_label "$label"
+    fi
+  done
+else
+  info "Leaving default labels untouched (pass --prune-defaults to remove them): ${DEFAULT_LABELS[*]}"
+fi
 
 # Sync Loom workflow labels
 info "Syncing Loom workflow labels..."

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -3325,6 +3325,31 @@ fi
 echo ""
 
 # ==========================================================================
+# scripts/install/sync-labels.sh --prune-defaults / --force (#5066)
+# ==========================================================================
+# Its own unit suite lives at defaults/scripts/tests/test-install-sync-labels.sh
+# (additive-by-default with no flags, --prune-defaults restoring the old
+# unconditional deletion, and the in-use-label warn/refuse-without-force
+# guard) — the source-only counterpart of the --repo/--dry-run suite above.
+echo "Test: scripts/install/sync-labels.sh --prune-defaults suite (test-install-sync-labels.sh)"
+INSTALL_SYNC_LABELS_TEST="$DEFAULTS_DIR/scripts/tests/test-install-sync-labels.sh"
+if [[ -f "$INSTALL_SYNC_LABELS_TEST" ]]; then
+  set +e
+  INSTALL_SYNC_LABELS_TEST_OUT=$(bash "$INSTALL_SYNC_LABELS_TEST" 2>&1)
+  INSTALL_SYNC_LABELS_TEST_RC=$?
+  set -e
+  if [[ $INSTALL_SYNC_LABELS_TEST_RC -eq 0 ]]; then
+    pass "test-install-sync-labels.sh: all cases passed"
+  else
+    fail "test-install-sync-labels.sh failed (rc=$INSTALL_SYNC_LABELS_TEST_RC)"
+    echo "$INSTALL_SYNC_LABELS_TEST_OUT" | tail -20
+  fi
+else
+  fail "test-install-sync-labels.sh not found at $INSTALL_SYNC_LABELS_TEST"
+fi
+echo ""
+
+# ==========================================================================
 # Summary
 # ==========================================================================
 echo "======================================"


### PR DESCRIPTION
## Summary

- `sync-labels.sh` no longer deletes GitHub's default labels (`bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`) by default — a bare run only creates/updates the Loom workflow labels from `.github/labels.yml`.
- New `--prune-defaults` opt-in restores the old (pre-#5066) unconditional deletion behavior, for the greenfield-repo case where clearing GitHub's defaults is genuinely wanted.
- Before deleting a default label still attached to any issue/PR, the script warns and skips it (listing the affected issue/PR numbers) unless `--force` is also given — it never silently deletes an in-use label.
- `--dry-run` combined with `--prune-defaults` performs a read-only in-use lookup so the preview flags which deletions would be skipped without `--force`; a bare `--dry-run` (no `--prune-defaults`) stays completely forge-free, as before.
- Parity kept between the installed-tree `defaults/scripts/sync-labels.sh` (symlinked as `.loom/scripts/sync-labels.sh`) and the source-only `scripts/install/sync-labels.sh` (which gained its own lightweight flag parser — it previously had none).
- Updated `defaults/docs/daemon-reference.md`'s `--repo` fleet-sync example to reflect the additive default and document `--prune-defaults`.

## Changes

- `defaults/scripts/sync-labels.sh`: `--prune-defaults`/`--force` flags, `github_label_usage`/`gitea_label_usage`/`join_usage_numbers`/`github_maybe_delete_label`/`gitea_maybe_delete_label` helpers, gated deletion loop, updated `--dry-run` output and `--help` text.
- `scripts/install/sync-labels.sh`: same behavior, plus a new minimal option parser (this copy previously took only a single positional `WORKTREE_PATH` argument — still the default when no flags are given, so `install-loom.sh`'s existing call site is unaffected).
- `defaults/scripts/tests/test-sync-labels-repo-flag.sh`: updated existing assertions for the new additive default, added coverage for `--prune-defaults`, `--force`, the in-use warn/refuse guard, and the `--prune-defaults --dry-run` in-use preview.
- `defaults/scripts/tests/test-install-sync-labels.sh` (new): equivalent black-box coverage for the source-only script, wired into `ci-wired.txt` and folded into `scripts/test-installer.sh`.
- `defaults/docs/daemon-reference.md`: updated the fleet-sync runbook section.

## Acceptance Criteria Verification

- [x] A bare `sync-labels.sh` run creates/updates Loom labels and deletes nothing — verified manually (`--dry-run` output shows "would leave default labels untouched") and via test.
- [x] Opt-in flag (`--prune-defaults`) restores the current prune behavior — verified via test.
- [x] Deleting an in-use label is refused (warns with affected issue/PR numbers) without `--force` — verified via test.
- [x] `--dry-run` output distinguishes "would create" from "would delete", and flags in-use deletions when combined with `--prune-defaults` — verified via test.
- [x] Parity kept between `.loom/scripts/sync-labels.sh` (symlink to `defaults/scripts/sync-labels.sh`) and `scripts/install/sync-labels.sh` — both scripts updated identically; parity assertion in the existing test still passes.
- [x] Quick-install guidance updated — `install.sh`'s message and `defaults/docs/troubleshooting.md`'s reference still point at the same bare invocation, which is now safe by default, so no wording change was needed there beyond the `daemon-reference.md` fleet-sync section (which did change since it previously relied on the deletion behavior for onboarding new repos).

## Test Plan

- `bash defaults/scripts/tests/test-sync-labels-repo-flag.sh` — 161/161 passed.
- `bash defaults/scripts/tests/test-install-sync-labels.sh` — 24/24 passed (new suite).
- `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — manifest invariant holds (new suite is wired).
- `bash -n` + `shellcheck` clean on both modified scripts and both test files.
- Manual smoke test: `--help` documents the new flags; a bare `--dry-run` against a scratch repo shows "would leave default labels untouched" plus per-label "would create or update" lines.

Closes #5066