### PR TITLE
fix(gitignore): ignore .loom/account-health.json runtime state (#5014)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Thumbs.db
 .loom-in-use
 .loom-checkpoint
 .loom-managed
+.no-changes-needed
 .loom/.daemon.pid
 .loom/.daemon.log
 .loom/daemon.sock
@@ -73,10 +74,13 @@ Thumbs.db
 .loom/claude-config/
 .loom/tokens/
 .loom/accounts.env
+.loom/account-health.json
+.loom/account-health.lock
 .loom/CANARY
 .loom/*.log
 .loom/*.sock
 .loom/*.tmp
+.loom/*.bak
 .loom/logs/
 # <<< loom-managed <<<
 .loom-test-failure-context.json

--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -106,6 +106,14 @@ const GITIGNORE_BLOCK_HEADER: &str = "# Loom runtime state (don't commit these)"
 /// converge on this list via the new `loom-daemon update-gitignore` subcommand,
 /// which `resync-installed.sh` invokes — the block was previously refreshed only
 /// during a full `init`, so a fix here never reached repos between installs.
+///
+/// #5014: added `.loom/account-health.json` + `.loom/account-health.lock` (the
+/// per-repo token-pool health cache and its sibling `mkdir` lock, written by the
+/// daemon token pool) — Loom-owned runtime state that surfaced as untracked dirt
+/// in 0.17.0. Also re-synced the committed source `.gitignore`, whose block had
+/// drifted behind this list (was missing `.no-changes-needed` and `.loom/*.bak`).
+/// `.loom/accounts.json` is intentionally left tracked: it is an optional,
+/// committable per-repo profile allowlist, not runtime state.
 pub const EPHEMERAL_PATTERNS: &[&str] = &[
     ".loom-in-use",
     // Per-worktree builder progress checkpoint. Its WRITER moved from Python to
@@ -162,6 +170,14 @@ pub const EPHEMERAL_PATTERNS: &[&str] = &[
     // hold OAuth keys and must never be committed.
     ".loom/tokens/",
     ".loom/accounts.env",
+    // Codex/token-pool per-repo health cache + its sibling `mkdir` lock, written
+    // atomically by the daemon token pool (#5014). Machine-local runtime state
+    // that surfaced as untracked dirt in 0.17.0. Not secret-bearing (account
+    // names + reason categories only — never auth.json or child output), but
+    // still never something to commit. NB: `.loom/accounts.json` is deliberately
+    // NOT ignored — it is an optional, committable per-repo profile allowlist.
+    ".loom/account-health.json",
+    ".loom/account-health.lock",
     // Uncommitted canary confirmation sentinel (#3731). Its guardrail power comes
     // from being uncommitted, so it must never be tracked.
     ".loom/CANARY",
@@ -590,6 +606,13 @@ mod tests {
         // is born absent in every fresh worktree.
         assert!(contents.contains(".no-changes-needed"));
 
+        // #5014: the per-repo token-pool health cache + its sibling mkdir lock
+        // must be ignored so 0.17.0 runtime state never surfaces as untracked
+        // dirt. The optional, committable `.loom/accounts.json` must NOT be.
+        assert!(contents.contains(".loom/account-health.json"));
+        assert!(contents.contains(".loom/account-health.lock"));
+        assert!(!contents.contains(".loom/accounts.json"));
+
         // Retired daemon-brain patterns must NOT be emitted (Phase 3.5, #3402)
         assert!(!contents.contains(".loom/daemon-state.json"));
         assert!(!contents.contains(".loom/[0-9][0-9]-daemon-state.json"));
@@ -695,11 +718,16 @@ mod tests {
             ".loom/metrics/",
             ".loom/usage-cache.json",
             ".loom/claude-config/",
+            // #5014: per-repo token-pool health cache + its sibling mkdir lock.
+            ".loom/account-health.json",
+            ".loom/account-health.lock",
             ".loom/*.log",
             ".loom/*.sock",
             // #4401: tmp sidecars from interrupted atomic writes (e.g.
             // `.loom/manifest.json.tmp` from verify-install.sh's `generate`).
             ".loom/*.tmp",
+            // #4641/#5014: salvage/backup sidecars from torn atomic writes.
+            ".loom/*.bak",
             ".loom/logs/",
         ];
 


### PR DESCRIPTION
Closes #5014

## Problem

The Loom 0.17.0 loom-managed `.gitignore` block (between the `# >>> loom-managed (do not edit) >>>` markers) never listed `.loom/account-health.json`, which the daemon token pool writes as a per-repo health cache. It showed up as untracked dirt in every Loom-managed repo.

## Fix

- Add `.loom/account-health.json` and its sibling `mkdir` lock `.loom/account-health.lock` to `EPHEMERAL_PATTERNS` in `loom-daemon/src/init/post_init.rs` (the single source of truth for the block).
- Re-sync the committed source `.gitignore` via the canonical `loom-daemon update-gitignore` generator, so ordering matches byte-for-byte and a future resync is a no-op. This also picked up two entries the committed block had drifted behind on (`.no-changes-needed`, `.loom/*.bak`) that were already in `EPHEMERAL_PATTERNS`.

## Audit of other 0.17.x runtime state under `.loom/`

- `.account-health.<pid>.tmp` — already covered by `.loom/*.tmp`.
- Daemon-home state (`fleet.json`, `sweeps.json`, `watches.json`, `workspaces.json`, `safehouse-completed.json`) — written under the daemon home (`home.join(".loom")`), not the repo, so not repo dirt.
- `.loom/main-clean-baseline.txt` — legacy location that `clean.rs` actively removes; current baseline lives under the already-ignored `.loom/sweep-checkpoint/`.
- `.loom/accounts.json` — **deliberately left tracked**: token-pool docs document it as an optional, committable per-repo profile allowlist, not runtime state. Added a negative test asserting it is never ignored.

## Acceptance criteria

- [x] `.loom/account-health.json` added to the loom-managed gitignore block template
- [x] Audited other 0.17.x runtime-state files; added the `.lock` sibling and re-synced two drifted entries
- [x] Reinstall/resync updates the block in place — existing 0.17.0 `update_gitignore` behavior, no new code needed (confirmed: regenerating produced exactly the intended diff)

## Testing

`cargo test --lib init::post_init` — 26 passed. Added assertions in `covers_all_source_repo_gitignore_patterns` and `creates_gitignore_with_all_patterns_when_none_exists` (positive for the two new patterns, negative for `.loom/accounts.json`). `cargo clippy --lib` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)