### PR TITLE
fix(scripts): auto-cleanup merged branch checked out in primary repo checkout

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -28,6 +28,16 @@
 #                          parent branch (feature/issue-N) still has open
 #                          stacked child PRs targeting it (operator asserts the
 #                          children are already reconciled). See #3747 item 2.
+#   --no-cleanup-primary   Skip the automatic primary-checkout branch cleanup
+#                          (#5015): when the merged branch is checked out in
+#                          the PRIMARY repo checkout (not a worktree) and it
+#                          is provably safe (clean tree, no stash entries,
+#                          tip matches the merged PR head SHA), the script
+#                          normally checks out the default branch there and
+#                          deletes the merged branch automatically instead of
+#                          just printing manual instructions. Pass this to
+#                          always print the manual instructions instead.
+#   --cleanup-primary      (no-op, primary-checkout cleanup is the default)
 #
 # By default, the local worktree AND the local branch it held are cleaned up
 # after a successful merge (#4100). Pass --no-cleanup-worktree to skip both
@@ -52,6 +62,16 @@
 # git itself refuses, and the refusal is reported with a specific message
 # rather than the generic "unmerged commits" warning. The repo's default
 # branch is never a delete target.
+#
+# Primary-checkout auto-cleanup (#5015): the one case above that is "checked
+# out as the current HEAD" AND is specifically the repo's PRIMARY checkout
+# (not a linked worktree) gets one extra step: if the tip-matches-head safety
+# check already passed AND the primary checkout's working tree is clean with
+# no stash entries (re-checked immediately before the mutating step, not
+# cached), the script checks out the default branch there and force-deletes
+# the branch automatically. A dirty tree, a stash entry, a tip mismatch, or
+# --no-cleanup-primary all fall back to printing the manual two-step
+# instructions unchanged.
 #
 # Override: pass --worktree-path <dir> to opt into removing a non-Loom
 # worktree (the sentinel guard is bypassed only when this flag is supplied).
@@ -118,6 +138,14 @@ Options:
                          Pass this flag only after you have manually reconciled
                          (or verified) the children — the operator asserts
                          responsibility, mirroring --worktree-path.
+  --no-cleanup-primary   Skip automatic primary-checkout branch cleanup (#5015).
+                         When the merged branch is checked out in the PRIMARY
+                         repo checkout (not a worktree), the script normally
+                         auto-checks-out the default branch and force-deletes
+                         it there ONLY when provably safe (clean tree, no
+                         stash entries, tip matches the merged PR head SHA).
+                         Pass this to always print manual instructions instead.
+  --cleanup-primary      (no-op, primary-checkout cleanup is the default)
   -h, --help             Show this help and exit
 
 By default, the local worktree AND the local branch it held are cleaned up
@@ -140,6 +168,15 @@ a squash merge): a matching tip uses 'git branch -D'; a non-matching tip
 branch and reports it instead of force-deleting. The branch currently
 checked out (main worktree or any other) is never deleted, and the repo's
 default branch is never a delete target.
+
+Primary-checkout auto-cleanup (#5015): the one exception to "checked out
+branches are never deleted" is when the branch is checked out in the repo's
+PRIMARY checkout specifically (not a linked worktree) AND it is provably
+safe — the tip-matches-head safety check above passed, the primary
+checkout's working tree is clean, and it has no stash entries. In that case
+the script checks out the default branch there and force-deletes the merged
+branch automatically instead of just printing instructions. Pass
+--no-cleanup-primary to always print the manual instructions instead.
 
 When --worktree-path <dir> is passed explicitly, the operator is taking
 responsibility for the cleanup decision: the sentinel guard is bypassed
@@ -181,6 +218,10 @@ Examples:
   ./.loom/scripts/merge-pr.sh 123 --worktree-path ../adhoc-wt
     Merges PR #123 and removes the worktree at ../adhoc-wt plus its
     matching local branch (bypasses the .loom-managed sentinel guard).
+
+  ./.loom/scripts/merge-pr.sh 123 --no-cleanup-primary
+    Merges PR but always prints manual instructions instead of
+    auto-cleaning a branch checked out in the primary repo checkout.
 EOF
 }
 
@@ -254,6 +295,10 @@ REPO_NWO="$(forge_get_repo_nwo "$GH")" || \
 # Parse arguments
 PR_NUMBER=""
 CLEANUP_WORKTREE=true
+# CLEANUP_PRIMARY_CHECKOUT (#5015): gates the automatic primary-checkout
+# branch cleanup performed by _maybe_delete_local_branch. Defaults on
+# (mirrors CLEANUP_WORKTREE's default); --no-cleanup-primary opts out.
+CLEANUP_PRIMARY_CHECKOUT=true
 DRY_RUN=false
 AUTO_MERGE=false
 WORKTREE_PATH_OVERRIDE=""
@@ -263,6 +308,8 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --cleanup-worktree) shift ;;  # no-op, cleanup is now the default
     --no-cleanup-worktree) CLEANUP_WORKTREE=false; shift ;;
+    --cleanup-primary) shift ;;  # no-op, primary-checkout cleanup is now the default
+    --no-cleanup-primary) CLEANUP_PRIMARY_CHECKOUT=false; shift ;;
     --worktree-path)
       [[ $# -lt 2 ]] && error "--worktree-path requires a value"
       WORKTREE_PATH_OVERRIDE="$2"
@@ -288,7 +335,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[[ -z "$PR_NUMBER" ]] && error "Usage: merge-pr.sh <pr-number> [--no-cleanup-worktree] [--worktree-path <dir>] [--dry-run] [--auto] [--allow-stacked-children]"
+[[ -z "$PR_NUMBER" ]] && error "Usage: merge-pr.sh <pr-number> [--no-cleanup-worktree] [--no-cleanup-primary] [--worktree-path <dir>] [--dry-run] [--auto] [--allow-stacked-children]"
 [[ "$PR_NUMBER" =~ ^[0-9]+$ ]] || error "PR number must be numeric: $PR_NUMBER"
 
 # Validate --worktree-path early (before any network calls) so bad input
@@ -1754,6 +1801,16 @@ _find_worktree_by_branch() {
 # behaviour: Git's own "not fully merged" safety net, which keeps the branch
 # and reports it rather than force-deleting.
 #
+# Primary-checkout auto-cleanup (#5015): when the branch turns out to be
+# checked out in the repo's PRIMARY working copy rather than a removable
+# worktree, and the tip-matches-head safety check above already held, and
+# the primary checkout's working tree is clean with no stash entries (see
+# the auto-cleanup block below for the exact gate), this checks out the
+# default branch there and force-deletes the now-unreferenced branch
+# instead of just printing manual instructions. Opt out with
+# --no-cleanup-primary (CLEANUP_PRIMARY_CHECKOUT=false) if silently moving
+# HEAD in the operator's primary checkout is unwanted.
+#
 # Never fails the cleanup pipeline — always returns 0, warns on errors.
 _maybe_delete_local_branch() {
   local branch="$1"
@@ -1806,6 +1863,37 @@ _maybe_delete_local_branch() {
     checkout_loc="$(_find_worktree_by_branch "$branch")"
     if [[ -n "$checkout_loc" ]] && _is_primary_worktree_path "$checkout_loc"; then
       local default_label="${DEFAULT_BRANCH_NAME:-<default-branch>}"
+
+      # Auto-cleanup (#5015): the two-step remediation below (checkout the
+      # default branch, then force-delete) is exactly what this script
+      # already knows is safe to do itself whenever ALL of the following
+      # hold — do it instead of just printing instructions:
+      #   1. Not opted out via --no-cleanup-primary / CLEANUP_PRIMARY_CHECKOUT.
+      #   2. The default branch actually resolved (never silently guess one).
+      #   3. delete_flag == "-D" — the tip-matches-merged-head-SHA safety
+      #      check above already passed, so every commit on $branch is part
+      #      of the merged PR; nothing is lost by deleting it.
+      #   4. The primary checkout's working tree is clean (no uncommitted
+      #      changes, no staged changes) AND has no stash entries — checked
+      #      HERE, immediately before the mutating `checkout`, not cached
+      #      earlier, to avoid a TOCTOU gap against a concurrent process
+      #      working in the same checkout.
+      # A dirty tree, a present stash, an opt-out, or a tip mismatch all fall
+      # straight through to the manual two-step instructions unchanged.
+      if [[ "${CLEANUP_PRIMARY_CHECKOUT:-true}" == "true" ]] && \
+         [[ -n "$DEFAULT_BRANCH_NAME" ]] && \
+         [[ "$delete_flag" == "-D" ]] && \
+         [[ -z "$(git -C "$checkout_loc" status --porcelain 2>/dev/null)" ]] && \
+         [[ -z "$(git -C "$checkout_loc" stash list 2>/dev/null)" ]]; then
+        if git -C "$checkout_loc" checkout -q "$DEFAULT_BRANCH_NAME" 2>/dev/null && \
+           git -C "$checkout_loc" branch -D "$branch" >/dev/null 2>&1; then
+          success "Local branch '$branch' deleted$safety_note"
+          info "Primary checkout ($checkout_loc) was on '$branch' — automatically switched to '$DEFAULT_BRANCH_NAME' to free it up for deletion"
+          return 0
+        fi
+        warning "Attempted to auto-clean up '$branch' in the primary checkout ($checkout_loc) but the checkout or delete failed — falling back to manual instructions"
+      fi
+
       warning "Could not delete local branch '$branch' — it is checked out in the primary repository checkout ($checkout_loc)."
       warning "To clean it up: git -C '$checkout_loc' checkout $default_label && git -C '$checkout_loc' branch -D $branch"
     else

--- a/defaults/scripts/tests/test-merge-pr-local-branch-cleanup.sh
+++ b/defaults/scripts/tests/test-merge-pr-local-branch-cleanup.sh
@@ -40,10 +40,23 @@
 #          warning.
 #      (f) no expected_head_sha supplied (the pre-#4100 --worktree-path
 #          caller shape) -> falls back to plain `-d` behaviour unchanged.
+#      (g)-(j) primary-checkout auto-cleanup (#5015): when the branch is
+#          checked out in the PRIMARY repo checkout (not a linked worktree)
+#          and the tip-match safety check passed, merge-pr.sh no longer just
+#          prints manual instructions — it completes the cleanup itself:
+#          (g) clean tree -> auto `checkout <default> && branch -D`.
+#          (h) dirty tree (control) -> unchanged manual-instructions
+#              behavior, HEAD untouched.
+#          (i) tree clean but a stash entry exists -> treated as unsafe, not
+#              auto-cleaned.
+#          (j) CLEANUP_PRIMARY_CHECKOUT=false (--no-cleanup-primary) opts out
+#              even when otherwise fully safe.
 #
 # This is the companion to test-merge-pr-worktree-path.sh (wiring/discovery)
 # and test-merge-pr-primary-worktree-guard.sh (the extract-and-eval pattern
-# this test reuses for _maybe_delete_local_branch).
+# this test reuses for _maybe_delete_local_branch). See also
+# test-merge-pr-primary-checkout-advice.sh (the #4171 companion, also
+# extended for #5015 with the tip-match auto-cleanup case).
 
 set -euo pipefail
 
@@ -116,6 +129,15 @@ warning() { echo "WARN: $*"; }
 success() { echo "OK: $*"; }
 error()   { echo "ERROR: $*" >&2; return 1; }
 
+# _maybe_delete_local_branch's primary-checkout auto-cleanup path (#5015)
+# calls _find_worktree_by_branch / _is_primary_worktree_path, which in turn
+# calls _primary_worktree_path — extract all three alongside it so the real
+# auto-cleanup branch actually runs in this harness (an undefined helper
+# silently no-ops instead of erroring, which would otherwise mask the new
+# behavior rather than exercise it).
+eval "$(extract_fn _primary_worktree_path "$MERGE_PR")"
+eval "$(extract_fn _is_primary_worktree_path "$MERGE_PR")"
+eval "$(extract_fn _find_worktree_by_branch "$MERGE_PR")"
 eval "$(extract_fn _maybe_delete_local_branch "$MERGE_PR")"
 
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/loom-merge-local-branch.XXXXXX")"
@@ -138,6 +160,8 @@ BASE_SHA="$(git -C "$REPO" rev-parse HEAD)"
 REPO_ROOT="$REPO"
 # shellcheck disable=SC2034
 DEFAULT_BRANCH_NAME="main"
+# shellcheck disable=SC2034
+CLEANUP_PRIMARY_CHECKOUT=true
 
 echo ""
 echo "Test 2: behavioral tests of the real _maybe_delete_local_branch body"
@@ -193,10 +217,16 @@ fi
 git -C "$REPO" worktree remove "$WT2" --force >/dev/null 2>&1 || true
 git -C "$REPO" branch -D feature/issue-300 >/dev/null 2>&1 || true
 
-# --- (c2) branch IS the current HEAD (primary checkout) -> also refused ---
+# --- (c2) branch IS the current HEAD (primary checkout) -> also refused.
+# REPO here IS the primary checkout, so with _is_primary_worktree_path /
+# _find_worktree_by_branch now extracted (needed by the #5015 auto-cleanup
+# tests below), this correctly gets the primary-checkout-specific message
+# rather than the generic one — no expected_head_sha means delete_flag stays
+# "-d", so the #5015 auto-cleanup gate (which requires "-D") never fires and
+# the branch is preserved either way. ---
 git -C "$REPO" checkout -q -b feature/issue-301
 out_c2="$(_maybe_delete_local_branch "feature/issue-301" "" 2>&1)"
-if [[ "$out_c2" == *"checked out (current HEAD or another worktree)"* ]] \
+if [[ "$out_c2" == *"checked out in the primary repository checkout"* ]] \
    && git -C "$REPO" show-ref --verify --quiet refs/heads/feature/issue-301; then
     pass "(c2) branch that is the current HEAD is never deleted"
 else
@@ -240,6 +270,93 @@ if [[ "$out_f" == *"OK: Local branch 'feature/issue-400' deleted"* ]] \
 else
     fail "(f) expected plain -d delete with no safety-note; got: $out_f"
 fi
+
+# --- (g) checked out in the PRIMARY checkout, clean tree, tip matches head SHA
+#     -> auto-cleanup: checkout the default branch, then force-delete (#5015) ---
+echo ""
+echo "Test 3: primary-checkout auto-cleanup (#5015)"
+
+git -C "$REPO" checkout -q -b feature/issue-500
+echo "change" >> "$REPO/README.md"
+git -C "$REPO" commit -q -am "issue 500 work"
+MATCH_SHA_G="$(git -C "$REPO" rev-parse feature/issue-500)"
+# feature/issue-500 remains checked out (current HEAD) — REPO IS the primary
+# checkout (the sole worktree in this repo), and the tree is clean.
+
+out_g="$(_maybe_delete_local_branch "feature/issue-500" "$MATCH_SHA_G" 2>&1)"
+if [[ "$out_g" == *"OK: Local branch 'feature/issue-500' deleted"* ]] \
+   && [[ "$out_g" == *"safe force-delete"* ]] \
+   && [[ "$out_g" == *"automatically switched to 'main'"* ]] \
+   && [[ "$(git -C "$REPO" branch --show-current)" == "main" ]] \
+   && ! git -C "$REPO" show-ref --verify --quiet refs/heads/feature/issue-500; then
+    pass "(g) clean tree + tip match in the primary checkout auto-checks-out default and force-deletes"
+else
+    fail "(g) expected auto-checkout + force-delete; got: $out_g (branch now: $(git -C "$REPO" branch --show-current))"
+fi
+
+# --- (h) control: same setup but a DIRTY tree -> unchanged manual-instructions
+#     behavior, HEAD untouched, branch preserved ---
+git -C "$REPO" checkout -q -b feature/issue-600
+echo "change" >> "$REPO/README.md"
+git -C "$REPO" commit -q -am "issue 600 work"
+MATCH_SHA_H="$(git -C "$REPO" rev-parse feature/issue-600)"
+echo "uncommitted work" >> "$REPO/README.md"   # dirty the tree, do NOT commit
+
+out_h="$(_maybe_delete_local_branch "feature/issue-600" "$MATCH_SHA_H" 2>&1)"
+if [[ "$out_h" == *"checked out in the primary repository checkout"* ]] \
+   && [[ "$out_h" == *"checkout main"* ]] \
+   && [[ "$out_h" == *"branch -D feature/issue-600"* ]] \
+   && [[ "$(git -C "$REPO" branch --show-current)" == "feature/issue-600" ]] \
+   && git -C "$REPO" show-ref --verify --quiet refs/heads/feature/issue-600; then
+    pass "(h) dirty tree in the primary checkout keeps current behavior — manual instructions, HEAD untouched"
+else
+    fail "(h) expected unchanged manual-instructions behavior on a dirty tree; got: $out_h"
+fi
+git -C "$REPO" checkout -q -- README.md
+git -C "$REPO" checkout -q main
+git -C "$REPO" branch -D feature/issue-600 >/dev/null 2>&1 || true
+
+# --- (i) edge case: tree is clean but a stash entry exists -> treated as
+#     unsafe, not auto-cleaned (AC: "no stash entries created by the script") ---
+git -C "$REPO" checkout -q -b feature/issue-700
+echo "change" >> "$REPO/README.md"
+git -C "$REPO" commit -q -am "issue 700 work"
+MATCH_SHA_I="$(git -C "$REPO" rev-parse feature/issue-700)"
+echo "stash me" >> "$REPO/README.md"
+git -C "$REPO" stash push -q -m "unrelated wip"   # tree is clean again, but a stash entry now exists
+
+out_i="$(_maybe_delete_local_branch "feature/issue-700" "$MATCH_SHA_I" 2>&1)"
+if [[ "$out_i" == *"checked out in the primary repository checkout"* ]] \
+   && [[ "$(git -C "$REPO" branch --show-current)" == "feature/issue-700" ]] \
+   && git -C "$REPO" show-ref --verify --quiet refs/heads/feature/issue-700; then
+    pass "(i) a present stash entry blocks auto-cleanup even with an otherwise-clean tree"
+else
+    fail "(i) expected stash presence to block auto-cleanup; got: $out_i"
+fi
+git -C "$REPO" stash drop -q >/dev/null 2>&1 || true
+git -C "$REPO" checkout -q main
+git -C "$REPO" branch -D feature/issue-700 >/dev/null 2>&1 || true
+
+# --- (j) opt-out: CLEANUP_PRIMARY_CHECKOUT=false disables auto-cleanup even
+#     when otherwise fully safe (--no-cleanup-primary sets this at the CLI) ---
+git -C "$REPO" checkout -q -b feature/issue-800
+echo "change" >> "$REPO/README.md"
+git -C "$REPO" commit -q -am "issue 800 work"
+MATCH_SHA_J="$(git -C "$REPO" rev-parse feature/issue-800)"
+
+CLEANUP_PRIMARY_CHECKOUT=false
+out_j="$(_maybe_delete_local_branch "feature/issue-800" "$MATCH_SHA_J" 2>&1)"
+CLEANUP_PRIMARY_CHECKOUT=true
+
+if [[ "$out_j" == *"checked out in the primary repository checkout"* ]] \
+   && [[ "$(git -C "$REPO" branch --show-current)" == "feature/issue-800" ]] \
+   && git -C "$REPO" show-ref --verify --quiet refs/heads/feature/issue-800; then
+    pass "(j) CLEANUP_PRIMARY_CHECKOUT=false (--no-cleanup-primary) opts out even when otherwise safe"
+else
+    fail "(j) expected opt-out to fall back to manual instructions; got: $out_j"
+fi
+git -C "$REPO" checkout -q main
+git -C "$REPO" branch -D feature/issue-800 >/dev/null 2>&1 || true
 
 # --- Summary ---
 echo ""

--- a/defaults/scripts/tests/test-merge-pr-local-branch-cleanup.sh
+++ b/defaults/scripts/tests/test-merge-pr-local-branch-cleanup.sh
@@ -346,6 +346,7 @@ MATCH_SHA_J="$(git -C "$REPO" rev-parse feature/issue-800)"
 
 CLEANUP_PRIMARY_CHECKOUT=false
 out_j="$(_maybe_delete_local_branch "feature/issue-800" "$MATCH_SHA_J" 2>&1)"
+# shellcheck disable=SC2034
 CLEANUP_PRIMARY_CHECKOUT=true
 
 if [[ "$out_j" == *"checked out in the primary repository checkout"* ]] \

--- a/defaults/scripts/tests/test-merge-pr-primary-checkout-advice.sh
+++ b/defaults/scripts/tests/test-merge-pr-primary-checkout-advice.sh
@@ -39,6 +39,14 @@
 #   4. Control: unchanged behavior for a genuine linked worktree — both the
 #      loom-managed (auto-removed) and user-owned (generic "lacks sentinel"
 #      advice, `git worktree remove` suggestion intact) cases.
+#   5. #5015 extension: the two-step advice above was previously the END of
+#      the story even when the tip-match safety check (already computed for
+#      the force-delete path) provably held. Now, when the primary
+#      checkout's tree is also clean, merge-pr.sh performs the checkout+
+#      delete itself rather than just printing instructions; a dirty tree
+#      keeps exactly the old print-only behavior. See also
+#      test-merge-pr-local-branch-cleanup.sh cases (g)-(j) for the
+#      opt-out-flag and active-stash edge cases.
 
 set -euo pipefail
 
@@ -238,6 +246,68 @@ else
         fail "user-owned worktree advice regressed: $user_sim_out"
     fi
 fi
+
+# --- Test 5: primary-checkout auto-cleanup when it is PROVABLY safe (#5015) ---
+#
+# Test 3 above only exercises the "print manual instructions" path because it
+# calls _maybe_delete_local_branch without an expected_head_sha, so the
+# tip-match safety check never engages. This distinguishes that case from the
+# genuinely-safe one: a clean tree AND a tip matching the merged PR head SHA
+# completes the cleanup automatically instead of just printing advice. The
+# companion dirty-tree control confirms the two-step advice remains unchanged
+# whenever the tree is NOT provably clean.
+echo ""
+echo "Test 5: primary-checkout auto-cleanup when provably safe (#5015)"
+
+# shellcheck disable=SC2034
+CLEANUP_PRIMARY_CHECKOUT=true
+
+# (a) clean tree + tip matches the merged PR head SHA -> auto checkout+delete.
+git -C "$PRIMARY" checkout -q -b feature/issue-501
+echo "clean work" >> "$PRIMARY/README.md"
+git -C "$PRIMARY" commit -q -am "issue 501 work"
+CLEAN_TIP_SHA="$(git -C "$PRIMARY" rev-parse feature/issue-501)"
+
+set +e
+clean_out="$(_maybe_delete_local_branch "feature/issue-501" "$CLEAN_TIP_SHA" 2>&1)"
+clean_rc=$?
+set -e
+
+if [[ $clean_rc -eq 0 ]] \
+   && [[ "$clean_out" == *"deleted"* ]] \
+   && [[ "$clean_out" == *"safe force-delete"* ]] \
+   && [[ "$(git -C "$PRIMARY" branch --show-current)" == "main" ]] \
+   && ! git -C "$PRIMARY" show-ref --verify --quiet refs/heads/feature/issue-501; then
+    pass "(5a) clean tree + tip-matching head SHA auto-cleans the branch instead of printing advice"
+else
+    fail "(5a) expected auto-cleanup; rc=$clean_rc, out: $clean_out, branch: $(git -C "$PRIMARY" branch --show-current)"
+fi
+
+# (b) control: same setup but a DIRTY tree -> unchanged manual-instructions
+# behavior (this is the "leave current behavior unchanged when the tree is
+# dirty" acceptance criterion).
+git -C "$PRIMARY" checkout -q -b feature/issue-502
+echo "clean work" >> "$PRIMARY/README.md"
+git -C "$PRIMARY" commit -q -am "issue 502 work"
+DIRTY_TIP_SHA="$(git -C "$PRIMARY" rev-parse feature/issue-502)"
+echo "uncommitted" >> "$PRIMARY/README.md"
+
+set +e
+dirty_out="$(_maybe_delete_local_branch "feature/issue-502" "$DIRTY_TIP_SHA" 2>&1)"
+dirty_rc=$?
+set -e
+
+if [[ $dirty_rc -eq 0 ]] \
+   && [[ "$dirty_out" == *"checked out in the primary repository checkout"* ]] \
+   && [[ "$dirty_out" == *"checkout main"* ]] \
+   && [[ "$dirty_out" == *"branch -D feature/issue-502"* ]] \
+   && [[ "$(git -C "$PRIMARY" branch --show-current)" == "feature/issue-502" ]] \
+   && git -C "$PRIMARY" show-ref --verify --quiet refs/heads/feature/issue-502; then
+    pass "(5b) a dirty tree keeps the manual-instructions behavior unchanged, HEAD untouched"
+else
+    fail "(5b) expected unchanged manual-instructions behavior on a dirty tree; rc=$dirty_rc, out: $dirty_out"
+fi
+git -C "$PRIMARY" checkout -q -- README.md
 
 # --- Summary ---
 echo ""

--- a/defaults/scripts/tests/test-merge-pr-primary-checkout-advice.sh
+++ b/defaults/scripts/tests/test-merge-pr-primary-checkout-advice.sh
@@ -126,6 +126,11 @@ git -C "$PRIMARY" config user.name "Test"
 echo "hello" > "$PRIMARY/README.md"
 git -C "$PRIMARY" add -A
 git -C "$PRIMARY" commit -q -m "initial"
+# Normalize the initial branch name so the test does not depend on the
+# runner's init.defaultBranch git config — _maybe_delete_local_branch()'s
+# auto-cleanup does `git checkout "$DEFAULT_BRANCH_NAME"` (main), which would
+# otherwise fail on runners where `git init` does not name the branch `main`.
+git -C "$PRIMARY" branch -M main
 
 # The merged PR's branch, checked out directly in the primary — NO
 # .loom-managed sentinel here (this is the real-world case: the primary


### PR DESCRIPTION
## Summary

- `merge-pr.sh` already detects when a merged PR's local branch is checked out in the **primary** repo checkout (not a linked worktree) and, up to now, could only print manual two-step remediation (`git checkout <default> && git branch -D <branch>`) instead of deleting it.
- `_maybe_delete_local_branch()` now performs that cleanup itself when it is provably safe, and falls back to the existing manual-instructions behavior otherwise (unchanged).
- Adds an opt-out flag, `--no-cleanup-primary` (`--cleanup-primary` is a documented no-op, mirroring the existing `--cleanup-worktree`/`--no-cleanup-worktree` precedent), for operators who don't want `HEAD` silently moved in their primary checkout.

## Changes

- `defaults/scripts/merge-pr.sh`:
  - Extended `_maybe_delete_local_branch()`'s primary-checkout branch: when the branch tip already matched the merged PR head SHA (`delete_flag == "-D"`, the existing safety check), and `CLEANUP_PRIMARY_CHECKOUT` is not disabled, and the primary checkout's working tree is clean (`git status --porcelain` empty, checked immediately before the mutating step — not cached earlier, to avoid a TOCTOU gap against a concurrent process in the same checkout) with no stash entries, it now runs `git checkout <default-branch> && git branch -D <branch>` in that checkout instead of just printing instructions.
  - Any failure of the checkout/delete step, a dirty tree, an active stash, an opt-out via `--no-cleanup-primary`, or a tip mismatch all fall straight through to the existing manual two-step instructions, unchanged.
  - Added `--no-cleanup-primary` / `--cleanup-primary` flag parsing plus documentation in the header comment, `show_help()`, and the usage-error string.
- `defaults/scripts/tests/test-merge-pr-local-branch-cleanup.sh`: extended with cases (g)-(j) — clean tree + tip match (auto-cleanup), dirty tree (control, unchanged behavior), an active stash entry (unsafe, not auto-cleaned), and the `--no-cleanup-primary` opt-out. Also extracted `_primary_worktree_path` / `_is_primary_worktree_path` / `_find_worktree_by_branch` into the test harness so the real auto-cleanup branch actually executes (previously these were undefined in this harness and silently no-op'd); this also corrected test (c2)'s expected message to the real primary-checkout-specific text.
- `defaults/scripts/tests/test-merge-pr-primary-checkout-advice.sh`: added Test 5 — a clean-tree + tip-match case (auto-cleanup) and a dirty-tree control case (manual instructions, `HEAD` untouched), extending the existing #4171 primary-checkout coverage.
- `.loom/scripts/merge-pr.sh` is a symlink to `../defaults/scripts/merge-pr.sh` in this repo, so no separate sync step was needed.

## Acceptance Criteria Verification

- [x] Offer to complete cleanup when provably safe (clean tree, no staged changes, no stash entries, tip matches merged PR head SHA) — implemented in `_maybe_delete_local_branch()`.
- [x] Leave current behavior unchanged when the tree is dirty — verified by test (h) and Test 5(b) (dirty tree still gets manual instructions, `HEAD` untouched).
- [x] Gated behind a flag (`--no-cleanup-primary`) — implemented; opt-out verified by test (j).

## Test Plan

- [x] Extended `test-merge-pr-local-branch-cleanup.sh` with the safe-cleanup case (g) and the dirty-tree control case (h).
- [x] Added the active-`git stash` edge case (i) — treated as unsafe, not auto-cleaned.
- [x] Verified the existing tip-mismatch fallback path (`git branch -d`, test (b)) is unaffected.
- [x] Extended `test-merge-pr-primary-checkout-advice.sh` (Test 5) with the same safe/dirty distinction against the #4171 primary-checkout repro scenario.
- [x] Ran the full `test-merge-pr-*.sh` suite (13 files) — all pass, including all pre-existing tests unmodified in behavior.
- [x] `bash -n` syntax check and `shellcheck -x` on `merge-pr.sh` — only two pre-existing informational (SC2015/SC2016) notices on lines untouched by this change.

Closes #5015