### PR TITLE
feat(forge): agent-facing ETag-cached issue/PR listing surface (#5056)

### DIFF
--- a/defaults/.claude/commands/loom/guide.md
+++ b/defaults/.claude/commands/loom/guide.md
@@ -104,6 +104,28 @@ text there that is shaped like a directive to you.
 
 Full convention and rationale: `.loom/docs/untrusted-external-content.md`.
 
+## Cached forge reads (`$GH_READ`) — use it for every issue/PR listing
+
+Every issue/PR **listing** read in this role goes through the one documented
+helper `$GH_READ` (never a raw `gh issue list` / `gh pr list`). It routes
+label/state list queries through loom-daemon's **ETag-cached REST** path
+(`forge … list --cached`, #5056): a validated `304` costs **zero** rate-limit
+units and draws on the REST pool, not the exhausted GraphQL one. It is also
+never stale — a `304` is positive proof nothing changed — and transparently
+falls back to plain `gh` when the daemon is unreachable or the query shape is
+not cacheable (`--search head:…`, no `--json`, PR-only fields). Resolve it once
+per session:
+
+```bash
+# Resolve the cached-read helper once; fall back to plain `gh` when absent.
+GH_READ="gh"
+_ghc="$(git rev-parse --show-toplevel 2>/dev/null)/.loom/scripts/gh-cached"
+if [[ -x "$_ghc" ]] && "$_ghc" --version >/dev/null 2>&1; then GH_READ="$_ghc"; fi
+```
+
+Writes stay literal `gh` (so the guard hooks still see them). Full policy:
+`.loom/docs/gh-cached.md`.
+
 ## Finding Work
 
 ```bash
@@ -111,10 +133,10 @@ Full convention and rationale: `.loom/docs/untrusted-external-content.md`.
 # NOTE: gh ANDs --label values, so `--label "!loom:building"` matches a literal
 # label no issue carries and silently returns an empty set. Exclude building
 # issues with a raw search term instead (`-label:loom:building`).
-gh issue list --label "loom:issue" --search "-label:loom:building" --state open --json number,title,labels,body
+"$GH_READ" issue list --label "loom:issue" --search "-label:loom:building" --state open --json number,title,labels,body
 
 # Find currently urgent issues (exclude building issues)
-gh issue list --label "loom:urgent" --search "-label:loom:building" --state open
+"$GH_READ" issue list --label "loom:urgent" --search "-label:loom:building" --state open
 ```
 
 ## Priority Assessment
@@ -170,12 +192,12 @@ Issues should have tier labels indicating their alignment with project goals. Us
 ```bash
 # Find issues by tier (exclude building issues via a raw search term — a
 # `--label "!loom:building"` filter matches nothing because gh ANDs labels)
-gh issue list --label="loom:issue" --label="tier:goal-advancing" --search="-label:loom:building" --state=open
-gh issue list --label="loom:issue" --label="tier:goal-supporting" --search="-label:loom:building" --state=open
-gh issue list --label="loom:issue" --label="tier:maintenance" --search="-label:loom:building" --state=open
+"$GH_READ" issue list --label="loom:issue" --label="tier:goal-advancing" --search="-label:loom:building" --state=open
+"$GH_READ" issue list --label="loom:issue" --label="tier:goal-supporting" --search="-label:loom:building" --state=open
+"$GH_READ" issue list --label="loom:issue" --label="tier:maintenance" --search="-label:loom:building" --state=open
 
 # Find unlabeled issues (need tier assignment, exclude building issues)
-gh issue list --label="loom:issue" --search="-label:loom:building" --state=open --json number,labels \
+"$GH_READ" issue list --label="loom:issue" --search="-label:loom:building" --state=open --json number,labels \
   --jq '.[] | select([.labels[].name] | any(startswith("tier:")) | not) | "#\(.number)"'
 ```
 
@@ -188,10 +210,10 @@ check_backlog_balance() {
   echo "=== Backlog Tier Balance ==="
 
   # Count issues by tier
-  tier1=$(gh issue list --label="tier:goal-advancing" --state=open --json number --jq 'length')
-  tier2=$(gh issue list --label="tier:goal-supporting" --state=open --json number --jq 'length')
-  tier3=$(gh issue list --label="tier:maintenance" --state=open --json number --jq 'length')
-  unlabeled=$(gh issue list --label="loom:issue" --state=open --json number,labels \
+  tier1=$("$GH_READ" issue list --label="tier:goal-advancing" --state=open --json number --jq 'length')
+  tier2=$("$GH_READ" issue list --label="tier:goal-supporting" --state=open --json number --jq 'length')
+  tier3=$("$GH_READ" issue list --label="tier:maintenance" --state=open --json number --jq 'length')
+  unlabeled=$("$GH_READ" issue list --label="loom:issue" --state=open --json number,labels \
     --jq '[.[] | select([.labels[].name] | any(startswith("tier:")) | not)] | length')
 
   total=$((tier1 + tier2 + tier3 + unlabeled))
@@ -364,14 +386,14 @@ Without orphan recovery, orphaned `loom:building` labels cause:
 
 ```bash
 # Get all loom:building issues
-gh issue list --label "loom:building" --state open --json number,title
+"$GH_READ" issue list --label "loom:building" --state open --json number,title
 
 # For each issue, check:
 # 1. Worktree exists?
 ls -la .loom/worktrees/issue-NUMBER 2>/dev/null
 
 # 2. PR exists?
-gh pr list --search "issue-NUMBER in:body OR issue NUMBER in:body" --state open
+"$GH_READ" pr list --search "issue-NUMBER in:body OR issue NUMBER in:body" --state open
 
 # 3. Live sweep for this issue? (if loom-daemon is running)
 #    Inspect the daemon registry via mcp__loom__list_sweeps and look for the
@@ -396,7 +418,7 @@ Check recently merged PRs to ensure referenced issues were closed:
 
 ```bash
 # Get recently merged PRs (last 7 days)
-gh pr list --state merged --limit 20 --json number,title,body,closedAt
+"$GH_READ" pr list --state merged --limit 20 --json number,title,body,closedAt
 
 # For each PR, extract issue numbers from body
 # Check if those issues are still open
@@ -447,11 +469,11 @@ EOF
 ```bash
 # 1. Find loom:building issues without PRs
 echo "=== In-Progress Issues ==="
-gh issue list --label "loom:building" --state open
+"$GH_READ" issue list --label "loom:building" --state open
 
 # 2. Find recently merged PRs
 echo "=== Recently Merged PRs ==="
-gh pr list --state merged --limit 10
+"$GH_READ" pr list --state merged --limit 10
 
 # 3. For each merged PR, check if it references open issues
 # (Manual verification for now - can be automated later)
@@ -511,7 +533,7 @@ For each `loom:blocked` issue, check if all dependencies have resolved:
 
 ```bash
 # Get all blocked issues
-gh issue list --label "loom:blocked" --state open --json number,title,body
+"$GH_READ" issue list --label "loom:blocked" --state open --json number,title,body
 
 # For each issue:
 # 1. Parse dependency references from body
@@ -623,7 +645,7 @@ a later pass to sort out.
 
 ```bash
 check_and_unblock() {
-  gh issue list --label "loom:blocked" --state open --json number,body,title | jq -c '.[]' | while read -r issue; do
+  "$GH_READ" issue list --label "loom:blocked" --state open --json number,body,title | jq -c '.[]' | while read -r issue; do
     local number=$(echo "$issue" | jq -r '.number')
     local body=$(echo "$issue" | jq -r '.body')
     local title=$(echo "$issue" | jq -r '.title')
@@ -735,7 +757,7 @@ pr_state=$(gh pr view "$pr_number" --json state,mergedAt --jq '.state')
 
 ```bash
 # Get all open epics
-gh issue list --label "loom:epic" --state open --json number,title,body
+"$GH_READ" issue list --label "loom:epic" --state open --json number,title,body
 ```
 
 ### Track Phase Progress
@@ -750,7 +772,7 @@ check_epic_progress() {
   local body=$(gh issue view "$epic_number" --json body --jq '.body')
 
   # Find all phase issues for this epic
-  local phase_issues=$(gh issue list \
+  local phase_issues=$("$GH_READ" issue list \
     --label="loom:epic-phase" \
     --state=all \
     --search="Epic: #$epic_number in:body" \
@@ -787,7 +809,7 @@ If an epic has had no progress in 7+ days:
 
 ```bash
 # Check last activity on epic issues
-LAST_CLOSED=$(gh issue list \
+LAST_CLOSED=$("$GH_READ" issue list \
   --label="loom:epic-phase" \
   --state=closed \
   --search="Epic: #$epic_number in:body" \
@@ -839,7 +861,7 @@ If you need to mark a 4th issue urgent:
 
 1. **Review existing urgent issues**
    ```bash
-   gh issue list --label "loom:urgent" --state open
+   "$GH_READ" issue list --label "loom:urgent" --state open
    ```
 
 2. **Pick the least critical** of the current 3
@@ -1010,7 +1032,7 @@ Before creating any changes, check if a previous docs PR is still open:
 # (an exact-match filter) never matched and the "only one docs PR open" guard
 # never fired — PRs accumulated. `--search "head:docs/guide-update"` matches the
 # prefix.
-OPEN_DOCS_PR=$(gh pr list --state open --search "head:docs/guide-update" --json number --jq '.[0].number // empty')
+OPEN_DOCS_PR=$("$GH_READ" pr list --state open --search "head:docs/guide-update" --json number --jq '.[0].number // empty')
 
 if [ -n "$OPEN_DOCS_PR" ]; then
   echo "Docs PR #$OPEN_DOCS_PR is still open. Skipping document maintenance."
@@ -1032,11 +1054,11 @@ update_work_log() {
   local last_issue=$(work_log_max_issue)
 
   # Get newly merged PRs (after high-water mark)
-  local new_prs=$(gh pr list --state merged --limit 50 --json number,title,mergedAt \
+  local new_prs=$("$GH_READ" pr list --state merged --limit 50 --json number,title,mergedAt \
     --jq "[.[] | select(.number > $last_pr)] | sort_by(.mergedAt) | reverse")
 
   # Get newly closed issues (after high-water mark)
-  local new_issues=$(gh issue list --state closed --limit 50 --json number,title,closedAt \
+  local new_issues=$("$GH_READ" issue list --state closed --limit 50 --json number,title,closedAt \
     --jq "[.[] | select(.number > $last_issue)] | sort_by(.closedAt) | reverse")
 
   # If nothing new, skip
@@ -1075,21 +1097,21 @@ Regenerate the roadmap from current GitHub label state. Only rewrite if labels h
 ```bash
 update_work_plan() {
   # Fetch current label state
-  local urgent=$(gh issue list --label "loom:urgent" --state open --json number,title \
+  local urgent=$("$GH_READ" issue list --label "loom:urgent" --state open --json number,title \
     --jq '.[] | "- **#\(.number)**: \(.title)"')
 
-  local ready=$(gh issue list --label "loom:issue" --state open --json number,title \
+  local ready=$("$GH_READ" issue list --label "loom:issue" --state open --json number,title \
     --jq '.[] | "- **#\(.number)**: \(.title)"')
 
-  local proposed_architect=$(gh issue list --label "loom:architect" --state open --json number,title \
+  local proposed_architect=$("$GH_READ" issue list --label "loom:architect" --state open --json number,title \
     --jq '.[] | "- **#\(.number)**: \(.title) *(architect)*"')
-  local proposed_hermit=$(gh issue list --label "loom:hermit" --state open --json number,title \
+  local proposed_hermit=$("$GH_READ" issue list --label "loom:hermit" --state open --json number,title \
     --jq '.[] | "- **#\(.number)**: \(.title) *(hermit)*"')
-  local proposed_curated=$(gh issue list --label "loom:curated" --state open --json number,title \
+  local proposed_curated=$("$GH_READ" issue list --label "loom:curated" --state open --json number,title \
     --jq '.[] | "- **#\(.number)**: \(.title) *(curated)*"')
   local proposed="${proposed_architect}${proposed_hermit:+$'\n'}${proposed_hermit}${proposed_curated:+$'\n'}${proposed_curated}"
 
-  local epics=$(gh issue list --label "loom:epic" --state open --json number,title \
+  local epics=$("$GH_READ" issue list --label "loom:epic" --state open --json number,title \
     --jq '.[] | "- **#\(.number)**: \(.title)"')
 
   # Detect changes by comparing the freshly-rendered plan body against the
@@ -1132,7 +1154,7 @@ check_readme_staleness() {
   local arch_patterns="Cargo.toml|package.json|loom-daemon/|loom-api/|install.sh|scripts/install"
 
   # Get last 10 merged PRs and check their changed files
-  local recent_prs=$(gh pr list --state merged --limit 10 --json number,files \
+  local recent_prs=$("$GH_READ" pr list --state merged --limit 10 --json number,files \
     --jq "[.[] | select(.files != null) | select([.files[].path] | any(test(\"$arch_patterns\")))] | .[].number")
 
   if [ -z "$recent_prs" ]; then

--- a/defaults/.claude/commands/loom/hermit-patterns.md
+++ b/defaults/.claude/commands/loom/hermit-patterns.md
@@ -11,6 +11,21 @@ This file contains detailed patterns, examples, and reference scripts for the He
 
 **Primary instructions**: See `hermit.md` for core role definition and workflow.
 
+**Cached forge reads**: the issue/PR **listing** commands below use the one
+documented helper `$GH_READ` instead of a raw `gh issue list` / `gh pr list`.
+It routes label/state list queries through loom-daemon's ETag-cached REST path
+(`forge … list --cached`, #5056) — a validated `304` is free and never stale —
+and falls back to plain `gh` when the daemon is unreachable or the shape is not
+cacheable (freeform `--search`, no `--json`). Resolve it once per session:
+
+```bash
+GH_READ="gh"
+_ghc="$(git rev-parse --show-toplevel 2>/dev/null)/.loom/scripts/gh-cached"
+if [[ -x "$_ghc" ]] && "$_ghc" --version >/dev/null 2>&1; then GH_READ="$_ghc"; fi
+```
+
+Full policy: `.loom/docs/gh-cached.md`.
+
 ---
 
 ## Detailed Code Smell Examples
@@ -585,7 +600,7 @@ git log --diff-filter=A --name-only --pretty=format: | \
 
 ```bash
 # Before creating an issue, check for duplicates
-gh issue list --search "filename.ts" --state=open
+"$GH_READ" issue list --search "filename.ts" --state=open
 ```
 
 ### Example Decision Process
@@ -733,8 +748,8 @@ discover_project_goals() {
 
   # 3. Check for urgent/high-priority goal-advancing issues
   echo "Current goal-advancing work:"
-  gh issue list --label="tier:goal-advancing" --state=open --limit=5
-  gh issue list --label="loom:urgent" --state=open --limit=5
+  "$GH_READ" issue list --label="tier:goal-advancing" --state=open --limit=5
+  "$GH_READ" issue list --label="loom:urgent" --state=open --limit=5
 
   # 4. Summary
   echo "Simplification proposals should support these focus areas"
@@ -753,10 +768,10 @@ check_backlog_balance() {
   echo "=== Backlog Tier Balance ==="
 
   # Count issues by tier
-  tier1=$(gh issue list --label="tier:goal-advancing" --state=open --json number --jq 'length')
-  tier2=$(gh issue list --label="tier:goal-supporting" --state=open --json number --jq 'length')
-  tier3=$(gh issue list --label="tier:maintenance" --state=open --json number --jq 'length')
-  unlabeled=$(gh issue list --label="loom:issue" --state=open --json number,labels \
+  tier1=$("$GH_READ" issue list --label="tier:goal-advancing" --state=open --json number --jq 'length')
+  tier2=$("$GH_READ" issue list --label="tier:goal-supporting" --state=open --json number --jq 'length')
+  tier3=$("$GH_READ" issue list --label="tier:maintenance" --state=open --json number --jq 'length')
+  unlabeled=$("$GH_READ" issue list --label="loom:issue" --state=open --json number,labels \
     --jq '[.[] | select([.labels[].name] | any(startswith("tier:")) | not)] | length')
 
   total=$((tier1 + tier2 + tier3 + unlabeled))
@@ -1102,7 +1117,7 @@ src/lib/old-api.ts:  // }
 # Found commented-out code - create standalone issue to remove it
 
 # 4. Check open issues for simplification opportunities
-$ gh issue list --state=open --json number,title,body --jq '.[] | "\(.number): \(.title)"'
+$ "$GH_READ" issue list --state=open --json number,title,body --jq '.[] | "\(.number): \(.title)"'
 42: Refactor authentication system
 55: Add user profile editor
 ...
@@ -1160,14 +1175,14 @@ rg "^import" --count | sort -t: -k2 -rn | head -20
 
 ```bash
 # Find open issues to potentially comment on
-gh issue list --state=open --json number,title,labels \
+"$GH_READ" issue list --state=open --json number,title,labels \
   --jq '.[] | select(([.labels[].name] | inside(["loom:hermit"])) | not) | "\(.number): \(.title)"'
 
 # View issue details before commenting
 gh issue view <number> --comments
 
 # Search for issues related to specific topic
-gh issue list --search "authentication" --state=open
+"$GH_READ" issue list --search "authentication" --state=open
 
 # Add simplification comment to issue
 gh issue comment <number> --body "$(cat <<'EOF'
@@ -1180,5 +1195,5 @@ EOF
 gh issue create --title "Remove [thing]" --body "..." --label "loom:hermit"
 
 # Check existing hermit suggestions
-gh issue list --label="loom:hermit" --state=open
+"$GH_READ" issue list --label="loom:hermit" --state=open
 ```

--- a/defaults/docs/gh-cached.md
+++ b/defaults/docs/gh-cached.md
@@ -42,8 +42,9 @@ resolution.
 
 | Command shape | Behavior | TTL |
 |---|---|---|
-| `gh issue view` / `issue list` | cached | 30s |
-| `gh pr view` / `pr list` | cached | 30s |
+| `gh issue view` | cached | 30s |
+| `gh pr view` | cached | 30s |
+| `gh issue list` / `pr list` (cacheable shape) | **ETag/REST (#5056)** — free 304, never stale; TTL fallback | 0s (revalidated) |
 | `gh label list`, `gh <x> search/status` | cached | 30s (default) |
 | `gh api` **without** `-X <non-GET>` / `-f` | cached | 30s |
 | `gh … edit/create/delete/close/reopen/merge/review/comment/label` | **bypassed**, and invalidates (but issue writes as literal `gh` — see below) | — |
@@ -53,6 +54,52 @@ Only **successful** (`rc == 0`) responses are cached, so a transient forge
 error is never memoized. TTL knobs: `GH_CACHE_TTL` (default 30s),
 `GH_CACHE_MAX_SIZE` (256 entries, LRU), `GH_CACHE_DIR`, `GH_CACHE_DISABLE=1`
 (hard off), `GH_CACHE_DEBUG=1` (per-call HIT/MISS/INVALIDATE lines on stderr).
+
+### ETag/REST cached listings — free, never-stale `issue list` / `pr list` (#5056)
+
+`gh issue list` / `gh pr list` are **GraphQL**, which has no conditional-request
+mechanism, so every call burns the shared GraphQL rate-limit pool even when the
+queue is unchanged. (Measured 2026-08-03: `graphql` at 1378/5000 in ~16 minutes
+while REST `core` sat at 19/5000 — `gh issue create` was already failing while
+the REST pool was 99.6% idle.) The daemon's own polling loops avoided this via
+`forge_listing::list_issues_cached` — a REST `GET` with `If-None-Match` that a
+matching ETag answers with a **304 at zero rate-limit cost** — but agents had no
+access to it.
+
+The wrapper now closes that gap. For an `issue list` / `pr list` whose shape the
+REST issues endpoint can serve, it first tries loom-daemon's **disk-persistent**
+ETag cache (`loom-daemon forge <issue|pr> list --cached …`, backed by
+`forge_listing::list_issues_cached_persistent`):
+
+- **Free on repeat.** A validated `304` costs zero rate-limit units, so the
+  second and later readers on a host pay nothing when the queue is unchanged.
+  The ETag + last-good body persist on disk (`${TMPDIR:-/tmp}/loom-forge-listing-cache`,
+  override `LOOM_LISTING_CACHE_DIR`), so this holds across the *separate*
+  short-lived agent processes — not just within one long-running daemon.
+- **Separate pool.** It draws on REST `core`, not the exhausted GraphQL pool.
+- **Never stale.** Unlike the 30s TTL cache below, a `304` is positive proof
+  nothing changed — so this path is safe even for claim-arbitration reads, and
+  is tried *before* the TTL cache.
+- **Degrades gracefully.** When loom-daemon is unreachable (binary absent) or
+  the shape is not cacheable, the daemon exits non-zero and the wrapper falls
+  through to its normal path (TTL cache / plain `gh`) — the same fallback
+  contract as the rest of this wrapper. `LOOM_ETAG_LIST_DISABLE=1` turns the
+  whole layer off.
+
+**Which shapes route here** (everything else declines to `gh`, so a repoint is
+always safe): a `list` with `--json` limited to
+`{number,title,state,body,labels,createdAt,updatedAt,closedAt,author}`; `--label`
+(AND) and `--search` restricted to `label:` / `-label:` include/exclude terms;
+`--state open|closed|all` for issues, `--state open` for PRs; not a
+possibly-truncated full page (>= 100 rows). A bare `list` (human table, no
+`--json`), a freeform `--search` (`head:…`, `in:body`, text), a PR-only field
+(`mergedAt`, `files`), or a merged/closed PR listing all fall back to `gh`.
+
+> **`loom-daemon forge issue` / `forge pr` WITHOUT `--cached` is NOT this path.**
+> The bare passthrough is a byte-identical GraphQL exec of `gh` and inherits its
+> full GraphQL cost. Only the explicit `--cached` flag (reached for you by this
+> wrapper) uses the ETag/REST cache. Never reach for the bare passthrough
+> expecting caching.
 
 ### Mutation-triggered invalidation — and why writes still use plain `gh`
 

--- a/defaults/scripts/gh-cached
+++ b/defaults/scripts/gh-cached
@@ -102,7 +102,7 @@ def read_stats() -> dict:
         with open(path) as f:
             return json.load(f)
     except (FileNotFoundError, json.JSONDecodeError):
-        return {"hits": 0, "misses": 0, "bypasses": 0, "invalidations": 0}
+        return {"hits": 0, "misses": 0, "bypasses": 0, "invalidations": 0, "etag": 0}
 
 
 def write_stats(stats: dict) -> None:
@@ -345,6 +345,58 @@ def run_gh(args: list[str]) -> tuple[str, str, int]:
     return proc.stdout, proc.stderr, proc.returncode
 
 
+# ─── ETag/REST cached listing (#5056) ────────────────────────────────────────
+
+def locate_loom_daemon() -> str | None:
+    """Resolve a loom-daemon binary for the ETag-cached `forge … list --cached`
+    path. Mirrors lib/locate-daemon-bin.sh's common cases: $LOOM_DAEMON_BIN, then
+    PATH, then the machine-level install. Returns None when none is executable —
+    the caller then degrades to plain `gh` (the "daemon unreachable" fallback)."""
+    bin_env = os.environ.get("LOOM_DAEMON_BIN", "")
+    if bin_env and os.access(bin_env, os.X_OK):
+        return bin_env
+    from shutil import which
+    found = which("loom-daemon")
+    if found:
+        return found
+    machine = os.path.join(
+        os.environ.get("LOOM_DAEMON_BIN_DIR", os.path.expanduser("~/.local/bin")),
+        "loom-daemon",
+    )
+    if os.access(machine, os.X_OK):
+        return machine
+    return None
+
+
+def try_etag_list(resource_type: str, args: list[str]) -> tuple[str, int] | None:
+    """Route a cacheable `issue list` / `pr list` through loom-daemon's
+    disk-persistent ETag REST cache (#5056).
+
+    A validated 304 costs **zero** rate-limit units — and, unlike the local TTL
+    cache below, is never stale (a 304 is positive proof nothing changed). So
+    this is tried *before* the TTL cache for the label/state listing shape.
+
+    Returns (stdout, 0) when the daemon served the query, or None to fall back
+    to the normal path (binary absent → daemon unreachable; or the daemon
+    declined an uncacheable shape — e.g. `--search head:…`, a table `list` with
+    no `--json`, a PR-only field — with a non-zero exit)."""
+    if os.environ.get("LOOM_ETAG_LIST_DISABLE", "") == "1":
+        return None
+    daemon = locate_loom_daemon()
+    if not daemon:
+        return None
+    # args == [resource_type, "list", <rest…>]; forward everything after "list".
+    rest = args[2:]
+    cmd = [daemon, "forge", resource_type, "list", "--cached", *rest]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+    except OSError:
+        return None
+    if proc.returncode == 0:
+        return proc.stdout, 0
+    return None
+
+
 def main() -> int:
     args = sys.argv[1:]
 
@@ -362,6 +414,7 @@ def main() -> int:
         print(f"Misses: {stats['misses']}", file=sys.stderr)
         print(f"Bypasses: {stats['bypasses']}", file=sys.stderr)
         print(f"Invalidations: {stats['invalidations']}", file=sys.stderr)
+        print(f"ETag (free 304 listings): {stats.get('etag', 0)}", file=sys.stderr)
         print(f"Hit rate: {rate:.1f}%", file=sys.stderr)
         return 0
 
@@ -400,6 +453,19 @@ def main() -> int:
 
         increment_stat("bypasses")
         return rc
+
+    # ETag/REST cached listing (#5056): `issue list` / `pr list` can be served
+    # for free on a validated 304 through loom-daemon's disk-persistent cache —
+    # a separate rate-limit pool (REST, not GraphQL) AND zero cost when nothing
+    # changed. Tried before the local TTL cache because a 304 is both free and
+    # never stale. On decline / absent binary it falls through to the TTL path.
+    if parsed["subcommand"] == "list" and parsed["resource_type"] in ("issue", "pr"):
+        etag_result = try_etag_list(parsed["resource_type"], args)
+        if etag_result is not None:
+            etag_stdout, etag_rc = etag_result
+            sys.stdout.write(etag_stdout)
+            increment_stat("etag")
+            return etag_rc
 
     # Read-only: check cache
     key = cache_key(args)

--- a/defaults/scripts/tests/test-gh-cached.sh
+++ b/defaults/scripts/tests/test-gh-cached.sh
@@ -116,10 +116,14 @@ echo '[{"number":99,"title":"an issue"}]'       > "$STATE_DIR/issue-list.json"
 CACHE_DIR="$TMP_ROOT/cache"
 
 # Run gh-cached with a hermetic environment. Args are passed through verbatim.
+# LOOM_ETAG_LIST_DISABLE=1 pins these to the TTL-cache layer under test — the
+# #5056 ETag/REST routing (which would otherwise front-run `issue/pr list` when
+# a loom-daemon is on PATH) has its own dedicated block at the end of this file.
 ghc() {
     PATH="$STUB_DIR:$PATH" \
     GH_CACHE_DIR="$CACHE_DIR" \
     GH_CACHE_TTL="${TTL_OVERRIDE:-30}" \
+    LOOM_ETAG_LIST_DISABLE=1 \
       "$GH_CACHED" "$@"
 }
 
@@ -263,6 +267,56 @@ echo "Testing the wrapper-resolution probe used by the skills..."
 reset_cache
 if ghc --version >/dev/null 2>&1; then probe_rc=0; else probe_rc=$?; fi
 assert_eq "0" "$probe_rc" "'gh-cached --version' succeeds (the skills' resolution probe)"
+
+# --- 9. ETag/REST routing (#5056) ------------------------------------------
+# `issue list` / `pr list` prefer loom-daemon's ETag-cached REST path when the
+# binary is present (free 304 on repeat, separate REST pool). Here a FAKE
+# loom-daemon on PATH proves: (a) a cacheable list shape is served by it, not
+# the stub gh; (b) a decline (non-zero exit) transparently falls through to the
+# normal gh path; (c) LOOM_ETAG_LIST_DISABLE=1 turns the whole layer off.
+echo ""
+echo "Testing the #5056 ETag/REST cached-listing routing..."
+
+FAKE_DAEMON_DIR="$TMP_ROOT/daemon"
+mkdir -p "$FAKE_DAEMON_DIR"
+# A fake loom-daemon: `forge <e> list --cached` with --json succeeds and emits a
+# sentinel; any shape without --json exits 3 (decline), mirroring the real one.
+cat > "$FAKE_DAEMON_DIR/loom-daemon" <<'FAKE'
+#!/usr/bin/env bash
+if [[ "$1" == "forge" && "$3" == "list" ]]; then
+    if printf '%s\n' "$@" | grep -q -- '--json'; then
+        echo '[{"number":777,"title":"from-etag-daemon"}]'
+        exit 0
+    fi
+    exit 3
+fi
+exit 3
+FAKE
+chmod +x "$FAKE_DAEMON_DIR/loom-daemon"
+
+# Runner with the fake daemon on PATH and the ETag layer ENABLED.
+ghc_etag() {
+    PATH="$STUB_DIR:$FAKE_DAEMON_DIR:$PATH" \
+    GH_CACHE_DIR="$CACHE_DIR" \
+    LOOM_DAEMON_BIN="$FAKE_DAEMON_DIR/loom-daemon" \
+      "$GH_CACHED" "$@"
+}
+
+reset_cache
+etag_out=$(ghc_etag issue list --label "loom:issue" --state open --json number,title)
+assert_eq '[{"number":777,"title":"from-etag-daemon"}]' "$etag_out" \
+    "a cacheable 'issue list --json' is served by the ETag daemon path, not stub gh"
+assert_eq "0" "$(call_count)" "…and the stub gh is never called for the ETag-served list"
+
+# A shape the daemon declines (no --json → daemon exits 3) falls through to gh.
+reset_cache
+ghc_etag pr list --label "loom:review-requested" --state open >/dev/null  # no --json → decline
+assert_eq "1" "$(call_count)" "a daemon-declined list shape falls through to a real gh call"
+
+# The kill switch disables the whole ETag layer even with the daemon present.
+reset_cache
+LOOM_ETAG_LIST_DISABLE=1 ghc_etag issue list --label "loom:issue" --state open --json number,title >/dev/null
+assert_eq "1" "$(call_count)" "LOOM_ETAG_LIST_DISABLE=1 bypasses the ETag path (falls to gh)"
 
 # --- Summary ---------------------------------------------------------------
 echo ""

--- a/loom-daemon/src/forge_cached_list.rs
+++ b/loom-daemon/src/forge_cached_list.rs
@@ -1,0 +1,599 @@
+//! Agent-facing cached issue/PR listing (Issue #5056).
+//!
+//! # Why this exists
+//!
+//! The daemon's polling loops already read issue lists nearly for free via
+//! [`crate::forge_listing::list_issues_cached`] — a REST `GET` with
+//! `If-None-Match` that a matching ETag answers with a **304 at zero
+//! rate-limit cost**. Agent role prompts never had that: their `gh issue list`
+//! / `gh pr list` invocations are **GraphQL**, which has no conditional-request
+//! mechanism, so every role tick on every host burned the shared GraphQL pool
+//! even when the queue was unchanged (measured: `graphql` at 1378/5000 in ~16
+//! minutes while REST `core` sat at 19/5000).
+//!
+//! This module exposes that same ETag/REST/304 mechanism to agents as
+//! `loom-daemon forge issue list --cached …` / `forge pr list --cached …`,
+//! backed by the **disk-persistent** variant
+//! [`crate::forge_listing::list_issues_cached_persistent`] (agents run each
+//! query as a fresh short-lived process, so the ETag must survive process
+//! exit for the second reader to get a free `304`).
+//!
+//! # Scope — what routes here vs. declines to `gh`
+//!
+//! Only the label/state listing shape the REST issues endpoint can serve is
+//! handled. Anything else **declines** (exit [`DECLINED`], no stdout) so the
+//! caller (`gh-cached`) falls back to plain `gh`, keeping every existing call
+//! site correct:
+//!
+//! - **Requires `--json`** with a field subset the REST row can supply
+//!   ({number,title,state,body,labels,createdAt,updatedAt,closedAt,author}).
+//!   A bare `gh issue list` (human table) or a PR-only field (`mergedAt`,
+//!   `files`) declines — we cannot reproduce those.
+//! - **`--search`** is honored only for pure `label:` / `-label:` terms
+//!   (client-side include/exclude); any other search token declines.
+//! - **`pr list`** is served only for `--state open` (the
+//!   `loom:review-requested` queue); merged/closed PR listings need the pulls
+//!   endpoint and decline.
+//! - A **possibly-truncated** full page (>= `PER_PAGE` rows) declines rather
+//!   than silently serve a partial set.
+//!
+//! Because declining is always safe (the caller re-runs the identical `gh`),
+//! repointing a prompt to the cached helper can never change results — only
+//! cost.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use serde_json::{json, Value};
+
+use crate::forge_cmd::{detect_forge, ForgeType};
+use crate::forge_listing::{list_issues_cached_persistent, CachedListing};
+
+/// Exit code signalling "this shape is not cacheable; fall back to `gh`".
+/// Shares the numeric value of [`crate::forge_cmd::EX_FORGE_DECLINED`].
+pub const DECLINED: i32 = crate::forge_cmd::EX_FORGE_DECLINED;
+
+/// The `--json` fields a REST issue row can supply, mapped to their gh names.
+const SUPPORTED_JSON_FIELDS: &[&str] = &[
+    "number",
+    "title",
+    "state",
+    "body",
+    "labels",
+    "createdAt",
+    "updatedAt",
+    "closedAt",
+    "author",
+];
+
+/// A parsed, cacheable `list` query. Returned by [`parse_query`]; `None` there
+/// means "decline — not a shape we can serve".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CachedQuery {
+    /// Positive labels (REST `labels=` AND filter). Comma-joined for the URL.
+    pub positive_labels: Vec<String>,
+    /// Labels to exclude client-side (from `--search "-label:X"`).
+    pub negative_labels: Vec<String>,
+    /// `open` | `closed` | `all`.
+    pub state: String,
+    /// Requested `--json` fields (already validated against
+    /// [`SUPPORTED_JSON_FIELDS`]).
+    pub json_fields: Vec<String>,
+    /// Optional `--jq` expression, applied after projection.
+    pub jq: Option<String>,
+    /// Optional `--limit` (applied client-side after filtering).
+    pub limit: Option<usize>,
+    /// Optional `--repo owner/name` override.
+    pub repo: Option<String>,
+}
+
+/// Is this a `forge <issue|pr> list --cached …` request?
+#[must_use]
+pub fn is_cached_list(args: &[String]) -> bool {
+    args.first().map(String::as_str) == Some("list") && args.iter().any(|a| a == "--cached")
+}
+
+/// Entry point from `forge_cmd::dispatch`. Serves the cached listing to stdout
+/// and exits `0`, or exits [`DECLINED`] (no stdout) when the shape is not
+/// cacheable / the lookup failed, so the caller falls back to `gh`. Never
+/// returns.
+pub fn handle(entity: &str, args: &[String]) -> ! {
+    // Gitea has no REST-ETag path here; decline to the shell/gh fallback.
+    if detect_forge(None) == ForgeType::Gitea {
+        std::process::exit(DECLINED);
+    }
+    match build_output(entity, args, &default_fetcher) {
+        Some(output) => {
+            print!("{output}");
+            std::process::exit(0);
+        }
+        None => {
+            eprintln!(
+                "loom-daemon forge {entity} list --cached: not a cacheable shape (or lookup \
+                 failed); caller should fall back to gh"
+            );
+            std::process::exit(DECLINED);
+        }
+    }
+}
+
+/// A fetcher abstraction so tests can inject a fake listing without a real
+/// `gh`. Production uses [`default_fetcher`].
+type Fetcher<'a> = dyn Fn(&str, &str, Option<&str>) -> Option<CachedListing> + 'a;
+
+fn default_fetcher(labels: &str, state: &str, repo: Option<&str>) -> Option<CachedListing> {
+    let gh_bin = std::env::var("LOOM_GH_BIN").unwrap_or_else(|_| "gh".to_string());
+    list_issues_cached_persistent(Path::new(&gh_bin), None, repo, labels, state).ok()
+}
+
+/// Core, side-effect-free (given the `fetch` closure) pipeline: parse → fetch →
+/// filter → project → optional jq. Returns `None` to decline.
+pub fn build_output(entity: &str, args: &[String], fetch: &Fetcher) -> Option<String> {
+    let want_pr = match entity {
+        "issue" => false,
+        "pr" => true,
+        _ => return None,
+    };
+    let q = parse_query(entity, args)?;
+
+    let labels_joined = q.positive_labels.join(",");
+    let listing = fetch(&labels_joined, &q.state, q.repo.as_deref())?;
+    // Never serve a possibly-truncated page — decline so gh returns the full set.
+    if listing.truncated {
+        return None;
+    }
+
+    let mut rows: Vec<Value> = listing
+        .issues
+        .into_iter()
+        .filter(|it| it.is_pull_request == want_pr)
+        .filter(|it| {
+            // Client-side exclusion for `-label:X` search terms.
+            !q.negative_labels
+                .iter()
+                .any(|neg| it.labels.iter().any(|l| l == neg))
+        })
+        .map(|it| project_row(&it, &q.json_fields))
+        .collect();
+
+    if let Some(limit) = q.limit {
+        rows.truncate(limit);
+    }
+
+    let array = Value::Array(rows);
+    match &q.jq {
+        Some(expr) => apply_jq(&array, expr),
+        // gh prints `--json` output as pretty JSON with a trailing newline.
+        None => serde_json::to_string_pretty(&array)
+            .ok()
+            .map(|s| format!("{s}\n")),
+    }
+}
+
+/// Build a gh-`--json`-shaped object with only the requested fields.
+fn project_row(it: &crate::forge_listing::RestIssue, fields: &[String]) -> Value {
+    let mut obj = serde_json::Map::new();
+    for f in fields {
+        let v = match f.as_str() {
+            "number" => json!(it.number),
+            "title" => json!(it.title.clone().unwrap_or_default()),
+            // gh emits state uppercase (OPEN/CLOSED); REST gives lowercase.
+            "state" => json!(it.state.to_ascii_uppercase()),
+            "body" => json!(it.body.clone().unwrap_or_default()),
+            "labels" => Value::Array(
+                it.labels
+                    .iter()
+                    .map(|name| json!({ "name": name }))
+                    .collect(),
+            ),
+            "createdAt" => json!(it.created_at.clone().unwrap_or_default()),
+            "updatedAt" => json!(it.updated_at.clone().unwrap_or_default()),
+            "closedAt" => json!(it.closed_at.clone().unwrap_or_default()),
+            "author" => json!({ "login": it.author.clone().unwrap_or_default() }),
+            _ => Value::Null,
+        };
+        obj.insert(f.clone(), v);
+    }
+    Value::Object(obj)
+}
+
+/// Apply a `--jq` expression via the system `jq` (compact + raw, matching gh's
+/// `--jq` output). Returns `None` (decline) when `jq` is missing or errors.
+fn apply_jq(array: &Value, expr: &str) -> Option<String> {
+    let input = serde_json::to_string(array).ok()?;
+    let mut child = Command::new("jq")
+        .arg("-c")
+        .arg("-r")
+        .arg(expr)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+    use std::io::Write;
+    child.stdin.take()?.write_all(input.as_bytes()).ok()?;
+    let out = child.wait_with_output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8(out.stdout).ok()
+}
+
+/// Parse the `list` argument vector into a cacheable [`CachedQuery`], or `None`
+/// to decline. Supports both `--flag value` and `--flag=value` forms.
+pub fn parse_query(entity: &str, args: &[String]) -> Option<CachedQuery> {
+    // args[0] is "list"; skip it.
+    let mut positive_labels: Vec<String> = Vec::new();
+    let mut negative_labels: Vec<String> = Vec::new();
+    let mut state: Option<String> = None;
+    let mut json_fields: Vec<String> = Vec::new();
+    let mut jq: Option<String> = None;
+    let mut limit: Option<usize> = None;
+    let mut repo: Option<String> = None;
+
+    let mut i = 1;
+    while i < args.len() {
+        let arg = &args[i];
+        // Split `--flag=value`.
+        let (flag, inline_val): (&str, Option<&str>) = match arg.split_once('=') {
+            Some((f, v)) if f.starts_with('-') => (f, Some(v)),
+            _ => (arg.as_str(), None),
+        };
+        // Fetch the value for a `--flag value` (or inline) flag; advances `i`.
+        let take_val = |i: &mut usize| -> Option<String> {
+            if let Some(v) = inline_val {
+                Some(v.to_string())
+            } else {
+                *i += 1;
+                args.get(*i).cloned()
+            }
+        };
+        match flag {
+            "--cached" => {}
+            "--label" | "-l" => positive_labels.push(take_val(&mut i)?),
+            "--state" | "-s" => state = Some(take_val(&mut i)?),
+            "--limit" | "-L" => limit = Some(take_val(&mut i)?.parse().ok()?),
+            "--repo" | "-R" => repo = Some(take_val(&mut i)?),
+            "--json" => {
+                let raw = take_val(&mut i)?;
+                for field in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+                    if !SUPPORTED_JSON_FIELDS.contains(&field) {
+                        return None; // a field we cannot supply → decline
+                    }
+                    json_fields.push(field.to_string());
+                }
+            }
+            "--jq" | "-q" => jq = Some(take_val(&mut i)?),
+            "--search" | "-S" => {
+                let raw = take_val(&mut i)?;
+                for tok in raw.split_whitespace() {
+                    if let Some(v) = tok.strip_prefix("-label:") {
+                        negative_labels.push(v.to_string());
+                    } else if let Some(v) = tok.strip_prefix("label:") {
+                        positive_labels.push(v.to_string());
+                    } else {
+                        return None; // unsupported search term → decline
+                    }
+                }
+            }
+            // Any other flag / positional → not a shape we can serve.
+            _ => return None,
+        }
+        i += 1;
+    }
+
+    // gh list without --json is a human table we cannot reproduce.
+    if json_fields.is_empty() {
+        return None;
+    }
+
+    let state = state.unwrap_or_else(|| "open".to_string());
+    // PRs: only the open queue is serviceable from the issues endpoint.
+    if entity == "pr" && state != "open" {
+        return None;
+    }
+    if !matches!(state.as_str(), "open" | "closed" | "all") {
+        return None;
+    }
+
+    Some(CachedQuery {
+        positive_labels,
+        negative_labels,
+        state,
+        json_fields,
+        jq,
+        limit,
+        repo,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::forge_listing::RestIssue;
+
+    fn s(v: &str) -> String {
+        v.to_string()
+    }
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|p| s(p)).collect()
+    }
+
+    fn issue(number: u32, labels: &[&str], is_pr: bool) -> RestIssue {
+        RestIssue {
+            number,
+            title: Some(format!("issue {number}")),
+            labels: labels.iter().map(|l| s(l)).collect(),
+            created_at: Some(s("2026-08-03T00:00:00Z")),
+            updated_at: Some(s("2026-08-03T01:00:00Z")),
+            closed_at: None,
+            state: s("open"),
+            body: Some(s("body")),
+            author: Some(s("octocat")),
+            is_pull_request: is_pr,
+        }
+    }
+
+    // ===== is_cached_list =====
+
+    #[test]
+    fn detects_cached_list_only_with_flag_and_list_verb() {
+        assert!(is_cached_list(&argv(&["list", "--cached", "--json", "number"])));
+        assert!(!is_cached_list(&argv(&["list", "--json", "number"])));
+        assert!(!is_cached_list(&argv(&["view", "42", "--cached"])));
+    }
+
+    // ===== parse_query decline rules =====
+
+    #[test]
+    fn declines_without_json() {
+        assert!(
+            parse_query("issue", &argv(&["list", "--cached", "--label", "loom:issue"])).is_none()
+        );
+    }
+
+    #[test]
+    fn declines_unsupported_json_field() {
+        // mergedAt / files are PR-endpoint fields we cannot supply.
+        assert!(
+            parse_query("pr", &argv(&["list", "--cached", "--json", "number,mergedAt"])).is_none()
+        );
+        assert!(parse_query("pr", &argv(&["list", "--cached", "--json", "files"])).is_none());
+    }
+
+    #[test]
+    fn declines_unsupported_search_term() {
+        assert!(parse_query(
+            "pr",
+            &argv(&[
+                "list",
+                "--cached",
+                "--json",
+                "number",
+                "--search",
+                "head:docs/x"
+            ])
+        )
+        .is_none());
+        assert!(parse_query(
+            "issue",
+            &argv(&[
+                "list",
+                "--cached",
+                "--json",
+                "number",
+                "--search",
+                "foo in:body"
+            ])
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn declines_unknown_flag_or_positional() {
+        assert!(parse_query(
+            "issue",
+            &argv(&["list", "--cached", "--json", "number", "--assignee", "me"])
+        )
+        .is_none());
+        assert!(
+            parse_query("issue", &argv(&["list", "--cached", "--json", "number", "42"])).is_none()
+        );
+    }
+
+    #[test]
+    fn declines_pr_non_open_state() {
+        assert!(parse_query(
+            "pr",
+            &argv(&["list", "--cached", "--json", "number", "--state", "merged"])
+        )
+        .is_none());
+    }
+
+    // ===== parse_query success shapes =====
+
+    #[test]
+    fn parses_labels_state_search_json_forms() {
+        let q = parse_query(
+            "issue",
+            &argv(&[
+                "list",
+                "--cached",
+                "--label",
+                "loom:issue",
+                "--label=tier:goal-supporting",
+                "--search",
+                "-label:loom:building",
+                "--state=open",
+                "--json",
+                "number,labels",
+            ]),
+        )
+        .unwrap();
+        assert_eq!(q.positive_labels, vec!["loom:issue", "tier:goal-supporting"]);
+        assert_eq!(q.negative_labels, vec!["loom:building"]);
+        assert_eq!(q.state, "open");
+        assert_eq!(q.json_fields, vec!["number", "labels"]);
+    }
+
+    #[test]
+    fn defaults_state_to_open() {
+        let q = parse_query("issue", &argv(&["list", "--cached", "--json", "number"])).unwrap();
+        assert_eq!(q.state, "open");
+    }
+
+    // ===== build_output: filtering + projection =====
+
+    fn fetch_fixture(
+        issues: Vec<RestIssue>,
+        truncated: bool,
+    ) -> impl Fn(&str, &str, Option<&str>) -> Option<CachedListing> {
+        move |_labels: &str, _state: &str, _repo: Option<&str>| {
+            Some(CachedListing {
+                issues: issues.clone(),
+                truncated,
+            })
+        }
+    }
+
+    #[test]
+    fn issue_list_excludes_prs_and_applies_negative_labels() {
+        let fixture = fetch_fixture(
+            vec![
+                issue(1, &["loom:issue"], false),
+                issue(2, &["loom:issue", "loom:building"], false), // excluded by -label
+                issue(3, &["loom:issue"], true),                   // a PR — excluded for issue list
+            ],
+            false,
+        );
+        let out = build_output(
+            "issue",
+            &argv(&[
+                "list",
+                "--cached",
+                "--label",
+                "loom:issue",
+                "--search",
+                "-label:loom:building",
+                "--json",
+                "number",
+            ]),
+            &fixture,
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let nums: Vec<u64> = v
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|o| o["number"].as_u64().unwrap())
+            .collect();
+        assert_eq!(nums, vec![1]);
+    }
+
+    #[test]
+    fn pr_list_keeps_only_prs() {
+        let fixture = fetch_fixture(
+            vec![
+                issue(10, &["loom:review-requested"], true),
+                issue(11, &["loom:review-requested"], false), // an issue — excluded
+            ],
+            false,
+        );
+        let out = build_output(
+            "pr",
+            &argv(&[
+                "list",
+                "--cached",
+                "--label",
+                "loom:review-requested",
+                "--json",
+                "number",
+            ]),
+            &fixture,
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["number"].as_u64().unwrap(), 10);
+    }
+
+    #[test]
+    fn truncated_page_declines() {
+        let fixture = fetch_fixture(vec![issue(1, &["loom:issue"], false)], true);
+        assert!(
+            build_output("issue", &argv(&["list", "--cached", "--json", "number"]), &fixture)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn projects_gh_json_shape() {
+        let fixture = fetch_fixture(vec![issue(7, &["loom:issue"], false)], false);
+        let out = build_output(
+            "issue",
+            &argv(&[
+                "list",
+                "--cached",
+                "--json",
+                "number,title,state,labels,author,closedAt",
+            ]),
+            &fixture,
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        let row = &v[0];
+        assert_eq!(row["number"].as_u64().unwrap(), 7);
+        assert_eq!(row["title"].as_str().unwrap(), "issue 7");
+        assert_eq!(row["state"].as_str().unwrap(), "OPEN"); // uppercased for gh parity
+        assert_eq!(row["labels"][0]["name"].as_str().unwrap(), "loom:issue");
+        assert_eq!(row["author"]["login"].as_str().unwrap(), "octocat");
+        assert_eq!(row["closedAt"].as_str().unwrap(), ""); // null → empty string
+                                                           // Only requested fields are present.
+        assert!(row.get("body").is_none());
+    }
+
+    #[test]
+    fn limit_truncates_result() {
+        let fixture = fetch_fixture(
+            vec![
+                issue(1, &["loom:issue"], false),
+                issue(2, &["loom:issue"], false),
+                issue(3, &["loom:issue"], false),
+            ],
+            false,
+        );
+        let out = build_output(
+            "issue",
+            &argv(&["list", "--cached", "--json", "number", "--limit", "2"]),
+            &fixture,
+        )
+        .unwrap();
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v.as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn jq_expression_applied_when_jq_present() {
+        // Skip if jq is unavailable in the test environment.
+        if Command::new("jq").arg("--version").output().is_err() {
+            return;
+        }
+        let fixture = fetch_fixture(
+            vec![
+                issue(5, &["loom:issue"], false),
+                issue(6, &["loom:issue"], false),
+            ],
+            false,
+        );
+        let out = build_output(
+            "issue",
+            &argv(&["list", "--cached", "--json", "number", "--jq", ".[].number"]),
+            &fixture,
+        )
+        .unwrap();
+        let nums: Vec<&str> = out.lines().collect();
+        assert_eq!(nums, vec!["5", "6"]);
+    }
+}

--- a/loom-daemon/src/forge_cmd.rs
+++ b/loom-daemon/src/forge_cmd.rs
@@ -12,6 +12,17 @@
 //! - `forge auto-merge <pr> [--method …]` — the merge path behind
 //!   `merge-pr.sh` (formerly `loom-auto-merge`).
 //!
+//! # NOT a cache — the passthrough burns full GraphQL (#5056)
+//!
+//! `forge issue …` / `forge pr …` are a **byte-identical GraphQL passthrough**
+//! to `gh` ([`gh_passthrough`]); they inherit `gh issue list`'s full GraphQL
+//! rate-limit cost and are **not** the ETag-cached path. The cached,
+//! zero-cost-on-`304` listing lives behind the explicit `--cached` flag
+//! (`forge issue list --cached …` / `forge pr list --cached …`, dispatched to
+//! [`crate::forge_cached_list`]); only that flag routes through the REST/ETag
+//! cache. Reach for it (via the `gh-cached` / `$GH_READ` helper) whenever you
+//! would otherwise write a raw `gh issue list` in an agent hot path.
+//!
 //! # Forge routing (option (b): native GitHub, shell fallback carries Gitea)
 //!
 //! For **GitHub** (the only forge any Loom consumer repo runs today) the
@@ -569,6 +580,16 @@ pub enum ForgeCmd {
 /// a child process cannot be spawned.
 pub fn dispatch(cmd: ForgeCmd) -> Result<()> {
     match cmd {
+        // `forge <issue|pr> list --cached …` routes to the agent-facing ETag
+        // cache (#5056); it serves-and-exits(0) or declines-and-exits(3) so the
+        // caller falls back to plain `gh`. Everything else is the byte-identical
+        // GraphQL passthrough — NOT the cached path.
+        ForgeCmd::Issue(args) if crate::forge_cached_list::is_cached_list(&args) => {
+            crate::forge_cached_list::handle("issue", &args)
+        }
+        ForgeCmd::Pr(args) if crate::forge_cached_list::is_cached_list(&args) => {
+            crate::forge_cached_list::handle("pr", &args)
+        }
         ForgeCmd::Issue(args) => gh_passthrough("issue", &args),
         ForgeCmd::Pr(args) => gh_passthrough("pr", &args),
         ForgeCmd::Auth(args) => gh_passthrough("auth", &args),

--- a/loom-daemon/src/forge_listing.rs
+++ b/loom-daemon/src/forge_listing.rs
@@ -45,16 +45,24 @@ pub const PER_PAGE: usize = 100;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RestIssue {
     pub number: u32,
+    /// Issue/PR title. Added for the agent-facing cached-listing surface
+    /// (#5056), which projects it into `gh issue list --json title` parity.
+    pub title: Option<String>,
     /// Label names (flattened from the REST label objects).
     pub labels: Vec<String>,
     /// RFC-3339 creation timestamp. Lexicographic order == chronological.
     pub created_at: Option<String>,
     /// RFC-3339 last-update timestamp.
     pub updated_at: Option<String>,
+    /// RFC-3339 close timestamp (`null` while open). Projected into
+    /// `gh … --json closedAt` parity for the #5056 cached surface.
+    pub closed_at: Option<String>,
     /// `"open"` / `"closed"` (REST lowercase; compare case-insensitively —
     /// GraphQL-era consumers saw `"OPEN"`).
     pub state: String,
     pub body: Option<String>,
+    /// Author login (`user.login` from REST), for `gh … --json author` parity.
+    pub author: Option<String>,
     /// Present when the row is actually a pull request (REST issue listings
     /// include PRs). Call sites filter on this to keep pre-#4428 semantics.
     pub is_pull_request: bool,
@@ -226,8 +234,15 @@ pub fn parse_rest_issues(body: &str) -> Result<Vec<RestIssue>> {
         name: String,
     }
     #[derive(serde::Deserialize)]
+    struct RawUser {
+        #[serde(default)]
+        login: Option<String>,
+    }
+    #[derive(serde::Deserialize)]
     struct RawIssue {
         number: u32,
+        #[serde(default)]
+        title: Option<String>,
         #[serde(default)]
         labels: Vec<RawLabel>,
         #[serde(default)]
@@ -235,9 +250,13 @@ pub fn parse_rest_issues(body: &str) -> Result<Vec<RestIssue>> {
         #[serde(default)]
         updated_at: Option<String>,
         #[serde(default)]
+        closed_at: Option<String>,
+        #[serde(default)]
         state: String,
         #[serde(default)]
         body: Option<String>,
+        #[serde(default)]
+        user: Option<RawUser>,
         #[serde(default)]
         pull_request: Option<serde_json::Value>,
     }
@@ -246,11 +265,14 @@ pub fn parse_rest_issues(body: &str) -> Result<Vec<RestIssue>> {
         .into_iter()
         .map(|r| RestIssue {
             number: r.number,
+            title: r.title,
             labels: r.labels.into_iter().map(|l| l.name).collect(),
             created_at: r.created_at,
             updated_at: r.updated_at,
+            closed_at: r.closed_at,
             state: r.state,
             body: r.body,
+            author: r.user.and_then(|u| u.login),
             is_pull_request: r.pull_request.is_some(),
         })
         .collect())
@@ -273,6 +295,184 @@ struct CacheEntry {
 fn cache() -> &'static Mutex<HashMap<String, CacheEntry>> {
     static CACHE: OnceLock<Mutex<HashMap<String, CacheEntry>>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+// ============================================================================
+// Disk-persistent cache (Issue #5056 — agent-facing cached listing surface)
+// ============================================================================
+//
+// The process-lifetime [`cache`] above serves the daemon's own long-running
+// polling loops: one process, so an in-memory `OnceLock` is the whole story.
+// Agent role prompts, by contrast, run each `gh issue list` as a **fresh,
+// short-lived process** — an in-process cache would be born empty and die
+// after one fetch, so it could never serve the "second and subsequent readers"
+// the way the daemon does. To give agents the same zero-cost-on-`304` win, the
+// ETag and the last-good body are persisted to a small per-host on-disk store,
+// keyed the same way. A second CLI invocation (even in a different process, for
+// a different label) reads the prior ETag, sends `If-None-Match`, and — when
+// nothing changed — gets a **free** `304` and serves the body from disk.
+//
+// This is deliberately the *same* ETag/REST/304 mechanism as the in-process
+// cache, not a second cache with different semantics: it reuses
+// [`build_issues_url`], [`parse_http_response`], and [`parse_rest_issues`]. The
+// only added axis is durability across process boundaries, which is exactly
+// what the agent hot path needs and the daemon loop does not.
+
+/// Result of a disk-cached listing: the parsed rows plus whether the single
+/// REST page was full (so the caller can decline rather than silently serve a
+/// truncated set — see [`PER_PAGE`]).
+#[derive(Debug, Clone)]
+pub struct CachedListing {
+    pub issues: Vec<RestIssue>,
+    /// `true` when the response filled a whole page and may be truncated.
+    pub truncated: bool,
+}
+
+/// On-disk store directory, shared across the short-lived agent CLI processes
+/// on one host. `LOOM_LISTING_CACHE_DIR` overrides (tests point it at a
+/// tempdir); otherwise `${TMPDIR:-/tmp}/loom-forge-listing-cache`, mirroring
+/// the existing `gh-cached` `/tmp/gh-cache` convention.
+fn disk_cache_dir() -> std::path::PathBuf {
+    if let Ok(d) = std::env::var("LOOM_LISTING_CACHE_DIR") {
+        if !d.is_empty() {
+            return std::path::PathBuf::from(d);
+        }
+    }
+    let base = std::env::var("TMPDIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "/tmp".to_string());
+    std::path::PathBuf::from(base).join("loom-forge-listing-cache")
+}
+
+/// Deterministic on-disk filename for a cache key (FNV-1a hash → hex, so no
+/// path-unsafe characters from the URL leak into the filename).
+fn disk_cache_path(cache_key: &str) -> std::path::PathBuf {
+    // FNV-1a 64-bit — dependency-free and more than adequate for a filename.
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in cache_key.as_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    disk_cache_dir().join(format!("listing-{hash:016x}.json"))
+}
+
+/// The on-disk entry shape: the validator ETag plus the raw JSON body it
+/// validated, so a `304` can reconstruct the exact prior parse.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct DiskEntry {
+    etag: String,
+    body: String,
+}
+
+fn read_disk_entry(path: &Path) -> Option<DiskEntry> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Write the entry atomically (temp file + rename) so a concurrent reader on
+/// the same host never observes a half-written file.
+fn write_disk_entry(path: &Path, entry: &DiskEntry) {
+    let Some(dir) = path.parent() else { return };
+    if std::fs::create_dir_all(dir).is_err() {
+        return;
+    }
+    let Ok(serialized) = serde_json::to_string(entry) else {
+        return;
+    };
+    let tmp = dir.join(format!(
+        ".tmp-{}-{}",
+        std::process::id(),
+        path.file_name().and_then(|n| n.to_str()).unwrap_or("entry")
+    ));
+    if std::fs::write(&tmp, serialized).is_ok() {
+        // Best-effort: a rename failure just means the next call re-fetches.
+        let _ = std::fs::rename(&tmp, path);
+    }
+}
+
+/// List issues carrying `label` (comma-joined AND when multiple) in `state`,
+/// via the **disk-persistent** ETag cache — the agent-facing analogue of
+/// [`list_issues_cached`].
+///
+/// Semantics match [`list_issues_cached`] (conditional `GET`, `304` served
+/// free, `200` re-cached) but the ETag/body survive process exit, so the
+/// second short-lived CLI process on a host pays zero rate-limit cost when the
+/// queue is unchanged. Returns [`CachedListing`] so the caller can decline on a
+/// possibly-truncated full page rather than serve a partial set.
+pub fn list_issues_cached_persistent(
+    gh_bin: &Path,
+    cwd: Option<&Path>,
+    repo_override: Option<&str>,
+    label: &str,
+    state: &str,
+) -> Result<CachedListing> {
+    let env_repo = std::env::var("LOOM_REPO").ok();
+    let repo = repo_override.or(env_repo.as_deref());
+    let url = build_issues_url(repo, label, state);
+    let cache_key = format!(
+        "{}|{url}",
+        cwd.map(Path::display)
+            .map_or_else(String::new, |d| d.to_string())
+    );
+    let entry_path = disk_cache_path(&cache_key);
+    let prior = read_disk_entry(&entry_path);
+
+    let mut cmd = Command::new(gh_bin);
+    cmd.arg("api").arg("--include").arg(&url);
+    if let Some(ref e) = prior {
+        cmd.arg("-H").arg(format!("If-None-Match: {}", e.etag));
+    }
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let out = cmd
+        .output()
+        .with_context(|| format!("failed to invoke {}", gh_bin.display()))?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let response = parse_http_response(&stdout);
+
+    match response {
+        Some(ref r) if r.status == 304 => match prior {
+            Some(e) => {
+                let issues = parse_rest_issues(&e.body)
+                    .with_context(|| format!("parse cached REST issues for {url}"))?;
+                let truncated = issues.len() >= PER_PAGE;
+                Ok(CachedListing { issues, truncated })
+            }
+            None => {
+                // A 304 can only occur because we sent an ETag; if the entry
+                // vanished under us, drop it and error so the next call
+                // re-fetches unconditionally.
+                let _ = std::fs::remove_file(&entry_path);
+                Err(anyhow!(
+                    "forge_listing: 304 for {url} but the on-disk entry vanished; will re-fetch"
+                ))
+            }
+        },
+        Some(ref r) if r.status == 200 && out.status.success() => {
+            let issues = parse_rest_issues(&r.body)
+                .with_context(|| format!("parse REST issues JSON from {url}"))?;
+            let truncated = issues.len() >= PER_PAGE;
+            if let Some(etag) = r.etag.clone() {
+                write_disk_entry(
+                    &entry_path,
+                    &DiskEntry {
+                        etag,
+                        body: r.body.clone(),
+                    },
+                );
+            }
+            Ok(CachedListing { issues, truncated })
+        }
+        _ => Err(anyhow!(
+            "gh api {url} failed{}: {}",
+            cwd.map(|d| format!(" in {}", d.display()))
+                .unwrap_or_default(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -477,6 +677,39 @@ esac
         let second =
             list_issues_cached(&gh, Some(dir.path()), Some(&repo), "loom:issue", "open").unwrap();
         assert_eq!(second, first);
+    }
+
+    /// The disk-persistent variant must behave like the in-process one across
+    /// *separate* short-lived processes: the first call (200) writes the ETag +
+    /// body to disk; a second call — which for the persistent path has no
+    /// in-memory state, exactly as a fresh agent CLI process would — presents
+    /// that ETag, gets a free 304, and reconstructs the identical listing from
+    /// the on-disk body.
+    #[test]
+    fn disk_cache_persists_etag_and_serves_304_across_processes() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = tempfile::tempdir().unwrap();
+        std::env::set_var("LOOM_LISTING_CACHE_DIR", cache.path());
+        let gh = write_fake_gh(dir.path());
+        let repo = format!("test/disk-flow-{}", std::process::id());
+
+        // Round 1: 200 → parsed + written to disk (not truncated: 1 row).
+        let first =
+            list_issues_cached_persistent(&gh, Some(dir.path()), Some(&repo), "loom:issue", "open")
+                .unwrap();
+        assert_eq!(first.issues.len(), 1);
+        assert_eq!(first.issues[0].number, 7);
+        assert!(!first.truncated);
+        // The entry file now exists on disk (durable across process exit).
+        assert!(std::fs::read_dir(cache.path()).unwrap().count() >= 1);
+
+        // Round 2: the fake gh answers 304 to the presented If-None-Match; the
+        // listing must come back identical, reconstructed from the disk body.
+        let second =
+            list_issues_cached_persistent(&gh, Some(dir.path()), Some(&repo), "loom:issue", "open")
+                .unwrap();
+        assert_eq!(second.issues, first.issues);
+        std::env::remove_var("LOOM_LISTING_CACHE_DIR");
     }
 
     #[test]

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -148,6 +148,7 @@ pub mod epic_supervisor;
 pub mod errors;
 pub mod event_bus;
 pub mod fleet;
+pub mod forge_cached_list;
 pub mod forge_cmd;
 pub mod forge_listing;
 pub mod forge_parser;


### PR DESCRIPTION
## What & why

Agent role prompts read the queue with `gh issue list` / `gh pr list` — all **GraphQL**, all uncacheable — so every role tick on every host burned the shared GraphQL rate-limit pool even when the queue was unchanged (measured 2026-08-03: `graphql` 1378/5000 in ~16 min while REST `core` sat at 19/5000). The daemon's own polling loops already avoid this via `forge_listing::list_issues_cached` (a REST `GET` with `If-None-Match` that a matching ETag answers with a **304 at zero rate-limit cost**). This PR exposes that same ETag/REST/304 mechanism to agents.

## How

- **`forge_listing::list_issues_cached_persistent`** — a **disk-persistent** variant of the ETag cache. Agents run each query as a fresh short-lived process, so the in-process `OnceLock` cache the daemon uses can never serve the "second reader"; the ETag + last-good body are persisted under `${TMPDIR:-/tmp}/loom-forge-listing-cache` (override `LOOM_LISTING_CACHE_DIR`) so a second process gets a free 304. Reuses the existing URL/response/JSON parsing; adds `title`/`closedAt`/`author` to `RestIssue` for gh `--json` parity.
- **New `forge_cached_list` module + `loom-daemon forge <issue|pr> list --cached`** — serves the label/state listing shape (client-side `-label:` exclusion, `--json` projection, `--jq`) as gh-compatible JSON, and **declines** (exit 3, no stdout) on any shape the REST issues endpoint cannot serve (freeform `--search`, no `--json`, PR-only fields like `mergedAt`/`files`, possibly-truncated full page) so callers fall back to plain `gh`. Declining is always safe, so a prompt repoint can never change results — only cost.
- **`gh-cached` wrapper** — routes cacheable `issue list` / `pr list` through the daemon's `--cached` path **before** the TTL cache (a 304 is both free AND never stale, so it is safe even for claim-arbitration reads), and falls back to plain `gh` when the daemon is unreachable or declines. `LOOM_ETAG_LIST_DISABLE=1` kill switch.
- **Docs** — `gh-cached.md` gains the ETag/REST section + an explicit note that the bare `loom-daemon forge issue` passthrough is **NOT** the cached path (full GraphQL cost); only `--cached` is. Same note added to `forge_cmd.rs` module docs.
- **Prompt repoints** — the two highest-traffic roles, guide.md (31) and hermit-patterns.md (11), now route every issue/PR listing through the one documented `$GH_READ` helper.

## Tests

- Rust: disk-cache 200-write → free-304-read across processes, truncation detection; parse/filter/project/decline unit tests (14 + 12 passing). `cargo clippy --lib` clean.
- Shell: existing `test-gh-cached.sh` pinned to the TTL layer (`LOOM_ETAG_LIST_DISABLE=1`) so its assertions hold; new block covers ETag routing, daemon-decline fallthrough, and the kill switch (24/24 passing).

## Acceptance criteria

- [x] Agents can list issues/PRs through a surface backed by `list_issues_cached` (its disk-persistent sibling, reusing the same parsing/URL/RestIssue).
- [x] An unchanged queue costs zero rate-limit units for second+ readers on a host (disk-persisted ETag → free 304).
- [x] Role prompts reference one documented helper (`$GH_READ`) — done for the two highest-traffic roles; see deferred note.
- [x] Agents degrade to direct `gh` when the daemon is unreachable / the shape is uncacheable.
- [x] `loom-daemon forge issue`'s GraphQL passthrough documented as NOT the cached path.
- [ ] **Before/after graphql-pool measurement** — deferred: this requires a live multi-repo fleet over a fixed window and cannot be produced in a build sandbox. Recommend recording it on the issue post-merge (compare `gh api rate_limit` graphql `used` over a fixed window before vs. after adoption). No numbers fabricated.

## Deferred (with rationale)

- **Remaining ~42 call sites** across doctor (8), champion (7), builder (5), judge (5), architect (5), auditor (4), curator (3), loom (3), builder-pr/worktree (2). The mechanism + the one documented helper are in place; converting these is mechanical `gh … list` → `"$GH_READ" … list` text work. Repointing is safe regardless of shape (the wrapper declines-and-falls-back), but converting them all in one PR would balloon the diff and review surface. Suggest a follow-up issue to finish the remaining roles.

Closes #5056

🤖 Generated with [Claude Code](https://claude.com/claude-code)