### PR TITLE
feat(forge): route the 38 gh issue create call sites through create-issue.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,11 @@ missing/exhausted pool exits `78` (`EX_CONFIG`). Full reference:
 - **GitHub** — Loom uses the `gh` CLI (the `gh auth login` credential; scope to
   one repo with `export GH_TOKEN=…`). Fleet rate-limit protections (breaker, ETag
   cache, App tokens — epic #4432) are `loom-daemon`-internal; hand-rolled parallel
-  `claude-wrapper.sh` loops get none. See [`.loom/docs/github-authentication.md`](.loom/docs/github-authentication.md).
+  `claude-wrapper.sh` loops get none. **File new issues with
+  `./.loom/scripts/create-issue.sh`, never a bare `gh issue create`** — that is
+  GraphQL-backed and dies on GraphQL exhaustion while the independent REST pool
+  sits idle; the script falls back to one REST POST with labels applied
+  atomically (#5047). See [`.loom/docs/github-authentication.md`](.loom/docs/github-authentication.md).
 - **Gitea** — set `GITEA_TOKEN` or `FORGE_TOKEN` (repository read/write). See
   [`.loom/docs/forge-authentication.md`](.loom/docs/forge-authentication.md).
 - **Releasing** — `scripts/version.sh` keeps all 5 version-bearing files in sync

--- a/defaults/.claude/commands/loom/architect-patterns.md
+++ b/defaults/.claude/commands/loom/architect-patterns.md
@@ -85,21 +85,18 @@ Briefly document other options you evaluated and why they were ruled out:
 ## Issue Creation Command
 
 ```bash
-# Create proposal issue
-gh issue create --title "..." --body "$(cat <<'EOF'
+# Create proposal issue with ALL labels applied ATOMICALLY (#5047) — a
+# follow-up `gh issue edit --add-label` doubles the request count and can
+# half-fail, leaving an unlabelled issue no queue query finds. Choose the
+# tier label that matches goal alignment.
+./.loom/scripts/create-issue.sh --title "..." \
+  --label "loom:architect" \
+  --label "tier:goal-advancing" \
+  --body "$(cat <<'EOF'
 [issue content here]
 EOF
 )"
-
-# Add proposal label (blue badge - awaiting user approval)
-gh issue edit <number> --add-label "loom:architect"
-
-# Add tier label based on goal alignment
-gh issue edit <number> --add-label "tier:goal-advancing"     # Tier 1
-# OR
-gh issue edit <number> --add-label "tier:goal-supporting"    # Tier 2
-# OR
-gh issue edit <number> --add-label "tier:maintenance"        # Tier 3
+# tier label above is one of: tier:goal-advancing | tier:goal-supporting | tier:maintenance
 ```
 
 ---
@@ -250,14 +247,13 @@ How do we know this epic is complete?
 ### Creating an Epic
 
 ```bash
-# Create epic issue
-gh issue create --title "Epic: [Title]" --body "$(cat <<'EOF'
+# Create epic issue, with its label (NOT loom:architect) applied atomically
+./.loom/scripts/create-issue.sh --title "Epic: [Title]" \
+  --label "loom:epic" \
+  --body "$(cat <<'EOF'
 [epic content using template above]
 EOF
 )"
-
-# Add epic label (NOT loom:architect)
-gh issue edit <number> --add-label "loom:epic"
 ```
 
 **Important**: Use `loom:epic` label, not `loom:architect`. Epics follow a different approval workflow.

--- a/defaults/.claude/commands/loom/architect-reference.md
+++ b/defaults/.claude/commands/loom/architect-reference.md
@@ -38,11 +38,8 @@ This file contains detailed reference documentation for the Architect role, incl
 # Check if there are already open proposals (don't spam)
 gh issue list --label="loom:architect" --state=open --limit 500
 
-# Create new proposal
-gh issue create --title "..." --body "..."
-
-# Add proposal label (blue badge)
-gh issue edit <number> --add-label "loom:architect"
+# Create new proposal — blue-badge label applied atomically at creation (#5047)
+./.loom/scripts/create-issue.sh --title "..." --body "..." --label "loom:architect"
 ```
 
 **Important**: Don't create too many proposals at once. If there are already 3+ open proposals, wait for the user to approve/reject some before creating more.
@@ -79,8 +76,12 @@ When the user explicitly instructs you to analyze a specific area or create a pr
 # Analyze the specified area
 # ... examine code, identify opportunities ...
 
-# Create proposal with clear context
-gh issue create --title "Refactor terminal state management to use reducer pattern" --body "$(cat <<'EOF'
+# Create proposal with clear context, applying its label ATOMICALLY at
+# creation (#5047) — a follow-up `gh issue edit --add-label` doubles the
+# request count and can half-fail, leaving an unlabelled issue behind.
+./.loom/scripts/create-issue.sh --title "Refactor terminal state management to use reducer pattern" \
+  --label "loom:architect" \
+  --body "$(cat <<'EOF'
 ## Problem Statement
 Per user request to analyze terminal state management architecture...
 
@@ -92,8 +93,6 @@ Per user request to analyze terminal state management architecture...
 EOF
 )"
 
-# Apply architect label
-gh issue edit <number> --add-label "loom:architect"
 gh issue comment <number> --body "Created per user request to analyze terminal state management"
 ```
 
@@ -124,16 +123,15 @@ gh issue comment <number> --body "Created per user request to analyze terminal s
 
 ### Applying Tier Labels
 
-```bash
-# After creating a proposal, add the appropriate tier label
-gh issue edit <number> --add-label "loom:architect"
+Apply `loom:architect` AND the tier label in the SAME `create-issue.sh` call
+that files the proposal (#5047) — never a follow-up `gh issue edit
+--add-label`, which doubles the request count and can half-fail into an
+unlabelled issue no queue query finds:
 
-# AND add the tier label based on goal alignment
-gh issue edit <number> --add-label "tier:goal-advancing"     # Tier 1
-# OR
-gh issue edit <number> --add-label "tier:goal-supporting"    # Tier 2
-# OR
-gh issue edit <number> --add-label "tier:maintenance"        # Tier 3
+```bash
+./.loom/scripts/create-issue.sh --title "..." --body "..." \
+  --label "loom:architect" \
+  --label "tier:goal-advancing"     # or tier:goal-supporting | tier:maintenance
 ```
 
 ---
@@ -153,8 +151,8 @@ gh issue edit <number> --add-label "tier:maintenance"        # Tier 3
 9. **Document alternatives considered**: Briefly mention other options and why they were ruled out
 10. **Estimate impact**: Complexity, risks, dependencies
 11. **Assess priority**: Determine if `loom:urgent` label is warranted
-12. **Create the issue**: Use `gh issue create` with focused recommendation
-13. **Add proposal label**: Run `gh issue edit <number> --add-label "loom:architect"`
+12. **Create the issue**: Use `./.loom/scripts/create-issue.sh` with focused recommendation
+13. **Add proposal label**: Pass `--label "loom:architect"` on that same creation call — never a follow-up `gh issue edit --add-label`
 
 **Key Difference from old workflow**: Steps 3-6 are about requirements gathering. You ask questions BEFORE creating issues, enabling you to recommend ONE approach instead of presenting multiple options without guidance.
 

--- a/defaults/.claude/commands/loom/architect.md
+++ b/defaults/.claude/commands/loom/architect.md
@@ -167,14 +167,21 @@ When creating a proposal:
 2. **Gather requirements** or **self-reflect** (autonomous mode)
 3. **Select ONE recommendation**: Choose approach that best fits constraints
 4. **Check for duplicates**: Run duplicate check before creating issue
-5. **Create the issue**: Use `gh issue create` with focused recommendation
-6. **Add labels**: `loom:architect` + tier label
+5. **Create the issue**: Use `./.loom/scripts/create-issue.sh` with focused recommendation
+6. **Add labels**: `loom:architect` + tier label — pass them as `--label` on the
+   creation command itself, never as a follow-up `gh issue edit`
 
 **For templates and examples**, read `.claude/commands/loom/architect-patterns.md`.
 
-> **Do not run concurrent Architects — serialize issue creation (#3707).** `gh issue create` returns a server-assigned number with no client-side coordination, so two Architects (or an Architect and a Curator-decomposition / Champion epic-phase run) filing issues at the same time in the same repo **race on issue numbers and cross-contaminate bodies**. Never place an issue-creating agent in a parallel wave; one issue-creating agent must finish its entire `gh issue create` burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the full invariant. Parallel **Builders** (implementing already-filed issues) stay safe — only issue *creation* must be serialized.
+> **File issues with `./.loom/scripts/create-issue.sh`, never a bare `gh issue create` (#5047).**
+> `gh issue create` is GraphQL-backed and dies outright once the shared GraphQL pool exhausts —
+> while the independent REST pool sits ~99% unused. The script takes the same flags (`--title`,
+> `--body`/`--body-file`, repeatable `--label`, `--repo`) and prints the same issue URL, but falls
+> back to a single REST POST that applies labels **atomically with creation**. Recipe and
+> rationale: `.loom/docs/gh-issue-create-rest-fallback.md`.
+> (`loom-daemon forge issue create` is a byte-identical `gh` passthrough — NOT a fallback.)
 
-> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`, or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+> **Do not run concurrent Architects — serialize issue creation (#3707).** `gh issue create` returns a server-assigned number with no client-side coordination, so two Architects (or an Architect and a Curator-decomposition / Champion epic-phase run) filing issues at the same time in the same repo **race on issue numbers and cross-contaminate bodies**. Never place an issue-creating agent in a parallel wave; one issue-creating agent must finish its entire `gh issue create` burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the full invariant. Parallel **Builders** (implementing already-filed issues) stay safe — only issue *creation* must be serialized.
 
 ### Duplicate Detection (CRITICAL)
 
@@ -184,7 +191,7 @@ When creating a proposal:
 # Check if similar issue already exists
 if ./.loom/scripts/check-duplicate.sh "Your proposed issue title" "Optional body text"; then
     # No duplicates found - safe to create
-    gh issue create --title "Your proposed issue title" ...
+    ./.loom/scripts/create-issue.sh --title "Your proposed issue title" ...
 else
     # Potential duplicate found - review existing issues first
     echo "Similar issue may already exist. Checking..."
@@ -207,14 +214,17 @@ TITLE="Your proposal title"
 BODY="Your proposal body..."
 
 if ./.loom/scripts/check-duplicate.sh "$TITLE" "$BODY"; then
-    # No duplicates - safe to create
-    gh issue create --title "$TITLE" --body "$(cat <<'EOF'
+    # No duplicates - safe to create. Labels ride along in the SAME call:
+    # a follow-up `gh issue edit --add-label` doubles the request count and
+    # can half-fail into an unlabelled issue no queue query finds.
+    ./.loom/scripts/create-issue.sh --title "$TITLE" \
+      --label "loom:architect" \
+      --label "tier:goal-advancing" \
+      --body "$(cat <<'EOF'
 [issue content - see architect-patterns.md for template]
 EOF
 )"
-    # Add labels
-    gh issue edit <number> --add-label "loom:architect"
-    gh issue edit <number> --add-label "tier:goal-advancing"  # or tier:goal-supporting or tier:maintenance
+    # tier label above is one of: tier:goal-advancing | tier:goal-supporting | tier:maintenance
 else
     echo "Skipping creation - potential duplicate found"
 fi
@@ -245,11 +255,8 @@ For large features that span multiple phases (4+ issues with dependencies), crea
 **For epic templates and workflow**, read `.claude/commands/loom/architect-patterns.md`.
 
 ```bash
-# Create epic issue
-gh issue create --title "Epic: [Title]" --body "..."
-
-# Add epic label (NOT loom:architect)
-gh issue edit <number> --add-label "loom:epic"
+# Create epic issue, with its label (NOT loom:architect) applied atomically
+./.loom/scripts/create-issue.sh --title "Epic: [Title]" --body "..." --label "loom:epic"
 ```
 
 ---

--- a/defaults/.claude/commands/loom/auditor.md
+++ b/defaults/.claude/commands/loom/auditor.md
@@ -248,7 +248,7 @@ one label: the Auditor runs across many repos and hosts, and an un-deduped filer
 is a noise machine (prior art: #4736 filed 7 duplicate "still blocked" comments).
 
 ```bash
-# Run this gate before EVERY gh issue create in this role, whatever the label:
+# Run this gate before EVERY issue filing in this role, whatever the label:
 TITLE="…"   # the title you are about to file
 if ./.loom/scripts/check-duplicate.sh "$TITLE" "one-line description"; then
     :   # exit 0 = no duplicate found -> safe to create
@@ -263,9 +263,14 @@ The label-specific dedup blocks later in this document (capability requests, bug
 reports, guard decisions) are concrete applications of this one rule — none of
 them is optional and none is an exception.
 
-> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST
-> fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`,
-> or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+> **File issues with `./.loom/scripts/create-issue.sh`, never a bare `gh issue create` (#5047).**
+> `gh issue create` fails outright when GraphQL quota is exhausted, while the independent REST
+> pool sits ~99% unused. The script takes the same flags (`--title`, `--body`/`--body-file`,
+> repeatable `--label`, `--repo`) and prints the same issue URL, but falls back to a single REST
+> POST that applies labels **atomically with creation**. Recipe and rationale:
+> `.loom/docs/gh-issue-create-rest-fallback.md` (or `forge_gh_create_issue_rl_safe` in
+> `lib/forge-helpers.sh` if scripting). `loom-daemon forge issue create` is a byte-identical `gh`
+> passthrough — NOT a fallback.
 
 ## When to Create Issues
 
@@ -291,7 +296,7 @@ Path Dedups First" above / "Avoiding Duplicate Issues" below), then create a
 detailed bug report:
 
 ```bash
-gh issue create --title "Build/runtime failure on main: [specific problem]" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Build/runtime failure on main: [specific problem]" --body "$(cat <<'EOF'
 ## Bug Description
 
 [Clear description of what's broken on main branch]
@@ -356,7 +361,7 @@ Before creating a new capability request:
 TITLE="Auditor Capability Request: [specific capability needed]"
 if ./.loom/scripts/check-duplicate.sh "$TITLE" "Description of capability gap"; then
     # No duplicates found - safe to create
-    gh issue create --title "$TITLE" ...
+    ./.loom/scripts/create-issue.sh --title "$TITLE" ...
 else
     # Potential duplicate found - review similar issues first
     echo "Similar capability request may already exist. Checking..."
@@ -374,7 +379,7 @@ If a similar request exists, add a comment instead of creating a duplicate.
 When you identify a validation gap, create a detailed capability request:
 
 ```bash
-gh issue create --title "Auditor Capability Request: [specific capability needed]" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Auditor Capability Request: [specific capability needed]" --body "$(cat <<'EOF'
 ## What I Attempted to Validate
 
 [Describe what you were trying to validate]
@@ -524,7 +529,7 @@ jq -c 'select(.pattern == "<pattern>")' .loom/logs/guard-decisions.log | tail -3
 TITLE="Build/runtime failure on main: [specific problem]"
 if ./.loom/scripts/check-duplicate.sh "$TITLE" "Description of the bug"; then
     # No duplicates found - safe to create
-    gh issue create --title "$TITLE" ...
+    ./.loom/scripts/create-issue.sh --title "$TITLE" ...
 else
     # Potential duplicate found - review similar issues first
     echo "Similar issue may already exist. Checking..."

--- a/defaults/.claude/commands/loom/builder-complexity.md
+++ b/defaults/.claude/commands/loom/builder-complexity.md
@@ -2,11 +2,6 @@
 
 This document covers complexity assessment, issue decomposition, and scope management for the Builder role. For the core builder workflow, see `builder.md`.
 
-> **`gh issue create` (used throughout this file's decomposition examples) fails
-> outright when GraphQL quota is exhausted.** REST fallback recipe (atomic
-> create+label): `.loom/docs/gh-issue-create-rest-fallback.md`, or
-> `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
-
 ## Never Abandon Work
 
 **You must NEVER stop work on a claimed issue without creating a clear path forward.**
@@ -21,15 +16,30 @@ When you claim an issue with `loom:building`, you are committing to ONE of these
 - Leave an issue with `loom:building` label but no PR and no sub-issues
 - Stop work because "it's too hard" without decomposing or documenting why
 
+> **File issues with `./.loom/scripts/create-issue.sh`, never a bare `gh issue create` (#5047).**
+> `gh issue create` is GraphQL-backed and dies outright once the shared GraphQL pool exhausts —
+> while the independent REST pool sits ~99% unused. The script takes the same flags (`--title`,
+> `--body`/`--body-file`, repeatable `--label`, `--repo`) and prints the same issue URL, but falls
+> back to a single REST POST that applies labels **atomically with creation**. Recipe and
+> rationale: `.loom/docs/gh-issue-create-rest-fallback.md`.
+> (`loom-daemon forge issue create` is a byte-identical `gh` passthrough — NOT a fallback.)
+> This matters most exactly here: a decomposition burst files 2-5 issues in a row, so it is the
+> single likeliest place in a Builder run to meet an exhausted GraphQL pool mid-sequence.
+
 ### If You Discover an Issue Is Too Complex
 
 When you claim an issue and realize mid-work it requires >6 hours or touches >8 files:
 
 **DO THIS** (create path forward):
 ```bash
-# 1. Create 2-5 focused sub-issues
-gh issue create --title "[Parent #812] Part 1: Core functionality" --body "..."
-gh issue create --title "[Parent #812] Part 2: Edge cases" --body "..."
+# 1. Create 2-5 focused sub-issues, each born at loom:triage -- applied
+#    atomically at creation (#5047), never a follow-up `gh issue edit
+#    --add-label`. A separate Curator pass produces loom:curated, and a
+#    human adds loom:issue; do NOT add loom:issue yourself to a sub-issue
+#    you just created -- that would skip both Curator review and the
+#    human-approval gate.
+./.loom/scripts/create-issue.sh --title "[Parent #812] Part 1: Core functionality" --body "..." --label "loom:triage"
+./.loom/scripts/create-issue.sh --title "[Parent #812] Part 2: Edge cases" --body "..." --label "loom:triage"
 # ... create remaining sub-issues ...
 
 # 2. Update parent issue explaining decomposition
@@ -43,13 +53,7 @@ gh issue comment 812 --body "This issue is complex (>6 hours). Decomposed into:
 #    is the record, loom:blocked is the terminal state.
 gh issue edit 812 --remove-label "loom:building" --add-label "loom:blocked"
 
-# 4. (Optional) Pick up a sub-issue once a Curator has enhanced it
-#    Sub-issues are born at loom:triage. A separate Curator pass produces
-#    loom:curated, and a human adds loom:issue. Do NOT add loom:issue
-#    yourself to a sub-issue you just created -- that would skip both
-#    Curator review and the human-approval gate.
-gh issue edit XXX --add-label "loom:triage"
-# Then exit and let the Curator/sweep pipeline pick it up.
+# Then exit and let the Curator/sweep pipeline pick up each sub-issue.
 ```
 
 **DON'T DO THIS** (abandon without path forward):
@@ -214,9 +218,9 @@ $ find . -name "*_test*" | xargs grep -l constraint
 # Issue #341: "Implement E141 Constraints"
 
 # WRONG: Skip straight to decomposition without checking
-gh issue create --title "[Parent #341] Part 1: Implement NOT NULL"
-gh issue create --title "[Parent #341] Part 2: Implement PRIMARY KEY"
-gh issue create --title "[Parent #341] Part 3: Implement UNIQUE"
+./.loom/scripts/create-issue.sh --title "[Parent #341] Part 1: Implement NOT NULL"
+./.loom/scripts/create-issue.sh --title "[Parent #341] Part 2: Implement PRIMARY KEY"
+./.loom/scripts/create-issue.sh --title "[Parent #341] Part 3: Implement UNIQUE"
 # ... creates 6 duplicate issues for already-complete features
 
 # Result: 6 issues created, all later closed as duplicates
@@ -301,7 +305,7 @@ Before claiming an issue, estimate the work required:
 
 ```bash
 # Create focused sub-issues
-gh issue create --title "Phase 1: <component> foundation" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Phase 1: <component> foundation" --body "$(cat <<'EOF'
 Parent Issue: #<parent-number>
 
 ## Scope
@@ -318,7 +322,7 @@ Estimated: 1-2 hours
 EOF
 )"
 
-gh issue create --title "Phase 2: <component> integration" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Phase 2: <component> integration" --body "$(cat <<'EOF'
 Parent Issue: #<parent-number>
 
 ## Scope
@@ -369,15 +373,15 @@ gh issue edit <parent-number> --remove-label "loom:building" --add-label "loom:b
 **Decomposition**:
 ```bash
 # Phase 1: Infrastructure
-gh issue create --title "Create JSON activity log structure and helper functions"
+./.loom/scripts/create-issue.sh --title "Create JSON activity log structure and helper functions"
 # -> Issue #534 (1-2 hours)
 
 # Phase 2: Integration
-gh issue create --title "Integrate activity logging into /builder and /judge"
+./.loom/scripts/create-issue.sh --title "Integrate activity logging into /builder and /judge"
 # -> Issue #535 (2-3 hours, depends on #534)
 
 # Phase 3: Querying
-gh issue create --title "Add activity querying to /loom heuristic"
+./.loom/scripts/create-issue.sh --title "Add activity querying to /loom heuristic"
 # -> Issue #536 (1-2 hours, depends on #535)
 
 # Mark parent blocked — a human closes it once the children are curated
@@ -509,7 +513,7 @@ Don't create issues for:
 # PAUSE: Stop trying to implement it
 # CREATE: Make an issue for it
 
-gh issue create --title "Add Vitest testing framework for frontend unit tests" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Add Vitest testing framework for frontend unit tests" --body "$(cat <<'EOF'
 ## Problem
 
 While working on #38, discovered we cannot write unit tests for the state management refactor because no test framework is configured for the frontend.

--- a/defaults/.claude/commands/loom/builder-pr.md
+++ b/defaults/.claude/commands/loom/builder-pr.md
@@ -828,12 +828,17 @@ Is the failure in YOUR changed files?
 
 If you want to track pre-existing issues for future cleanup:
 
-> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST
-> fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`,
-> or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+> **File issues with `./.loom/scripts/create-issue.sh`, never a bare `gh issue create` (#5047).**
+> `gh issue create` fails outright when GraphQL quota is exhausted, while the independent REST
+> pool sits ~99% unused. The script takes the same flags (`--title`, `--body`/`--body-file`,
+> repeatable `--label`, `--repo`) and prints the same issue URL, but falls back to a single REST
+> POST that applies labels **atomically with creation**. Recipe and rationale:
+> `.loom/docs/gh-issue-create-rest-fallback.md` (or `forge_gh_create_issue_rl_safe` in
+> `lib/forge-helpers.sh` if scripting). `loom-daemon forge issue create` is a byte-identical `gh`
+> passthrough — NOT a fallback.
 
 ```bash
-gh issue create --title "Tech debt: Migrate biome.json to v2 schema" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Tech debt: Migrate biome.json to v2 schema" --body "$(cat <<'EOF'
 ## Problem
 
 `biome.json` uses deprecated v1 schema which causes warnings on every lint run.
@@ -891,7 +896,7 @@ After completing your assigned work, you can suggest improvements by creating un
 
 **Example of post-work suggestion:**
 ```bash
-gh issue create --title "Refactor terminal state management to use reducer pattern" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Refactor terminal state management to use reducer pattern" --body "$(cat <<'EOF'
 ## Problem
 
 While implementing #42, I noticed that terminal state updates are scattered across multiple files with inconsistent patterns.

--- a/defaults/.claude/commands/loom/champion-epic.md
+++ b/defaults/.claude/commands/loom/champion-epic.md
@@ -93,7 +93,7 @@ If all 6 criteria pass:
 # in the body. Phase-completion detection searches for this exact token (see
 # "Detecting Phase Completion"), NOT the natural-language "**Epic**: / **Phase**:"
 # prose — which drifts and is unreliable for GitHub `--search in:body`.
-gh issue create --title "[Epic #<epic>] <Issue Title>" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "[Epic #<epic>] <Issue Title>" --body "$(cat <<'EOF'
 <!-- loom:epic:<epic-number>:phase:1 -->
 **Epic**: #<epic-number> - <Epic Title>
 **Phase**: 1 of N

--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -1125,13 +1125,14 @@ ISSUE_BODY="${ISSUE_BODY}## Acceptance Criteria
 # Follow-on issues go to the Champion evaluation queue.
 ISSUE_LABEL="loom:curated"
 
-# Create the issue.
-# NOTE: `gh issue create` does NOT support --json/--jq (only `gh issue view`
-# and `gh issue list` do). On success it prints the new issue's URL to stdout
-# (e.g. https://github.com/<owner>/<repo>/issues/<N>); parse the trailing
-# number from that URL.
+# Create the issue with ./.loom/scripts/create-issue.sh, never a bare
+# `gh issue create` (#5047/#5077) -- it falls back to a REST POST (labels
+# applied atomically) if the shared GraphQL pool is exhausted. On success it
+# prints the new issue's URL to stdout (e.g.
+# https://github.com/<owner>/<repo>/issues/<N>); parse the trailing number
+# from that URL.
 ISSUE_TITLE="Follow-on: Work identified in PR #$PR_NUMBER"
-NEW_ISSUE_URL=$(gh issue create \
+NEW_ISSUE_URL=$(./.loom/scripts/create-issue.sh \
   --title "$ISSUE_TITLE" \
   --body "$ISSUE_BODY" \
   --label "$ISSUE_LABEL")

--- a/defaults/.claude/commands/loom/champion-reference.md
+++ b/defaults/.claude/commands/loom/champion-reference.md
@@ -354,7 +354,7 @@ NOTES=$(gh api repos/.../pulls/$PR_NUMBER/comments --jq '...')
 EXISTING=$(gh issue list --search "Follow-on from PR #$PR_NUMBER" --limit 500)
 
 # Stage 6: Create issue with proper linking
-gh issue create --title "Follow-on: Work identified in PR #$PR_NUMBER" --label "$LABEL"
+./.loom/scripts/create-issue.sh --title "Follow-on: Work identified in PR #$PR_NUMBER" --label "$LABEL"
 ```
 
 **Decision**: **Create follow-on issue if thresholds met** - captures future work.

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -318,10 +318,7 @@ If, during curation, you determine an issue is too large to be a single Builder 
 4. **Do not close the parent during decomposition** — it now tracks its children; keep it open (or relabel it as a tracking issue). Closing here would orphan the sub-issues. (Closing/rescoping in general is allowed with a rationale — see "Issues Are Suggestions — Close or Rescope With Rationale" below — but a freshly-decomposed parent is not a close candidate.)
 5. **Do not self-curate your own sub-issues in the same session.** A separate Curator pass (could be the same human-role agent in a later session, or a different agent) must independently review each sub-issue before it can earn `loom:curated`.
 6. **Serialize this `gh issue create` burst against any other issue-creating agent (#3707).** Do not run your sub-issue creation concurrently with another issue-creating agent (Architect / another Curator-decomposition / Champion epic-phase) in the same repo — concurrent `gh issue create` bursts race on server-assigned issue numbers and cross-contaminate bodies. One filer finishes its full burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the invariant.
-
-> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST
-> fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`,
-> or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+7. **File each sub-issue with `./.loom/scripts/create-issue.sh`, never a bare `gh issue create` (#5047).** `gh issue create` is GraphQL-backed and dies outright once the shared GraphQL pool exhausts — while the independent REST pool sits ~99% unused. The script takes the same flags (`--title`, `--body`/`--body-file`, repeatable `--label`, `--repo`) and prints the same issue URL, but falls back to a single REST POST that applies labels **atomically with creation**. A decomposition burst files several issues in a row, so it is the likeliest place in a Curator run to meet an exhausted pool mid-sequence. Recipe and rationale: `.loom/docs/gh-issue-create-rest-fallback.md`. (`loom-daemon forge issue create` is a byte-identical `gh` passthrough — NOT a fallback.)
 
 ### Why this matters
 
@@ -339,10 +336,10 @@ When skipped, the Builder hits these issues at implementation time — usually a
 
 ```bash
 # WRONG: decomposer-curates in one pass
-gh issue create --title "Sub-issue A" --label "loom:curated"  # FORBIDDEN
+./.loom/scripts/create-issue.sh --title "Sub-issue A" --label "loom:curated"  # FORBIDDEN
 
 # RIGHT: decomposer creates at triage, leaves for separate curator pass
-gh issue create --title "Sub-issue A" --label "loom:triage"
+./.loom/scripts/create-issue.sh --title "Sub-issue A" --label "loom:triage"
 ```
 
 ### Related: Builder decomposition

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -931,13 +931,18 @@ If feedback requires substantial work:
 4. Let Workers handle the complex refactoring
 5. Comment on PR explaining an issue was created
 
-> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST
-> fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`,
-> or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
+> **File issues with `./.loom/scripts/create-issue.sh`, never a bare `gh issue create` (#5047).**
+> `gh issue create` fails outright when GraphQL quota is exhausted, while the independent REST
+> pool sits ~99% unused. The script takes the same flags (`--title`, `--body`/`--body-file`,
+> repeatable `--label`, `--repo`) and prints the same issue URL, but falls back to a single REST
+> POST that applies labels **atomically with creation**. Recipe and rationale:
+> `.loom/docs/gh-issue-create-rest-fallback.md` (or `forge_gh_create_issue_rl_safe` in
+> `lib/forge-helpers.sh` if scripting). `loom-daemon forge issue create` is a byte-identical `gh`
+> passthrough — NOT a fallback.
 
 **Example:**
 ```bash
-gh issue create --title "Refactor authentication system per PR #123 review" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Refactor authentication system per PR #123 review" --body "$(cat <<'EOF'
 ## Context
 
 PR #123 review requested major changes to authentication system:

--- a/defaults/.claude/commands/loom/epic.md
+++ b/defaults/.claude/commands/loom/epic.md
@@ -163,7 +163,7 @@ MILESTONE=$(grep -i "milestone" README.md 2>/dev/null | head -1)
 
 ### Ensure Epic Labels Exist (Preflight)
 
-Epic creation depends on the `loom:epic` and `loom:epic-phase` labels, which may not yet exist in the target repository (e.g., if the install bundle predates these labels, or if a user manually deleted them). Run this idempotent preflight before any `gh issue create` call below. The `|| true` suffix keeps the skill working for users who lack `label:write` permission -- in that case, the subsequent `gh issue create --label` calls will fail cleanly with a clear "label not found" error rather than the skill silently dropping the epic.
+Epic creation depends on the `loom:epic` and `loom:epic-phase` labels, which may not yet exist in the target repository (e.g., if the install bundle predates these labels, or if a user manually deleted them). Run this idempotent preflight before any `./.loom/scripts/create-issue.sh` call below (file issues with that script, never a bare `gh issue create` — see #5047). The `|| true` suffix keeps the skill working for users who lack `label:write` permission -- in that case, the subsequent `create-issue.sh --label` calls will fail cleanly with a clear "label not found" error rather than the skill silently dropping the epic.
 
 ```bash
 # Idempotent: gh label create exits non-zero if the label already exists,
@@ -183,7 +183,7 @@ gh label create 'loom:epic-phase' \
 ### Create the Epic
 
 ```bash
-EPIC_URL=$(gh issue create \
+EPIC_URL=$(./.loom/scripts/create-issue.sh \
   --title "Epic: [Title]" \
   --body "$(cat <<'EOF'
 # Epic: [Title]
@@ -256,7 +256,7 @@ Create individual issues for Phase 1 only. Later phases will be created by Champ
 
 ```bash
 # For each Phase 1 issue:
-ISSUE_URL=$(gh issue create \
+ISSUE_URL=$(./.loom/scripts/create-issue.sh \
   --title "[Epic #$EPIC_NUMBER] [Issue Title]" \
   --body "$(cat <<'EOF'
 **Epic**: #EPIC_NUMBER - [Epic Title]

--- a/defaults/.claude/commands/loom/hermit-patterns.md
+++ b/defaults/.claude/commands/loom/hermit-patterns.md
@@ -657,7 +657,7 @@ $ wc -l src/components/Button.tsx
 ### Random File Review Issue Template
 
 ```bash
-gh issue create --title "Simplify <filename>: <specific improvement>" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Simplify <filename>: <specific improvement>" --body "$(cat <<'EOF'
 ## What to Simplify
 
 <file-path> - <specific bloat identified>
@@ -851,15 +851,19 @@ git log --all --format=%cd --date=short <file> | head -1
 
 ## Creating Removal Proposals - Full Templates
 
-> **`gh issue create` (used throughout the templates below) fails outright when
-> GraphQL quota is exhausted.** REST fallback recipe (atomic create+label):
-> `.loom/docs/gh-issue-create-rest-fallback.md`, or `forge_gh_create_issue_rl_safe`
-> in `lib/forge-helpers.sh` if scripting.
+> **File issues with `./.loom/scripts/create-issue.sh` (used throughout the templates
+> below), never a bare `gh issue create` (#5047).** `gh issue create` fails outright when
+> GraphQL quota is exhausted, while the independent REST pool sits ~99% unused. The script
+> takes the same flags (`--title`, `--body`/`--body-file`, repeatable `--label`, `--repo`) and
+> prints the same issue URL, but falls back to a single REST POST that applies labels
+> **atomically with creation**. Recipe and rationale: `.loom/docs/gh-issue-create-rest-fallback.md`
+> (or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting).
+> `loom-daemon forge issue create` is a byte-identical `gh` passthrough — NOT a fallback.
 
 ### Standalone Issue Template
 
 ```bash
-gh issue create --title "Remove [specific thing]: [brief reason]" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Remove [specific thing]: [brief reason]" --body "$(cat <<'EOF'
 ## What to Remove
 
 [Specific file, function, dependency, or feature]
@@ -914,7 +918,7 @@ EOF
 ### Example Standalone Issue
 
 ```bash
-gh issue create --title "Remove unused UserSerializer class" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Remove unused UserSerializer class" --body "$(cat <<'EOF'
 ## What to Remove
 
 `src/lib/serializers/user-serializer.ts` - entire file
@@ -1197,7 +1201,7 @@ EOF
 )"
 
 # Create standalone removal issue
-gh issue create --title "Remove [thing]" --body "..." --label "loom:hermit"
+./.loom/scripts/create-issue.sh --title "Remove [thing]" --body "..." --label "loom:hermit"
 
 # Check existing hermit suggestions
 "$GH_READ" issue list --label="loom:hermit" --state=open

--- a/defaults/.claude/commands/loom/hermit.md
+++ b/defaults/.claude/commands/loom/hermit.md
@@ -251,11 +251,14 @@ rg "if|for|while|switch|match" <random-file-path> --count
 | **Tier 2** | `tier:goal-supporting` | Simplification supports infrastructure for milestone features |
 | **Tier 3** | `tier:maintenance` | General cleanup not tied to current goals |
 
-**IMPORTANT**: Always apply tier labels to new proposals.
+**IMPORTANT**: Always apply tier labels to new proposals — pass BOTH `loom:hermit`
+and the tier label on the same `create-issue.sh` call that files the proposal
+(#5047), never a follow-up `gh issue edit --add-label`:
 
 ```bash
-gh issue edit <number> --add-label "loom:hermit"
-gh issue edit <number> --add-label "tier:goal-advancing"  # or tier:goal-supporting or tier:maintenance
+./.loom/scripts/create-issue.sh --title "..." --body "..." \
+  --label "loom:hermit" \
+  --label "tier:goal-advancing"  # or tier:goal-supporting or tier:maintenance
 ```
 
 *For goal discovery scripts and backlog balance checking, see `hermit-patterns.md`.*
@@ -291,10 +294,6 @@ When you identify bloat, you have two options:
 
 > **Do not run concurrent Hermits — serialize issue creation (#3707).** `gh issue create` returns a server-assigned number with no client-side coordination, so two Hermits (or a Hermit and an Architect / Curator-decomposition / Champion epic-phase run) filing issues at the same time in the same repo **race on issue numbers and cross-contaminate bodies**. Never place an issue-creating agent in a parallel wave; one issue-creating agent must finish its entire `gh issue create` burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the full invariant.
 
-> **`gh issue create` fails outright when GraphQL quota is exhausted.** REST
-> fallback recipe (atomic create+label): `.loom/docs/gh-issue-create-rest-fallback.md`,
-> or `forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh` if scripting.
-
 ### When to Create a New Issue vs Comment
 
 **Create New Issue:**
@@ -311,12 +310,20 @@ When you identify bloat, you have two options:
 
 **BEFORE creating any issue, check for potential duplicates:**
 
+> **File issues with `./.loom/scripts/create-issue.sh`, never a bare `gh issue create` (#5047).**
+> `gh issue create` is GraphQL-backed and dies outright once the shared GraphQL pool exhausts —
+> while the independent REST pool sits ~99% unused. The script takes the same flags (`--title`,
+> `--body`/`--body-file`, repeatable `--label`, `--repo`) and prints the same issue URL, but falls
+> back to a single REST POST that applies labels **atomically with creation**. Recipe and
+> rationale: `.loom/docs/gh-issue-create-rest-fallback.md`.
+> (`loom-daemon forge issue create` is a byte-identical `gh` passthrough — NOT a fallback.)
+
 ```bash
 # Check if similar issue already exists
 TITLE="Remove [thing]: [brief reason]"
 if ./.loom/scripts/check-duplicate.sh "$TITLE" "Your proposal body text"; then
     # No duplicates found - safe to create
-    gh issue create --title "$TITLE" ...
+    ./.loom/scripts/create-issue.sh --title "$TITLE" ...
 else
     # Potential duplicate found - review existing issues first
     echo "Similar issue may already exist. Checking..."
@@ -334,7 +341,7 @@ fi
 ### Brief Issue Template
 
 ```bash
-gh issue create --title "Remove [thing]: [brief reason]" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Remove [thing]: [brief reason]" --body "$(cat <<'EOF'
 ## What to Remove
 [Specific file, function, dependency, or feature]
 
@@ -380,7 +387,7 @@ EOF
 
 ```bash
 # Create issue with hermit suggestion
-gh issue create --label "loom:hermit" --title "..." --body "..."
+./.loom/scripts/create-issue.sh --label "loom:hermit" --title "..." --body "..."
 
 # User approves by adding loom:issue label (you don't do this)
 # gh issue edit <number> --add-label "loom:issue"

--- a/defaults/.claude/commands/loom/imagine.md
+++ b/defaults/.claude/commands/loom/imagine.md
@@ -397,7 +397,7 @@ Create 3-5 GitHub issues from the user's feature list so `/loom:sweep` has work 
 # Each issue gets the loom:issue label so builders can claim them
 
 # Issue 1: Project scaffolding (always included)
-gh issue create \
+./.loom/scripts/create-issue.sh \
   --title "Project scaffolding and build setup" \
   --label "loom:issue" \
   --label "tier:goal-advancing" \
@@ -415,7 +415,7 @@ BODY
 )"
 
 # Issue 2: Core component (always included)
-gh issue create \
+./.loom/scripts/create-issue.sh \
   --title "Core {{CORE_COMPONENT}} implementation" \
   --label "loom:issue" \
   --label "tier:goal-advancing" \
@@ -431,19 +431,19 @@ BODY
 )"
 
 # Issues 3-5: User-requested features
-gh issue create \
+./.loom/scripts/create-issue.sh \
   --title "{{FEATURE_1}}" \
   --label "loom:issue" \
   --label "tier:goal-advancing" \
   --body "## Summary\n\n{{FEATURE_1_DESCRIPTION}}\n\n## Acceptance Criteria\n\n- [ ] Feature implemented\n- [ ] Tests passing"
 
-gh issue create \
+./.loom/scripts/create-issue.sh \
   --title "{{FEATURE_2}}" \
   --label "loom:issue" \
   --label "tier:goal-supporting" \
   --body "## Summary\n\n{{FEATURE_2_DESCRIPTION}}\n\n## Acceptance Criteria\n\n- [ ] Feature implemented\n- [ ] Tests passing"
 
-gh issue create \
+./.loom/scripts/create-issue.sh \
   --title "{{FEATURE_3}}" \
   --label "loom:issue" \
   --label "tier:goal-supporting" \

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -123,8 +123,18 @@ fallback exists for (#4659). Anything else — auth failure, network error, a
 retry over REST. `merge-pr.sh`'s `lib/forge-helpers.sh` implements this same
 signature table plus ready-made wrappers
 (`forge_gh_comment_rl_safe`, `forge_gh_swap_label_rl_safe`,
-`forge_gh_reopen_issue_rl_safe`, #4856) if you are scripting rather than
-running `gh` interactively.
+`forge_gh_reopen_issue_rl_safe`, #4856, and `forge_gh_create_issue_rl_safe`,
+#5047) if you are scripting rather than running `gh` interactively.
+
+**Filing a follow-up issue has the same exposure, and its own tool.** `gh issue
+create` is GraphQL-backed too, so it dies on the same exhaustion — use
+`./.loom/scripts/create-issue.sh` instead of a bare `gh issue create` (#5047).
+Same flags (`--title`, `--body`/`--body-file`, repeatable `--label`, `--repo`),
+same printed issue URL, but it falls back to one REST POST that applies labels
+**atomically with creation** (never create-then-label). Full rationale:
+`.loom/docs/github-authentication.md` → "Filing issues under GraphQL
+exhaustion". `loom-daemon forge issue create` is a byte-identical `gh`
+passthrough and is **not** an alternative.
 
 **This section covers labels/comments only** — `gh issue create` (used below
 under "Creating Follow-up Issues" and "Raising Concerns") is a separate
@@ -1782,7 +1792,7 @@ When you identify issues during evaluation, take concrete action - never leave c
 # Judge finds minor documentation issue during evaluation
 # Instead of just noting it, create an issue:
 
-gh issue create --title "Update design doc to reflect new label colors" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Update design doc to reflect new label colors" --body "$(cat <<'EOF'
 While evaluating PR #557, noticed that `docs/design/issue-332-label-state-machine.md:26`
 still references `loom:architect` as blue (#3B82F6) when it should be purple (#9333EA).
 
@@ -1820,7 +1830,7 @@ During code evaluation, you may discover bugs or issues that aren't related to t
 **Example:**
 ```bash
 # Create unlabeled issue - Architect will triage it
-gh issue create --title "Terminal output corrupted when special characters in path" --body "$(cat <<'EOF'
+./.loom/scripts/create-issue.sh --title "Terminal output corrupted when special characters in path" --body "$(cat <<'EOF'
 ## Bug Description
 
 While evaluating PR #45, I noticed that terminal output becomes corrupted when the working directory path contains special characters like `&` or `$`.

--- a/defaults/docs/gh-issue-create-rest-fallback.md
+++ b/defaults/docs/gh-issue-create-rest-fallback.md
@@ -15,8 +15,29 @@ typically sits nearly untouched (observed live: `core` 19/5000 used vs.
 
 This page is the **single source** for the fallback recipe — role prompts
 link here rather than repeating it. If the recipe needs to change, change it
-here (and in `forge_gh_create_issue_rl_safe`, its scripted equivalent), not
-in nine separate files.
+here (and in `forge_gh_create_issue_rl_safe` / `create-issue.sh`, its
+executable equivalents), not in nine separate files.
+
+## Use `./.loom/scripts/create-issue.sh`, never a bare `gh issue create` (#5077)
+
+A role prompt can only teach an executable command, not a bash function
+sourced from a library — so `./.loom/scripts/create-issue.sh` is the
+canonical entry point every issue-filing role invokes directly:
+
+```bash
+./.loom/scripts/create-issue.sh \
+  --title "Some title" \
+  --body-file /tmp/issue-body.md \
+  --label "loom:triage"
+# prints the new issue's URL, exactly like `gh issue create`
+```
+
+Flags are a `gh issue create`-compatible subset — `--title/-t`, `--body/-b`,
+`--body-file/-F`, repeatable (or comma-separated) `--label/-l`, `--repo/-R` —
+chosen so an existing invocation transfers by changing only the command name.
+It tries `gh issue create` first and, only on one of the five documented
+rate-limit signatures below, retries the identical filing as a single REST
+POST.
 
 ## The five-signature table
 
@@ -44,33 +65,31 @@ count (worse under the exact quota pressure this fallback exists for) and
 can half-fail, leaving an unlabeled issue behind.
 
 ```bash
-# Primary path — unchanged, still try this first:
+# Primary path — unchanged, still tried first:
 gh issue create --repo "$NWO" --title "$TITLE" --body "$BODY" --label "$LABEL"
 
 # On a rate-limit rejection (see the signature table above), fall back to a
-# REST POST with labels in the SAME payload:
-jq -n --arg t "$TITLE" --arg b "$BODY" --arg labels "$LABEL" \
-  '{title: $t, body: $b, labels: ($labels | split(","))}' > payload.json
-gh api --method POST "repos/$NWO/issues" --input payload.json --jq '.html_url'
+# REST POST with labels in the SAME payload. With no NWO, `repos/{owner}/{repo}`
+# is a literal placeholder `gh api` expands from the git remote — zero extra
+# API calls, unlike `gh repo view`, itself GraphQL-backed (#4659):
+REST_PATH="repos/${NWO:-\{owner\}/\{repo\}}/issues"
+jq -n --arg t "$TITLE" --arg b "$BODY" --arg l "$LABEL" \
+  '{title: $t, body: $b, labels: [$l]}' | \
+  gh api --method POST "$REST_PATH" --input - --jq '.html_url'
 ```
-
-`--input payload.json` (a real file) also sidesteps the guard false positive
-where a heredoc body containing `>=` gets misclassified as a Bash redirect,
-and correctly handles a multi-line/markdown body — unlike `-f`/`--raw-field`,
-which does not expand `@file` and would post the literal string (the same
-`-f` vs. `-F` trap documented in `judge.md` for comments).
 
 ## Scripted callers: `forge_gh_create_issue_rl_safe`
 
-If you are scripting rather than running `gh` interactively, use the
-ready-made wrapper in `lib/forge-helpers.sh` instead of hand-rolling the
-above:
+`create-issue.sh` above is a thin CLI wrapper over this bash function in
+`lib/forge-helpers.sh`; if you are already sourcing that library, call it
+directly instead of shelling out:
 
 ```bash
 source "$(dirname "${BASH_SOURCE[0]}")/lib/forge-helpers.sh"
 
-# forge_gh_create_issue_rl_safe NWO TITLE BODY [LABELS_CSV]
-url=$(forge_gh_create_issue_rl_safe "$NWO" "$TITLE" "$BODY" "loom:triage,bug")
+# forge_gh_create_issue_rl_safe NWO TITLE BODY [LABEL...]
+# NWO may be "" for "the repo of the current working directory".
+url=$(forge_gh_create_issue_rl_safe "" "$TITLE" "$BODY" "loom:triage" "bug")
 ```
 
 It tries `gh issue create` first, falls back to the REST POST above on a
@@ -88,7 +107,8 @@ execs the real `gh` binary with the same arguments and inherits the same
 GraphQL cost, with **no** REST-fallback interception for `issue create`
 specifically (the passthrough is generic across every `gh issue` subcommand,
 not create-aware). It is not a safe alternative to reach for under GraphQL
-exhaustion. Use the recipe or helper above instead.
+exhaustion — `forge issue create` prints a one-line stderr notice pointing
+back here. Use `create-issue.sh` or the recipe above instead.
 
 ## Serialize issue creation, fallback or not
 

--- a/defaults/docs/github-authentication.md
+++ b/defaults/docs/github-authentication.md
@@ -372,6 +372,15 @@ outlives a ~1h App-token lifetime starts 401ing with no automatic fallback. See
 "Long-running sweep children and credential snapshots (#4458)" above for the
 mechanics and the workaround (a long-lived PAT for consistently long workloads).
 
+## Filing issues under GraphQL exhaustion
+
+GitHub's GraphQL quota and REST quota are independent buckets, and `gh issue
+create` is GraphQL-backed with no REST fallback of its own (#5047) — file new
+issues with `./.loom/scripts/create-issue.sh`, never a bare `gh issue create`.
+Full recipe, the atomic create+label requirement, the scripted
+`forge_gh_create_issue_rl_safe` equivalent, and why `loom-daemon forge issue
+create` is NOT a fallback: [`gh-issue-create-rest-fallback.md`](gh-issue-create-rest-fallback.md).
+
 ## Troubleshooting
 
 ### Token not being picked up

--- a/defaults/scripts/check-duplicate.sh
+++ b/defaults/scripts/check-duplicate.sh
@@ -161,7 +161,7 @@ INTEGRATION:
     Use in Architect/Hermit/Auditor roles before gh issue create:
 
     if ./.loom/scripts/check-duplicate.sh "My issue title"; then
-        gh issue create --title "My issue title" ...
+        ./.loom/scripts/create-issue.sh --title "My issue title" ...
     else
         echo "Potential duplicate detected, skipping creation"
     fi

--- a/defaults/scripts/create-issue.sh
+++ b/defaults/scripts/create-issue.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# create-issue.sh - File a new issue, surviving GraphQL rate-limit exhaustion.
+#
+# `gh issue create` is GraphQL-backed. GitHub's GraphQL quota (5000/hr, shared
+# across every agent + tool) and its REST quota are INDEPENDENT, and in a busy
+# fleet the GraphQL pool exhausts while REST sits nearly untouched (observed
+# 2026-08-03: core 19/5000 consumed vs graphql 1378/5000). Before #5047, every
+# issue-filing role -- Architect, Auditor, Curator (decomposition), Builder
+# (decomposition), Doctor, Hermit, Judge -- died outright at that moment, even
+# though comments, labels and issue state already had documented REST
+# fallbacks (#4856).
+#
+# This script is the single-sourced replacement for a bare `gh issue create`
+# in a role prompt: it tries `gh issue create` first, and on a rate-limit
+# rejection (and ONLY on a rate-limit rejection) retries the identical filing
+# as one REST POST to `repos/{owner}/{repo}/issues`. Labels ride along in the
+# same call on both paths -- never a create-then-label sequence.
+#
+# Usage:
+#   create-issue.sh --title TITLE (--body BODY | --body-file PATH) \
+#                   [--label LABEL]... [--repo OWNER/REPO]
+#   create-issue.sh --help
+#
+# Flags are a subset of `gh issue create`'s, chosen so a role prompt's
+# existing invocation can be switched over by changing the command name:
+#   --title, -t TITLE     Issue title (required).
+#   --body, -b BODY       Issue body as literal text.
+#   --body-file, -F PATH  Read the body from PATH ("-" = stdin). Mutually
+#                         exclusive with --body.
+#   --label, -l LABEL     Label to apply at creation. Repeatable. A single
+#                         comma-separated value is also accepted, matching
+#                         `gh issue create --label "a,b"`.
+#   --repo, -R OWNER/REPO Target repository. Omit for the current repo (the
+#                         preferred form -- the REST path then resolves the
+#                         repo from the git remote with zero API calls).
+#
+# Output: the new issue's URL on stdout (identical to `gh issue create`).
+#
+# Exit codes:
+#   0 - Issue created (via either path).
+#   1 - Creation failed (message on stderr). A non-rate-limit failure is
+#       reported as-is and is NEVER retried over REST.
+#   2 - Invalid arguments.
+#
+# NOTE: this is GitHub-specific, like the other `*_rl_safe` helpers. On a
+# Gitea forge it exits 2 with a pointer to `gh`/`tea` -- Gitea does not have
+# GitHub's split GraphQL/REST quota, so it has no equivalent failure mode.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=./lib/forge-helpers.sh
+source "$SCRIPT_DIR/lib/forge-helpers.sh"
+
+usage() {
+  sed -n '2,47p' "${BASH_SOURCE[0]:-$0}" | sed 's/^# \{0,1\}//'
+}
+
+TITLE=""
+BODY=""
+BODY_FILE=""
+REPO_NWO=""
+LABELS=()
+HAVE_BODY=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help | -h)
+      usage
+      exit 0
+      ;;
+    --title | -t)
+      TITLE="${2:-}"
+      shift 2
+      ;;
+    --body | -b)
+      BODY="${2:-}"
+      HAVE_BODY=true
+      shift 2
+      ;;
+    --body-file | -F)
+      BODY_FILE="${2:-}"
+      shift 2
+      ;;
+    --label | -l)
+      # `gh issue create --label "a,b"` splits on commas; match that so a
+      # prompt's existing invocation transfers unchanged.
+      IFS=',' read -r -a _split <<< "${2:-}"
+      for _l in "${_split[@]}"; do
+        # Trim surrounding whitespace from "a, b".
+        _l="${_l#"${_l%%[![:space:]]*}"}"
+        _l="${_l%"${_l##*[![:space:]]}"}"
+        [[ -n "$_l" ]] && LABELS+=("$_l")
+      done
+      shift 2
+      ;;
+    --repo | -R)
+      REPO_NWO="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "create-issue.sh: unknown argument: $1" >&2
+      echo "Run 'create-issue.sh --help' for usage." >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$TITLE" ]]; then
+  echo "create-issue.sh: --title is required" >&2
+  exit 2
+fi
+
+if [[ -n "$BODY_FILE" ]] && [[ "$HAVE_BODY" == "true" ]]; then
+  echo "create-issue.sh: --body and --body-file are mutually exclusive" >&2
+  exit 2
+fi
+
+if [[ -n "$BODY_FILE" ]]; then
+  if [[ "$BODY_FILE" == "-" ]]; then
+    BODY="$(cat)"
+  elif [[ -r "$BODY_FILE" ]]; then
+    BODY="$(cat "$BODY_FILE")"
+  else
+    echo "create-issue.sh: cannot read --body-file: $BODY_FILE" >&2
+    exit 2
+  fi
+fi
+
+forge_detect
+if [[ "$FORGE_TYPE" != "github" ]]; then
+  echo "create-issue.sh: this GraphQL-exhaustion fallback is GitHub-specific; \
+on $FORGE_TYPE file the issue with your forge's own CLI (Gitea has no split \
+GraphQL/REST quota, so it has no equivalent failure mode)." >&2
+  exit 2
+fi
+
+if ! forge_gh_create_issue_rl_safe "$REPO_NWO" "$TITLE" "$BODY" "${LABELS[@]+"${LABELS[@]}"}"; then
+  exit 1
+fi

--- a/defaults/scripts/lib/forge-helpers.sh
+++ b/defaults/scripts/lib/forge-helpers.sh
@@ -840,69 +840,91 @@ forge_gh_swap_label_rl_safe() {
   return 1
 }
 
-# Create an issue via `gh issue create`, falling back to a REST POST
-# (`repos/{nwo}/issues`) on a GraphQL rate-limit rejection (#5047). Labels are
-# applied ATOMICALLY in the same request on both paths -- `gh issue create
-# --label` on the primary path, the payload's `labels` array on the REST
-# fallback -- never a create-then-label two-step (that doubles the request
-# count and can half-fail, leaving an unlabeled issue behind).
+# File a NEW issue via `gh issue create`, falling back to a single REST POST
+# to `repos/{nwo}/issues` on a GraphQL rate-limit rejection (#5047).
+#
+# `gh issue create` is GraphQL-backed, so every issue-filing role (Architect,
+# Auditor, Curator decomposition, Builder decomposition, Doctor, Hermit,
+# Judge) died outright once the GraphQL pool exhausted -- even though the
+# independent REST pool routinely sits ~99% unused at that moment (observed
+# 2026-08-03: core 19/5000 consumed vs graphql 1378/5000). Comments, labels
+# and state already had REST fallbacks (#4856, above); creation did not.
+#
+# **Labels are applied atomically with creation on BOTH paths** -- `--label`
+# on the primary path, a `labels` array in the same POST body on the REST
+# path. Never degrade this to create-then-label: that doubles the request
+# count under exactly the conditions where requests are scarce, and can
+# half-fail, leaving an unlabelled issue that no role's queue query finds.
+#
+# NWO may be the empty string, meaning "the repo of the current working
+# directory". That is the preferred form: the REST path then uses `gh api`'s
+# literal `{owner}/{repo}` placeholder, which gh expands from the git remote
+# with ZERO API calls -- unlike `gh repo view --json nameWithOwner`, which is
+# itself GraphQL-backed and so fails first under the very exhaustion this
+# fallback exists for (#4659).
 #
 # This is the single-sourced recipe referenced by the role prompts that file
 # issues (architect.md, auditor.md, builder-complexity.md, builder-pr.md,
-# curator.md, doctor.md, hermit.md, hermit-patterns.md, judge.md) -- update
-# this function, not each prompt, if the recipe needs to change.
+# curator.md, doctor.md, hermit.md, hermit-patterns.md, judge.md) -- via the
+# executable wrapper `create-issue.sh`. Update this function, not each
+# prompt, if the recipe needs to change.
 #
-# Usage: forge_gh_create_issue_rl_safe NWO TITLE BODY [LABELS_CSV]
-#   NWO         - "owner/repo"
-#   TITLE       - issue title
-#   BODY        - issue body (may be multi-line / markdown)
-#   LABELS_CSV  - optional comma-separated label list, e.g. "loom:triage,bug"
-#     (matches the `--label` flag's own comma-separated convention, so
-#     callers can pass the same string they'd otherwise give `gh issue
-#     create --label`)
-#
-# On success, prints the created issue's URL to stdout (matching `gh issue
-# create`'s own output) and returns 0. On failure, prints the error to
-# stderr and returns 1. GitHub-only, like the other `*_rl_safe` helpers above
-# -- callers gate on `FORGE_TYPE == github` before calling this.
+# Usage: forge_gh_create_issue_rl_safe NWO TITLE BODY [LABEL...]
+# Stdout: the new issue's URL (both paths).
+# Returns 0 on success (either path), 1 on failure (message on stderr).
 forge_gh_create_issue_rl_safe() {
-  local nwo="$1" title="$2" body="$3" labels_csv="${4:-}"
-  local -a label_args=()
-  local out
+  local nwo="$1" title="$2" body="$3"
+  shift 3
+  local labels=("$@")
 
-  if [[ -n "$labels_csv" ]]; then
-    local IFS=','
-    local label
-    for label in $labels_csv; do
-      label_args+=(--label "$label")
-    done
+  local -a create_args=(--title "$title" --body "$body")
+  if [[ -n "$nwo" ]]; then
+    create_args+=(--repo "$nwo")
   fi
+  local label
+  for label in "${labels[@]+"${labels[@]}"}"; do
+    create_args+=(--label "$label")
+  done
 
-  if out=$(gh issue create --repo "$nwo" --title "$title" --body "$body" "${label_args[@]}" 2>&1); then
+  # Capture stdout (the issue URL) separately from stderr (the error text the
+  # rate-limit signature table is matched against), so a successful create
+  # never returns gh's progress chatter as the URL.
+  local err_file out err rc=0
+  err_file=$(mktemp)
+  out=$(gh issue create "${create_args[@]}" 2>"$err_file") || rc=$?
+  err=$(cat "$err_file" 2>/dev/null || true)
+  rm -f "$err_file"
+
+  if [[ $rc -eq 0 ]]; then
     printf '%s\n' "$out"
     return 0
   fi
 
-  if is_rate_limit_error "$out"; then
-    local payload_file rc=0 url
-    payload_file=$(mktemp)
-    if [[ -n "$labels_csv" ]]; then
-      jq -n --arg t "$title" --arg b "$body" --arg labels "$labels_csv" \
-        '{title: $t, body: $b, labels: ($labels | split(","))}' > "$payload_file"
+  if is_rate_limit_error "$err"; then
+    # One POST carries title + body + labels together. `--input -` takes the
+    # JSON body on stdin, which also sidesteps the guard false positive where
+    # a heredoc body containing `>=` is classified as a Bash redirect.
+    local payload labels_json
+    labels_json=$(jq -nc '$ARGS.positional' --args "${labels[@]+"${labels[@]}"}")
+    payload=$(jq -n --arg t "$title" --arg b "$body" --argjson l "$labels_json" \
+      '{title: $t, body: $b, labels: $l}')
+    local rest_path
+    if [[ -n "$nwo" ]]; then
+      rest_path="repos/$nwo/issues"
     else
-      jq -n --arg t "$title" --arg b "$body" '{title: $t, body: $b}' > "$payload_file"
+      # Literal placeholder — gh expands it from the git remote, no API call.
+      rest_path='repos/{owner}/{repo}/issues'
     fi
-    url=$(gh api --method POST "repos/$nwo/issues" --input "$payload_file" --jq '.html_url' 2>&1) || rc=$?
-    rm -f "$payload_file"
-    if [[ $rc -eq 0 ]]; then
-      printf '%s\n' "$url"
+    if out=$(printf '%s' "$payload" \
+        | gh api --method POST "$rest_path" --input - --jq '.html_url' 2>/dev/null); then
+      printf '%s\n' "$out"
       return 0
     fi
-    echo "gh issue create rate-limited on \"$title\", and the REST fallback also failed: $url" >&2
+    echo "gh issue create rate-limited, and the REST fallback also failed: $err" >&2
     return 1
   fi
 
-  echo "$out" >&2
+  echo "$err" >&2
   return 1
 }
 

--- a/defaults/scripts/tests/test-forge-helpers-rate-limit-fallback.sh
+++ b/defaults/scripts/tests/test-forge-helpers-rate-limit-fallback.sh
@@ -27,6 +27,15 @@
 #      create-then-label two-step.
 #   4. merge-pr.sh source wiring: the four mutating call sites this issue
 #      is about actually route through the new wrappers.
+#   5. create-issue.sh (#5047/#5077): the CLI wrapper role prompts actually
+#      invoke -- flag parsing, --body-file, and both the primary and REST
+#      paths end to end. Regression guard: no role prompt under
+#      defaults/.claude/commands/loom/ contains a line-anchored bare
+#      `gh issue create`, all nine primary + five companion prompts named
+#      in #5077 reference create-issue.sh, no prompt teaches a
+#      create-issue.sh call immediately followed by a separate `gh issue
+#      edit --add-label` (create-then-label), and `loom-daemon forge issue
+#      create` documents that it has no REST fallback of its own.
 #
 # Usage:
 #   ./.loom/scripts/tests/test-forge-helpers-rate-limit-fallback.sh
@@ -126,10 +135,14 @@ echo "Testing forge_gh_*_rl_safe REST-fallback wrappers..."
 STUB_DIR=$(mktemp -d)
 ARGV_LOG="$STUB_DIR/argv.log"
 GH_MODE_FILE="$STUB_DIR/mode.txt"
+# Captures the JSON body a `gh api ... --input -` call reads from stdin, so
+# the #5047 tests can assert labels ride along in the SAME POST as the title
+# and body (atomic create+label, not create-then-label).
+API_STDIN_LOG="$STUB_DIR/api-stdin.json"
 # The stub script below runs as a separate process, so these must be
 # exported for it to see them (a plain `VAR=x cmd` prefix only exports for
 # the immediate command, not variables set earlier in this shell).
-export ARGV_LOG GH_MODE_FILE
+export ARGV_LOG GH_MODE_FILE API_STDIN_LOG
 
 # A `gh` stub whose behavior is driven by $GH_MODE_FILE:
 #   "ok"          - the primary (non-`api`) mutation succeeds immediately.
@@ -144,7 +157,15 @@ mode="$(cat "$GH_MODE_FILE" 2>/dev/null || echo ok)"
 printf '%s\n' "$*" >> "$ARGV_LOG"
 
 if [[ "$1" == "api" ]]; then
+  # Drain stdin only when the caller actually piped a body in (`--input -`),
+  # never unconditionally -- an unconditional `cat` would block on the
+  # inherited terminal for the label/comment fallbacks that use -f/-F.
+  if [[ "$*" == *"--input -"* ]]; then
+    cat > "$API_STDIN_LOG"
+  fi
   if [[ "$mode" == "ratelimited" ]]; then
+    # POST .../issues --jq .html_url returns the new issue's URL (#5047).
+    [[ "$*" == *"--method POST"*/issues* ]] && echo "https://github.test/o/r/issues/1234"
     exit 0
   fi
   # Reached only when it should not have been.
@@ -153,7 +174,11 @@ if [[ "$1" == "api" ]]; then
 fi
 
 case "$mode" in
-  ok) exit 0 ;;
+  ok)
+    # `gh issue create` prints the new issue's URL on stdout (#5047).
+    [[ "$1 $2" == "issue create" ]] && echo "https://github.test/o/r/issues/99"
+    exit 0
+    ;;
   ratelimited)
     echo "GraphQL: API rate limit already exceeded for user ID 1" >&2
     exit 1
@@ -170,6 +195,7 @@ _run_stubbed() {
     local mode="$1"; shift
     echo "$mode" > "$GH_MODE_FILE"
     : > "$ARGV_LOG"
+    : > "$API_STDIN_LOG"
     PATH="$STUB_DIR:$PATH" "$@"
 }
 
@@ -252,149 +278,78 @@ rc=0
 _run_stubbed other-error forge_gh_swap_label_rl_safe "owner/repo" "7" "loom:building" "loom:issue" >/dev/null 2>&1 || rc=$?
 assert_eq "1" "$rc" "forge_gh_swap_label_rl_safe: non-rate-limit failure propagates"
 
-rm -rf "$STUB_DIR"
-
-# --- 2.5. forge_gh_create_issue_rl_safe (#5047), with its own stubbed `gh` ---
+# --- forge_gh_create_issue_rl_safe (#5047) ---
 echo ""
-echo "Testing forge_gh_create_issue_rl_safe REST-fallback wrapper (#5047)..."
+echo "Testing forge_gh_create_issue_rl_safe (#5047 issue-creation fallback)..."
 
-CREATE_STUB_DIR=$(mktemp -d)
-CREATE_ARGV_LOG="$CREATE_STUB_DIR/argv.log"
-CREATE_MODE_FILE="$CREATE_STUB_DIR/mode.txt"
-CREATE_PAYLOAD_LOG="$CREATE_STUB_DIR/payload.log"
-export CREATE_ARGV_LOG CREATE_MODE_FILE CREATE_PAYLOAD_LOG
-
-# A `gh` stub whose behavior is driven by $CREATE_MODE_FILE:
-#   "ok"          - `gh issue create` succeeds immediately.
-#   "ratelimited" - `gh issue create` is rate-limited; the REST POST fallback
-#                   (`gh api --method POST repos/.../issues --input <file>`)
-#                   succeeds. The stub also copies the --input payload file's
-#                   contents to $CREATE_PAYLOAD_LOG so the test can assert
-#                   labels traveled in the SAME request body as title/body.
-#   "other-error" - `gh issue create` fails with an unrelated error; `gh api`
-#                   must NEVER be reached (recorded as a FAIL marker if it is).
-cat > "$CREATE_STUB_DIR/gh" <<'STUB'
-#!/usr/bin/env bash
-mode="$(cat "$CREATE_MODE_FILE" 2>/dev/null || echo ok)"
-printf '%s\n' "$*" >> "$CREATE_ARGV_LOG"
-
-if [[ "$1" == "api" ]]; then
-  if [[ "$mode" == "ratelimited" ]]; then
-    prev=""
-    for a in "$@"; do
-      if [[ "$prev" == "--input" ]]; then
-        cat "$a" >> "$CREATE_PAYLOAD_LOG"
-      fi
-      prev="$a"
-    done
-    echo "https://github.com/owner/repo/issues/999"
-    exit 0
-  fi
-  echo "UNEXPECTED_REST_CALL" >> "$CREATE_ARGV_LOG"
-  exit 1
-fi
-
-case "$mode" in
-  ok)
-    echo "https://github.com/owner/repo/issues/42"
-    exit 0
-    ;;
-  ratelimited)
-    echo "GraphQL: API rate limit already exceeded for user ID 1" >&2
-    exit 1
-    ;;
-  other-error)
-    echo "HTTP 404: Not Found" >&2
-    exit 1
-    ;;
-esac
-STUB
-chmod +x "$CREATE_STUB_DIR/gh"
-
-_run_create_stubbed() {
-    local mode="$1"; shift
-    echo "$mode" > "$CREATE_MODE_FILE"
-    : > "$CREATE_ARGV_LOG"
-    : > "$CREATE_PAYLOAD_LOG"
-    PATH="$CREATE_STUB_DIR:$PATH" "$@"
-}
-
-# ok mode: primary `gh issue create` succeeds, labels passed as repeated
-# --label flags, no REST call at all.
-out=""
-rc=0
-out=$(_run_create_stubbed ok forge_gh_create_issue_rl_safe "owner/repo" "My Title" "My Body" "loom:triage,bug" 2>&1) || rc=$?
-assert_eq "0" "$rc" "forge_gh_create_issue_rl_safe: primary gh issue create succeeds -> no REST call"
-assert_eq "https://github.com/owner/repo/issues/42" "$out" "forge_gh_create_issue_rl_safe (ok mode) returns the created issue URL"
+# Primary path: `gh issue create` succeeds -> URL on stdout, no REST call.
+out=$(_run_stubbed ok forge_gh_create_issue_rl_safe "owner/repo" "A title" "A body" "loom:triage" 2>/dev/null)
+assert_eq "https://github.test/o/r/issues/99" "$out" \
+    "forge_gh_create_issue_rl_safe: primary path returns the created issue URL"
 TESTS_RUN=$((TESTS_RUN + 1))
-if grep -q -- '--label loom:triage --label bug' "$CREATE_ARGV_LOG"; then
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe passes each CSV label as its own --label flag"
-else
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe did not expand the labels CSV correctly"
-fi
-TESTS_RUN=$((TESTS_RUN + 1))
-if ! grep -q "^api " "$CREATE_ARGV_LOG"; then
+if ! grep -q "^api " "$ARGV_LOG"; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
     echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe (ok mode) never calls gh api"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe (ok mode) unexpectedly called gh api"
 fi
-
-# ratelimited mode: falls back to a single atomic REST POST carrying title,
-# body, AND labels in one payload -- never a create-then-label two-step.
-out=""
-rc=0
-out=$(_run_create_stubbed ratelimited forge_gh_create_issue_rl_safe "owner/repo" "My Title" "My Body" "loom:triage,bug" 2>&1) || rc=$?
-assert_eq "0" "$rc" "forge_gh_create_issue_rl_safe: rate-limited primary call recovers via REST fallback"
-assert_eq "https://github.com/owner/repo/issues/999" "$out" "forge_gh_create_issue_rl_safe (ratelimited mode) returns the REST-created issue URL"
 TESTS_RUN=$((TESTS_RUN + 1))
-if grep -q "^api --method POST repos/owner/repo/issues --input" "$CREATE_ARGV_LOG"; then
+if grep -q -- "issue create --title A title --body A body --repo owner/repo --label loom:triage" "$ARGV_LOG"; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe REST fallback POSTs to the correct issues endpoint"
+    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe primary path passes --label in the SAME create call"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe primary path must apply labels atomically via --label"
+fi
+
+# Exhausted-GraphQL path: falls back to ONE REST POST carrying labels inline.
+out=$(_run_stubbed ratelimited forge_gh_create_issue_rl_safe "owner/repo" "A title" "A body" "loom:triage" "tier:goal-supporting" 2>/dev/null)
+assert_eq "https://github.test/o/r/issues/1234" "$out" \
+    "forge_gh_create_issue_rl_safe: exhausted GraphQL recovers via REST and returns the URL"
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q "^api --method POST repos/owner/repo/issues --input - --jq .html_url" "$ARGV_LOG"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe REST fallback POSTs to repos/{nwo}/issues"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe REST fallback endpoint wrong or missing"
 fi
-api_call_count="$(grep -c '^api ' "$CREATE_ARGV_LOG" || true)"
-assert_eq "1" "$api_call_count" "forge_gh_create_issue_rl_safe REST fallback makes exactly ONE REST call (atomic, not create-then-label)"
+
+# The atomicity guarantee: title + body + BOTH labels in one payload.
+assert_eq "A title" "$(jq -r '.title' "$API_STDIN_LOG")" \
+    "forge_gh_create_issue_rl_safe REST payload carries the title"
+assert_eq "A body" "$(jq -r '.body' "$API_STDIN_LOG")" \
+    "forge_gh_create_issue_rl_safe REST payload carries the body"
+assert_eq "loom:triage,tier:goal-supporting" "$(jq -r '.labels | join(",")' "$API_STDIN_LOG")" \
+    "forge_gh_create_issue_rl_safe REST payload applies ALL labels atomically with creation"
+
+# Exactly one REST call -- never create-then-label (that doubles the request
+# count under exactly the scarcity this fallback exists for, and can half-fail).
+rest_call_count="$(grep -c "^api " "$ARGV_LOG" || true)"
+assert_eq "1" "$rest_call_count" \
+    "forge_gh_create_issue_rl_safe REST fallback is a SINGLE call (no create-then-label)"
+
+# Empty NWO -> gh's literal {owner}/{repo} placeholder, which gh expands from
+# the git remote with zero API calls (never `gh repo view`, itself GraphQL).
+_run_stubbed ratelimited forge_gh_create_issue_rl_safe "" "T" "B" >/dev/null 2>&1
 TESTS_RUN=$((TESTS_RUN + 1))
-if jq -e '.title == "My Title" and .body == "My Body" and .labels == ["loom:triage","bug"]' \
-    "$CREATE_PAYLOAD_LOG" >/dev/null 2>&1; then
+if grep -qF "api --method POST repos/{owner}/{repo}/issues" "$ARGV_LOG"; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe REST payload carries title+body+labels atomically"
+    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe uses the zero-API-call {owner}/{repo} placeholder when NWO is empty"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe REST payload missing/malformed title|body|labels"
-    echo "    Payload: $(cat "$CREATE_PAYLOAD_LOG" 2>/dev/null)"
+    echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe must use the {owner}/{repo} placeholder when NWO is empty"
 fi
+assert_eq "[]" "$(jq -c '.labels' "$API_STDIN_LOG")" \
+    "forge_gh_create_issue_rl_safe REST payload uses an empty labels array when no labels are given"
 
-# ratelimited mode, no labels: payload still valid JSON without a labels key
-# forced in (an empty/absent labels field, never a spurious create-then-label
-# follow-up call).
-out=""
+# A non-rate-limit failure must propagate untouched, with no REST retry.
 rc=0
-out=$(_run_create_stubbed ratelimited forge_gh_create_issue_rl_safe "owner/repo" "No Labels" "Body text" 2>&1) || rc=$?
-assert_eq "0" "$rc" "forge_gh_create_issue_rl_safe: REST fallback works with no labels argument"
-TESTS_RUN=$((TESTS_RUN + 1))
-if jq -e '.title == "No Labels" and .body == "Body text" and (has("labels") | not)' \
-    "$CREATE_PAYLOAD_LOG" >/dev/null 2>&1; then
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe omits labels from the payload when none given"
-else
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe payload wrong when no labels given"
-fi
-
-# other-error mode: propagate, never attempt the REST fallback.
-out=""
-rc=0
-out=$(_run_create_stubbed other-error forge_gh_create_issue_rl_safe "owner/repo" "My Title" "My Body" "loom:triage" 2>&1) || rc=$?
+_run_stubbed other-error forge_gh_create_issue_rl_safe "owner/repo" "T" "B" >/dev/null 2>&1 || rc=$?
 assert_eq "1" "$rc" "forge_gh_create_issue_rl_safe: non-rate-limit failure propagates (not swallowed)"
 TESTS_RUN=$((TESTS_RUN + 1))
-if ! grep -q "UNEXPECTED_REST_CALL" "$CREATE_ARGV_LOG"; then
+if ! grep -q "UNEXPECTED_REST_CALL" "$ARGV_LOG"; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
     echo -e "  ${GREEN}PASS${NC}: forge_gh_create_issue_rl_safe never retries over REST on a non-rate-limit failure"
 else
@@ -402,7 +357,62 @@ else
     echo -e "  ${RED}FAIL${NC}: forge_gh_create_issue_rl_safe incorrectly retried over REST on a non-rate-limit failure"
 fi
 
-rm -rf "$CREATE_STUB_DIR"
+# --- create-issue.sh CLI wrapper (#5047), the surface role prompts invoke ---
+echo ""
+echo "Testing create-issue.sh CLI wrapper (#5047)..."
+
+CREATE_ISSUE_SH="$HELPERS_DIR/create-issue.sh"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -x "$CREATE_ISSUE_SH" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: create-issue.sh exists and is executable"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: create-issue.sh missing or not executable at $CREATE_ISSUE_SH"
+fi
+
+BODY_TMP="$STUB_DIR/body.md"
+cat > "$BODY_TMP" <<'BODY'
+## Problem
+
+A body read from a file.
+BODY
+
+out=$(_run_stubbed ratelimited env LOOM_FORGE_TYPE=github "$CREATE_ISSUE_SH" \
+    --title "From CLI" --body-file "$BODY_TMP" --label "loom:triage,tier:goal-supporting" 2>/dev/null)
+assert_eq "https://github.test/o/r/issues/1234" "$out" \
+    "create-issue.sh: exhausted GraphQL still files the issue (REST) and prints the URL"
+assert_eq "loom:triage,tier:goal-supporting" "$(jq -r '.labels | join(",")' "$API_STDIN_LOG")" \
+    "create-issue.sh: comma-separated --label splits like gh, applied atomically"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$(jq -r '.body' "$API_STDIN_LOG")" == *"A body read from a file."* ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: create-issue.sh --body-file sends the file CONTENTS (not the path)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: create-issue.sh --body-file must send file contents, not the literal path"
+fi
+
+rc=0
+_run_stubbed ok env LOOM_FORGE_TYPE=github "$CREATE_ISSUE_SH" --body "no title" >/dev/null 2>&1 || rc=$?
+assert_eq "2" "$rc" "create-issue.sh: missing --title exits 2"
+
+rc=0
+_run_stubbed ok env LOOM_FORGE_TYPE=github "$CREATE_ISSUE_SH" --title "T" --body "B" --nope >/dev/null 2>&1 || rc=$?
+assert_eq "2" "$rc" "create-issue.sh: unknown argument exits 2"
+
+rc=0
+_run_stubbed ok env LOOM_FORGE_TYPE=github "$CREATE_ISSUE_SH" \
+    --title "T" --body "B" --body-file "$BODY_TMP" >/dev/null 2>&1 || rc=$?
+assert_eq "2" "$rc" "create-issue.sh: --body and --body-file together exit 2"
+
+rc=0
+_run_stubbed other-error env LOOM_FORGE_TYPE=github "$CREATE_ISSUE_SH" \
+    --title "T" --body "B" >/dev/null 2>&1 || rc=$?
+assert_eq "1" "$rc" "create-issue.sh: a non-rate-limit gh failure exits 1"
+
+rm -rf "$STUB_DIR"
 
 # --- 3. merge-pr.sh source wiring: the four #4856 call sites use the wrappers ---
 echo ""
@@ -441,6 +451,86 @@ if ! grep -q 'gh issue reopen "\$issue_num" --repo "\$REPO_NWO" >/dev/null 2>&1'
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "  ${RED}FAIL${NC}: the old unwrapped 'gh issue reopen' call site is still present"
+fi
+
+# --- 4. Role-prompt wiring (#5047): no prompt teaches a bare `gh issue create` ---
+#
+# This is the forcing function that keeps the fix from regressing back into
+# nine prompts. A role prompt is what an agent actually follows, so an
+# executable `gh issue create` line in one of them IS the bug, however well
+# documented the fallback is elsewhere. Prose mentions of `gh issue create`
+# (the #3707 serialization warnings, and the pointer blocks this issue added)
+# are fine and expected -- they never start a line, so anchoring on
+# line-start cleanly separates "instruction to run" from "discussion of".
+echo ""
+echo "Testing role-prompt wiring (#5047)..."
+
+PROMPT_DIR="$(cd "$HELPERS_DIR/../.claude/commands/loom" && pwd)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+# Matches both a line-start invocation (`gh issue create ...`) and the
+# `VAR=$(gh issue create ...` assignment form (#5077's epic.md /
+# champion-pr-merge.md finding) -- both are executable, not prose. Prose
+# mentions (backtick-quoted, mid-sentence) never match either shape.
+bare_creates="$(grep -rlnE '^[[:space:]]*gh issue create|=\$\(gh issue create' "$PROMPT_DIR" || true)"
+if [[ -z "$bare_creates" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: no role prompt instructs a bare 'gh issue create'"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: these role prompts still instruct a bare 'gh issue create'"
+    echo "    (use ./.loom/scripts/create-issue.sh instead — see #5047):"
+    printf '    %s\n' $bare_creates
+fi
+
+# The nine prompts named in #5047, PLUS the five companion prompt/template
+# files #5077 found still teaching a bare `gh issue create` (architect-
+# patterns.md, architect-reference.md, champion-epic.md, champion-
+# reference.md, imagine.md), must each reach the helper -- either by
+# invoking it or by pointing at it.
+for prompt in architect.md auditor.md builder-complexity.md builder-pr.md \
+              curator.md doctor.md hermit.md hermit-patterns.md judge.md \
+              architect-patterns.md architect-reference.md champion-epic.md \
+              champion-reference.md imagine.md; do
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if grep -q 'create-issue\.sh' "$PROMPT_DIR/$prompt"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $prompt routes issue filing through create-issue.sh"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $prompt has no reference to create-issue.sh (#5047)"
+    fi
+done
+
+# create-then-label regression guard (#5077): a role prompt must never teach
+# applying a label via a follow-up `gh issue edit --add-label` on an issue
+# number/placeholder produced by the create call directly above it. This
+# doesn't try to parse "is this label call related to that create call" --
+# far simpler and just as effective: assert no `gh issue edit ... --add-label`
+# line ever appears within 2 lines of a `create-issue.sh` invocation, which is
+# exactly the shape a create-then-label two-step takes in these prompts.
+TESTS_RUN=$((TESTS_RUN + 1))
+create_then_label="$(grep -rn -A2 'create-issue\.sh' "$PROMPT_DIR" \
+    | grep -E '[-:]gh issue edit .*--add-label' || true)"
+if [[ -z "$create_then_label" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: no role prompt follows a create-issue.sh call with a separate --add-label edit"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: these lines teach create-then-label right after create-issue.sh (#5077):"
+    echo "$create_then_label"
+fi
+
+# `loom-daemon forge issue` must not silently look like an escape hatch: the
+# passthrough either gains the fallback or says out loud that it has none.
+TESTS_RUN=$((TESTS_RUN + 1))
+FORGE_CMD_SRC="$(cd "$HELPERS_DIR/../../loom-daemon/src" 2>/dev/null && pwd || true)/forge_cmd.rs"
+if [[ -f "$FORGE_CMD_SRC" ]] && grep -q 'create-issue.sh' "$FORGE_CMD_SRC"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: loom-daemon forge issue create documents its lack of a REST fallback"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_cmd.rs must state that 'forge issue create' has no REST fallback (#5047)"
 fi
 
 # --- Summary ---

--- a/loom-daemon/src/forge_cmd.rs
+++ b/loom-daemon/src/forge_cmd.rs
@@ -29,7 +29,12 @@
 //! subcommands are native:
 //! - reads/auth are a byte-identical passthrough to `gh` (the same binary the
 //!   scripts' `FORGE=gh` fallback uses — so a consumer workspace with zero pip
-//!   installs works unchanged);
+//!   installs works unchanged). Being byte-identical, the passthrough also
+//!   inherits `gh`'s transport: `forge issue create` is GraphQL-backed and has
+//!   **no REST fallback** for GraphQL-quota exhaustion (#5047). That is
+//!   deliberate — the passthrough contract is that `forge issue X` behaves
+//!   identically to `gh issue X` — so it emits an advisory stderr notice
+//!   pointing at `.loom/scripts/create-issue.sh`, which does have the fallback;
 //! - `auto-merge` enables GitHub's native auto-merge via the
 //!   `enablePullRequestAutoMerge` GraphQL mutation (a pure API call with no
 //!   working-tree checkout — the reason `gh pr merge --auto` is avoided from
@@ -371,6 +376,12 @@ fn gh_bin() -> String {
 /// propagating the exit code. On GitHub this is byte-identical to the scripts'
 /// `FORGE=gh` fallback. Never returns on success/failure of `gh` (calls
 /// `std::process::exit`); returns `Err` only when `gh` cannot be spawned.
+/// Whether a `forge <entity> <args…>` invocation is an issue *creation*, i.e.
+/// `forge issue create …`. Used only to emit the #5047 advisory notice.
+fn is_issue_create(entity: &str, args: &[String]) -> bool {
+    entity == "issue" && args.first().is_some_and(|a| a == "create")
+}
+
 fn gh_passthrough(entity: &str, args: &[String]) -> Result<()> {
     let ft = detect_forge(None);
     if ft == ForgeType::Gitea {
@@ -379,6 +390,22 @@ fn gh_passthrough(entity: &str, args: &[String]) -> Result<()> {
              caller's shell path"
         );
         std::process::exit(EX_FORGE_DECLINED);
+    }
+
+    // #5047: `forge issue` is a byte-identical passthrough to `gh issue`, so
+    // `forge issue create` inherits `gh issue create`'s GraphQL cost and dies
+    // on exactly the same GraphQL-quota exhaustion. It is NOT an escape hatch,
+    // and being a *daemon* subcommand it looks like one. Keep the passthrough
+    // contract intact (silently rerouting one subcommand's transport would
+    // break every caller that parses gh's output) and point at the tool that
+    // does have the REST fallback. Advisory only: stderr, no behavior change.
+    if is_issue_create(entity, args) {
+        eprintln!(
+            "loom-daemon forge issue create: NOTE — this is a byte-identical passthrough \
+             to `gh issue create` (GraphQL-backed) with NO REST fallback. If GraphQL quota \
+             is exhausted, use `.loom/scripts/create-issue.sh` instead (see \
+             docs/github-authentication.md → \"Filing issues under GraphQL exhaustion\")."
+        );
     }
 
     let mut command = Command::new(gh_bin());
@@ -654,6 +681,24 @@ mod tests {
             serde_json::to_string(&json!({ "forge": forge })).unwrap(),
         )
         .unwrap();
+    }
+
+    // ===== #5047: issue-create advisory notice targeting =====
+
+    #[test]
+    fn is_issue_create_matches_only_issue_create() {
+        let create = vec!["create".to_string(), "--title".to_string(), "T".to_string()];
+        assert!(is_issue_create("issue", &create));
+
+        // Other issue subcommands are untouched (no notice, no behavior change).
+        assert!(!is_issue_create("issue", &["view".to_string(), "42".to_string()]));
+        assert!(!is_issue_create("issue", &["list".to_string()]));
+        assert!(!is_issue_create("issue", &[]));
+
+        // `pr create` is not issue creation -- it is not GraphQL-quota
+        // equivalent and has no create-issue.sh counterpart.
+        assert!(!is_issue_create("pr", &create));
+        assert!(!is_issue_create("auth", &create));
     }
 
     // ===== host parsing =====

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1401,6 +1401,12 @@ enum QuarantineAction {
 enum ForgeAction {
     /// `forge issue <args…>` — e.g. `issue view 42 --json labels --jq
     /// '.labels[].name'`. GitHub: exec `gh issue <args…>`.
+    ///
+    /// This is a byte-identical passthrough, so `forge issue create` is
+    /// GraphQL-backed and has **no REST fallback** — it dies on GraphQL-quota
+    /// exhaustion exactly like `gh issue create`, and is not an escape hatch
+    /// from it (#5047). To file an issue that survives an exhausted GraphQL
+    /// pool, use `.loom/scripts/create-issue.sh`.
     Issue {
         #[arg(
             trailing_var_arg = true,


### PR DESCRIPTION
## Summary

Closes #5077. PR #5070 (closing #5047) added `forge_gh_create_issue_rl_safe`
to `lib/forge-helpers.sh` plus a doc, and pointed nine filing role prompts at
it via prose notes — but a bash function isn't something a role prompt can
actually *invoke*; it can only name an executable command. So every
executable `gh issue create` line in the prompts was unchanged, and an agent
following a prompt verbatim still died outright once the shared GraphQL pool
exhausted.

This closes the three gaps the issue called out:

1. **No executable entry point** → new `defaults/scripts/create-issue.sh`, a
   `gh issue create`-compatible CLI wrapper over `forge_gh_create_issue_rl_safe`
   (`--title/-t`, `--body/-b`, `--body-file/-F`, repeatable `--label/-l`,
   `--repo/-R`), printing the same issue URL.
2. **Companion files not covered** → `architect-patterns.md`,
   `architect-reference.md`, `champion-epic.md`, `champion-reference.md`,
   `imagine.md` now route through `create-issue.sh` too, and
   `architect-patterns.md`'s create-then-`gh issue edit --add-label` two-step
   collapses into one atomic `--label` call. Also fixed two call sites the
   issue didn't name but the same grep sweep turned up: `epic.md` and
   `champion-pr-merge.md` (both used the `VAR=$(gh issue create ...)`
   assignment form, which a line-start-anchored grep alone misses).
3. **No regression guard** → `test-forge-helpers-rate-limit-fallback.sh`
   (already CI-wired via `ci-wired.txt`) now asserts: no role prompt contains
   a bare `gh issue create` (line-anchored *or* `VAR=$(gh issue create`
   assignment form), all 14 prompts reference `create-issue.sh`, and no
   prompt follows a `create-issue.sh` call with a separate `--add-label` edit
   within two lines (create-then-label).

## Reconciling `feature/issue-5047-callsites`

A parallel branch (`feature/issue-5047-callsites`) existed with a full,
independent implementation of this same idea, built while #5070 was in
flight and never rebased onto its merge. I inspected it (`git show
feature/issue-5047-callsites:...` / `git diff main...feature/issue-5047-callsites`)
and cherry-picked its content as a starting point, then reconciled the two
divergent `forge_gh_create_issue_rl_safe` implementations to one:

- Kept the branch's richer shape — a label **varargs list** (not #5070's
  CSV string) and an **optional-empty NWO** that uses `gh api`'s
  zero-API-call `{owner}/{repo}` placeholder when omitted — plus its
  stdout/stderr separation fix, so a successful create never returns `gh`'s
  progress chatter as the URL.
- Removed the now-superseded CSV-based test block and duplicate
  "file issues with create-issue.sh" pointer paragraphs the cherry-pick's
  3-way merge left in several prompts (git's line-based merge inserted the
  branch's new paragraph next to #5070's existing one without a conflict).
- Standardized every prompt's fallback-recipe doc link on the existing
  `.loom/docs/gh-issue-create-rest-fallback.md` (from #5070) rather than also
  duplicating the recipe into `github-authentication.md` as the parallel
  branch had — updated that doc to lead with `create-issue.sh` as the primary
  entry point instead, and left `github-authentication.md` with a one-line
  pointer to it.
- Kept the branch's `loom-daemon forge issue create` advisory stderr notice
  (byte-identical passthrough contract preserved) and its Rust unit test.

Exactly one issue-creation helper implementation now exists:
`forge_gh_create_issue_rl_safe` in `lib/forge-helpers.sh`, wrapped by the
single `create-issue.sh` CLI surface.

## Test plan

- [x] `bash defaults/scripts/tests/test-forge-helpers-rate-limit-fallback.sh` — 65/65 passed
- [x] `cargo test --package loom-daemon --lib forge_cmd` — 22/22 passed (incl. new `is_issue_create_matches_only_issue_create`)
- [x] `cargo build --package loom-daemon` and `cargo clippy --package loom-daemon -- -D warnings ...` (CI's exact flag set) — clean
- [x] `bash defaults/scripts/check-phantom-labels.sh`, `check-labels-drift.sh`, `check-label-descriptions.sh`, `check-ci-suite-manifest.sh` — all OK
- [x] `bash scripts/check-claude-md-budget.sh` — OK (291/320 lines)
- [x] Mechanical verification of all 5 acceptance criteria via grep (line-anchored **and** `VAR=$(gh issue create` assignment-form), not spot-checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)