### PR TITLE
fix(health): report a missing gh as one PATH fact, not N forge-query failures

### DIFF
--- a/loom-daemon/src/cli/health.rs
+++ b/loom-daemon/src/cli/health.rs
@@ -15,6 +15,32 @@
 //! determine" (which the collector renders as a non-green `UNKNOWN` section,
 //! exit `1`) rather than aborting — the *only* thing that can stop this
 //! command from printing a report is a panic.
+//!
+//! # Daemon-authoritative vs. caller-process sections (#5061)
+//!
+//! Not every section's verdict is trustworthy from the same vantage point,
+//! which matters most exactly when this command is run somewhere other than
+//! the machine that ran `loom-daemon health`'s writer (an SSH probe of a
+//! remote fleet host, a non-login shell whose `PATH` differs from an
+//! interactive login shell's):
+//!
+//! - **`liveness`, `dispatch`, `tokens`, `roles`, `observability`** are
+//!   **daemon-authoritative** — every fact comes from the daemon's own IPC
+//!   round-trip ([`DaemonStatusReport`]) or a local probe of *this host's*
+//!   process table/filesystem, never a forge call made by this CLI process.
+//!   A verdict here reflects the daemon's own state, not this caller's
+//!   environment, so it is trustworthy the same way over SSH as locally.
+//! - **`queues`, `throughput`** execute `gh` calls **in this CLI process**
+//!   ([`pipeline_snapshot::GhPipelineSource`]), scoped to whatever `gh`
+//!   resolves to and however it is authenticated *here* — which can differ
+//!   from the daemon's own (already-verified, see `credential_preflight` in
+//!   `status`/`--json`) forge credential. A missing/non-executable `gh` in
+//!   *this* process (the common case: a non-login SSH shell whose `PATH`
+//!   lacks `~/.local/bin` / `/opt/homebrew/bin`, #4875's failure class) is
+//!   reported as a single distinct fact rather than a per-repo forge-query
+//!   failure, and cross-references the daemon's own `credential_preflight`
+//!   verdict when it is available — see `health::assess_queues` /
+//!   `assess_throughput` / `gh_unavailable_section`.
 
 use anyhow::Result;
 use std::path::Path;
@@ -95,8 +121,23 @@ async fn collect(window: Duration) -> HealthReport {
     //    across the roots the daemon reported. Skipped entirely when the daemon
     //    is unreachable: without its root list there is nothing to query, and
     //    the sections honestly report "not collected".
-    let pipeline = match &status {
-        Some(report) => {
+    //
+    //    4a. Before fanning out to N repos, check ONCE whether this process
+    //    can even run `gh` at all (#5061). A missing/non-executable `gh` — the
+    //    common case being a non-login SSH shell whose PATH lacks
+    //    `~/.local/bin` / `/opt/homebrew/bin` (the same failure class as
+    //    #4875) — would otherwise fail identically for every managed repo,
+    //    rendering as "forge query FAILED for: <every repo>" and reading like
+    //    a forge outage rather than what it actually is: a fact about this
+    //    caller's own environment. `Some` here means the fan-out below is
+    //    skipped entirely (there is no value in spawning N `gh` calls already
+    //    known to fail the same way), and `queues`/`throughput` render the
+    //    single fact instead — see `health::assess_queues`/`assess_throughput`.
+    let gh_unavailable =
+        pipeline_snapshot::probe_gh_availability(Path::new(pipeline_snapshot::DEFAULT_GH_BIN))
+            .err();
+    let pipeline = match (&status, &gh_unavailable) {
+        (Some(report), None) => {
             let roots = report
                 .per_repo
                 .iter()
@@ -112,7 +153,7 @@ async fn collect(window: Duration) -> HealthReport {
             );
             Some(pipeline_snapshot::collect_pipeline_snapshots(source, roots).await)
         }
-        None => None,
+        _ => None,
     };
 
     // 5. The daemon log's newest `work_finder:` line (#4824) — a *corroborating*
@@ -138,6 +179,7 @@ async fn collect(window: Duration) -> HealthReport {
         ranking_present,
         ranking_age_secs,
         pipeline,
+        gh_unavailable,
         // This CLI process's own build commit (#4824), compared daemon-side
         // against `DaemonStatusReport::daemon_build_commit` so a newer CLI
         // querying an older daemon reports build skew rather than a phantom

--- a/loom-daemon/src/health.rs
+++ b/loom-daemon/src/health.rs
@@ -340,7 +340,24 @@ pub struct HealthInputs {
     /// Age of the resolved pool's `.ranking` in seconds, when readable.
     pub ranking_age_secs: Option<u64>,
     /// Per-repo forge snapshot (`queued` + merged-in-window), when collected.
+    /// `None` both when the daemon was unreachable (nothing to fan out to)
+    /// and when [`Self::gh_unavailable`] is `Some` — the collector skips the
+    /// per-repo fan-out entirely once it already knows every call would fail
+    /// identically (#5061).
     pub pipeline: Option<Vec<RepoPipelineSnapshot>>,
+    /// Set when the collector's one-time [`crate::pipeline_snapshot::probe_gh_availability`]
+    /// check (#5061) found the client-side `gh` binary this process would use
+    /// for the `queues`/`throughput` forge fan-out missing or non-executable.
+    /// This is an **environment fact about this process**, not a forge
+    /// outage — [`assess_queues`]/[`assess_throughput`] report it once,
+    /// distinctly from a genuine per-repo forge query failure, and
+    /// cross-reference [`Self::status`]'s `credential_preflight` (the
+    /// daemon's own IPC-answered "is the forge credential OK" verdict) when
+    /// available, so the two signals can never silently contradict each
+    /// other the way they did before this field existed (a caller with no
+    /// `gh` on `PATH` reporting "forge query FAILED for: <every repo>" next
+    /// to a daemon reporting "Forge credential: OK").
+    pub gh_unavailable: Option<crate::pipeline_snapshot::GhUnavailable>,
     /// The commit **this client process** was built from (Issue #4824) —
     /// [`crate::self_update::BUILT_COMMIT`], threaded in by the collector
     /// rather than read directly here so the skew rules are unit-testable
@@ -1308,6 +1325,9 @@ fn is_review_stalled(snap: &RepoPipelineSnapshot) -> bool {
 /// summary either way.
 #[must_use]
 pub fn assess_queues(inputs: &HealthInputs) -> HealthSection {
+    if let Some(gh) = &inputs.gh_unavailable {
+        return gh_unavailable_section("queues", gh, inputs);
+    }
     let Some(pipeline) = &inputs.pipeline else {
         return unknown_section("queues", "forge snapshot not collected");
     };
@@ -1440,6 +1460,9 @@ pub fn assess_queues(inputs: &HealthInputs) -> HealthSection {
 /// non-green here.
 #[must_use]
 pub fn assess_throughput(inputs: &HealthInputs) -> HealthSection {
+    if let Some(gh) = &inputs.gh_unavailable {
+        return gh_unavailable_section("throughput", gh, inputs);
+    }
     let Some(pipeline) = &inputs.pipeline else {
         return unknown_section("throughput", "forge snapshot not collected");
     };
@@ -1602,6 +1625,58 @@ fn unknown_section(key: &'static str, why: &str) -> HealthSection {
         Verdict::Unknown,
         why.to_string(),
         serde_json::json!({ "unavailable": why }),
+    )
+}
+
+/// Render `queues`/`throughput` for a missing/non-executable `gh` (#5061):
+/// one distinct, environment-attributed reason instead of the pre-#5061
+/// "forge query FAILED for: <every managed repo>" — which duplicated the
+/// same environment fact once per repo and read exactly like a forge outage.
+///
+/// Still [`Verdict::Unknown`] (not [`Verdict::Degraded`]): the queue depth /
+/// merge count genuinely could not be determined, so the existing "unknown
+/// != healthy" exit-code contract (exit `1`) is unchanged — only the
+/// *reason string* changes.
+///
+/// When the daemon answered IPC and reported its own `credential_preflight`
+/// verdict, that signal is cross-referenced by name so an operator never has
+/// to manually reconcile "forge query FAILED" here against "Forge
+/// credential: OK" from `status`/`--json`'s `credential_preflight` — the
+/// exact disagreement that prompted #5061.
+fn gh_unavailable_section(
+    key: &'static str,
+    gh: &crate::pipeline_snapshot::GhUnavailable,
+    inputs: &HealthInputs,
+) -> HealthSection {
+    let credential_preflight = inputs
+        .status
+        .as_ref()
+        .and_then(|s| s.credential_preflight.as_ref());
+    let cred_note = match credential_preflight {
+        Some(c) if c.ok => format!(
+            " (the daemon's own IPC reports its forge credential OK via {} — this is a \
+             caller-side PATH problem in the process running `health`, not a forge outage or a \
+             bad credential)",
+            c.mechanism
+        ),
+        Some(c) => format!(
+            " (the daemon's own IPC separately reports its forge credential as DEGRADED: {} — \
+             but that is the daemon's credential, not this caller's missing `gh`)",
+            c.message
+        ),
+        None => String::new(),
+    };
+    HealthSection::new(
+        key,
+        Verdict::Unknown,
+        format!("{}{cred_note}", gh.reason),
+        serde_json::json!({
+            "unavailable": "gh not found on PATH or not executable",
+            "gh_bin": gh.gh_bin,
+            "reason": gh.reason,
+            "observed_path": gh.observed_path,
+            "daemon_credential_preflight": credential_preflight,
+        }),
     )
 }
 
@@ -1800,6 +1875,7 @@ mod tests {
                 merged_24h: Some(3),
                 ..Default::default()
             }]),
+            gh_unavailable: None,
             cli_build_commit: CLI_COMMIT.to_string(),
             work_finder_log_tick_age_secs: None,
         }
@@ -2874,6 +2950,98 @@ mod tests {
         let section = assess_queues(&inputs);
         assert_eq!(section.verdict, Verdict::Unknown);
         assert_eq!(assess(&inputs).exit_code(), EXIT_DEGRADED);
+    }
+
+    // ===================================================================
+    // A missing/non-executable `gh` is one fact, not N per-repo failures
+    // (#5061)
+    // ===================================================================
+
+    fn gh_unavailable_fixture() -> crate::pipeline_snapshot::GhUnavailable {
+        crate::pipeline_snapshot::GhUnavailable {
+            gh_bin: "gh".to_string(),
+            reason: "`gh` not found on PATH — cannot assess queue depth / merge throughput. \
+                     This looks like a non-login shell missing PATH entries a login shell would \
+                     add — the same failure class as #4875."
+                .to_string(),
+            observed_path: Some("/usr/bin:/bin".to_string()),
+        }
+    }
+
+    fn credential_preflight_ok() -> crate::types::CredentialPreflightReport {
+        crate::types::CredentialPreflightReport {
+            ok: true,
+            mechanism: "keyring".to_string(),
+            fingerprint: Some("rjwalters".to_string()),
+            message: "authenticated as rjwalters via keyring".to_string(),
+            checked_at: now(),
+        }
+    }
+
+    /// The core #5061 regression pin: a missing `gh` collapses to a single
+    /// section-level reason naming PATH, never a per-repo "forge query
+    /// FAILED for: repoA, repoB, ..." list — even though `pipeline` itself is
+    /// `None` (the collector never ran the fan-out).
+    #[test]
+    fn a_missing_gh_is_one_fact_not_a_per_repo_failure_list() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = None;
+        inputs.gh_unavailable = Some(gh_unavailable_fixture());
+
+        let queues = assess_queues(&inputs);
+        assert_eq!(queues.verdict, Verdict::Unknown);
+        assert!(queues.summary.contains("PATH"), "{}", queues.summary);
+        assert!(queues.summary.contains("#4875"), "{}", queues.summary);
+        assert!(
+            !queues.summary.contains("forge query FAILED for:"),
+            "must not regress to the per-repo phrasing: {}",
+            queues.summary
+        );
+
+        let throughput = assess_throughput(&inputs);
+        assert_eq!(throughput.verdict, Verdict::Unknown);
+        assert!(
+            !throughput.summary.contains("forge query FAILED for:"),
+            "must not regress to the per-repo phrasing: {}",
+            throughput.summary
+        );
+
+        // exit-code contract is unchanged: still "could not determine", exit 1.
+        assert_eq!(assess(&inputs).exit_code(), EXIT_DEGRADED);
+    }
+
+    /// AC: cross-reference the daemon's own IPC-answered credential verdict
+    /// so the two signals never silently contradict each other.
+    #[test]
+    fn a_missing_gh_cross_references_a_healthy_daemon_credential() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = None;
+        inputs.gh_unavailable = Some(gh_unavailable_fixture());
+        inputs.status.as_mut().unwrap().credential_preflight = Some(credential_preflight_ok());
+
+        let queues = assess_queues(&inputs);
+        assert!(
+            queues.summary.contains("credential OK"),
+            "should cross-reference the daemon's own OK verdict: {}",
+            queues.summary
+        );
+        assert!(queues.detail["daemon_credential_preflight"]["ok"] == true);
+    }
+
+    /// Without a daemon-reported credential verdict (unreachable IPC, or a
+    /// pre-#4005 daemon), the section must still render — no cross-reference
+    /// clause, not a panic or an empty summary.
+    #[test]
+    fn a_missing_gh_with_no_daemon_credential_signal_still_renders() {
+        let mut inputs = healthy_inputs();
+        inputs.pipeline = None;
+        inputs.gh_unavailable = Some(gh_unavailable_fixture());
+        inputs.status = None;
+
+        let queues = assess_queues(&inputs);
+        assert_eq!(queues.verdict, Verdict::Unknown);
+        assert!(!queues.summary.is_empty());
+        assert!(queues.detail["daemon_credential_preflight"].is_null());
     }
 
     // ===================================================================

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -144,6 +144,16 @@ enum Commands {
     /// probe is never trusted alone (#4694: it twice declared a live,
     /// dispatching daemon dead). A DEAD verdict requires all three independent
     /// signals (IPC, launchd/pid-file classification, `pgrep`) to agree.
+    ///
+    /// Not every section is trustworthy from the same vantage point (#5061):
+    /// `liveness`/`dispatch`/`tokens`/`roles`/`observability` are
+    /// daemon-authoritative (sourced from the daemon's own IPC round-trip or
+    /// a local probe of this host), so they read the same over SSH as
+    /// locally. `queues`/`throughput` instead run `gh` calls in THIS
+    /// process — a `gh` missing from a non-login shell's `PATH` (this
+    /// process's `PATH`, not the daemon's) reports as one distinct fact
+    /// rather than a per-repo forge-query failure, and cross-references the
+    /// daemon's own `credential_preflight` verdict when available.
     Health {
         /// Window for the role-tick and throughput sections: `30m` (default),
         /// `2h`, `90s`, `1d`, or a bare number of seconds.

--- a/loom-daemon/src/pipeline_snapshot.rs
+++ b/loom-daemon/src/pipeline_snapshot.rs
@@ -165,6 +165,125 @@ impl Default for PipelineMetrics {
 /// named for, and what every pre-#4761 caller gets.
 pub const DEFAULT_MERGE_WINDOW_HOURS: i64 = 24;
 
+/// The default `gh` binary this module invokes when nothing overrides it —
+/// the single source of truth so [`GhPipelineSource::new`] and
+/// [`probe_gh_availability`]'s caller (`loom-daemon health`'s collector,
+/// #5061) can never drift into checking a different binary than the one that
+/// actually runs the per-repo queries.
+pub const DEFAULT_GH_BIN: &str = "gh";
+
+// ============================================================================
+// `gh` binary availability (Issue #5061)
+// ============================================================================
+
+/// The client-side `gh` binary this process would use for a
+/// [`GhPipelineSource`] fan-out could not be found or executed at all — an
+/// **environment fact about this process**, not a forge outage.
+///
+/// Produced once by [`probe_gh_availability`], *before* any per-repo `gh`
+/// call, precisely so a caller (`loom-daemon health`, #5061) can report it as
+/// a single fact rather than as N independent "forge query FAILED" entries —
+/// one per managed repo — which is what happened before this type existed: a
+/// missing `gh` on a non-login SSH `PATH` made every repo's query fail
+/// identically, and the resulting message read exactly like a forge outage or
+/// a dead credential.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct GhUnavailable {
+    /// The configured `gh` binary path/name (`gh` unless overridden via
+    /// [`GhPipelineSource::with_gh_bin`]).
+    pub gh_bin: String,
+    /// Operator-facing reason, already naming the specific cause: PATH
+    /// resolution failure (the common case — the same failure class as
+    /// #4875) vs. an explicit path that does not exist vs. a file found but
+    /// not executable.
+    pub reason: String,
+    /// This process's raw `PATH` value at probe time, when the failure was a
+    /// PATH lookup — `None` for an explicit-path failure (nothing to blame
+    /// on `PATH`) or a permission failure. Kept out of `reason` because a
+    /// summary line should not have to enumerate an arbitrarily long,
+    /// host-specific `PATH`; carried here for `--json` diagnostics.
+    pub observed_path: Option<String>,
+}
+
+/// Probe whether `gh_bin` can be located and invoked at all: a single,
+/// bounded `<gh_bin> --version` spawn attempt — no network, no repo context,
+/// just "does exec even start". `Ok(())` on any outcome other than the
+/// binary failing to *launch*: a `gh` that launches but exits non-zero (an
+/// unexpected `--version` failure) is still "available" for this purpose.
+/// Only [`std::io::ErrorKind::NotFound`] (not on `PATH`, or an explicit path
+/// that does not exist) and [`std::io::ErrorKind::PermissionDenied`] (found
+/// but not executable) are treated as unavailable — matching the acceptance
+/// criteria's "missing or non-executable `gh`". Any other spawn error (e.g. a
+/// transient fork/exec failure) is left for the real per-repo `gh` calls to
+/// surface, exactly as before this probe existed — this function's whole
+/// point is narrowly distinguishing "the binary itself cannot run" from
+/// every other kind of forge-query failure.
+pub fn probe_gh_availability(gh_bin: &Path) -> Result<(), GhUnavailable> {
+    match Command::new(gh_bin).arg("--version").output() {
+        Ok(_) => Ok(()),
+        Err(e)
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
+            ) =>
+        {
+            Err(describe_gh_unavailable(gh_bin, &e))
+        }
+        Err(_) => Ok(()),
+    }
+}
+
+/// Build the operator-facing [`GhUnavailable`] for [`probe_gh_availability`]'s
+/// failure, naming the specific PATH problem (the same failure class as
+/// #4875) when `gh_bin` is a bare name subject to a `PATH` lookup, rather
+/// than an explicit path.
+fn describe_gh_unavailable(gh_bin: &Path, err: &std::io::Error) -> GhUnavailable {
+    if err.kind() == std::io::ErrorKind::PermissionDenied {
+        return GhUnavailable {
+            gh_bin: gh_bin.display().to_string(),
+            reason: format!(
+                "`{}` was found but is not executable ({err}) — check its file permissions",
+                gh_bin.display()
+            ),
+            observed_path: None,
+        };
+    }
+
+    // A path is subject to PATH-lookup exec semantics only when it has no
+    // directory component at all (mirrors how `exec`/`Command` itself decides
+    // whether to search `PATH`: any path separator anywhere opts out of the
+    // search). An explicit path (`./gh`, `/usr/bin/gh`, a `with_gh_bin`
+    // override pointing at a specific file) that does not exist is not a
+    // `PATH` problem — no separate hint is useful there.
+    let is_bare_name = gh_bin.parent().is_none_or(|p| p.as_os_str().is_empty());
+    if !is_bare_name {
+        return GhUnavailable {
+            gh_bin: gh_bin.display().to_string(),
+            reason: format!("`{}` does not exist", gh_bin.display()),
+            observed_path: None,
+        };
+    }
+
+    let path = std::env::var("PATH").unwrap_or_default();
+    let hint = crate::fleet::path_bootstrap::CANONICAL_PATH_DIRS
+        .iter()
+        .take(3)
+        .copied()
+        .collect::<Vec<_>>()
+        .join(", ");
+    GhUnavailable {
+        gh_bin: gh_bin.display().to_string(),
+        reason: format!(
+            "`{}` not found on PATH — cannot assess queue depth / merge throughput. This looks \
+             like a non-login shell (e.g. a bare `ssh host 'cmd'` invocation) missing PATH \
+             entries a login shell would add — the same failure class as #4875. Commonly \
+             missing: {hint}",
+            gh_bin.display()
+        ),
+        observed_path: Some(path),
+    }
+}
+
 /// A `gh`-backed [`PipelineSource`]. Runs up to six `gh` invocations per repo
 /// (one per requested metric — see [`PipelineMetrics`]) scoped to that repo's
 /// own working directory so `gh` auto-detects the remote — same convention as
@@ -183,7 +302,7 @@ impl GhPipelineSource {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            gh_bin: PathBuf::from("gh"),
+            gh_bin: PathBuf::from(DEFAULT_GH_BIN),
             metrics: PipelineMetrics::ALL,
             merge_window: chrono::Duration::hours(DEFAULT_MERGE_WINDOW_HOURS),
         }
@@ -441,6 +560,72 @@ mod tests {
     #[test]
     fn format_count_renders_number_for_some() {
         assert_eq!(format_count(Some(7)), "7");
+    }
+
+    // ===================================================================
+    // probe_gh_availability — #5061
+    // ===================================================================
+
+    #[test]
+    fn probe_gh_availability_ok_for_a_real_executable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gh = write_fake_gh(tmp.path(), "echo 'gh version 2.0.0'");
+        assert_eq!(probe_gh_availability(&gh), Ok(()));
+    }
+
+    /// `#[serial]` is load-bearing (#4547): this test mutates the process-wide
+    /// `PATH` env var, which every concurrently-running `Command` spawn in
+    /// this file's other tests implicitly reads.
+    #[test]
+    #[serial]
+    fn probe_gh_availability_names_the_path_problem_for_a_bare_name_missing_from_path() {
+        let saved = std::env::var("PATH").ok();
+        std::env::set_var("PATH", "/no-such-loom-test-dir-5061");
+        let result = probe_gh_availability(Path::new("definitely-not-a-real-gh-binary-5061"));
+        match saved {
+            Some(p) => std::env::set_var("PATH", p),
+            None => std::env::remove_var("PATH"),
+        }
+
+        let err = result.expect_err("a binary absent from PATH must be reported as unavailable");
+        assert_eq!(err.gh_bin, "definitely-not-a-real-gh-binary-5061");
+        assert!(err.reason.contains("PATH"), "reason should name PATH: {}", err.reason);
+        assert!(
+            err.reason.contains("#4875"),
+            "reason should cross-reference #4875: {}",
+            err.reason
+        );
+        assert!(
+            err.observed_path.is_some(),
+            "a PATH-lookup failure should carry the observed PATH for --json"
+        );
+    }
+
+    #[test]
+    fn probe_gh_availability_reports_a_missing_explicit_path_without_a_path_hint() {
+        let err = probe_gh_availability(Path::new("/no/such/gh-binary-5061"))
+            .expect_err("a nonexistent explicit path must be reported as unavailable");
+        assert!(err.reason.contains("does not exist"));
+        assert!(
+            err.observed_path.is_none(),
+            "an explicit-path failure is not a PATH problem, so no PATH should be attached"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn probe_gh_availability_reports_permission_denied_for_a_non_executable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("not-executable-gh");
+        std::fs::write(&path, "#!/bin/sh\necho hi\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let err = probe_gh_availability(&path)
+            .expect_err("a non-executable file must be reported as unavailable");
+        assert!(err.reason.contains("not executable"), "reason: {}", err.reason);
+        assert!(err.observed_path.is_none());
     }
 
     // ===================================================================

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -599,8 +599,20 @@ async fn handle_health(
         Err(e) => (None, Some(e.to_string())),
     };
 
-    let pipeline = match &report {
-        Some(r) => {
+    // Probe ONCE whether this process can even run `gh` at all (#5061) —
+    // same rule and same rationale as `cli::health`'s collector: a missing/
+    // non-executable `gh` would otherwise fail identically for every managed
+    // repo, rendering as "forge query FAILED for: <every repo>" and reading
+    // like a forge outage. In practice this daemon process already passed
+    // `credential_preflight` at startup (which itself depends on `gh`
+    // working), so this mostly guards a `gh` that has gone missing since —
+    // but the check is symmetric with the CLI collector so this route's
+    // `queues`/`throughput` never regress to the pre-#5061 per-repo noise.
+    let gh_unavailable =
+        pipeline_snapshot::probe_gh_availability(Path::new(pipeline_snapshot::DEFAULT_GH_BIN))
+            .err();
+    let pipeline = match (&report, &gh_unavailable) {
+        (Some(r), None) => {
             let roots: Vec<PathBuf> = r.per_repo.iter().map(|repo| repo.root.clone()).collect();
             Some(
                 pipeline_rows_cached(source, roots, cache)
@@ -610,7 +622,7 @@ async fn handle_health(
                     .collect::<Vec<_>>(),
             )
         }
-        None => None,
+        _ => None,
     };
 
     let (ranking_present, ranking_age_secs) = report
@@ -647,6 +659,7 @@ async fn handle_health(
         ranking_present,
         ranking_age_secs,
         pipeline,
+        gh_unavailable,
         // #4824 — this route runs *inside* the daemon, so its own
         // `BUILT_COMMIT` is by construction the answering daemon's and the
         // skew check resolves to `Match`. Threaded in anyway (rather than


### PR DESCRIPTION
## Summary

`loom-daemon health --json`'s `queues`/`throughput` sections run their forge
queries (`gh`) in the **invoking** process, not the daemon's own process. When
probed over a non-login SSH shell where `gh` isn't on `PATH`, every managed
repo's query failed identically, rendering as:

```
forge query FAILED for: safehouse, loom, klayout-tools, claude-monitor, anvil
```

which reads exactly like a forge outage or a dead credential — even while the
daemon's own IPC round-trip correctly reports `Forge credential: OK`. The two
signals contradicted each other, and the false one is what an operator sees
first.

## Changes

- **`pipeline_snapshot::probe_gh_availability()`** (new): a single, bounded
  `<gh_bin> --version` spawn attempt, run **once** before any per-repo `gh`
  call. Distinguishes:
  - a bare name missing from `PATH` (names the PATH problem specifically —
    same failure class as #4875, cites the canonical `~/.local/bin` /
    `/opt/homebrew/bin` / `~/.cargo/bin` directories a non-login shell is
    commonly missing)
  - an explicit path that does not exist (no PATH hint — not a PATH problem)
  - a file found but not executable (`PermissionDenied`)
- **`health::assess_queues` / `assess_throughput`**: when the collector's
  probe found `gh` unavailable, both sections short-circuit to a single
  distinct reason (`Verdict::Unknown`, same exit-code contract as before —
  only the *reason string* changes) instead of the per-repo
  "forge query FAILED for: ..." list. The N-repo fan-out is skipped entirely
  (no value in spawning calls already known to fail identically).
- **Cross-reference to the daemon's own IPC verdict**: when the daemon
  answered IPC and reported `credential_preflight`, the section names it
  (`"...the daemon's own IPC reports its forge credential OK via keyring —
  this is a caller-side PATH problem, not a forge outage"`), so the two
  signals never silently contradict each other again.
- **`loom-daemon health --help`** and the module doc now document which
  sections are daemon-authoritative (`liveness`/`dispatch`/`tokens`/`roles`/
  `observability` — trustworthy the same way over SSH as locally) vs. which
  execute `gh` calls in the caller's own process (`queues`/`throughput`).
- Applied symmetrically to the dashboard's `GET /api/health` route
  (`serve.rs`), which shares the same `health::assess` collector.

## Test plan

- [x] `cargo test -p loom-daemon --lib` — 3249 passed, 0 failed (full `loom-daemon` crate)
- [x] `cargo clippy -p loom-daemon --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p loom-daemon -- --check` — clean
- [x] New unit tests: `pipeline_snapshot::tests::probe_gh_availability_*` (missing-on-PATH, explicit missing path, non-executable file, real executable) and `health::tests::a_missing_gh_is_one_fact_not_a_per_repo_failure_list` / `a_missing_gh_cross_references_a_healthy_daemon_credential` / `a_missing_gh_with_no_daemon_credential_signal_still_renders`
- [x] Manual repro: `PATH="/usr/bin:/bin" loom-daemon health` now reports a single
  PATH-attributed `queues`/`throughput` line instead of per-repo failures;
  with `gh` present the pre-existing "forge snapshot not collected" (daemon
  unreachable) message is unchanged

Closes #5061