### PR TITLE
feat(release,daemon-update): sign Linux artifacts keylessly and verify by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,22 +15,35 @@ name: Build and Release
 #
 #   - macOS Developer ID codesign of the aarch64-apple-darwin artifact, plus
 #     optional notarization, when the Developer ID / notary secrets are set.
-#   - Optional cosign detached-signature (`.sig`) over the Linux artifacts when
-#     a cosign key secret is set.
+#   - cosign detached-signature (`.sig`) over the Linux artifacts.
 #
-# EVERY signing step is gated on Actions secrets being present and skips
+# The macOS signing steps are gated on Actions secrets being present and skip
 # cleanly (with a LOUD entry in the run summary, never silent) when they are
-# absent — a no-secrets release still succeeds with unsigned artifacts +
+# absent — a no-secrets release still succeeds with unsigned macOS artifacts +
 # checksums, byte-for-byte as Phase 1 left it. No org name, team ID, cert
 # reference, or other deployer identity lives in this file or any tracked file:
 # all identity comes from secrets only. If you ever need to hardcode one here,
 # that's a scope regression — put it in a secret instead.
 #
+# Linux signing is KEYLESS by default (#5054): cosign gets a short-lived
+# Sigstore certificate from the workflow's own GitHub Actions OIDC token, so it
+# needs NO secret to be provisioned and publishes no long-lived key material.
+# That is what lets `loom-daemon-update.sh` verify for real on a stock install
+# instead of loud-skipping for want of a distributed public key. A repo that
+# still wants classic key signing sets the COSIGN_PRIVATE_KEY secret, which
+# takes precedence (see the detect step below); it then owes its consumers the
+# matching public key out of band.
+#
 # Output format (for Phase 3's verifier): the checksum is always present and is
 # computed over the FINAL artifact (after any in-place codesign), so it matches
 # whatever bytes are uploaded. macOS signatures are embedded in the Mach-O
 # (verify with `codesign --verify`); Linux signatures are detached `.sig` files
-# (verify with `cosign verify-blob --key <pubkey> --signature <sig>`).
+# — keyless ones ship the signing certificate alongside as `.pem` (verify with
+# `cosign verify-blob --certificate <pem> --signature <sig>
+# --certificate-identity-regexp ... --certificate-oidc-issuer ...`), key-signed
+# ones ship the bare `.sig` (verify with `cosign verify-blob --key <pubkey>
+# --signature <sig>`). The presence of the `.pem` is the wire signal that tells
+# the consumer which mode was used.
 #
 # Consuming these artifacts from `loom-daemon-update.sh` / the daemon
 # auto-updater is out of scope here (#4990 Phase 3) — the LOCAL `cargo build`
@@ -54,6 +67,11 @@ on:
 
 permissions:
   contents: write
+  # Keyless cosign signing of the Linux artifacts (#5054): mints the workflow's
+  # OIDC token so Fulcio can issue the short-lived signing certificate. This is
+  # the ONLY thing that grants signing authority here — there is no key to leak,
+  # and no secret to provision before a release can be signed.
+  id-token: write
 
 jobs:
   build-daemon:
@@ -139,6 +157,7 @@ jobs:
           macos_sign=false
           notarize=false
           linux_sign=false
+          linux_sign_mode=none
 
           summary() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
           summary "### Signing (${target})"
@@ -165,12 +184,23 @@ jobs:
               fi
               ;;
             *-linux-*)
+              # Precedence: an explicitly provisioned key wins (a repo that set
+              # COSIGN_PRIVATE_KEY has already told its consumers which key to
+              # trust, and silently switching it to keyless would invalidate
+              # that). Otherwise keyless, which needs no secret at all — so the
+              # DEFAULT for this repo, and for every fork, is a really-signed
+              # Linux artifact rather than an unsigned one (#5054).
               if [ -n "${COSIGN_PRIVATE_KEY:-}" ]; then
                 linux_sign=true
-                summary "- Signed: cosign key secret present — writing detached \`${target}.sig\`."
+                linux_sign_mode=key
+                summary "- Signed (key mode): COSIGN_PRIVATE_KEY secret present — writing detached \`${target}.sig\`. Consumers must resolve the matching public key themselves (LOOM_DAEMON_UPDATE_COSIGN_PUBKEY / \`.loom/cosign.pub\`)."
+              elif [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+                linux_sign=true
+                linux_sign_mode=keyless
+                summary "- Signed (keyless): using this workflow's GitHub Actions OIDC identity — writing detached \`${target}.sig\` + its signing certificate \`${target}.pem\`. No key material is distributed; consumers verify the signer identity."
               else
-                summary "- SKIPPED signing: cosign key secret absent — shipping UNSIGNED \`${target}\` + checksum (Phase 1 behavior)."
-                echo "::notice::Linux signing skipped for ${target} (cosign key absent); shipping unsigned artifact + checksum."
+                summary "- SKIPPED signing: no COSIGN_PRIVATE_KEY secret AND no OIDC token (the job lacks \`id-token: write\`) — shipping UNSIGNED \`${target}\` + checksum (Phase 1 behavior)."
+                echo "::notice::Linux signing skipped for ${target} (no cosign key and no OIDC token); shipping unsigned artifact + checksum."
               fi
               ;;
           esac
@@ -179,6 +209,7 @@ jobs:
             echo "macos_sign=${macos_sign}"
             echo "notarize=${notarize}"
             echo "linux_sign=${linux_sign}"
+            echo "linux_sign_mode=${linux_sign_mode}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Sign macOS artifact (Developer ID)
@@ -250,18 +281,37 @@ jobs:
         env:
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          SIGN_MODE: ${{ steps.signing.outputs.linux_sign_mode }}
         run: |
           set -euo pipefail
           artifact="dist/loom-daemon-${{ matrix.target }}"
-          # Detached signature so Phase 3 can verify with the matching public key:
-          #   cosign verify-blob --key <pubkey> --signature <target>.sig <binary>
-          # COSIGN_PASSWORD is read from the env by cosign to decrypt the key.
-          key="$RUNNER_TEMP/cosign.key"
-          printf '%s' "$COSIGN_PRIVATE_KEY" > "$key"
-          cosign sign-blob --yes --key "$key" \
-            --output-signature "dist/loom-daemon-${{ matrix.target }}.sig" \
-            "$artifact"
-          rm -f "$key"
+          sig="dist/loom-daemon-${{ matrix.target }}.sig"
+          cert="dist/loom-daemon-${{ matrix.target }}.pem"
+          if [ "$SIGN_MODE" = "keyless" ]; then
+            # Keyless (#5054): cosign exchanges this workflow's OIDC token for a
+            # short-lived Fulcio certificate whose SAN is
+            #   https://github.com/<owner>/<repo>/.github/workflows/release.yml@refs/tags/<tag>
+            # and records the signature in Rekor. Publishing the certificate
+            # next to the signature is what lets a consumer verify with NO
+            # distributed key:
+            #   cosign verify-blob --certificate <target>.pem --signature <target>.sig \
+            #     --certificate-identity-regexp '^https://github\.com/<slug>/\.github/workflows/[^@]+@refs/tags/<tag>$' \
+            #     --certificate-oidc-issuer https://token.actions.githubusercontent.com <binary>
+            cosign sign-blob --yes \
+              --output-signature "$sig" \
+              --output-certificate "$cert" \
+              "$artifact"
+          else
+            # Key mode (only when COSIGN_PRIVATE_KEY is set): detached signature
+            # verified as `cosign verify-blob --key <pubkey> --signature <sig>`.
+            # COSIGN_PASSWORD is read from the env by cosign to decrypt the key.
+            key="$RUNNER_TEMP/cosign.key"
+            printf '%s' "$COSIGN_PRIVATE_KEY" > "$key"
+            cosign sign-blob --yes --key "$key" \
+              --output-signature "$sig" \
+              "$artifact"
+            rm -f "$key"
+          fi
 
       # Checksum is computed AFTER signing so it covers the FINAL bytes (macOS
       # codesign rewrites the Mach-O in place). Phase 3 verifies this checksum
@@ -285,11 +335,15 @@ jobs:
         with:
           # The `*.sig` glob matches the detached Linux signature when cosign
           # signing ran and matches nothing otherwise (skipped, not an error) —
-          # so the same block covers signed and unsigned releases.
+          # so the same block covers signed and unsigned releases. `*.pem`
+          # likewise matches only for a KEYLESS-signed artifact; its presence
+          # (or absence) is the signal Phase 3's verifier uses to pick keyless
+          # vs. key verification, so it must be uploaded alongside the `.sig`.
           files: |
             dist/loom-daemon-${{ matrix.target }}
             dist/loom-daemon-${{ matrix.target }}.sha256
             dist/loom-daemon-${{ matrix.target }}*.sig
+            dist/loom-daemon-${{ matrix.target }}*.pem
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -5007,13 +5007,61 @@ dev machines, canaries, and forks behave exactly as before.
     all" (a release built without the Developer ID secrets) is an expected
     **soft-skip**; "signed but verification fails" is treated as tamper evidence
     and **aborts (exit 1)**.
-  - Linux: the detached `loom-daemon-<target>.sig` (published only when the
-    release was built with a cosign key) is verified with `cosign verify-blob`.
-    If `cosign` is missing, or no public key is resolvable, the script emits a
-    **loud skip** and proceeds — no cosign public key is distributed with this
-    repo yet. Point `LOOM_DAEMON_UPDATE_COSIGN_PUBKEY` at a key (or commit one at
-    `.loom/cosign.pub` / `defaults/cosign.pub`) to turn that skip into real
-    verification. A resolvable key plus a failing verification **aborts (exit 1)**.
+  - Linux: the detached `loom-daemon-<target>.sig` is verified with
+    `cosign verify-blob`, **keylessly by default** (#5054) — see below. If
+    `cosign` itself is missing the script emits a **loud skip** and proceeds;
+    a verification that actually runs and *fails* **aborts (exit 1)**.
+
+**Linux signature trust root: keyless (Sigstore/OIDC), no distributed key (#5054)**
+
+The release workflow signs Linux artifacts with cosign in **keyless** mode: it
+exchanges the workflow's own GitHub Actions OIDC token for a short-lived Fulcio
+certificate and publishes that certificate next to the signature as
+`loom-daemon-<target>.pem`. Nothing is verified against a long-lived key, so
+**no public key is committed to this repo and none needs to be** — a stock
+install performs real verification with zero operator configuration.
+
+The **artifact's own shape** selects the mode, never local config:
+
+| Published assets | Mode | Behavior |
+|------------------|------|----------|
+| `.sig` **+** `.pem` | **keyless** (default) | Verified against the expected *signer identity* + issuer. Failure ⇒ **abort (exit 1)** |
+| `.sig` only | key | Needs a resolvable public key (`LOOM_DAEMON_UPDATE_COSIGN_PUBKEY`, `.loom/cosign.pub`, `defaults/cosign.pub`); none resolvable ⇒ **loud skip**; failure ⇒ **abort (exit 1)** |
+| neither | — | Soft-skip (absence of a signature never blocks) |
+
+The expected signer identity is **derived** from the release being fetched:
+
+```
+^https://github\.com/<owner/repo>/\.github/workflows/[^@]+@refs/tags/<tag>$
+   issuer: https://token.actions.githubusercontent.com
+```
+
+i.e. *"a workflow in the same repo this artifact came from, running at exactly
+this release's tag, with a certificate issued by GitHub Actions."* The workflow
+**file** is deliberately not pinned: a future rename of `release.yml` would
+otherwise hard-abort updates fleet-wide, while adding no real constraint —
+anything that can run a workflow in this repo at this tag can already publish
+the release assets. Pin the exact identity with
+`LOOM_DAEMON_UPDATE_COSIGN_IDENTITY` if you want the stricter form.
+
+**Why keyless rather than committing `defaults/cosign.pub`.** A committed public
+key would also close the loud-skip gap, but it (a) pins the whole fleet to one
+keypair, so rotating it silently breaks verification on every host still
+carrying the old key, and (b) requires a private key to be provisioned as an
+Actions secret before *any* release can be signed at all — which is exactly why
+no release had ever been signed: no `COSIGN_PRIVATE_KEY` secret was ever set, so
+there was no production public key to distribute in the first place. Keyless
+signing needs no secret, so it is on by default for this repo *and every fork*.
+A repo that prefers classic key signing sets `COSIGN_PRIVATE_KEY` (which takes
+precedence in the workflow) and distributes the matching public key itself; its
+releases then publish a bare `.sig` and consumers fall back to the key path
+above.
+
+> Keyless verification contacts Sigstore's transparency log, so a host with no
+> egress to it will see the verification fail and the update **abort** rather
+> than install an unverified binary. That is the intended failure direction:
+> the running daemon is left untouched, and `LOOM_DAEMON_UPDATE_FETCH=0` opts
+> such a host out of artifact fetching entirely.
 
 **Provisioning and restart are unchanged.** A verified artifact goes through the
 *same* `provision_machine_daemon()` seam as a freshly compiled binary (no parallel
@@ -5068,7 +5116,9 @@ seams):
 | `LOOM_DAEMON_UPDATE_FETCH` | `1`/`true`/`yes` ⇒ force (`--fetch`); `0`/`false`/`no` ⇒ off (`--no-fetch`); unset ⇒ auto |
 | `LOOM_DAEMON_UPDATE_GH_REPO` | Override the `owner/repo` slug used for release resolution (default: parsed from the `origin` remote) |
 | `LOOM_DAEMON_UPDATE_TARGET` | Override the detected release target triple |
-| `LOOM_DAEMON_UPDATE_COSIGN_PUBKEY` | Path to the cosign public key used to verify a Linux `.sig` |
+| `LOOM_DAEMON_UPDATE_COSIGN_PUBKEY` | Path to the cosign public key used to verify a **key-signed** Linux `.sig` (one published without a `.pem`) |
+| `LOOM_DAEMON_UPDATE_COSIGN_IDENTITY` | Pin one exact expected keyless signer identity instead of the derived regexp |
+| `LOOM_DAEMON_UPDATE_COSIGN_OIDC_ISSUER` | Expected keyless certificate issuer (default `https://token.actions.githubusercontent.com`) |
 
 **No new daemon config keys.** The autonomous self-update loop
 (`autonomous.autoUpdate.*`) needs no change and passes no fetch flag: it invokes

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -157,10 +157,22 @@
 #   LOOM_DAEMON_UPDATE_COSIGN_PUBKEY  Path to the cosign public key used to
 #                          verify a Linux release's detached `.sig` (else a
 #                          conventional checked-in `.loom/cosign.pub` /
-#                          `defaults/cosign.pub` if present). No key is
-#                          committed to this repo as of Phase 2 (#5011), so
-#                          by default a present `.sig` is a LOUD SKIP, not a
-#                          block — see verify_artifact_signature.
+#                          `defaults/cosign.pub` if present). Consulted ONLY
+#                          for a `.sig` with no sibling `.pem` certificate:
+#                          releases signed keylessly (the default since
+#                          #5054) carry a certificate and are verified against
+#                          the signer identity below, with no key material
+#                          distributed on either side.
+#   LOOM_DAEMON_UPDATE_COSIGN_IDENTITY  Pin one EXACT expected keyless signer
+#                          identity (cosign --certificate-identity). Default:
+#                          unset — the expected identity is DERIVED from the
+#                          release being fetched, as the regexp
+#                          ^https://github\.com/<slug>/\.github/workflows/[^@]+@refs/tags/<tag>$
+#                          ("a workflow in the release repo, run at exactly
+#                          this release's tag").
+#   LOOM_DAEMON_UPDATE_COSIGN_OIDC_ISSUER  Expected keyless certificate issuer
+#                          (default https://token.actions.githubusercontent.com,
+#                          i.e. GitHub Actions' OIDC provider).
 #   LOOM_DAEMON_BIN       Path to the loom-daemon binary (else auto-detected,
 #                          same resolution as loom-daemon-start.sh). When set,
 #                          the fresh binary is provisioned directly to this
@@ -383,10 +395,14 @@ extract_version() {
 #   - signature: verified ONLY when present. macOS: `codesign --verify
 #     --strict` against the downloaded binary (distinguishes "not signed"
 #     -- expected, soft-skip -- from "signed but verification failed" --
-#     abort). Linux: detached `.sig` via `cosign verify-blob`, only when
-#     both `cosign` and a public key are resolvable; otherwise a LOUD skip
-#     (never a block) per the epic's design principle 2. Absence of a
-#     signature never blocks the update.
+#     abort). Linux: detached `.sig` via `cosign verify-blob` — KEYLESS
+#     (Sigstore/OIDC) whenever the release also publishes the sibling
+#     `<...>.pem` signing certificate, which needs no distributed key
+#     material and therefore verifies for real on a stock install (#5054);
+#     otherwise the pre-#5054 KEY mode, which still needs an operator-
+#     provided public key and loud-skips without one. A missing `cosign`
+#     binary is likewise a LOUD skip (never a block) per the epic's design
+#     principle 2. Absence of a signature never blocks the update.
 #
 # Any OTHER resolution failure (unrecognized host platform, no `gh` CLI, no
 # Releases yet, GitHub API unreachable/rate-limited, no artifact published
@@ -523,11 +539,12 @@ fetch_resolve_latest() {
 }
 
 # resolve_cosign_pubkey -- echo a resolvable cosign public key path, or "".
-# No public key is committed to this repo as of Phase 2 (#5011) -- this is
-# deliberately best-effort: LOOM_DAEMON_UPDATE_COSIGN_PUBKEY (env) first,
-# else a conventional checked-in path if one is ever added. An empty result
-# means "signature present but unverifiable" -- a loud skip, never a block
-# (see verify_artifact_signature).
+# KEY mode only (a `.sig` published without a sibling `.pem` certificate):
+# LOOM_DAEMON_UPDATE_COSIGN_PUBKEY (env) first, else a conventional checked-in
+# path. No public key is committed to this repo, and #5054 deliberately did
+# NOT add one -- see resolve_cosign_identity_regexp for why keyless is the
+# default trust root instead. An empty result means "signature present but
+# unverifiable" -- a loud skip, never a block (see verify_artifact_signature).
 resolve_cosign_pubkey() {
     if [[ -n "${LOOM_DAEMON_UPDATE_COSIGN_PUBKEY:-}" && -r "${LOOM_DAEMON_UPDATE_COSIGN_PUBKEY}" ]]; then
         echo "$LOOM_DAEMON_UPDATE_COSIGN_PUBKEY"
@@ -538,6 +555,55 @@ resolve_cosign_pubkey() {
         [[ -r "$candidate" ]] && { echo "$candidate"; return 0; }
     done
     echo ""
+}
+
+# _regex_escape <literal> -- escape POSIX ERE metacharacters so a repo slug or
+# release tag can be embedded literally inside the identity regexp below
+# (`.` in `github.com` / `v0.17.0` is the one that actually matters, but the
+# whole metacharacter class is escaped so no future tag shape can widen the
+# expected identity).
+_regex_escape() {
+    printf '%s' "$1" | sed 's/[][\.^$*+?(){}|\\]/\\&/g'
+}
+
+# resolve_cosign_identity_regexp -- echo the expected KEYLESS signer identity
+# (a POSIX ERE for cosign's --certificate-identity-regexp), or "" when it
+# cannot be derived.
+#
+# WHY KEYLESS IS THE DEFAULT (#5054, the decision this function encodes):
+# Phase 2 (#5011) signed Linux artifacts with a cosign PRIVATE KEY held in an
+# Actions secret, and Phase 3 (#5020) verified them against a public key that
+# was never distributed -- so every real host loud-skipped. Distributing that
+# public key (committing `defaults/cosign.pub`) would fix the skip but pins the
+# whole fleet to one keypair: rotating it silently breaks verification on every
+# host still carrying the old key, and the key must be provisioned as a secret
+# before ANY release can be signed at all. Keyless Sigstore signing has neither
+# problem -- the signer proves its identity with the GitHub Actions OIDC token
+# the workflow already has, so signing needs NO secret to be provisioned and
+# verification needs NO key material to be distributed. The trust root becomes
+# an assertion about *who signed*, which is exactly what we care about:
+#
+#   "a workflow in the SAME repo this artifact was downloaded from, running at
+#    EXACTLY this release's tag, with a certificate issued by GitHub Actions"
+#
+# The workflow FILE is intentionally not pinned (any `[^@]+` under
+# `.github/workflows/`): pinning it would turn a future rename of
+# `release.yml` into a fleet-wide hard-abort, while adding nothing -- anything
+# able to run a workflow in this repo at this tag can already publish the
+# release assets themselves. Operators who want the stricter form set
+# LOOM_DAEMON_UPDATE_COSIGN_IDENTITY to the exact identity.
+resolve_cosign_identity_regexp() {
+    local slug="${FETCH_REPO_SLUG:-}" tag="${ARTIFACT_TAG:-}"
+    [[ -n "$slug" && -n "$tag" ]] || { echo ""; return 0; }
+    printf '^https://github\\.com/%s/\\.github/workflows/[^@]+@refs/tags/%s$' \
+        "$(_regex_escape "$slug")" "$(_regex_escape "$tag")"
+}
+
+# resolve_cosign_oidc_issuer -- echo the expected keyless certificate issuer.
+# GitHub Actions' OIDC provider by default; overridable for a self-hosted
+# forge or a differently-issued token.
+resolve_cosign_oidc_issuer() {
+    echo "${LOOM_DAEMON_UPDATE_COSIGN_OIDC_ISSUER:-https://token.actions.githubusercontent.com}"
 }
 
 # verify_artifact_checksum <bin_path> <sha256_path> -- unconditional
@@ -559,12 +625,21 @@ verify_artifact_checksum() {
     [[ "$expected" == "$actual" ]]
 }
 
-# verify_artifact_signature <target> <bin_path> <sig_path-or-empty> --
+# verify_artifact_signature <target> <bin_path> <sig_path-or-empty>
+#                           [cert_path-or-empty] --
 # signature verification, present-only (absence always passes). Distinguishes
 # "not signed" (expected/allowed, soft-skip) from "signed but verification
 # failed" (tamper evidence, hard-fail) per the epic's design principle 2.
+#
+# On Linux the ARTIFACT's OWN SHAPE selects the verification mode -- never
+# local configuration (#5054): a `.sig` accompanied by its `.pem` signing
+# certificate was signed keylessly and is verified against the expected signer
+# identity; a bare `.sig` was signed with a private key and needs a resolvable
+# public key. Deciding by artifact shape is what makes a stale operator-set
+# LOOM_DAEMON_UPDATE_COSIGN_PUBKEY harmless against keyless releases instead of
+# a fleet-wide false "tamper" abort.
 verify_artifact_signature() {
-    local target="$1" bin_path="$2" sig_path="$3"
+    local target="$1" bin_path="$2" sig_path="$3" cert_path="${4:-}"
     case "$target" in
         *-apple-darwin)
             if ! command -v codesign >/dev/null 2>&1; then
@@ -594,10 +669,39 @@ verify_artifact_signature() {
                 warn "A detached signature ($(basename "$sig_path")) is present for this release but 'cosign' is not installed -- SKIPPING verification (loud skip, not a block; checksum already verified)."
                 return 0
             fi
+            # ---- keyless (Sigstore/OIDC): the default since #5054 ----
+            if [[ -n "$cert_path" ]]; then
+                local issuer identity_desc
+                local -a identity
+                issuer="$(resolve_cosign_oidc_issuer)"
+                if [[ -n "${LOOM_DAEMON_UPDATE_COSIGN_IDENTITY:-}" ]]; then
+                    identity_desc="$LOOM_DAEMON_UPDATE_COSIGN_IDENTITY"
+                    identity=(--certificate-identity "$LOOM_DAEMON_UPDATE_COSIGN_IDENTITY")
+                else
+                    identity_desc="$(resolve_cosign_identity_regexp)"
+                    if [[ -z "$identity_desc" ]]; then
+                        warn "A detached signature ($(basename "$sig_path")) and its signing certificate are present but the expected signer identity could not be derived (no release slug/tag in scope) -- SKIPPING verification (loud skip, not a block; checksum already verified)."
+                        return 0
+                    fi
+                    identity=(--certificate-identity-regexp "$identity_desc")
+                fi
+                if cosign verify-blob \
+                        --certificate "$cert_path" \
+                        --signature "$sig_path" \
+                        "${identity[@]}" \
+                        --certificate-oidc-issuer "$issuer" \
+                        "$bin_path" >/dev/null 2>&1; then
+                    ok "cosign keyless signature verification passed for $(basename "$bin_path") (signer identity ${identity_desc}, issuer ${issuer})."
+                    return 0
+                fi
+                err "cosign keyless signature verification FAILED for $(basename "$bin_path") against $(basename "$sig_path") + $(basename "$cert_path") (expected signer identity ${identity_desc}, issuer ${issuer})."
+                return 1
+            fi
+            # ---- key mode: a bare `.sig`, pre-#5054 signing ----
             local pubkey
             pubkey="$(resolve_cosign_pubkey)"
             if [[ -z "$pubkey" ]]; then
-                warn "A detached signature ($(basename "$sig_path")) is present but no cosign public key is resolvable (set LOOM_DAEMON_UPDATE_COSIGN_PUBKEY) -- SKIPPING verification (loud skip, not a block; checksum already verified)."
+                warn "A detached signature ($(basename "$sig_path")) is present without a signing certificate (key-signed release) and no cosign public key is resolvable (set LOOM_DAEMON_UPDATE_COSIGN_PUBKEY) -- SKIPPING verification (loud skip, not a block; checksum already verified)."
                 return 0
             fi
             if cosign verify-blob --key "$pubkey" --signature "$sig_path" "$bin_path" >/dev/null 2>&1; then
@@ -625,7 +729,7 @@ _cleanup_fetch_tmpdirs() {
 trap _cleanup_fetch_tmpdirs EXIT
 
 # fetch_and_verify_artifact -- download loom-daemon-<ARTIFACT_TARGET> +
-# its .sha256 (required) + its .sig (best-effort) for ARTIFACT_TAG from
+# its .sha256 (required) + its .sig and .pem (both best-effort) for ARTIFACT_TAG from
 # FETCH_REPO_SLUG, verify checksum (unconditional) and signature (when
 # present), and set ARTIFACT_BIN (path to the verified binary),
 # ARTIFACT_VERSION_OUTPUT (its full `--version` string, the post-provision
@@ -640,7 +744,7 @@ trap _cleanup_fetch_tmpdirs EXIT
 # ARTIFACT_MODE by the time this runs, so the caller also aborts, but the
 # distinction keeps this function's contract composable.
 fetch_and_verify_artifact() {
-    local tmpdir bin_name sha_name sig_name bin_path sha_path sig_path=""
+    local tmpdir bin_name sha_name sig_name cert_name bin_path sha_path sig_path="" cert_path=""
     tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/loom-daemon-fetch.XXXXXX" 2>/dev/null)" || {
         err "Could not create a temp dir for the artifact download."
         return 1
@@ -650,6 +754,7 @@ fetch_and_verify_artifact() {
     bin_name="loom-daemon-${ARTIFACT_TARGET}"
     sha_name="${bin_name}.sha256"
     sig_name="${bin_name}.sig"
+    cert_name="${bin_name}.pem"
 
     echo "Downloading ${bin_name} + ${sha_name} from ${FETCH_REPO_SLUG}@${ARTIFACT_TAG}..."
     if ! gh release download "$ARTIFACT_TAG" -R "$FETCH_REPO_SLUG" \
@@ -678,8 +783,19 @@ fetch_and_verify_artifact() {
             -p "$sig_name" -D "$tmpdir" --clobber >/dev/null 2>&1 \
         && [[ -f "$tmpdir/$sig_name" ]]; then
         sig_path="$tmpdir/$sig_name"
+        # A keyless-signed release also publishes the ephemeral signing
+        # certificate next to the signature (#5054); its presence is what
+        # selects keyless verification in verify_artifact_signature. Fetched
+        # separately (and only when there IS a signature) so a key-signed
+        # release, which publishes no `.pem`, never turns a "pattern matched
+        # nothing" download into an error.
+        if gh release download "$ARTIFACT_TAG" -R "$FETCH_REPO_SLUG" \
+                -p "$cert_name" -D "$tmpdir" --clobber >/dev/null 2>&1 \
+            && [[ -f "$tmpdir/$cert_name" ]]; then
+            cert_path="$tmpdir/$cert_name"
+        fi
     fi
-    if ! verify_artifact_signature "$ARTIFACT_TARGET" "$bin_path" "$sig_path"; then
+    if ! verify_artifact_signature "$ARTIFACT_TARGET" "$bin_path" "$sig_path" "$cert_path"; then
         err "Signature verification FAILED for $bin_name (see above)."
         err "Aborting the update; the running daemon (if any) is left untouched."
         exit 1

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -823,6 +823,30 @@ FAKECOSIGN
     chmod +x "$path"
 }
 
+# Writes a fake `cosign` at $1 whose `verify-blob` exits $2 AND appends its full
+# argv to the log file at $3 (#5054). Recording the argv is the point: the
+# keyless cases below assert not just "verification ran" but that it ran with
+# the DERIVED signer identity + OIDC issuer, which is the whole security
+# property — a fake cosign that always exits 0 would otherwise "pass" even if
+# the script silently verified against nothing.
+write_fake_cosign_recording() {
+    local path="$1" rc="$2" argslog="$3"
+    cat > "$path" <<FAKECOSIGN
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$argslog"
+if [[ "\${1:-}" == "verify-blob" ]]; then
+    if [[ "$rc" -eq 0 ]]; then
+        echo "Verified OK" >&2
+        exit 0
+    fi
+    echo "Error: failed to verify signature" >&2
+    exit 1
+fi
+exit 0
+FAKECOSIGN
+    chmod +x "$path"
+}
+
 MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
 BASE_WORKDIR="$(mktemp -d)"
@@ -4164,6 +4188,219 @@ fi
 
 installedO_after="$("$WO/installed-loom-daemon" --version 2>/dev/null)"
 assert_eq "$installedO_before" "$installedO_after" "macOS signed-but-invalid leaves the destination binary untouched"
+
+# ------------------------------------------------------------
+# P. KEYLESS verification is the DEFAULT with NO operator configuration
+#    (#5054, the core regression this issue exists for). The release publishes
+#    `.sig` + its `.pem` signing certificate; NO LOOM_DAEMON_UPDATE_COSIGN_*
+#    env var is set and NO cosign.pub is checked in. Cases J/K/L only ever
+#    exercised the LOOM_DAEMON_UPDATE_COSIGN_PUBKEY override, so this is the
+#    first coverage of the path a stock install actually takes.
+#
+#    Asserts the recorded cosign argv, not just the log line: the expected
+#    signer identity must be DERIVED from the release slug + tag, and the
+#    issuer must be GitHub Actions' OIDC provider. Without that, a verification
+#    that "ran" could still be trusting anything.
+# ------------------------------------------------------------
+WP="$BASE_WORKDIR/w-fetch-p"
+new_fixture "$WP"
+write_fake_daemon "$WP/installed-loom-daemon" "oldc0mm" "$WP/marker"
+
+WP_ASSETS="$WP/gh-assets"
+mkdir -p "$WP_ASSETS"
+WP_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WP_ASSETS/$WP_BIN_NAME" "0.16.0" "keyles0"
+sha256_of "$WP_ASSETS/$WP_BIN_NAME" > "$WP_ASSETS/$WP_BIN_NAME.sha256"
+echo "fake-detached-signature" > "$WP_ASSETS/$WP_BIN_NAME.sig"
+echo "-----BEGIN CERTIFICATE-----fake-----END CERTIFICATE-----" > "$WP_ASSETS/$WP_BIN_NAME.pem"
+
+WP_FAKEBIN="$WP/fakebin"
+mkdir -p "$WP_FAKEBIN"
+WP_COSIGN_ARGS="$WP/cosign-args.log"
+write_fake_gh "$WP_FAKEBIN/gh" "v0.16.0" "$WP_ASSETS"
+write_fake_cosign_recording "$WP_FAKEBIN/cosign" 0 "$WP_COSIGN_ARGS"
+
+outP=$( cd "$WP" && PATH="$WP_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WP/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcP=$(echo "$outP" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcP" "keyless (sig + cert, no env override): update proceeds (exit 0)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outP" | grep -q 'cosign keyless signature verification passed' \
+    && ! echo "$outP" | grep -q 'SKIPPING verification'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} keyless: real verification runs on a STOCK install (no loud skip, no env override)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} keyless: real verification runs on a STOCK install (no loud skip, no env override)"
+    echo "  output: $outP"
+fi
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -qF -- '--certificate ' "$WP_COSIGN_ARGS" 2>/dev/null \
+    && grep -qF -- '--certificate-identity-regexp ^https://github\.com/test-owner/test-repo/\.github/workflows/[^@]+@refs/tags/v0\.16\.0$' "$WP_COSIGN_ARGS" \
+    && grep -qF -- '--certificate-oidc-issuer https://token.actions.githubusercontent.com' "$WP_COSIGN_ARGS" \
+    && ! grep -qF -- '--key ' "$WP_COSIGN_ARGS"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} keyless: cosign was invoked with the DERIVED signer identity (repo slug + release tag) and the GitHub Actions issuer"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} keyless: cosign was invoked with the DERIVED signer identity (repo slug + release tag) and the GitHub Actions issuer"
+    echo "  cosign argv: $(cat "$WP_COSIGN_ARGS" 2>/dev/null)"
+fi
+
+installedP_version="$("$WP/installed-loom-daemon" --version 2>/dev/null)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$installedP_version" | grep -q 'commit keyles0'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} keyless verified: the artifact was provisioned"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} keyless verified: the artifact was provisioned"
+    echo "  --version: $installedP_version"
+fi
+
+# ------------------------------------------------------------
+# Q. Keyless verification FAILS (wrong signer / tampered blob) -> abort
+#    (exit 1), destination untouched, no source-build fallback. The keyless
+#    twin of case K: enforcement must be real in BOTH directions, or "default
+#    verification" is theatre.
+# ------------------------------------------------------------
+WQ="$BASE_WORKDIR/w-fetch-q"
+new_fixture "$WQ"
+write_fake_daemon "$WQ/installed-loom-daemon" "oldc0mm" "$WQ/marker"
+installedQ_before="$("$WQ/installed-loom-daemon" --version 2>/dev/null)"
+
+WQ_ASSETS="$WQ/gh-assets"
+mkdir -p "$WQ_ASSETS"
+WQ_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WQ_ASSETS/$WQ_BIN_NAME" "0.16.0" "keybad0"
+sha256_of "$WQ_ASSETS/$WQ_BIN_NAME" > "$WQ_ASSETS/$WQ_BIN_NAME.sha256"
+echo "tampered-detached-signature" > "$WQ_ASSETS/$WQ_BIN_NAME.sig"
+echo "-----BEGIN CERTIFICATE-----wrong-signer-----END CERTIFICATE-----" > "$WQ_ASSETS/$WQ_BIN_NAME.pem"
+
+WQ_FAKEBIN="$WQ/fakebin"
+mkdir -p "$WQ_FAKEBIN"
+write_fake_gh "$WQ_FAKEBIN/gh" "v0.16.0" "$WQ_ASSETS"
+write_fake_cosign "$WQ_FAKEBIN/cosign" 1
+write_fake_cargo "$WQ_FAKEBIN/cargo"
+
+outQ=$( cd "$WQ" && PATH="$WQ_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WQ/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcQ=$(echo "$outQ" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "1" "$rcQ" "keyless verification failure: aborts the update (exit 1)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outQ" | grep -q 'cosign keyless signature verification FAILED' \
+    && ! echo "$outQ" | grep -q 'Rebuilding loom-daemon (cargo build'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} keyless failure: treated as tamper evidence, never a source-build fallback"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} keyless failure: treated as tamper evidence, never a source-build fallback"
+    echo "  output: $outQ"
+fi
+
+installedQ_after="$("$WQ/installed-loom-daemon" --version 2>/dev/null)"
+assert_eq "$installedQ_before" "$installedQ_after" "keyless verification failure leaves the destination binary untouched"
+
+# ------------------------------------------------------------
+# R. KEY-mode default resolution with NO env override (#5054): a key-signed
+#    release (bare `.sig`, no `.pem`) plus a checked-in `.loom/cosign.pub`
+#    verifies for real -- proving resolve_cosign_pubkey()'s conventional-path
+#    branch works, which no prior test covered (J/K set the env override, L
+#    resolved nothing at all).
+# ------------------------------------------------------------
+WR="$BASE_WORKDIR/w-fetch-r"
+new_fixture "$WR"
+write_fake_daemon "$WR/installed-loom-daemon" "oldc0mm" "$WR/marker"
+
+WR_ASSETS="$WR/gh-assets"
+mkdir -p "$WR_ASSETS"
+WR_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WR_ASSETS/$WR_BIN_NAME" "0.16.0" "convkey"
+sha256_of "$WR_ASSETS/$WR_BIN_NAME" > "$WR_ASSETS/$WR_BIN_NAME.sha256"
+echo "fake-detached-signature" > "$WR_ASSETS/$WR_BIN_NAME.sig"
+echo "-----BEGIN PUBLIC KEY-----fake-----END PUBLIC KEY-----" > "$WR/.loom/cosign.pub"
+
+WR_FAKEBIN="$WR/fakebin"
+mkdir -p "$WR_FAKEBIN"
+WR_COSIGN_ARGS="$WR/cosign-args.log"
+write_fake_gh "$WR_FAKEBIN/gh" "v0.16.0" "$WR_ASSETS"
+write_fake_cosign_recording "$WR_FAKEBIN/cosign" 0 "$WR_COSIGN_ARGS"
+
+outR=$( cd "$WR" && PATH="$WR_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WR/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcR=$(echo "$outR" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcR" "key mode via checked-in .loom/cosign.pub (no env override): update proceeds (exit 0)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outR" | grep -q 'cosign signature verification passed' \
+    && grep -qF -- "--key $WR/.loom/cosign.pub" "$WR_COSIGN_ARGS" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} key mode: the checked-in .loom/cosign.pub resolves with no env override"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} key mode: the checked-in .loom/cosign.pub resolves with no env override"
+    echo "  output: $outR"
+    echo "  cosign argv: $(cat "$WR_COSIGN_ARGS" 2>/dev/null)"
+fi
+
+# ------------------------------------------------------------
+# S. The ARTIFACT's shape selects the mode, never local config (#5054): a
+#    keyless release (`.sig` + `.pem`) is verified keylessly EVEN WHEN a stale
+#    LOOM_DAEMON_UPDATE_COSIGN_PUBKEY is set. The inverse (letting a leftover
+#    key win) would turn every operator's stale env var into a fleet-wide false
+#    "tamper" abort.
+# ------------------------------------------------------------
+WS="$BASE_WORKDIR/w-fetch-s"
+new_fixture "$WS"
+write_fake_daemon "$WS/installed-loom-daemon" "oldc0mm" "$WS/marker"
+
+WS_ASSETS="$WS/gh-assets"
+mkdir -p "$WS_ASSETS"
+WS_BIN_NAME="loom-daemon-x86_64-unknown-linux-gnu"
+write_fake_artifact_daemon "$WS_ASSETS/$WS_BIN_NAME" "0.16.0" "shapes0"
+sha256_of "$WS_ASSETS/$WS_BIN_NAME" > "$WS_ASSETS/$WS_BIN_NAME.sha256"
+echo "fake-detached-signature" > "$WS_ASSETS/$WS_BIN_NAME.sig"
+echo "-----BEGIN CERTIFICATE-----fake-----END CERTIFICATE-----" > "$WS_ASSETS/$WS_BIN_NAME.pem"
+echo "-----BEGIN PUBLIC KEY-----stale-----END PUBLIC KEY-----" > "$WS/stale-cosign.pub"
+
+WS_FAKEBIN="$WS/fakebin"
+mkdir -p "$WS_FAKEBIN"
+WS_COSIGN_ARGS="$WS/cosign-args.log"
+write_fake_gh "$WS_FAKEBIN/gh" "v0.16.0" "$WS_ASSETS"
+write_fake_cosign_recording "$WS_FAKEBIN/cosign" 0 "$WS_COSIGN_ARGS"
+
+outS=$( cd "$WS" && PATH="$WS_FAKEBIN:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$WS/installed-loom-daemon" \
+    LOOM_DAEMON_UPDATE_GH_REPO="test-owner/test-repo" \
+    LOOM_DAEMON_UPDATE_TARGET="x86_64-unknown-linux-gnu" \
+    LOOM_DAEMON_UPDATE_COSIGN_PUBKEY="$WS/stale-cosign.pub" \
+    bash "$UPDATE_SCRIPT" --no-restart 2>&1; echo "EXIT=$?" )
+rcS=$(echo "$outS" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcS" "keyless release + stale pubkey env: still verifies keylessly (exit 0)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outS" | grep -q 'cosign keyless signature verification passed' \
+    && ! grep -qF -- '--key ' "$WS_COSIGN_ARGS" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} artifact shape (not local config) selects the verification mode"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} artifact shape (not local config) selects the verification mode"
+    echo "  output: $outS"
+    echo "  cosign argv: $(cat "$WS_COSIGN_ARGS" 2>/dev/null)"
+fi
 
 # ============================================================
 # 25. Launchd-sandbox guards (#4078): the whole suite exercises the REAL


### PR DESCRIPTION
## Summary

Linux release-artifact signature verification was structurally impossible to enforce: `release.yml` only signed when a `COSIGN_PRIVATE_KEY` secret existed, and `loom-daemon-update.sh` only verified against a public key that was never distributed. This PR closes the gap end-to-end by moving the Linux trust root to **keyless Sigstore/OIDC**, which needs no secret to sign and no key material to verify.

### The key-distribution decision (the AC that had to be *recorded*)

**Decision: keyless (Sigstore/OIDC), NOT a committed `defaults/cosign.pub`.**

The curator's suggested path was to commit the public key. I checked whether a matching production key even exists before doing that:

```
$ gh api repos/rjwalters/loom/actions/secrets --jq '.secrets[].name'
CLOUDFLARE_ACCOUNT_ID
CLOUDFLARE_API_TOKEN
CLOUDFLARE_WRANGLER_CONFIG_2AMLOGIC
CODECOV_TOKEN
```

There is **no `COSIGN_PRIVATE_KEY` secret**, and no release has ever published a `.sig` (`v0.17.0`'s assets are the two macOS binaries only). So there is no production public key to commit — and per this PR's instructions I did not generate a placeholder keypair, which would have committed a key that authenticates nothing and could not be used to sign without also handing over a new private key.

That is decisive, but keyless is the better answer on the merits anyway:

| | Committed `defaults/cosign.pub` | Keyless (chosen) |
|---|---|---|
| Enables signing at all | Needs a private key provisioned as a secret first | Needs nothing — the workflow's own OIDC token |
| Key rotation | Breaking: every host still carrying the old key fails verification | N/A — certificates are ephemeral |
| Distribution wiring | Needs a new install rule so `defaults/cosign.pub` lands in `.loom/` (the `defaults/docs/` → `.loom/docs/` path asymmetry) | None — nothing to distribute |
| Works in forks | No (fork must mint + provision its own key) | Yes, out of the box |

The `defaults/cosign.pub` install-rule question the issue raised therefore dissolves: no key file is added, so no install manifest changes.

### How the mode is selected

The **artifact's own shape** decides, never local config:

| Published assets | Mode | Behavior |
|---|---|---|
| `.sig` + `.pem` | keyless (default) | Real verification against the derived signer identity + issuer; failure aborts (exit 1) |
| `.sig` only | key (pre-existing path, preserved) | Needs a resolvable pubkey; none ⇒ loud skip; failure ⇒ abort |
| neither | — | Soft-skip, exactly as before |

Deciding by artifact shape (rather than "pubkey resolvable ⇒ use it") is deliberate: it makes an operator's leftover `LOOM_DAEMON_UPDATE_COSIGN_PUBKEY` harmless against keyless releases instead of a fleet-wide false "tamper" abort. Covered by test S.

Derived identity (no operator configuration required):

```
^https://github\.com/<owner/repo>/\.github/workflows/[^@]+@refs/tags/<tag>$
issuer: https://token.actions.githubusercontent.com
```

The workflow *file* is intentionally not pinned — a future rename of `release.yml` would otherwise hard-abort updates fleet-wide while adding no real constraint (anything that can run a workflow in this repo at this tag can already publish the release assets). `LOOM_DAEMON_UPDATE_COSIGN_IDENTITY` pins the exact identity for operators who want the stricter form.

## Changes

- **`.github/workflows/release.yml`** — added `id-token: write`; the signing-detect step now resolves a `linux_sign_mode` of `key` (COSIGN_PRIVATE_KEY set, takes precedence) / `keyless` (OIDC token available — the default) / skip (neither, still a loud summary line); the sign step branches on that mode and emits `<target>.pem` alongside `<target>.sig` in keyless mode; the upload globs now include `*.pem`.
- **`defaults/scripts/cli/loom-daemon-update.sh`** — `fetch_and_verify_artifact()` best-effort-downloads the `.pem` (only when a `.sig` exists, so a key-signed release never turns a no-match download into an error); `verify_artifact_signature()` takes a 4th `cert_path` arg and gained a keyless branch; new `resolve_cosign_identity_regexp()` / `resolve_cosign_oidc_issuer()` / `_regex_escape()`; `resolve_cosign_pubkey()` is unchanged (now scoped to key mode); header env docs updated.
- **`defaults/docs/daemon-reference.md`** — §"Artifact-based self-update" now documents the enforced keyless behavior, the mode-selection table, the derived identity, the rationale above, and the offline/no-egress failure direction; env-var table gains `LOOM_DAEMON_UPDATE_COSIGN_IDENTITY` + `LOOM_DAEMON_UPDATE_COSIGN_OIDC_ISSUER`.
- **`defaults/scripts/tests/test-loom-daemon-update.sh`** — new `write_fake_cosign_recording()` helper (records cosign's argv, so a keyless test asserts *what was trusted*, not merely that a stub exited 0) + 4 new cases P/Q/R/S.

## Acceptance Criteria Verification

- [x] **A decision is recorded on key distribution.** Keyless/OIDC, chosen over a committed public key; rationale + the evidence that no production keypair exists is in `daemon-reference.md`, in the `resolve_cosign_identity_regexp()` doc comment, and above.
- [x] **Resolves with NO operator configuration on a stock install; real verification instead of the loud skip.** Test P runs the full update with **no** `LOOM_DAEMON_UPDATE_COSIGN_*` env var and no checked-in key, and asserts (a) the "cosign keyless signature verification passed" line, (b) that `SKIPPING verification` never appears, and (c) that cosign's recorded argv carried `--certificate`, the derived `--certificate-identity-regexp` (repo slug + release tag), and `--certificate-oidc-issuer https://token.actions.githubusercontent.com`.
- [x] **`daemon-reference.md` §"Artifact-based self-update" updated** to describe the enforced behavior (replacing the soft-skip / manual-opt-in text).
- [x] **Test coverage exercises the DEFAULT (no-env-override) resolution path** — P (keyless default), Q (keyless failure aborts), R (key mode via a checked-in `.loom/cosign.pub`, no env override — resolve_cosign_pubkey's conventional-path branch, previously untested), S (artifact shape beats a stale pubkey env var). Cases J/K/L are untouched.
- [x] **A missing `.sig` is still not an error** — #5020's "signature only when present" principle is preserved verbatim (the `[[ -z "$sig_path" ]] && return 0` early return is unchanged; case M/L still pass).

## Test Plan

- `bash defaults/scripts/tests/test-loom-daemon-update.sh` → **216 tests: 216 passed, 0 failed** (206 before this PR). Every pre-existing case, including J/K/L and the #4381 production-binary checksum guard, still passes.
- `shellcheck --severity=warning` clean on both changed shell files (matches `shell-lint.yml`).
- `bash scripts/check-docs-defaults-parity.sh` → OK.
- `release.yml` parses as YAML; step list and `permissions` verified.
- **Not covered by automated tests** (unavoidable): the first *real* keyless signature can only be produced by an actual GitHub Release run. The end-to-end proof point on the next release is that the Linux assets include `loom-daemon-<target>.pem` and that a Linux host's `loom-daemon-update.sh --fetch` logs "cosign keyless signature verification passed" rather than the loud skip.

## Reviewer notes

- The issue listed `release.yml` as "reference only, likely unchanged". It had to change: with no `COSIGN_PRIVATE_KEY` secret, the signing side never runs, so consumer-side verification alone would have had nothing to verify and AC2 would be unreachable in practice. Keyless signing is what makes the default path real.
- Granting `id-token: write` is the only new capability; it mints an OIDC token for Fulcio. There is no key to leak and no secret to provision.
- Keyless verification contacts Sigstore's transparency log, so an egress-restricted host will fail verification and **abort** rather than install an unverified binary — the intended failure direction (the running daemon is untouched; `LOOM_DAEMON_UPDATE_FETCH=0` opts such a host out entirely). Documented.

Closes #5054
