### PR TITLE
fix(fleet): an empty roster must not read as a healthy fleet in `fleet status`

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -822,10 +822,39 @@ format was needed.
 - **`safehoused` presence**: a cheap best-effort probe (socket / `pgrep`);
   degrades to `unknown` rather than erroring the row.
 - **Empty roster**: never renders as empty output — prints an explicit "no
-  fleet workers registered" notice alongside the local host's row.
-- **Exit code**: `0` only when every roster host is `UP`; non-zero otherwise
-  (a monitor/CI check should treat any non-zero exit as "go look" — including
-  a `POWERED OFF` host, since it is still not confirmed-alive).
+  fleet workers registered" notice alongside the local host's row, **and**
+  (#5060) a qualified summary line (`1 of 1 known host(s) up — ROSTER IS
+  EMPTY, showing the local host only; this is NOT a healthy fleet`) instead of
+  the unqualified `N host(s): N up` a real fleet gets. Both the notice and the
+  summary line are load-bearing: an operator (or log scraper) reading only the
+  last line of the output must not mistake "this command saw no fleet" for
+  "the fleet is fine".
+- **Exit code**: `0` only when every roster host is `UP` **and the roster is
+  non-empty**; non-zero otherwise (a monitor/CI check should treat any
+  non-zero exit as "go look" — including a `POWERED OFF` host, since it is
+  still not confirmed-alive).
+  - **Empty-roster carve-out** (#5060): an empty registry exits **non-zero**
+    even though the only row present (the local host) is `UP`. A 1-of-1 all-up
+    report is byte-identical in shape to a genuinely healthy single-host
+    fleet, so an unconfigured, lost, or mis-pathed `~/.loom/fleet.json` would
+    otherwise read as "all clear" to every scripted consumer. `empty_roster:
+    true` in `--json` means *this command saw no fleet* — a state to
+    investigate, not to pass. (Note that the registry is resolved per-host: on
+    a host whose registry is empty, `fleet status` sees **only** the local
+    host and knows nothing about peers, however healthy they are.)
+- **Should every host be registered?** **Yes** — including self-maintained
+  hosts that were never provisioned via `fleet add-worker` (an operator's own
+  laptop/workstation running its own `loom-daemon`). The registry is the only
+  inventory `fleet status` has; a live daemon that is not in *some* host's
+  registry is invisible to fleet-wide checks, will never be probed, and will
+  never appear in a summary count. Treat an unregistered live daemon as a
+  **warning in its own right**, not a benign configuration style: add it with
+  `loom-daemon fleet add-worker <ssh-host> --repo <owner/name>` (idempotent —
+  every step is `check`-guarded, so registering an already-configured host
+  reports `unchanged` and touches nothing) so it is covered by the exit-code
+  policy above. *Not* covered here (deferred to a follow-up): any soft
+  cross-check that compares the roster against tailnet/known-hosts peers to
+  flag unregistered-but-reachable hosts automatically.
 - **`--json`** schema: `{ "hosts": [ { "alias", "state", "tailnet_name"?,
   "provider_instance_id"?, "added_by"?, "is_local", "workspaces", "status"?,
   "detail"?, "safehoused" } ], "summary": { "total", "up", "daemon_down",

--- a/loom-daemon/src/fleet/status.rs
+++ b/loom-daemon/src/fleet/status.rs
@@ -752,8 +752,19 @@ impl FleetStatusReport {
     /// Exit-code policy (AC 3): `0` only when every host is [`HostState::Up`];
     /// otherwise non-zero so a monitor/CI check fails loudly rather than
     /// silently reading an unreachable/down/draining host as fine.
+    ///
+    /// #5060: an EMPTY roster is also non-zero, even though the only row
+    /// present (the local host) is `Up`. A 1-of-1 all-up report from an empty
+    /// registry is indistinguishable from a genuinely healthy fleet, so an
+    /// unconfigured/lost/mis-pathed registry would otherwise read as "all
+    /// clear" to every scripted consumer — the exact fleet-visibility blind
+    /// spot this policy exists to prevent. `empty_roster` means "this command
+    /// saw no fleet", which is a state to investigate, not to pass.
     #[must_use]
     pub fn exit_code(&self) -> i32 {
+        if self.summary.empty_roster {
+            return 1;
+        }
         if self.summary.up == self.summary.total {
             0
         } else {
@@ -763,7 +774,8 @@ impl FleetStatusReport {
 
     /// Render the human-readable table (AC 1: one command, every host side by
     /// side). Never empty output (AC 2): an empty roster prints an explicit
-    /// notice in addition to the local host's row.
+    /// notice in addition to the local host's row, AND (#5060) a qualified
+    /// roster-coverage summary line rather than an unqualified count.
     #[must_use]
     pub fn render_human(&self) -> String {
         let mut out = String::new();
@@ -809,16 +821,33 @@ impl FleetStatusReport {
                 out.push_str(&format!("      workspaces: {}\n", host.workspaces.join(", ")));
             }
         }
-        out.push_str(&format!(
-            "\n{} host(s): {} up, {} daemon-down, {} unreachable, {} powered-off (expected), {} parse-error, {} draining.\n",
-            self.summary.total,
-            self.summary.up,
+        let breakdown = format!(
+            "{} daemon-down, {} unreachable, {} powered-off (expected), {} parse-error, {} draining",
             self.summary.daemon_down,
             self.summary.unreachable,
             self.summary.powered_off,
             self.summary.parse_error,
             self.summary.draining,
-        ));
+        );
+        // #5060: the SUMMARY LINE ITSELF — not just the notice above the table
+        // — has to read as "not a healthy fleet" for an empty roster. An
+        // operator scanning only the last line of `fleet status` (or a log
+        // scraper matching it) otherwise sees an unqualified "1 host(s): 1 up"
+        // that is byte-for-byte the shape of a real, healthy single-host
+        // fleet. Qualifying it as ROSTER COVERAGE ("N of M KNOWN hosts") makes
+        // the denominator's provenance explicit.
+        if self.summary.empty_roster {
+            out.push_str(&format!(
+                "\n{} of {} known host(s) up — ROSTER IS EMPTY, showing the local host only; \
+                 this is NOT a healthy fleet ({}).\n",
+                self.summary.up, self.summary.total, breakdown,
+            ));
+        } else {
+            out.push_str(&format!(
+                "\n{} host(s): {} up, {}.\n",
+                self.summary.total, self.summary.up, breakdown,
+            ));
+        }
         out
     }
 }
@@ -1330,9 +1359,57 @@ mod tests {
         assert!(report.hosts[0].is_local);
         assert!(report.summary.empty_roster);
 
+        // #5060: an empty roster must NEVER read as "all clear", even though
+        // the only row present (the local host) is Up. A 1-of-1 all-up report
+        // is indistinguishable from a genuinely healthy single-host fleet.
+        assert_eq!(report.summary.up, report.summary.total);
+        assert_ne!(report.exit_code(), 0);
+
         let rendered = report.render_human();
         assert!(rendered.contains("no fleet workers registered"));
         assert!(rendered.contains(LOCAL_HOST_ALIAS));
+        // #5060 AC 2: the summary LINE ITSELF (not just the notice above the
+        // table) is qualified as roster coverage, so it cannot be mistaken for
+        // a healthy fleet by an operator/scraper reading only the last line.
+        assert!(
+            rendered.contains("1 of 1 known host(s) up"),
+            "summary line not qualified as roster coverage: {rendered}"
+        );
+        assert!(rendered.contains("ROSTER IS EMPTY"));
+        assert!(rendered.contains("NOT a healthy fleet"));
+        assert!(
+            !rendered.contains("1 host(s): 1 up"),
+            "empty roster must not render the unqualified healthy-fleet summary line: {rendered}"
+        );
+    }
+
+    /// #5060 non-regression: the empty-roster carve-out above must not make a
+    /// genuinely populated, fully-up roster report unhealthy — that would
+    /// invert the whole exit-code contract for every real fleet.
+    #[tokio::test]
+    async fn non_empty_all_up_roster_still_exits_zero_with_unqualified_summary() {
+        let mut responses = HashMap::new();
+        responses.insert("up-host".to_string(), MockOutcome::Output(up_output(r#"{}"#)));
+        responses.insert("other-up-host".to_string(), MockOutcome::Output(up_output(r#"{}"#)));
+        let source: Arc<dyn HostStatusSource> = Arc::new(MockSource::new(responses));
+        let mut registry = FleetRegistry::default();
+        registry.upsert(worker("up-host"));
+        registry.upsert(worker("other-up-host"));
+        let local = HostReport::local_up(serde_json::json!({}));
+        let report = collect_fleet_report(source, registry, local, Duration::from_secs(5)).await;
+
+        assert!(!report.summary.empty_roster);
+        assert_eq!(report.summary.total, 3);
+        assert_eq!(report.summary.up, 3);
+        assert_eq!(report.exit_code(), 0);
+
+        let rendered = report.render_human();
+        assert!(
+            rendered.contains("3 host(s): 3 up"),
+            "healthy fleet lost its unqualified summary line: {rendered}"
+        );
+        assert!(!rendered.contains("ROSTER IS EMPTY"));
+        assert!(!rendered.contains("no fleet workers registered"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #5060

## Problem

`loom-daemon fleet status` on a host with an empty fleet registry rendered:

```
1 host(s): 1 up, 0 daemon-down, 0 unreachable, 0 powered-off (expected), 0 parse-error, 0 draining.
```

and exited `0` — byte-for-byte the shape of a genuinely healthy single-host fleet.
An unconfigured, lost, or mis-pathed `~/.loom/fleet.json` therefore read as "all
clear" to every scripted consumer, and to any operator scanning only the last line.

`FleetStatusSummary.empty_roster` already existed and was already surfaced in
`--json` and in the parenthetical notice above the table — but neither
`exit_code()` nor the summary line consulted it.

## Changes

**`loom-daemon/src/fleet/status.rs`**

- `FleetStatusReport::exit_code()` (AC 1) — returns non-zero when
  `summary.empty_roster` is true, even though the only row present (the local
  host) is `Up`. "This command saw no fleet" is a state to investigate, not to pass.
- `render_human()` (AC 2) — the summary **line itself** is now qualified as roster
  coverage for an empty roster:
  `1 of 1 known host(s) up — ROSTER IS EMPTY, showing the local host only; this is NOT a healthy fleet (0 daemon-down, ...).`
  A non-empty roster keeps the exact pre-existing `N host(s): N up, ...` line
  (the per-state breakdown was factored out to a shared `breakdown` string, so
  both branches render identical tallies).

**`defaults/docs/daemon-reference.md`** (AC 3) — `### fleet status [--json]`:

- The exit-code contract gets an explicit **empty-roster carve-out** sub-bullet.
- The empty-roster bullet documents the new qualified summary line and why both
  the notice and the summary line are load-bearing.
- New **"Should every host be registered?"** guidance: **yes**, including
  self-maintained hosts never provisioned via `fleet add-worker`. The registry is
  the only inventory `fleet status` has, so an unregistered live daemon is
  invisible to fleet-wide checks — a warning in its own right, not a benign
  configuration style.

## Tests

- `empty_roster_yields_local_only_row_and_explicit_notice` (AC 4) — extended to
  assert `report.exit_code() != 0`, that `up == total` (i.e. the fix is *not*
  coming from a state count), that the summary line is qualified, and that the
  unqualified `1 host(s): 1 up` string is **absent**.
- `non_empty_all_up_roster_still_exits_zero_with_unqualified_summary` (AC 5, new)
  — a genuinely populated 3-host, fully-up roster still exits `0` and still
  renders `3 host(s): 3 up`, with no empty-roster wording. This fix must not make
  a healthy multi-host fleet report unhealthy.

```
cargo test -p loom-daemon --lib fleet::   →  157 passed; 0 failed
cargo clippy -p loom-daemon --lib --all-targets  →  clean
cargo fmt -p loom-daemon -- --check      →  clean
bash scripts/check-docs-defaults-parity.sh  →  OK
```

## Out of scope (AC 6)

No tailnet/known-hosts soft cross-check for unregistered-but-reachable peers —
explicitly deferred to a follow-up issue. The docs note the deferral so the gap
is visible rather than silently absent.

## Risk

Low / additive. `empty_roster` has no consumer outside `status.rs` (verified by
grep across `*.rs`/`*.ts`/`*.js`/`*.sh`/`*.py`), the `--json` schema is unchanged,
and the non-empty rendering path is byte-identical to before.

Behavior change worth flagging for review: any monitor that today shells out to
`fleet status` on a deliberately roster-less host will start seeing a non-zero
exit. That is the intended fix (an empty roster is a blind spot, not a pass), but
it is a contract change, hence the docs update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
