### PR TITLE
fix(docs): replace echo "$VAR" | jq with printf in role-doc JSON pipelines

### DIFF
--- a/defaults/.claude/commands/loom/champion-epic.md
+++ b/defaults/.claude/commands/loom/champion-epic.md
@@ -185,9 +185,11 @@ PHASE_ISSUES=$(gh issue list \
   --json number,state \
   --jq '.')
 
-# Count open vs closed
-OPEN_COUNT=$(echo "$PHASE_ISSUES" | jq '[.[] | select(.state == "OPEN")] | length')
-CLOSED_COUNT=$(echo "$PHASE_ISSUES" | jq '[.[] | select(.state == "CLOSED")] | length')
+# Count open vs closed. NOTE: `printf '%s\n' "$VAR" | jq`, never `echo "$VAR" |
+# jq` — zsh's `echo` builtin reinterprets `\n`/`\t` escapes by default, which
+# corrupts captured `gh --json` output before jq ever parses it (#5094).
+OPEN_COUNT=$(printf '%s\n' "$PHASE_ISSUES" | jq '[.[] | select(.state == "OPEN")] | length')
+CLOSED_COUNT=$(printf '%s\n' "$PHASE_ISSUES" | jq '[.[] | select(.state == "CLOSED")] | length')
 
 if [ "$OPEN_COUNT" -eq 0 ] && [ "$CLOSED_COUNT" -gt 0 ]; then
     echo "Phase $PHASE complete! Creating Phase $((PHASE + 1)) issues..."

--- a/defaults/.claude/commands/loom/champion-issue-promo.md
+++ b/defaults/.claude/commands/loom/champion-issue-promo.md
@@ -238,22 +238,29 @@ _sha256() {
   elif command -v shasum >/dev/null 2>&1; then shasum -a 256
   else cksum; fi
 }
+# NOTE: use `printf '%s\n' "$VAR" | jq`, never `echo "$VAR" | jq`, for any
+# variable holding captured `gh --json` output. zsh's `echo` builtin
+# reinterprets `\n`/`\t` escape sequences by default, so a body/comment string
+# containing a literal two-character `\n` inside the JSON gets turned into a
+# raw newline before it reaches jq — corrupting the JSON and causing jq to
+# fail (or, worse, an `-e ... && echo yes || echo no` construct to silently
+# take the "no" branch). See #5094.
 BODY_HASH=$(printf '%s\n%s' \
-  "$(echo "$ISSUE_JSON" | jq -r '.title // ""')" \
-  "$(echo "$ISSUE_JSON" | jq -r '.body // ""')" \
+  "$(printf '%s\n' "$ISSUE_JSON" | jq -r '.title // ""')" \
+  "$(printf '%s\n' "$ISSUE_JSON" | jq -r '.body // ""')" \
   | _sha256 | awk '{print substr($1, 1, 16)}')
 VERDICT_MARKER="<!-- champion:proposal-verdict:body-$BODY_HASH -->"
 
 # Escalation inputs, computed HERE rather than in Step 4 (#4967): the skip path
 # below must be able to decide "escalate instead of skipping again" without ever
 # reaching Step 4. Step 4 reuses these same variables.
-PRIOR_REJECTIONS=$(echo "$ISSUE_JSON" | jq \
+PRIOR_REJECTIONS=$(printf '%s\n' "$ISSUE_JSON" | jq \
   '[.comments[] | select(.body | contains("Champion Review: NEEDS REVISION"))] | length')
-ALREADY_ROUTED=$(echo "$ISSUE_JSON" | jq -e '.labels[] | select(.name=="loom:operator-only")' >/dev/null && echo yes || echo no)
+ALREADY_ROUTED=$(printf '%s\n' "$ISSUE_JSON" | jq -e '.labels[] | select(.name=="loom:operator-only")' >/dev/null && echo yes || echo no)
 SKIP_STREAK=0            # silent skips already recorded for THIS body revision
 ESCALATE_UNREVISED=no    # set to yes to bypass re-evaluation and go straight to Step 4's escalation
 
-if echo "$ISSUE_JSON" | jq -e --arg m "$VERDICT_MARKER" \
+if printf '%s\n' "$ISSUE_JSON" | jq -e --arg m "$VERDICT_MARKER" \
      '.comments[] | select(.body | contains($m))' >/dev/null; then
   # This exact revision was already evaluated. Read the silent-skip tally carried
   # by the matching verdict comment. REST, not `gh issue view`: only the REST
@@ -261,8 +268,8 @@ if echo "$ISSUE_JSON" | jq -e --arg m "$VERDICT_MARKER" \
   # `gh issue view --json comments` is a GraphQL node id and cannot be PATCHed).
   VERDICT_COMMENT=$(gh api "repos/{owner}/{repo}/issues/$ISSUE_NUMBER/comments" --paginate \
     --jq ".[] | select(.body | contains(\"$VERDICT_MARKER\"))" | jq -s 'last')
-  COMMENT_ID=$(echo "$VERDICT_COMMENT" | jq -r '.id // empty')
-  COMMENT_BODY=$(echo "$VERDICT_COMMENT" | jq -r '.body // ""')
+  COMMENT_ID=$(printf '%s\n' "$VERDICT_COMMENT" | jq -r '.id // empty')
+  COMMENT_BODY=$(printf '%s\n' "$VERDICT_COMMENT" | jq -r '.body // ""')
   SKIP_STREAK=$(printf '%s' "$COMMENT_BODY" \
     | sed -n "s|.*<!-- champion:unrevised-skips:$BODY_HASH:\([0-9]\{1,\}\) -->.*|\1|p" | tail -n 1)
   SKIP_STREAK=${SKIP_STREAK:-0}

--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -640,16 +640,21 @@ echo "PASS: Recently updated ($HOURS_AGO hours ago)"
 # is passthrough inside the wrapper anyway; this is belt-and-suspenders.)
 CHECKS=$(gh pr checks <number> --json bucket,name 2>/dev/null)
 
-# Handle case where no checks exist (empty stdout, or an empty JSON array)
-if [ -z "$CHECKS" ] || [ "$(echo "$CHECKS" | jq 'length')" = "0" ]; then
+# Handle case where no checks exist (empty stdout, or an empty JSON array).
+# NOTE: pipe raw `gh --json` output to jq via `printf '%s\n' "$VAR" | jq`, never
+# `echo "$VAR" | jq` — zsh's `echo` builtin reinterprets `\n`/`\t` escape
+# sequences by default, turning a literal two-char `\n` inside a JSON string
+# value into a raw newline and corrupting the JSON before jq ever parses it
+# (#5094).
+if [ -z "$CHECKS" ] || [ "$(printf '%s\n' "$CHECKS" | jq 'length')" = "0" ]; then
   echo "PASS: No CI checks required"
   exit 0
 fi
 
 # Parse checks by bucket. Buckets: pass, fail, pending, skipping, cancel.
 # `fail`/`cancel` block the merge; `pending` defers; `pass`/`skipping` are OK.
-FAILING_CHECKS=$(echo "$CHECKS" | jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | .name')
-PENDING_CHECKS=$(echo "$CHECKS" | jq -r '.[] | select(.bucket == "pending") | .name')
+FAILING_CHECKS=$(printf '%s\n' "$CHECKS" | jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | .name')
+PENDING_CHECKS=$(printf '%s\n' "$CHECKS" | jq -r '.[] | select(.bucket == "pending") | .name')
 
 # Check for failing checks
 if [ -n "$FAILING_CHECKS" ]; then
@@ -725,11 +730,11 @@ PR_NUMBER=$1
 # THIS pass, and answering from cache is the same failure as restating it from
 # memory (#4613; see "Cached forge reads").
 PR_DATA=$(gh pr view "$PR_NUMBER" --json additions,deletions,updatedAt)
-ADDITIONS=$(echo "$PR_DATA" | jq -r '.additions')
-DELETIONS=$(echo "$PR_DATA" | jq -r '.deletions')
+ADDITIONS=$(printf '%s\n' "$PR_DATA" | jq -r '.additions')
+DELETIONS=$(printf '%s\n' "$PR_DATA" | jq -r '.deletions')
 TOTAL_LINES=$((ADDITIONS + DELETIONS))
 
-UPDATED_AT=$(echo "$PR_DATA" | jq -r '.updatedAt')
+UPDATED_AT=$(printf '%s\n' "$PR_DATA" | jq -r '.updatedAt')
 UPDATED_TS=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$UPDATED_AT" +%s 2>/dev/null || \
              date -d "$UPDATED_AT" +%s 2>/dev/null)
 NOW_TS=$(date +%s)
@@ -737,7 +742,7 @@ HOURS_AGO=$(( (NOW_TS - UPDATED_TS) / 3600 ))
 
 # Check CI status (empty stdout = no checks; see criterion #6 above)
 CHECKS=$(gh pr checks "$PR_NUMBER" --json bucket,name 2>/dev/null)
-if [ -z "$CHECKS" ] || [ "$(echo "$CHECKS" | jq 'length')" = "0" ]; then
+if [ -z "$CHECKS" ] || [ "$(printf '%s\n' "$CHECKS" | jq 'length')" = "0" ]; then
   CI_STATUS="No CI checks required"
 else
   CI_STATUS="All CI checks passing"

--- a/defaults/.claude/commands/loom/champion-reference.md
+++ b/defaults/.claude/commands/loom/champion-reference.md
@@ -17,8 +17,12 @@ This section documents how Champion handles non-standard situations during PR au
 # With no checks, `gh pr checks --json bucket,name` prints "no checks reported..."
 # to STDERR, exits non-zero, and emits EMPTY stdout. Detect via empty stdout
 # (robust) rather than matching error text. CHECKS captured with 2>/dev/null.
+# NOTE: `printf '%s\n' "$VAR" | jq`, never `echo "$VAR" | jq` — zsh's `echo`
+# builtin reinterprets `\n`/`\t` escapes by default, which corrupts captured
+# `gh --json` output (embedded newlines in body/comment text are represented
+# as literal `\n` inside the JSON string) before jq ever parses it (#5094).
 CHECKS=$(gh pr checks "$PR_NUMBER" --json bucket,name 2>/dev/null)
-if [ -z "$CHECKS" ] || [ "$(echo "$CHECKS" | jq 'length')" = "0" ]; then
+if [ -z "$CHECKS" ] || [ "$(printf '%s\n' "$CHECKS" | jq 'length')" = "0" ]; then
   echo "PASS: No CI checks required"
   # Continue to merge
 fi
@@ -37,7 +41,7 @@ fi
 **Handling**:
 ```bash
 # Check for pending/running checks (bucket == "pending")
-PENDING=$(echo "$CHECKS" | jq -r '.[] | select(.bucket == "pending") | .name')
+PENDING=$(printf '%s\n' "$CHECKS" | jq -r '.[] | select(.bucket == "pending") | .name')
 if [ -n "$PENDING" ]; then
   echo "SKIP: CI checks still running - will retry next iteration"
   # Skip this PR, try again later
@@ -234,7 +238,7 @@ done
 ```bash
 # A "fail" or "cancel" bucket blocks the merge; "pending" defers; "pass" and
 # "skipping" are acceptable. (gh buckets: pass, fail, pending, skipping, cancel.)
-FAILING=$(echo "$CHECKS" | jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | .name')
+FAILING=$(printf '%s\n' "$CHECKS" | jq -r '.[] | select(.bucket == "fail" or .bucket == "cancel") | .name')
 if [ -n "$FAILING" ]; then
   echo "FAIL: Some checks did not pass"
 fi

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -866,7 +866,11 @@ _sha256() {
 # One "<pr#>:<state>:<sorted block labels>" line per current blocker, sorted so
 # ordering churn from the API never looks like a changed conclusion. Prefix with
 # the verdict so blocked→clear can never collide with clear→blocked.
-BLOCKERS=$(for PR in $(echo "$ISSUE_JSON" | jq -r '.closedByPullRequestsReferences[].number'); do
+# NOTE: `printf '%s\n' "$VAR" | jq`, never `echo "$VAR" | jq` — zsh's `echo`
+# builtin reinterprets `\n`/`\t` escapes by default, corrupting captured
+# `gh --json` output (a literal `\n` inside a body/comment string becomes a
+# raw newline) before jq ever parses it (#5094).
+BLOCKERS=$(for PR in $(printf '%s\n' "$ISSUE_JSON" | jq -r '.closedByPullRequestsReferences[].number'); do
   gh pr view "$PR" --json number,state,labels --jq \
     '"\(.number):\(.state):\([.labels[].name | select(startswith("loom:"))] | sort | join(","))"'
 done | sort)
@@ -881,10 +885,10 @@ CONCLUSION_HASH=$(printf '%s\n%s\n%s' "$VERDICT" "$BLOCKERS" "$BLOCK_REASON" \
 RECHECK_MARKER="<!-- curator:dep-recheck:$CONCLUSION_HASH -->"
 
 # Most recent prior Curator re-check comment, of ANY conclusion.
-PRIOR=$(echo "$ISSUE_JSON" | jq -c '[.comments[] | select(.body | test("<!-- curator:dep-recheck:"))] | last // {}')
-PRIOR_HASH=$(echo "$PRIOR" | jq -r '.body // ""' \
+PRIOR=$(printf '%s\n' "$ISSUE_JSON" | jq -c '[.comments[] | select(.body | test("<!-- curator:dep-recheck:"))] | last // {}')
+PRIOR_HASH=$(printf '%s\n' "$PRIOR" | jq -r '.body // ""' \
   | sed -n 's|.*<!-- curator:dep-recheck:\([0-9a-f]\{1,\}\) -->.*|\1|p' | tail -n 1)
-PRIOR_AT=$(echo "$PRIOR" | jq -r '.createdAt // empty')
+PRIOR_AT=$(printf '%s\n' "$PRIOR" | jq -r '.createdAt // empty')
 
 # Age in hours (portable: BSD `date -j -f` on macOS, GNU `date -d` elsewhere).
 _epoch() { date -j -f '%Y-%m-%dT%H:%M:%SZ' "$1" +%s 2>/dev/null || date -d "$1" +%s; }

--- a/defaults/.claude/commands/loom/guide.md
+++ b/defaults/.claude/commands/loom/guide.md
@@ -619,8 +619,11 @@ has_superseding_block() {
   for pr in $pr_numbers; do
     local pr_json
     pr_json=$(gh pr view "$pr" --json state,labels 2>/dev/null) || continue
-    local pr_state=$(echo "$pr_json" | jq -r '.state')
-    local pr_blocked=$(echo "$pr_json" | jq -r \
+    # NOTE: `printf '%s\n' "$VAR" | jq`, never `echo "$VAR" | jq` — zsh's
+    # `echo` builtin reinterprets `\n`/`\t` escapes by default, which
+    # corrupts captured `gh --json` output before jq ever parses it (#5094).
+    local pr_state=$(printf '%s\n' "$pr_json" | jq -r '.state')
+    local pr_blocked=$(printf '%s\n' "$pr_json" | jq -r \
       '[.labels[].name] | any(. == "loom:changes-requested" or . == "loom:blocked")')
     if [ "$pr_state" = "OPEN" ] && [ "$pr_blocked" = "true" ]; then
       echo "true"
@@ -646,9 +649,9 @@ a later pass to sort out.
 ```bash
 check_and_unblock() {
   "$GH_READ" issue list --label "loom:blocked" --state open --json number,body,title | jq -c '.[]' | while read -r issue; do
-    local number=$(echo "$issue" | jq -r '.number')
-    local body=$(echo "$issue" | jq -r '.body')
-    local title=$(echo "$issue" | jq -r '.title')
+    local number=$(printf '%s\n' "$issue" | jq -r '.number')
+    local body=$(printf '%s\n' "$issue" | jq -r '.body')
+    local title=$(printf '%s\n' "$issue" | jq -r '.title')
 
     local deps=$(parse_dependencies "$body")
 
@@ -778,9 +781,12 @@ check_epic_progress() {
     --search="Epic: #$epic_number in:body" \
     --json number,state,title)
 
-  local total=$(echo "$phase_issues" | jq 'length')
-  local closed=$(echo "$phase_issues" | jq '[.[] | select(.state == "CLOSED")] | length')
-  local open=$(echo "$phase_issues" | jq '[.[] | select(.state == "OPEN")] | length')
+  # NOTE: `printf '%s\n' "$VAR" | jq`, never `echo "$VAR" | jq` — zsh's `echo`
+  # builtin reinterprets `\n`/`\t` escapes by default, corrupting captured
+  # `gh --json` output before jq ever parses it (#5094).
+  local total=$(printf '%s\n' "$phase_issues" | jq 'length')
+  local closed=$(printf '%s\n' "$phase_issues" | jq '[.[] | select(.state == "CLOSED")] | length')
+  local open=$(printf '%s\n' "$phase_issues" | jq '[.[] | select(.state == "OPEN")] | length')
 
   echo "Epic #$epic_number: $closed/$total complete ($open in progress)"
 }
@@ -1061,8 +1067,10 @@ update_work_log() {
   local new_issues=$("$GH_READ" issue list --state closed --limit 50 --json number,title,closedAt \
     --jq "[.[] | select(.number > $last_issue)] | sort_by(.closedAt) | reverse")
 
-  # If nothing new, skip
-  if [ "$(echo "$new_prs" | jq 'length')" -eq 0 ] && [ "$(echo "$new_issues" | jq 'length')" -eq 0 ]; then
+  # If nothing new, skip. NOTE: `printf '%s\n' "$VAR" | jq`, never `echo "$VAR"
+  # | jq` — zsh's `echo` builtin reinterprets `\n`/`\t` escapes by default,
+  # corrupting captured `gh --json` output before jq ever parses it (#5094).
+  if [ "$(printf '%s\n' "$new_prs" | jq 'length')" -eq 0 ] && [ "$(printf '%s\n' "$new_issues" | jq 'length')" -eq 0 ]; then
     echo "No new merged PRs or closed issues. WORK_LOG.md is current."
     return 1
   fi


### PR DESCRIPTION
## Summary

- Role instruction docs pipe captured `gh ... --json` payloads into `jq` (or `grep`) via `echo "$VAR" | jq ...`. Under zsh (this fleet's default shell), the `echo` builtin reinterprets `\n`/`\t` escape sequences by default — `gh issue view` / `gh pr view --json` output represents embedded newlines/tabs inside body/comment text as literal two-character `\n`/`\t` escape sequences within JSON string values. Echoing that captured text before it reaches `jq` turns those escapes into raw control characters, producing invalid JSON that `jq` either hard-fails on, or — worse, inside a `jq -e '...' && echo yes || echo no` construct — silently swallows by taking the "no" branch.
- This caused a live near-miss: Champion's idempotency check in `champion-issue-promo.md` reported a false "marker not found" for issue #5063, almost causing a duplicate re-evaluation of an already-decided proposal.
- Replaces every `echo "$VAR" | jq ...` instance in the affected files, where `$VAR` holds captured `gh --json` output, with `printf '%s\n' "$VAR" | jq ...`.

## Changes

- `defaults/.claude/commands/loom/champion-issue-promo.md` — idempotency check (`ISSUE_JSON`, `VERDICT_COMMENT`) now piped via `printf`.
- `defaults/.claude/commands/loom/champion-pr-merge.md` — CI-check parsing (`CHECKS`) and pre-merge comment data gathering (`PR_DATA`) now piped via `printf`.
- `defaults/.claude/commands/loom/champion-epic.md` — phase-progress counting (`PHASE_ISSUES`) now piped via `printf`.
- `defaults/.claude/commands/loom/champion-reference.md` — the three CI-check edge-case snippets (`CHECKS`) now piped via `printf`.
- `defaults/.claude/commands/loom/curator.md` — dependency-recheck fingerprinting (`ISSUE_JSON`, `PRIOR`) now piped via `printf`.
- `defaults/.claude/commands/loom/guide.md` — superseding-block check (`pr_json`), unblock loop (`issue`), epic progress (`phase_issues`), and work-log high-water-mark diffing (`new_prs`/`new_issues`) now piped via `printf`.
- Added a one explanatory NOTE comment per file (near the first fixed instance) documenting why `printf` is required, so a future edit doesn't reintroduce `echo "$VAR"` for JSON payloads.

Left unchanged (out of scope, by design): `echo "$VAR" | grep`/`sed` pipes where `$VAR` already holds **plain text** extracted by an earlier `jq -r` call (e.g. `$LABELS` from `--jq '[.labels[].name] | join(",")'`, `$BLOCKED_BODY` from `--jq '.body'`, `$todo_line`, `$NEW_ISSUE_URL`) — these are no longer raw JSON by the time they're echoed, so zsh's escape reinterpretation doesn't corrupt anything structural.

## Acceptance Criteria Verification

- [x] Every `echo "$VAR" | jq` instance where `$VAR` holds captured `gh --json` output is replaced with `printf '%s\n' "$VAR" | ...` — verified via `grep -rn 'echo "\$[A-Za-z_]*" | jq'` across the six files: only comment lines (the explanatory NOTEs) match, no live code.
- [x] One explanatory comment added per file (near the first fixed instance) explaining the zsh `echo` escape-reinterpretation hazard.
- [x] No new tests/CI scripts added (docs/prose with embedded bash recipes) — verified by grep as described above, plus manual review of every remaining `echo "$VAR" | grep` hit to confirm each operates on already-extracted plain text, not raw JSON.

## Test Plan

- `grep -rn 'echo "\$[A-Za-z_]*" | jq' defaults/.claude/commands/loom/{champion-issue-promo,champion-pr-merge,champion-epic,champion-reference,curator,guide}.md` — only comment-line matches remain.
- `grep -rn 'echo "\$[A-Za-z_]*" | grep' <same files>` — all remaining matches manually reviewed; each `$VAR` is plain text (already `jq -r`-extracted), not raw JSON.
- `./.loom/scripts/check-main-clean.sh` — confirms main checkout untouched.

Closes #5094