### PR TITLE
fix(installer): add .loom/account-health.json to the loom-managed gitignore block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ Thumbs.db
 .loom/claude-config/
 .loom/tokens/
 .loom/accounts.env
+.loom/account-health.json
+.loom/account-health.lock
 .loom/CANARY
 .loom/*.log
 .loom/*.sock

--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -106,6 +106,13 @@ const GITIGNORE_BLOCK_HEADER: &str = "# Loom runtime state (don't commit these)"
 /// converge on this list via the new `loom-daemon update-gitignore` subcommand,
 /// which `resync-installed.sh` invokes — the block was previously refreshed only
 /// during a full `init`, so a fix here never reached repos between installs.
+///
+/// #5014: added `.loom/account-health.json` and `.loom/account-health.lock`
+/// (`tokens_pool::health`'s provider-health cache + its `mkdir`-based lock
+/// dir, [`crate::tokens_pool::locking::MkdirLock`]) — the 0.17.0 rewrite of
+/// this block gained other new entries but missed this one, so every
+/// Loom-managed repo running the daemon's account-health probe showed it as
+/// untracked dirt in `git status`.
 pub const EPHEMERAL_PATTERNS: &[&str] = &[
     ".loom-in-use",
     // Per-worktree builder progress checkpoint. Its WRITER moved from Python to
@@ -162,6 +169,12 @@ pub const EPHEMERAL_PATTERNS: &[&str] = &[
     // hold OAuth keys and must never be committed.
     ".loom/tokens/",
     ".loom/accounts.env",
+    // Provider-health probe cache written by `tokens_pool::health` (the token
+    // pool's account-liveness cache) + its sibling `mkdir`-based lock dir
+    // (#5014). Runtime state, not secret-bearing, but must stay untracked for
+    // the same reason as the rest of this list.
+    ".loom/account-health.json",
+    ".loom/account-health.lock",
     // Uncommitted canary confirmation sentinel (#3731). Its guardrail power comes
     // from being uncommitted, so it must never be tracked.
     ".loom/CANARY",
@@ -590,6 +603,11 @@ mod tests {
         // is born absent in every fresh worktree.
         assert!(contents.contains(".no-changes-needed"));
 
+        // #5014: the account-health probe cache + its lock dir must be
+        // ignored so they never surface as untracked dirt.
+        assert!(contents.contains(".loom/account-health.json"));
+        assert!(contents.contains(".loom/account-health.lock"));
+
         // Retired daemon-brain patterns must NOT be emitted (Phase 3.5, #3402)
         assert!(!contents.contains(".loom/daemon-state.json"));
         assert!(!contents.contains(".loom/[0-9][0-9]-daemon-state.json"));
@@ -695,6 +713,9 @@ mod tests {
             ".loom/metrics/",
             ".loom/usage-cache.json",
             ".loom/claude-config/",
+            // #5014: account-health probe cache + its lock dir.
+            ".loom/account-health.json",
+            ".loom/account-health.lock",
             ".loom/*.log",
             ".loom/*.sock",
             // #4401: tmp sidecars from interrupted atomic writes (e.g.


### PR DESCRIPTION
Closes #5014

## Summary

The daemon's account-health probe (`tokens_pool::health`) writes
`.loom/account-health.json`, and its sibling `mkdir`-based lock guard
(`tokens_pool::locking::MkdirLock`) creates `.loom/account-health.lock`. The
0.17.0 rewrite of the loom-managed `.gitignore` block template
(`EPHEMERAL_PATTERNS` in `loom-daemon/src/init/post_init.rs`) gained other new
entries (`.no-changes-needed`, `.loom/*.bak`) but missed both of these, so
every Loom-managed repo running the account-health probe shows the file as
untracked dirt in `git status`.

## Changes

- Added `.loom/account-health.json` and `.loom/account-health.lock` to
  `EPHEMERAL_PATTERNS` in `loom-daemon/src/init/post_init.rs` (the single
  source of truth the daemon's `update-gitignore` subcommand and
  `resync-installed.sh` both drive off).
- Added the same two lines to this repo's own committed `.gitignore` (inside
  the managed block) — template changes don't retroactively re-run on this
  repo, and the entries were genuinely missing from the committed file (not
  just from local resync drift).
- Updated the two `post_init.rs` unit tests that assert the full managed-block
  pattern set (`creates_gitignore_with_all_patterns_when_none_exists`,
  `covers_all_source_repo_gitignore_patterns`) to cover the new entries.

## Quick audit of other runtime state files

Searched `loom-daemon/src` for `.loom/*.json` (and other `.loom/*`) files
written by the daemon/sweep and cross-referenced against
`EPHEMERAL_PATTERNS`. Found no other gaps with high confidence:

- All other `.loom/*.json` writers I found (`daemon-metrics.json`,
  `issue-failures.json`, `state.json`, `mcp-command.json`,
  `guide-docs-state.json`, `metrics_state.json`, `manifest.json`,
  `stuck-config.json`, `usage-cache.json`, `spawn-loop-state.json`, plus
  `install-metadata.json` and `config.json`, which are *intentionally*
  committed) are already covered.
- `main_health_gate.rs` has its own, separate `LOOM_OWNED_PREFIXES` list (a
  bash mirror lives in `defaults/scripts/check-main-clean.sh`) used only by
  this repo's own dogfooded dirty-tree/health-gate check. That mechanism
  handles a different problem (already-*tracked* files whose content churns,
  e.g. `install-metadata.json`) and doesn't need an `account-health.*` entry —
  once the files are gitignored, plain `git status --porcelain` won't surface
  them there at all. Left untouched; noting it here in case a future pass
  wants to double check.
- `.loom/*.tmp` already covers `account-health`'s atomic-write temp file
  (`.account-health.<pid>.tmp`, written by `write_state` in
  `tokens_pool/health.rs`) via the existing glob.

## Test plan

- [x] `cargo test --lib init::post_init::` in `loom-daemon/` — 26 passed, 0
      failed (includes the two updated assertions).
- [x] `cargo fmt --check -- loom-daemon/src/init/post_init.rs` — clean.