### PR TITLE
fix(guard): mask heredoc-body write-idiom syntax in extract_write_targets() (#5000)

### DIFF
--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1455,6 +1455,34 @@ function unmask_ws(s) {
 # and the surrounding qsplit()/strip_literal_text() `$(`-floor logic are
 # unaffected -- ONLY the inert body content disappears.
 #
+# MASK ONLY A *CLOSED* BLOCK (#5087 -- the fail-open regression this two-pass
+# structure exists to prevent). The masking decision is made per candidate
+# opener with the closing-delimiter line ALREADY LOCATED: for each candidate
+# on a line, a forward scan looks for the terminating bare-delimiter line
+# FIRST, and only a block that is genuinely closed inside this buffer has its
+# body masked. A candidate whose delimiter line never appears masks NOTHING
+# and the scan simply moves on to the next candidate -- because the original
+# single-pass form (which flipped a sticky `inbody` flag the instant it saw
+# `<<` and only ever cleared it on a delimiter line) silently masked
+# EVERYTHING from a FALSE opener to the end of the command whenever no such
+# line followed, swallowing any real `>`/`tee`/`cp`/`mv` target after it and
+# defeating the write-confinement guard (#4178) outright. Two ordinary,
+# heredoc-free command shapes hit that: a quoted string that merely CONTAINS
+# `<<TOKEN` (`echo "test <<TOKEN"`), and an arithmetic bitshift
+# (`x=$((1 << 3))`) -- both followed by a genuine out-of-worktree write, both
+# ALLOWed pre-#5087 where `main` DENIed. Masking is a NARROWING operation, so
+# it must never be applied speculatively: when in doubt, mask nothing and let
+# the text flow through the pre-#5000 per-line scan.
+#
+# Opener detection is correspondingly tightened so the commonest false
+# openers are rejected before the forward scan even runs: a `<<<` herestring
+# is never a heredoc opener, and a BARE (unquoted) delimiter starting with a
+# DIGIT is read as an arithmetic shift operand (`1 << 3`), not a delimiter --
+# `<<'3'`/`<<"3"` stay recognized, since an explicitly quoted delimiter is
+# unambiguous heredoc intent. Every `<<` occurrence on a line is considered
+# in turn (not just the first), so one rejected candidate never hides a real
+# terminated heredoc later on the same line.
+#
 # Deliberately narrow / best-effort, consistent with every other quote-
 # tracking scan in this file: an exotic delimiter (not a bare identifier, or
 # using shell metacharacters) is simply not recognized as a heredoc opener --
@@ -1467,51 +1495,73 @@ function unmask_ws(s) {
 # completely unaffected and still flows through unchanged.
 # =============================================================================
 _MASKHEREDOC_AWK='
-function mask_heredoc_bodies(s,   out, lines, nl, i, line, trimmed, body, delim, inbody, p, start, qc, c, wordend, SQ, DQ, MASKC) {
+# Return the heredoc delimiter opened by the `<<` at byte offset p in line,
+# or "" when that `<<` is not a recognized heredoc opener.
+function heredoc_delim_at(line, p,   start, qc, c, wordend, d, SQ, DQ) {
     SQ = sprintf("%c", 39)    # single quote
     DQ = sprintf("%c", 34)    # double quote
+    start = p + 2
+    # `<<<` is a herestring, never a heredoc opener.
+    if (substr(line, start, 1) == "<") return ""
+    if (substr(line, start, 1) == "-") start++
+    while (substr(line, start, 1) == " " || substr(line, start, 1) == "\t") start++
+    qc = ""
+    c = substr(line, start, 1)
+    if (c == SQ || c == DQ) { qc = c; start++ }
+    wordend = start
+    while (1) {
+        c = substr(line, wordend, 1)
+        if (c ~ /^[A-Za-z0-9_]$/) { wordend++; continue }
+        break
+    }
+    if (wordend <= start) return ""
+    d = substr(line, start, wordend - start)
+    # A BARE delimiter starting with a digit is an arithmetic shift operand
+    # (`$((1 << 3))`) far more often than a real heredoc delimiter. A quoted
+    # one (`<<"3"`) is unambiguous heredoc intent, so it stays recognized.
+    if (qc == "" && d ~ /^[0-9]/) return ""
+    return d
+}
+function mask_heredoc_bodies(s,   out, lines, nl, i, j, line, trimmed, body, delim, closeat, p, off, MASKC) {
     MASKC = sprintf("%c", 23) # ETB -- placeholder for inert heredoc-body text
     nl = split(s, lines, "\n")
     if (nl == 0) return ""
-    inbody = 0
-    delim = ""
     for (i = 1; i <= nl; i++) {
         line = lines[i]
-        if (inbody) {
-            # A `<<-` opener permits (and strips) leading tabs on the
-            # delimiter line; a bare `<<` requires an exact match. Either
-            # way only leading TABS (never spaces) are stripped, per real
-            # heredoc semantics.
-            trimmed = line
-            sub(/^\t+/, "", trimmed)
-            if (trimmed == delim) {
-                inbody = 0
-                delim = ""
-            } else {
-                body = line
+        off = 1
+        # Consider every `<<` on this line, left to right, until one is
+        # confirmed to open a CLOSED heredoc block.
+        while (1) {
+            p = index(substr(line, off), "<<")
+            if (p == 0) break
+            p = off + p - 1        # absolute offset of `<<` within line
+            off = p + 2            # where the next candidate search resumes
+            delim = heredoc_delim_at(line, p)
+            if (delim == "") continue
+            # PASS 1 -- locate the terminating delimiter line. A `<<-` opener
+            # permits (and strips) leading tabs on the delimiter line; only
+            # leading TABS (never spaces) are ever stripped, per real heredoc
+            # semantics. Stripping them unconditionally can only terminate the
+            # block EARLIER, i.e. mask LESS -- the safe direction here.
+            closeat = 0
+            for (j = i + 1; j <= nl; j++) {
+                trimmed = lines[j]
+                sub(/^\t+/, "", trimmed)
+                if (trimmed == delim) { closeat = j; break }
+            }
+            # Unterminated / false opener: mask NOTHING for this candidate and
+            # keep looking. Everything after it stays visible to the caller,
+            # exactly as in the pre-#5000 per-line scan (#5087).
+            if (closeat == 0) continue
+            # PASS 2 -- only now that the block is known to be closed, mask
+            # the body lines strictly between opener and delimiter line.
+            for (j = i + 1; j < closeat; j++) {
+                body = lines[j]
                 gsub(/./, MASKC, body)
-                lines[i] = body
+                lines[j] = body
             }
-            continue
-        }
-        p = index(line, "<<")
-        if (p > 0) {
-            start = p + 2
-            if (substr(line, start, 1) == "-") start++
-            while (substr(line, start, 1) == " " || substr(line, start, 1) == "\t") start++
-            qc = ""
-            c = substr(line, start, 1)
-            if (c == SQ || c == DQ) { qc = c; start++ }
-            wordend = start
-            while (1) {
-                c = substr(line, wordend, 1)
-                if (c ~ /^[A-Za-z0-9_]$/) { wordend++; continue }
-                break
-            }
-            if (wordend > start) {
-                delim = substr(line, start, wordend - start)
-                inbody = 1
-            }
+            i = closeat            # resume scanning after the delimiter line
+            break
         }
     }
     out = lines[1]

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1418,6 +1418,108 @@ function unmask_ws(s) {
 }
 '
 
+# =============================================================================
+# HEREDOC-BODY MASKING (#5000)
+#
+# extract_write_targets() (below) is fed the RAW, un-redacted value of a
+# --body/-m/--title/--notes/--comment flag whenever strip_literal_text()'s own
+# `$(`/backtick safety floor (#3679) declines to redact it -- the common
+# real-world trigger being a heredoc-wrapped value, `--body "$(cat <<'EOF'
+# ... EOF)"`, this repo's OWN recommended idiom (see CLAUDE.md/builder role)
+# for any multi-line/special-character body text. A `>` (or `;`, `&`, `|`, or
+# a write-idiom command word like `tee`) sitting on a heredoc BODY line is
+# genuinely inert DATA -- a heredoc body is never shell-parsed for
+# redirection/separator syntax, regardless of whether its delimiter is quoted
+# -- but qsplit()/mask_gt()/mask_ws() are (like awk itself) driven one
+# PHYSICAL LINE at a time, with no memory of the `"` opened several lines
+# earlier once a later heredoc-body line is reached, so a write-idiom-looking
+# byte on such a line was misread as real shell syntax, manufacturing a
+# phantom write target and denying a command that writes nothing to the
+# filesystem (#5000; same failure family as #4245/#3679, one line-boundary
+# narrower).
+#
+# mask_heredoc_bodies() sidesteps that per-line memory gap entirely rather
+# than teaching qsplit()/mask_gt()/mask_ws() cross-line state -- those three
+# are SHARED with extract_rm_targets()/parse_force_ops()/
+# lifecycle_or_cloud_reason(), out of THIS fix's scope (#5000's own Affected
+# Files list names only strip_literal_text() and extract_write_targets()/
+# mask_gt()). It walks the WHOLE (possibly multi-line) buffer ONCE, looking
+# for a `<<`/`<<-` heredoc opener whose delimiter is a bare or single/double
+# -quoted identifier (`EOF`, `'EOF'`, `"EOF"`, ... -- the near-universal
+# real-world shape), then replaces every byte of the BODY -- every full line
+# strictly between the opener line and the first following line that is
+# exactly (barring `<<-`'s permitted leading tabs) the bare delimiter -- with
+# a neutral placeholder byte (ETB, 0x17: never meaningful shell syntax, never
+# matched by any pattern elsewhere in this file). Real newlines, the opener
+# line, and the delimiter line itself are all left untouched, so line counts
+# and the surrounding qsplit()/strip_literal_text() `$(`-floor logic are
+# unaffected -- ONLY the inert body content disappears.
+#
+# Deliberately narrow / best-effort, consistent with every other quote-
+# tracking scan in this file: an exotic delimiter (not a bare identifier, or
+# using shell metacharacters) is simply not recognized as a heredoc opener --
+# fail-open for THIS masking pass only, never a NEW risk, since the text then
+# flows through the pre-#5000 per-line scan exactly as it always has. Never
+# denies by itself; only ever narrows what extract_write_targets() can find,
+# matching that scanner's own documented fail-open contract (a missed target
+# is the accepted safe direction there) -- a real write-idiom byte OUTSIDE
+# any recognized heredoc body, even in the SAME multi-line command, is
+# completely unaffected and still flows through unchanged.
+# =============================================================================
+_MASKHEREDOC_AWK='
+function mask_heredoc_bodies(s,   out, lines, nl, i, line, trimmed, body, delim, inbody, p, start, qc, c, wordend, SQ, DQ, MASKC) {
+    SQ = sprintf("%c", 39)    # single quote
+    DQ = sprintf("%c", 34)    # double quote
+    MASKC = sprintf("%c", 23) # ETB -- placeholder for inert heredoc-body text
+    nl = split(s, lines, "\n")
+    if (nl == 0) return ""
+    inbody = 0
+    delim = ""
+    for (i = 1; i <= nl; i++) {
+        line = lines[i]
+        if (inbody) {
+            # A `<<-` opener permits (and strips) leading tabs on the
+            # delimiter line; a bare `<<` requires an exact match. Either
+            # way only leading TABS (never spaces) are stripped, per real
+            # heredoc semantics.
+            trimmed = line
+            sub(/^\t+/, "", trimmed)
+            if (trimmed == delim) {
+                inbody = 0
+                delim = ""
+            } else {
+                body = line
+                gsub(/./, MASKC, body)
+                lines[i] = body
+            }
+            continue
+        }
+        p = index(line, "<<")
+        if (p > 0) {
+            start = p + 2
+            if (substr(line, start, 1) == "-") start++
+            while (substr(line, start, 1) == " " || substr(line, start, 1) == "\t") start++
+            qc = ""
+            c = substr(line, start, 1)
+            if (c == SQ || c == DQ) { qc = c; start++ }
+            wordend = start
+            while (1) {
+                c = substr(line, wordend, 1)
+                if (c ~ /^[A-Za-z0-9_]$/) { wordend++; continue }
+                break
+            }
+            if (wordend > start) {
+                delim = substr(line, start, wordend - start)
+                inbody = 1
+            }
+        }
+    }
+    out = lines[1]
+    for (i = 2; i <= nl; i++) out = out "\n" lines[i]
+    return out
+}
+'
+
 # Parse force-op segments out of a command, emitting one TAB-separated
 # "<cpath>\t<target>" line per genuine git force-push / hard-reset. Portable awk
 # only (mirrors extract_rm_targets / lifecycle_or_cloud_reason segment parsing):
@@ -2166,13 +2268,31 @@ extract_rm_targets() {
 # contract this file uses everywhere: ambiguity never widens a deny).
 # =============================================================================
 extract_write_targets() {
-    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK""$_MASKGT_AWK""$_MASKWS_AWK"'
+    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK""$_MASKGT_AWK""$_MASKWS_AWK""$_MASKHEREDOC_AWK"'
     BEGIN {
         SEP = sprintf("%c", 31)
         curcwd = startcwd
     }
-    {
-        $0 = qsplit($0)   # quote-aware segmentation (#3755)
+    # Slurp the whole (possibly multi-line) command into ONE buffer,
+    # preserving embedded newlines (mirrors the #3898 multi-line
+    # accumulation strip_literal_text() already uses), then do ALL
+    # processing ONCE in END rather than once per PHYSICAL LINE -- the
+    # default per-record awk behaviour, which is what silently reset
+    # qsplit()/mask_gt()/mask_ws() to "unquoted" at every embedded newline
+    # before the #5000 fix below.
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        # Heredoc-body masking (#5000) runs BEFORE qsplit(): once a heredoc
+        # body write-idiom-looking bytes (`>`, `;`, `tee`, ...) are replaced
+        # with inert placeholders, the per-line loop below -- which still
+        # resets mask_gt()/mask_ws() per SEGMENT, exactly as before -- has
+        # nothing dangerous-looking left to misread on those lines,
+        # regardless of that per-line reset. A real write-idiom byte OUTSIDE
+        # any recognized heredoc body, even later in the SAME multi-line
+        # command, is untouched and still flows through the unchanged
+        # pipeline below.
+        buf = mask_heredoc_bodies(buf)
+        $0 = qsplit(buf)   # quote-aware segmentation (#3755)
         n = split($0, segs, "\n")
         for (i = 1; i <= n; i++) {
             seg = segs[i]

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2593,6 +2593,45 @@ assert_deny "write-confinement (#4245): bare '>' redirection still denies (regre
     "echo x > $WT_REPO/defaults/hooks/g.sh" "$WT_REPO"
 
 # -------------------------------------------------------------------------
+# Heredoc-body masking (#5000) -- extract_write_targets()/mask_gt() no longer
+# misreads a `>` (or other write-idiom syntax) sitting on a heredoc BODY line
+# as a real redirection target. Distinct from #4245 above: #4245 covers a `>`
+# quoted on the SAME line as the opening quote; this covers a `>` several
+# PHYSICAL LINES later, inside a heredoc-wrapped `--body "$(cat <<'EOF' ...
+# EOF)"` value -- the idiom this repo's own conventions recommend for any
+# multi-line/special-character --body/-m/--title/--notes/--comment value, and
+# whose `$(` trips strip_literal_text()'s own command-substitution safety
+# floor (#3679), so the raw multi-line text (never X-redacted) flows
+# unmodified into extract_write_targets(). Distinct from #4881 (unexpanded
+# $VAR redirect *targets*) -- this is misparsed heredoc-body *content*, not
+# an unresolvable target.
+#
+# The literal confirmed repro from #5000 (a `>` several lines into a
+# heredoc-wrapped --body value, with a real semicolon elsewhere in the same
+# body line):
+assert_allow "write-confinement (#5000): heredoc-wrapped --body with '>' in the body allows" \
+    'gh issue comment 253 --repo 2AMLogic/klayout-tools --body "$(cat <<'"'"'EOF'"'"'
+... observed >240s; later boots ~19s ...
+EOF
+)"' "$WT_REPO"
+
+# The plain single-line form of the same prose (no heredoc) was already
+# allowed pre-#5000 but was never covered by an explicitly named regression
+# test -- add one now per the #5000 acceptance criteria.
+assert_allow "write-confinement (#5000): plain single-line --body with '>240s' prose allows" \
+    'gh issue comment 253 --repo 2AMLogic/klayout-tools --body "... observed >240s; later boots ~19s ..."' "$WT_REPO"
+
+# Narrows, never widens: a REAL unquoted '>' target OUTSIDE the heredoc body
+# (in the same multi-line command) must still deny -- proves the heredoc-body
+# masking does not blanket-disable write-target detection for the rest of the
+# command.
+assert_deny "write-confinement (#5000): real unquoted '>' outside a heredoc body still denies" \
+    'gh issue comment 253 --body "$(cat <<'"'"'EOF'"'"'
+prose with >240s inside, harmless
+EOF
+)" && echo pwned > '"$WT_REPO"'/defaults/hooks/h.sh' "$WT_REPO"
+
+# -------------------------------------------------------------------------
 # Regression (#4210): CWD is the builder's own LINKED worktree, and the write
 # targets the MAIN checkout by absolute path (or via `cd $MAIN`). This is the
 # canonical builder setup (`cd .loom/worktrees/issue-N`). The guard must key

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2632,6 +2632,77 @@ EOF
 )" && echo pwned > '"$WT_REPO"'/defaults/hooks/h.sh' "$WT_REPO"
 
 # -------------------------------------------------------------------------
+# Fail-open regression (#5087) -- mask_heredoc_bodies() must NEVER mask a
+# heredoc body whose closing delimiter line does not actually exist in the
+# buffer.
+#
+# The first cut of the #5000 fix flipped a sticky `inbody` flag the moment it
+# saw the literal substring `<<` anywhere on a line, and only ever cleared it
+# on a line that was exactly the bare delimiter. With no such line following,
+# `inbody` never reset, so EVERYTHING from that (false) opener to the end of
+# the command was replaced with inert placeholders -- including a genuine
+# `>`/`tee`/`cp`/`mv` target on a later line, which then never reached
+# qsplit()/mask_gt() and so could not be denied. That silently defeated the
+# whole write-confinement guard (#4178) on ordinary multi-line Bash-tool
+# input containing no heredoc at all.
+#
+# Both shapes below DENY on pre-#5000 `main` and must keep denying: masking is
+# a NARROWING pass, so an unterminated/false opener has to mask nothing rather
+# than swallow the rest of the command. These are the two confirmed repros
+# from #5087; the three #5000 tests above all use a properly CLOSED
+# `<<'EOF' ... EOF` block, which is exactly why none of them caught this.
+
+# 1. A quoted string that merely CONTAINS `<<TOKEN` (no heredoc anywhere),
+#    followed on the next line by a real out-of-worktree write.
+assert_deny "write-confinement (#5087): quoted '<<TOKEN' then a real '>' write still denies" \
+    "echo \"test <<TOKEN\"
+echo \"malicious content\" > $WT_REPO/pwned.txt" "$WT_REPO"
+
+# 2. An ordinary arithmetic bitshift (`1 << 3` -- zero heredoc intent),
+#    followed on the next line by the same real write. Also pins the
+#    opener-detection tightening: a BARE delimiter starting with a digit is a
+#    shift operand, not a heredoc delimiter.
+assert_deny "write-confinement (#5087): arithmetic '<<' bitshift then a real '>' write still denies" \
+    "x=\$((1 << 3))
+echo pwned > $WT_REPO/evil.txt" "$WT_REPO"
+
+# Same fail-open shape reached through the other write idioms the masking pass
+# feeds -- proves the fix is not `>`-specific.
+assert_deny "write-confinement (#5087): unterminated heredoc opener then a real 'tee' still denies" \
+    "cat <<UNTERMINATED
+some body text that never closes
+echo x | tee $WT_REPO/defaults/hooks/teed.sh" "$WT_REPO"
+assert_deny "write-confinement (#5087): unterminated heredoc opener then a real 'cp' still denies" \
+    "echo \"prose mentioning <<EOF in passing\"
+cp /tmp/a.sh $WT_REPO/defaults/hooks/copied.sh" "$WT_REPO"
+
+# A `<<<` herestring is not a heredoc opener either, so a later real write
+# must still be seen.
+assert_deny "write-confinement (#5087): '<<<' herestring then a real '>' write still denies" \
+    "cat <<<\"some string\"
+echo pwned > $WT_REPO/defaults/hooks/hs.sh" "$WT_REPO"
+
+# Narrows-not-widens, the other direction: the #5000 false positive must stay
+# fixed even when an unterminated/false opener appears EARLIER in the same
+# command -- a rejected candidate opener must not prevent a genuinely CLOSED
+# heredoc later in the buffer from being masked.
+assert_allow "write-confinement (#5087): false opener before a CLOSED heredoc body with '>' still allows" \
+    'echo "mentions <<NOPE in prose"
+gh issue comment 253 --body "$(cat <<'"'"'EOF'"'"'
+... observed >240s; later boots ~19s ...
+EOF
+)"' "$WT_REPO"
+
+# A quoted delimiter that starts with a digit IS unambiguous heredoc intent
+# (unlike a bare `<< 3` shift operand), so a properly closed `<<'3'` block
+# still gets its body masked.
+assert_allow "write-confinement (#5087): quoted digit delimiter <<'3' masks a closed body" \
+    'gh issue comment 253 --body "$(cat <<'"'"'3'"'"'
+... observed >240s in the body ...
+3
+)"' "$WT_REPO"
+
+# -------------------------------------------------------------------------
 # Regression (#4210): CWD is the builder's own LINKED worktree, and the write
 # targets the MAIN checkout by absolute path (or via `cd $MAIN`). This is the
 # canonical builder setup (`cd .loom/worktrees/issue-N`). The guard must key


### PR DESCRIPTION
## Summary

The Bash write-confinement guard (`defaults/hooks/guard-destructive-generic.sh`) misread a `>` (or other write-idiom syntax) sitting on a heredoc **body** line, several physical lines past the opening `--body "$(cat <<'EOF' ...` quote, as a real redirection target -- causing a false-positive `BLOCKED` denial on commands that write nothing to the filesystem. This is the exact idiom this repo's own conventions recommend for any multi-line/special-character `--body`/`-m`/`--title`/`--notes`/`--comment` value.

## Root cause

`strip_literal_text()`'s own `$(`/backtick command-substitution safety floor (#3679) correctly declines to redact a heredoc-wrapped `--body` value (since it genuinely contains `$(`), so the raw multi-line text flows unmodified into `extract_write_targets()`. That function's quote-tracking helpers (`qsplit()`/`mask_gt()`/`mask_ws()`) are driven one physical line at a time by awk's default per-record processing, so they have no memory that a `"` opened on an earlier line is still "open" once a later heredoc-body line is reached -- a `>` on that later line is then misread as a real unquoted redirection operator.

## Fix

- Added `mask_heredoc_bodies()` (`defaults/hooks/guard-destructive-generic.sh`): walks the whole (possibly multi-line) command once, recognizes a `<<`/`<<-` heredoc opener with a bare or quoted identifier delimiter, and replaces every byte of the body (between the opener and the matching delimiter line) with a neutral placeholder. Real newlines, the opener line, and the delimiter line are untouched.
- Restructured `extract_write_targets()` to accumulate the full multi-line command into one buffer (mirroring the existing #3898 pattern in `strip_literal_text()`) and run `mask_heredoc_bodies()` + `qsplit()` on it once in `END`, instead of once per awk record.
- Scope is intentionally narrow: `qsplit()`/`mask_gt()`/`mask_ws()` themselves are untouched (they are shared with `extract_rm_targets()`/`parse_force_ops()`/`lifecycle_or_cloud_reason()`, out of this issue's scope) -- only `extract_write_targets()`'s own input is pre-masked.
- A real unquoted write target OUTSIDE any recognized heredoc body -- even later in the same multi-line command -- is completely unaffected and still denies (verified by a new regression test).

Cross-linking #4881 (related quote/redirect-parsing false-positive family: unexpanded `$VAR` redirect *targets*) -- distinct root cause from this issue (misparsed heredoc-body *content*, not an unresolvable target).

## Test plan

- [x] Added 3 regression tests to `tests/hooks/test-guard-destructive.sh` (#5000 block): the confirmed heredoc repro allows, the plain single-line form (previously passing but uncovered by name) allows, and a real unquoted `>` outside the heredoc body in the same command still denies (narrows, never widens).
- [x] Ran the full `tests/hooks/test-guard-destructive.sh` suite: 653/653 passed (650 pre-existing + 3 new), no regressions.
- [x] Manually piped the exact JSON repro from #5000 through the hook before/after the fix -- confirmed BLOCKED before, ALLOWED after.

Closes #5000

## Update — `dc3e2266` (fail-open fix, #5087)

The first cut (`80af881f`) of the masking pass fail-opened: `mask_heredoc_bodies()`
set a sticky `inbody` flag on the first literal `<<` on a line and only cleared it
on an exact bare-delimiter line, so an **unterminated or false** opener masked
everything to the end of the command — swallowing genuine `>`/`>>`/`tee`/`cp`/`mv`/
`sed -i` targets and defeating write confinement (#4178) on ordinary heredoc-free
input (`echo "test <<TOKEN"`, `x=$((1 << 3))`).

`dc3e2266` restructures the pass so masking is never speculative:

- **Two-pass per candidate opener** — locate the terminating bare-delimiter line
  *first*; only a block genuinely closed inside the buffer has its body masked. An
  unterminated/false opener masks **nothing** and the scan moves on.
- **Every `<<` on a line is considered in turn**, so a rejected candidate cannot
  hide a real terminated heredoc later on the same line.
- **Opener detection tightened** via a new `heredoc_delim_at()` helper: `<<<` is a
  herestring, never an opener; a *bare* delimiter starting with a digit is an
  arithmetic shift operand (`1 << 3`). An explicitly quoted `<<'3'` / `<<"3"` stays
  recognized.

Test plan (supersedes the counts above): **7** further regression tests added
(10 total for this PR); full `tests/hooks/test-guard-destructive.sh` is
**660/660 pass** (653 before).
