### PR TITLE
fix(fleet): empty roster must not exit 0 or read as a healthy fleet status

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -822,10 +822,37 @@ format was needed.
 - **`safehoused` presence**: a cheap best-effort probe (socket / `pgrep`);
   degrades to `unknown` rather than erroring the row.
 - **Empty roster**: never renders as empty output — prints an explicit "no
-  fleet workers registered" notice alongside the local host's row.
-- **Exit code**: `0` only when every roster host is `UP`; non-zero otherwise
-  (a monitor/CI check should treat any non-zero exit as "go look" — including
-  a `POWERED OFF` host, since it is still not confirmed-alive).
+  fleet workers registered" notice alongside the local host's row. #5060: an
+  empty (or effectively-empty, i.e. only the always-present local row)
+  registry is **not** a healthy fleet reading — see the exit-code carve-out
+  and summary-line wording below. Registered-fleet visibility only covers
+  what has actually been `fleet add-worker`'d; a self-maintained host that is
+  never registered is invisible to every `fleet status` run on every other
+  host, not just flagged unhealthy — this is why the incident that motivated
+  #5060 went unnoticed for hours despite one of the unregistered hosts being
+  genuinely broken. **Guidance**: any host that is meant to be part of this
+  fleet's cross-host visibility (i.e. anything other than a pure local dev
+  checkout) should be registered via `fleet add-worker` from at least one
+  other host's registry; an unregistered-but-live self-maintained daemon is
+  itself worth treating as a gap, not an acceptable steady state. A soft
+  cross-check that surfaces unregistered-but-reachable peers (e.g. by probing
+  the tailnet or a known-hosts list) was considered but is out of scope here
+  — track it separately if still wanted.
+- **Exit code**: `0` only when the roster is non-empty **and** every roster
+  host is `UP`; non-zero otherwise (a monitor/CI check should treat any
+  non-zero exit as "go look" — including a `POWERED OFF` host, since it is
+  still not confirmed-alive). #5060: an empty roster (nothing but the local
+  row) always exits non-zero, even though that lone local row is itself
+  `UP` — a 1-of-1 "everyone present is up" reading is not the same claim as
+  "the fleet was checked and is healthy," and a watch loop must not be able
+  to read an empty-roster run as an all-clear. The human-readable summary
+  line is likewise qualified for this case (`EMPTY ROSTER — N of N known
+  host(s) up (...); this is roster coverage (local host only), NOT a
+  confirmed healthy fleet.`) rather than the unqualified `N host(s): N up,
+  ...` line used for a real, populated roster — a reader skimming just the
+  last line, not the notice above the table, still sees the distinction. The
+  `--json` `summary.empty_roster` field already existed before this fix and
+  is unchanged; only the exit code and the human summary line now consult it.
 - **`--json`** schema: `{ "hosts": [ { "alias", "state", "tailnet_name"?,
   "provider_instance_id"?, "added_by"?, "is_local", "workspaces", "status"?,
   "detail"?, "safehoused" } ], "summary": { "total", "up", "daemon_down",

--- a/loom-daemon/src/fleet/status.rs
+++ b/loom-daemon/src/fleet/status.rs
@@ -749,11 +749,23 @@ fn summarize(hosts: &[HostReport], empty_roster: bool) -> FleetStatusSummary {
 }
 
 impl FleetStatusReport {
-    /// Exit-code policy (AC 3): `0` only when every host is [`HostState::Up`];
-    /// otherwise non-zero so a monitor/CI check fails loudly rather than
-    /// silently reading an unreachable/down/draining host as fine.
+    /// Exit-code policy (AC 3): `0` only when every host is [`HostState::Up`]
+    /// **and** the roster is not empty; otherwise non-zero so a monitor/CI
+    /// check fails loudly rather than silently reading an unreachable/down/
+    /// draining/never-registered fleet as fine.
+    ///
+    /// #5060: an empty registry (no `fleet add-worker`'d hosts — only the
+    /// always-present local row) satisfies `up == total` on a technicality
+    /// (1-of-1, the local host, is up) and must NOT be allowed to exit `0`.
+    /// A `0` here is meant to say "the whole fleet was checked and every
+    /// member is healthy" — that claim is meaningless with nothing but the
+    /// local host in the roster, so callers (a watch loop included) cannot
+    /// mistake "nothing registered" for "fleet confirmed healthy".
     #[must_use]
     pub fn exit_code(&self) -> i32 {
+        if self.summary.empty_roster {
+            return 1;
+        }
         if self.summary.up == self.summary.total {
             0
         } else {
@@ -809,16 +821,36 @@ impl FleetStatusReport {
                 out.push_str(&format!("      workspaces: {}\n", host.workspaces.join(", ")));
             }
         }
-        out.push_str(&format!(
-            "\n{} host(s): {} up, {} daemon-down, {} unreachable, {} powered-off (expected), {} parse-error, {} draining.\n",
-            self.summary.total,
-            self.summary.up,
-            self.summary.daemon_down,
-            self.summary.unreachable,
-            self.summary.powered_off,
-            self.summary.parse_error,
-            self.summary.draining,
-        ));
+        if self.summary.empty_roster {
+            // #5060: the plain "N host(s): N up, ..." phrasing below reads as
+            // "the fleet was checked and is healthy" — for an empty roster
+            // that is only true of the single local row, not the fleet, so
+            // this branch must be visually distinct (own leading line, an
+            // explicit "EMPTY ROSTER" marker, and "known" rather than an
+            // unqualified host count) even to a reader skimming just this
+            // last line rather than the notice above the table.
+            out.push_str(&format!(
+                "\nEMPTY ROSTER — {} of {} known host(s) up ({} daemon-down, {} unreachable, {} powered-off (expected), {} parse-error, {} draining); this is roster coverage (local host only), NOT a confirmed healthy fleet.\n",
+                self.summary.up,
+                self.summary.total,
+                self.summary.daemon_down,
+                self.summary.unreachable,
+                self.summary.powered_off,
+                self.summary.parse_error,
+                self.summary.draining,
+            ));
+        } else {
+            out.push_str(&format!(
+                "\n{} host(s): {} up, {} daemon-down, {} unreachable, {} powered-off (expected), {} parse-error, {} draining.\n",
+                self.summary.total,
+                self.summary.up,
+                self.summary.daemon_down,
+                self.summary.unreachable,
+                self.summary.powered_off,
+                self.summary.parse_error,
+                self.summary.draining,
+            ));
+        }
         out
     }
 }
@@ -1307,6 +1339,13 @@ mod tests {
         let report =
             collect_fleet_report(source.clone(), registry, local, Duration::from_secs(5)).await;
         assert_eq!(report.exit_code(), 0);
+        // #5060 regression guard: this fix is additive to the empty-roster
+        // case only — a genuinely populated, all-up roster must still
+        // exit 0 and render the plain, unqualified summary line.
+        assert!(!report.summary.empty_roster);
+        let rendered = report.render_human();
+        assert!(rendered.contains("2 host(s): 2 up"));
+        assert!(!rendered.contains("EMPTY ROSTER"));
 
         let mut responses2 = HashMap::new();
         responses2.insert("down-host".to_string(), MockOutcome::LaunchErr);
@@ -1330,9 +1369,18 @@ mod tests {
         assert!(report.hosts[0].is_local);
         assert!(report.summary.empty_roster);
 
+        // #5060: an empty roster must never exit 0 — that reads as "fleet
+        // confirmed healthy", which is not a claim we can make about a
+        // registry with nothing but the local host in it.
+        assert_ne!(report.exit_code(), 0);
+
         let rendered = report.render_human();
         assert!(rendered.contains("no fleet workers registered"));
         assert!(rendered.contains(LOCAL_HOST_ALIAS));
+        // The summary line itself (not just the notice above the table) must
+        // also read as distinct from a genuinely healthy fleet.
+        assert!(rendered.contains("EMPTY ROSTER"));
+        assert!(!rendered.contains("1 host(s): 1 up"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`loom-daemon fleet status` on a host with an empty fleet registry (no
workers ever added via `fleet add-worker`) printed a summary line like
`1 host(s): 1 up, 0 unreachable` (the local host only) and exited `0` —
indistinguishable from "the whole registered fleet is healthy." This
happened in practice on 2026-08-03: two other live hosts (one genuinely
broken) were invisible because they were never registered, and the command
reported all-clear.

`FleetStatusSummary` already carried a correct `empty_roster: bool` field
(set at `collect_fleet_report()`), so a `--json` consumer could already
detect this — the gap was entirely in the two human-facing surfaces:

- `FleetStatusReport::exit_code()` never consulted `empty_roster`, so an
  empty/1-host roster (`total: 1, up: 1`, the local host) satisfied
  `up == total` and returned `0`.
- `render_human()`'s summary line never consulted `empty_roster` either —
  it printed the same unqualified `N host(s): N up, ...` line regardless.

### Changes

- `exit_code()` now returns non-zero whenever `summary.empty_roster` is
  true, even though the lone local row is itself `Up`.
- `render_human()`'s summary line is now visually distinct for the
  empty-roster case: `EMPTY ROSTER — N of N known host(s) up (...); this
  is roster coverage (local host only), NOT a confirmed healthy fleet.`
  A genuinely populated roster still renders the original, unqualified
  line — this is additive to the empty-roster case only.
- `--json` output is unchanged (`summary.empty_roster` already existed and
  was already correct); only the exit code and human summary line now
  consult it.
- `defaults/docs/daemon-reference.md`'s `fleet status` section documents
  the exit-code carve-out and adds guidance: a self-maintained host meant
  to be part of this fleet's cross-host visibility should be registered via
  `fleet add-worker`; an unregistered-but-live daemon is itself a gap, not
  a steady state.

### Scope guard

Out of scope, per the issue's curator note: a soft cross-check that
surfaces unregistered-but-reachable peers (tailnet/known-hosts probing).
Documented as a follow-up if still wanted — this fix is the mechanical
exit-code/summary-line correction only.

## Test plan

- [x] `cargo test -p loom-daemon --lib fleet::status` — all 26 tests pass,
      including the extended `empty_roster_yields_local_only_row_and_explicit_notice`
      (now asserts `exit_code() != 0` and the `EMPTY ROSTER` summary text)
      and a new regression assertion on `exit_code_zero_only_when_every_host_up`
      confirming a populated, all-up roster still exits `0` with the plain,
      unqualified summary line.
- [x] `cargo test -p loom-daemon --lib` — full crate suite, 3242 tests pass.
- [x] `cargo build -p loom-daemon` and `cargo fmt -p loom-daemon -- --check` — clean.
- [x] Manual reasoning: confirmed no other code path formats/matches on the
      `"N host(s): N up"` string (only the two new tests reference it).

Closes #5060