### PR TITLE
fix(dashboard): exclude health-less hosts from fleet counts, filter D1-revoked hosts

### DIFF
--- a/dashboard/src/fleetState.ts
+++ b/dashboard/src/fleetState.ts
@@ -188,6 +188,41 @@ export interface FleetSnapshot {
   activeSweeps: ActiveSweepState[];
 }
 
+/**
+ * Drop any `hosts` entry belonging to a hostId D1 has recorded as revoked
+ * (Issue #5078, mechanism 2 — "a host known only from a stale DO record").
+ *
+ * `handleRevokeHost` (`src/index.ts`) writes D1's `revoked_at` unconditionally,
+ * then best-effort clears this DO's `health:`/`tokens:` entries for that host
+ * — that cleanup fetch is wrapped in try/catch specifically so a transient DO
+ * failure can't fail the revoke itself (see `FleetState.removeHost`'s doc
+ * comment), which means a failed cleanup can leave those entries in the DO
+ * indefinitely. Rather than rely on that best-effort cleanup having
+ * succeeded, `src/index.ts` treats D1's `revoked_at` as authoritative at
+ * *read* time too: a snapshot never renders a revoked host as live, whether
+ * or not its DO-side cleanup actually ran.
+ *
+ * Deliberately does **not** touch `activeSweeps` — a sweep still reporting
+ * against a host revoked mid-run is a real anomaly (`removeHost`'s own doc
+ * comment: "an in-flight sweep on a host being revoked mid-run is a real
+ * anomaly worth surfacing"), not something this filter should hide; it stays
+ * visible (as an unattributed sweep, once the host's `hosts` entry above is
+ * gone — see `publicPage.ts`'s `renderFleetOverview`).
+ */
+export function filterRevokedHosts(
+  snapshot: FleetSnapshot,
+  revokedHostIds: ReadonlySet<string>,
+): FleetSnapshot {
+  if (revokedHostIds.size === 0) return snapshot;
+  const hosts: FleetSnapshot["hosts"] = {};
+  for (const [hostId, entry] of Object.entries(snapshot.hosts)) {
+    if (!revokedHostIds.has(hostId)) {
+      hosts[hostId] = entry;
+    }
+  }
+  return { hosts, activeSweeps: snapshot.activeSweeps };
+}
+
 /** Body accepted by the internal `POST /update` route — one record's worth
  * of live-state effect, already authenticated/validated by the Worker
  * before it reaches the Durable Object. */
@@ -323,7 +358,11 @@ export class FleetState implements DurableObject {
    * concept at this layer. Does **not** touch that host's `sweep:<sweepId>`
    * entries: an in-flight sweep on a host being revoked mid-run is a real
    * anomaly worth surfacing (via its own staleness), not something this
-   * best-effort cleanup should paper over.
+   * best-effort cleanup should paper over. Because the caller's fetch to
+   * this route is itself best-effort (issue #5078), a failure here can leave
+   * these entries behind indefinitely — [`filterRevokedHosts`] is the
+   * read-time backstop for exactly that case, treating D1's `revoked_at` as
+   * authoritative over whatever this method did or did not manage to delete.
    */
   private async removeHost(hostId: string): Promise<void> {
     await this.state.storage.delete([`health:${hostId}`, `tokens:${hostId}`]);

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -104,7 +104,7 @@
 
 import { extractBearerToken, authenticateHost, hashIngestKey } from "./auth";
 import { validateAccessJwt } from "./accessAuth";
-import { FleetState, type FleetSnapshot } from "./fleetState";
+import { FleetState, filterRevokedHosts, type FleetSnapshot } from "./fleetState";
 import { renderPublicPage } from "./publicPage";
 import {
   createLiveTailStream,
@@ -162,6 +162,37 @@ function jsonError(status: number, message: string): Response {
 
 function fleetStateStub(env: Env): DurableObjectStub {
   return env.FLEET_STATE.get(env.FLEET_STATE.idFromName(FLEET_STATE_ID_NAME));
+}
+
+/** D1 host_ids, among `hostIds`, whose `hosts` row is revoked — bounded to
+ * the snapshot's own host set rather than scanning the whole `hosts` table,
+ * since that is all `filterRevokedHosts` needs. */
+async function fetchRevokedHostIds(env: Env, hostIds: readonly string[]): Promise<Set<string>> {
+  if (hostIds.length === 0) return new Set();
+  const placeholders = hostIds.map(() => "?").join(",");
+  const { results } = await env.DB.prepare(
+    `SELECT host_id FROM hosts WHERE revoked_at IS NOT NULL AND host_id IN (${placeholders})`,
+  )
+    .bind(...hostIds)
+    .all<{ host_id: string }>();
+  return new Set(results.map((row) => row.host_id));
+}
+
+/**
+ * The Durable Object's live snapshot, with any host D1 has recorded as
+ * revoked filtered out (issue #5078, mechanism 2) — the single point every
+ * dashboard-facing read (`/api/fleet-state`, `/public/fleet-state`, the
+ * server-rendered `/` fallback) goes through, so a `handleRevokeHost` cleanup
+ * fetch that silently failed can never leave a stale `health:`/`tokens:`
+ * entry rendering as a live host. `GET /admin/fleet-state` deliberately does
+ * **not** use this helper — it is introspection of the DO's own raw state
+ * (see its route doc), and filtering there would hide the very staleness it
+ * exists to let an operator diagnose. */
+async function fetchLiveFleetSnapshot(env: Env): Promise<FleetSnapshot> {
+  const response = await fleetStateStub(env).fetch("https://fleet-state/snapshot");
+  const snapshot = (await response.json()) as FleetSnapshot;
+  const revokedHostIds = await fetchRevokedHostIds(env, Object.keys(snapshot.hosts));
+  return filterRevokedHosts(snapshot, revokedHostIds);
 }
 
 // ---------------------------------------------------------------------------
@@ -421,15 +452,16 @@ async function handleAdmin(request: Request, env: Env, url: URL): Promise<Respon
 // ---------------------------------------------------------------------------
 
 /** `GET /api/fleet-state` (authenticated) / `GET /public/fleet-state`
- * (public, redacted) — the query-API equivalent of `GET /admin/fleet-state`:
- * same Durable Object snapshot, no admin token required. `isAuthenticated`
- * is purely a function of which route matched (see the module doc); the
- * response is redacted via `./redaction.ts` when it is `false`. */
+ * (public, redacted) — the query-API equivalent of `GET /admin/fleet-state`,
+ * but through `fetchLiveFleetSnapshot` rather than the DO's raw snapshot, so
+ * a D1-revoked host filtered there never reaches either response — no admin
+ * token required. `isAuthenticated` is purely a function of which route
+ * matched (see the module doc); the response is redacted via
+ * `./redaction.ts` when it is `false`. */
 async function handleFleetStateQuery(env: Env, isAuthenticated: boolean): Promise<Response> {
-  const response = await fleetStateStub(env).fetch("https://fleet-state/snapshot");
-  const snapshot = (await response.json()) as FleetSnapshot;
+  const snapshot = await fetchLiveFleetSnapshot(env);
   const body = isAuthenticated ? snapshot : redactFleetSnapshot(snapshot, isAuthenticated);
-  return new Response(JSON.stringify(body), { status: response.status, headers: JSON_HEADERS });
+  return new Response(JSON.stringify(body), { status: 200, headers: JSON_HEADERS });
 }
 
 /** `GET /api/history` (authenticated) / `GET /public/history` (public,
@@ -485,8 +517,7 @@ function handleLiveTail(request: Request, env: Env, url: URL, isAuthenticated: b
  * (the root route below) has already confirmed the JWT via
  * `./accessAuth.ts` before reaching here. */
 async function handleDashboardPage(env: Env, isAuthenticated: boolean): Promise<Response> {
-  const stateResponse = await fleetStateStub(env).fetch("https://fleet-state/snapshot");
-  const snapshot = (await stateResponse.json()) as FleetSnapshot;
+  const snapshot = await fetchLiveFleetSnapshot(env);
   const displaySnapshot = isAuthenticated ? snapshot : redactFleetSnapshot(snapshot, false);
 
   const historyResult = await queryHistory(env.DB, { limit: DEFAULT_HISTORY_LIMIT });

--- a/dashboard/src/publicPage.ts
+++ b/dashboard/src/publicPage.ts
@@ -271,9 +271,9 @@ function renderHostHealthRow(
 }
 
 /** "3 hosts: 2 live, 1 offline (robb-pro, last seen 5h ago)" — the overview
- * heading's explicit totals (issue #4957's AC). Hosts with no `health` entry
- * at all (known only from `activeSweeps`) are counted in `hostIds.length`
- * but contribute no freshness bucket — nothing to classify. */
+ * heading's explicit totals (issue #4957's AC). `hostIds` is already the
+ * health-bearing host set (see `renderFleetOverview`), so every id here
+ * contributes a freshness bucket — nothing to skip. */
 function renderFreshnessSummary(hostIds: readonly string[], hosts: RedactedFleetSnapshot["hosts"], now: Date): string {
   const counts: Record<HostFreshness, number> = { live: 0, stale: 0, offline: 0 };
   const offlineDescriptions: string[] = [];
@@ -295,14 +295,65 @@ function renderFreshnessSummary(hostIds: readonly string[], hosts: RedactedFleet
   return `: ${parts.join(", ")}`;
 }
 
+/**
+ * Fleet overview: hosts with current `health:` data, plus active sweeps
+ * split into "attributed" (their `hostId` is one of those hosts) and
+ * "unattributed" (issue #5078).
+ *
+ * **Host count/cards**: `hostIds` — and therefore both the "Hosts (N)"
+ * heading and every rendered card — is the set of `snapshot.hosts` entries
+ * that actually carry a `health` record, not every key `snapshot.hosts`
+ * happens to have. A `tokens`-only entry (no `health`) never rendered a card
+ * anyway (`renderHostHealthRow` returns `""` without `health`) but was still
+ * counted in the old `Object.keys(snapshot.hosts).length` heading — this
+ * keeps the count and the card list in exact agreement. Combined with
+ * `src/fleetState.ts`'s `filterRevokedHosts` (mechanism 2: a D1-revoked host
+ * whose best-effort DO cleanup failed) and the simple fact that the Durable
+ * Object never creates a `hosts` entry from a `sweep:`-only record at all
+ * (mechanism 1's originally-suspected cause — see `classifyAndPruneHosts`),
+ * this is the AC's "header host count reflects hosts with health data" and
+ * "a host known only from activeSweeps does not render as a fleet card".
+ *
+ * **Active sweeps**: sweeps whose `hostId` is not in `hostIds` — a host with
+ * no current health data, whether because its `sweep.started` arrived before
+ * its first `host.health`, or because it was revoked mid-run with genuinely
+ * in-flight work (`fleetState.ts:323-330`'s deliberate "don't touch
+ * `sweep:` entries on revoke" behavior) — are rendered in their own
+ * "Unattributed sweeps" table instead of the main one, so the mid-run-revoke
+ * anomaly stays visible rather than silently vanishing (AC: "remains
+ * discoverable") while no longer inflating the primary "Active sweeps (N)"
+ * count with sweeps that have no live host behind them.
+ */
 export function renderFleetOverview(snapshot: RedactedFleetSnapshot, now: Date = new Date()): string {
-  const hostIds = Object.keys(snapshot.hosts).sort();
+  const hostIds = Object.keys(snapshot.hosts)
+    .filter((id) => snapshot.hosts[id]?.health)
+    .sort();
+  const hostIdSet = new Set(hostIds);
   const healthRows = hostIds
     .map((id) => renderHostHealthRow(id, snapshot.hosts[id]?.health, now))
     .filter((row) => row.length > 0)
     .join("\n");
-  const sweepRows = snapshot.activeSweeps.map(renderActiveSweepRow).join("\n");
+
+  const attributedSweeps = snapshot.activeSweeps.filter((sweep) => hostIdSet.has(sweep.hostId));
+  const unattributedSweeps = snapshot.activeSweeps.filter((sweep) => !hostIdSet.has(sweep.hostId));
+  const sweepRows = attributedSweeps.map(renderActiveSweepRow).join("\n");
+  const unattributedSweepRows = unattributedSweeps.map(renderActiveSweepRow).join("\n");
+
   const freshnessSummary = renderFreshnessSummary(hostIds, snapshot.hosts, now);
+
+  const unattributedSection =
+    unattributedSweeps.length > 0
+      ? `<h3>Unattributed sweeps (${unattributedSweeps.length})</h3>
+    <p class="muted">Reporting against a host with no current health data — a
+      host that has not yet sent its first <code>host.health</code>, or one
+      revoked mid-run. Not counted in "Active sweeps" above.</p>
+    <table>
+      <thead>
+        <tr><th>Host</th><th>Visibility</th><th>Repo / Issue</th><th>Phase</th><th>Model</th><th>Effort</th><th>Started</th><th>Updated</th></tr>
+      </thead>
+      <tbody>${unattributedSweepRows}</tbody>
+    </table>`
+      : "";
 
   return `<section id="fleet-overview">
     <h2>Fleet overview</h2>
@@ -311,13 +362,14 @@ export function renderFleetOverview(snapshot: RedactedFleetSnapshot, now: Date =
       <thead><tr><th>Host</th><th>Status</th><th>Saturation</th><th>Detail</th></tr></thead>
       <tbody>${healthRows || `<tr><td colspan="4" class="muted">No host health reported yet.</td></tr>`}</tbody>
     </table>
-    <h3>Active sweeps (${snapshot.activeSweeps.length})</h3>
+    <h3>Active sweeps (${attributedSweeps.length})</h3>
     <table>
       <thead>
         <tr><th>Host</th><th>Visibility</th><th>Repo / Issue</th><th>Phase</th><th>Model</th><th>Effort</th><th>Started</th><th>Updated</th></tr>
       </thead>
       <tbody>${sweepRows || `<tr><td colspan="8" class="muted">No sweeps currently running.</td></tr>`}</tbody>
     </table>
+    ${unattributedSection}
   </section>`;
 }
 

--- a/dashboard/test/fleetState.test.ts
+++ b/dashboard/test/fleetState.test.ts
@@ -24,6 +24,7 @@ import { describe, expect, it } from "vitest";
 import {
   classifyAndPruneHosts,
   classifyFreshness,
+  filterRevokedHosts,
   isSweepEntryStale,
   LIVE_AFTER_SEC,
   OFFLINE_AFTER_SEC,
@@ -149,6 +150,54 @@ describe("classifyAndPruneHosts", () => {
     expect(pruneKeys).toEqual(["health:host-a"]);
     expect(hosts["host-a"]?.health).toBeUndefined();
     expect(hosts["host-a"]?.tokens?.freshness?.status).toBe("live");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterRevokedHosts (Issue #5078, mechanism 2): a D1-revoked host must never
+// keep rendering as live off a `handleRevokeHost` cleanup fetch that failed
+// and left stale `health:`/`tokens:` entries behind in the DO.
+// ---------------------------------------------------------------------------
+
+describe("filterRevokedHosts", () => {
+  function snapshotWith(hosts: FleetSnapshot["hosts"], activeSweeps: ActiveSweepState[] = []): FleetSnapshot {
+    return { hosts, activeSweeps };
+  }
+
+  it("drops a host entry whose id is in the revoked set — the stale-DO-cleanup case", () => {
+    // Simulates `handleRevokeHost`'s best-effort DO cleanup having failed:
+    // D1 says "revoked", but the DO still has this host's last-known
+    // health/tokens entries.
+    const snapshot = snapshotWith({
+      "host-revoked": { health: { record: { kind: "host.health" }, updatedAt: secondsAgo(60) } },
+      "host-live": { health: { record: { kind: "host.health" }, updatedAt: secondsAgo(30) } },
+    });
+    const filtered = filterRevokedHosts(snapshot, new Set(["host-revoked"]));
+    expect(filtered.hosts["host-revoked"]).toBeUndefined();
+    expect(filtered.hosts["host-live"]).toBeDefined();
+  });
+
+  it("leaves activeSweeps untouched — a mid-run-revoke anomaly must remain visible, not be hidden", () => {
+    const sweep = sweepEntry({ hostId: "host-revoked", sweepId: "still-running" });
+    const snapshot = snapshotWith(
+      { "host-revoked": { health: { record: {}, updatedAt: secondsAgo(60) } } },
+      [sweep],
+    );
+    const filtered = filterRevokedHosts(snapshot, new Set(["host-revoked"]));
+    expect(filtered.hosts["host-revoked"]).toBeUndefined();
+    expect(filtered.activeSweeps).toEqual([sweep]);
+  });
+
+  it("an empty revoked set is a no-op, returning the same snapshot", () => {
+    const snapshot = snapshotWith({ "host-a": { health: { record: {}, updatedAt: secondsAgo(10) } } });
+    expect(filterRevokedHosts(snapshot, new Set())).toBe(snapshot);
+  });
+
+  it("a revoked id absent from the snapshot's hosts is simply a no-op for that id", () => {
+    const snapshot = snapshotWith({ "host-a": { health: { record: {}, updatedAt: secondsAgo(10) } } });
+    const filtered = filterRevokedHosts(snapshot, new Set(["host-never-existed"]));
+    expect(filtered.hosts["host-a"]).toBeDefined();
+    expect(Object.keys(filtered.hosts)).toEqual(["host-a"]);
   });
 });
 

--- a/dashboard/test/index.test.ts
+++ b/dashboard/test/index.test.ts
@@ -13,7 +13,7 @@ import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:
 import { exportJWK, generateKeyPair, SignJWT } from "jose";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import worker from "../src/index";
-import { seedHost, sweepOutcomeEnvelope } from "./testHelpers";
+import { hostHealthEnvelope, revokeHost, seedHost, sweepOutcomeEnvelope } from "./testHelpers";
 
 // Matches the `CF_ACCESS_TEAM_DOMAIN`/`CF_ACCESS_AUD` test bindings in
 // vitest.config.ts.
@@ -376,5 +376,73 @@ describe("GET / — Access JWT wired end to end (real createRemoteJWKSet path)",
 
     expect(response.status).toBe(200);
     expectAuthState(await response.text(), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phantom fleet member, mechanism 2 (issue #5078): a host revoked in D1 whose
+// `FleetState` Durable Object `health:`/`tokens:` entries were never cleaned
+// up (the `handleRevokeHost` cleanup fetch is best-effort — a DO hiccup must
+// not fail the revoke itself, see its doc comment) must not keep rendering
+// as a live fleet member off that stale DO data.
+// ---------------------------------------------------------------------------
+
+async function ingestHostHealth(hostId: string, key: string): Promise<void> {
+  const response = await callWorker(
+    new Request("https://ingest.example/ingest", {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${key}` },
+      body: JSON.stringify([hostHealthEnvelope()]),
+    }),
+  );
+  expect(response.status).toBe(200);
+}
+
+describe("GET /public/fleet-state, /api/fleet-state — D1-revoked host with un-cleaned-up DO state (issue #5078)", () => {
+  it("a host whose D1 row is revoked but whose DO health/tokens entries were never cleaned up does not appear in /public/fleet-state", async () => {
+    await seedHost(env.DB, "host-stale-revoke", "stale-revoke-key");
+    await ingestHostHealth("host-stale-revoke", "stale-revoke-key");
+
+    // Directly flips D1's revoked_at WITHOUT going through
+    // `handleRevokeHost`'s `/admin/hosts/:id/revoke` route — i.e. without
+    // ever calling the DO's best-effort `/remove-host` cleanup at all. This
+    // is exactly the state a failed (swallowed) cleanup fetch would leave
+    // behind: D1 says revoked, the DO's health:/tokens: entries are untouched.
+    await revokeHost(env.DB, "host-stale-revoke");
+
+    const response = await callWorker(new Request("https://ingest.example/public/fleet-state"));
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { hosts: Record<string, unknown> };
+    expect(body.hosts["host-stale-revoke"]).toBeUndefined();
+  });
+
+  it("...and does not appear in /api/fleet-state (authenticated) either", async () => {
+    await seedHost(env.DB, "host-stale-revoke-2", "stale-revoke-key-2");
+    await ingestHostHealth("host-stale-revoke-2", "stale-revoke-key-2");
+    await revokeHost(env.DB, "host-stale-revoke-2");
+
+    const restore = mockJwksFetch();
+    try {
+      const token = await signToken();
+      const response = await callWorker(
+        new Request("https://ingest.example/api/fleet-state", {
+          headers: { cookie: `CF_Authorization=${token}` },
+        }),
+      );
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { hosts: Record<string, unknown> };
+      expect(body.hosts["host-stale-revoke-2"]).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  it("a non-revoked host's health/tokens entries are unaffected", async () => {
+    await seedHost(env.DB, "host-live", "live-key");
+    await ingestHostHealth("host-live", "live-key");
+
+    const response = await callWorker(new Request("https://ingest.example/public/fleet-state"));
+    const body = (await response.json()) as { hosts: Record<string, unknown> };
+    expect(body.hosts["host-live"]).toBeDefined();
   });
 });

--- a/dashboard/test/publicPage.test.ts
+++ b/dashboard/test/publicPage.test.ts
@@ -297,6 +297,121 @@ describe("renderFleetOverview — host staleness (issue #4957)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Phantom fleet member (issue #5078): a `sweep:`-only host must never render
+// as a fleet card or inflate the header host count, and its sweeps must
+// still be visible somewhere (not silently dropped) rather than commingled
+// with the "Active sweeps" count of hosts with real health data.
+// ---------------------------------------------------------------------------
+
+describe("renderFleetOverview — unattributed sweeps (issue #5078)", () => {
+  const NOW = new Date("2026-08-03T12:00:00Z");
+
+  function sweepFor(hostId: string, overrides: Partial<PublicActiveSweep> = {}): PublicActiveSweep {
+    return {
+      hostId,
+      visibility: "public",
+      repo: "rjwalters/loom",
+      issue: 5078,
+      sweepId: `sweep-${hostId}`,
+      phase: "builder",
+      startedAt: "2026-08-03T11:00:00Z",
+      updatedAt: "2026-08-03T11:55:00Z",
+      ...overrides,
+    };
+  }
+
+  it("a snapshot containing only a sweep: entry (no health: entry for that host) renders no fleet card for it", () => {
+    const snapshot: RedactedFleetSnapshot = {
+      hosts: {},
+      activeSweeps: [sweepFor("sweep-only-host")],
+    };
+    const html = renderFleetOverview(snapshot, NOW);
+    // No card/row for the phantom host in the Hosts table specifically, and
+    // the header count is 0 — not 1. (The host id is still expected to
+    // appear elsewhere on the page, in the Unattributed sweeps table — see
+    // the next test — so this asserts against the Hosts table body only.)
+    expect(html).toContain("Hosts (0)");
+    const hostsTableBody = html.slice(html.indexOf("<h3>Hosts"), html.indexOf("<h3>Active sweeps"));
+    expect(hostsTableBody).not.toContain("sweep-only-host");
+    expect(hostsTableBody).toContain("No host health reported yet.");
+  });
+
+  it("does not count a sweep-only host's sweeps in the primary Active sweeps total", () => {
+    const snapshot: RedactedFleetSnapshot = {
+      hosts: {},
+      activeSweeps: [sweepFor("sweep-only-host")],
+    };
+    const html = renderFleetOverview(snapshot, NOW);
+    expect(html).toContain("Active sweeps (0)");
+  });
+
+  it("groups a sweep-only host's sweeps into a distinct Unattributed sweeps section instead of hiding them", () => {
+    const snapshot: RedactedFleetSnapshot = {
+      hosts: {},
+      activeSweeps: [sweepFor("sweep-only-host")],
+    };
+    const html = renderFleetOverview(snapshot, NOW);
+    expect(html).toContain("Unattributed sweeps (1)");
+    expect(html).toContain("sweep-only-host");
+    expect(html).toContain("#5078");
+  });
+
+  it("a host with real health data keeps its sweeps in the primary Active sweeps table, not unattributed", () => {
+    const snapshot: RedactedFleetSnapshot = {
+      hosts: {
+        "host-a": { health: { record: { kind: "host.health" }, updatedAt: "2026-08-03T11:58:00Z" } },
+      },
+      activeSweeps: [sweepFor("host-a")],
+    };
+    const html = renderFleetOverview(snapshot, NOW);
+    expect(html).toContain("Active sweeps (1)");
+    expect(html).not.toContain("Unattributed sweeps");
+  });
+
+  it("a host known only from tokens.snapshot (no health) does not render a card or count toward Hosts", () => {
+    // Belt-and-braces: the header count must track health data specifically,
+    // not "any snapshot.hosts entry" — a tokens-only host never rendered a
+    // row (renderHostHealthRow returns "" without health) but was still
+    // being counted in the pre-fix heading.
+    const snapshot: RedactedFleetSnapshot = {
+      hosts: {
+        "tokens-only-host": {
+          tokens: { record: { kind: "tokens.snapshot" }, updatedAt: "2026-08-03T11:58:00Z" },
+        },
+      },
+      activeSweeps: [],
+    };
+    const html = renderFleetOverview(snapshot, NOW);
+    expect(html).toContain("Hosts (0)");
+  });
+
+  it("a mid-run-revoke anomaly (a host with in-flight sweeps but no health entry) stays discoverable, not silently dropped", () => {
+    // Mirrors fleetState.ts's removeHost, which deliberately never touches
+    // sweep: entries on revoke — the host's card disappears, but its sweeps
+    // must remain visible as a signal something needs investigating.
+    const snapshot: RedactedFleetSnapshot = {
+      hosts: {},
+      activeSweeps: [sweepFor("revoked-mid-run", { sweepId: "sweep-mid-run" })],
+    };
+    const html = renderFleetOverview(snapshot, NOW);
+    expect(html).toContain("Unattributed sweeps (1)");
+    expect(html).toContain("revoked-mid-run");
+    expect(html).toContain("sweep-mid-run");
+  });
+
+  it("no Unattributed sweeps section renders when every sweep is attributed", () => {
+    const snapshot: RedactedFleetSnapshot = {
+      hosts: {
+        "host-a": { health: { record: { kind: "host.health" }, updatedAt: "2026-08-03T11:58:00Z" } },
+      },
+      activeSweeps: [sweepFor("host-a")],
+    };
+    const html = renderFleetOverview(snapshot, NOW);
+    expect(html).not.toContain("Unattributed sweeps");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Host saturation (issue #4998): a per-host `load_per_core` signal
 // distinguishable from an idle host without expanding details, with
 // thresholds matching `loom-daemon`'s `host_breaker`


### PR DESCRIPTION
## Summary

A host known only from `activeSweeps` (no `health:` entry) could inflate the
public dashboard page's header host count, and a D1-revoked host whose
best-effort Durable Object cleanup silently failed could keep rendering as a
live fleet card off stale `health:`/`tokens:` data indefinitely. This fixes
both mechanisms confirmed by the curator's re-verification against current
`dashboard/src/*` code (see issue #5078 for the two-mechanism breakdown).

## Changes

- `dashboard/src/fleetState.ts`: new `filterRevokedHosts(snapshot,
  revokedHostIds)` — a pure function that drops any `hosts` entry for a
  hostId D1 has recorded as revoked, without touching `activeSweeps` (so a
  genuine mid-run-revoke anomaly stays visible rather than being hidden).
- `dashboard/src/index.ts`: new `fetchLiveFleetSnapshot(env)` — fetches the
  Durable Object's live snapshot, cross-references D1's `revoked_at` for the
  hosts present in it, and filters via `filterRevokedHosts`. Wired into both
  `handleFleetStateQuery` (`/api/fleet-state`, `/public/fleet-state`) and
  `handleDashboardPage` (the `/` no-UI-build fallback). `GET
  /admin/fleet-state` deliberately stays unfiltered — it is raw DO
  introspection, and filtering there would hide the exact staleness it
  exists to let an operator diagnose.
- `dashboard/src/publicPage.ts`: `renderFleetOverview`'s `hostIds` is now the
  set of `snapshot.hosts` entries that actually carry a `health` record (not
  every key `snapshot.hosts` happens to have), so the "Hosts (N)" header
  count and the rendered card list are always in exact agreement.
  `activeSweeps` is split into "attributed" (hostId has current health data)
  and "unattributed" (rendered in a new "Unattributed sweeps" section)
  instead of commingling with, or silently dropping from, the primary
  "Active sweeps (N)" count.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| A host known only from `activeSweeps` does not render as a fleet card | ✅ | `renderFleetOverview`'s `hostIds` now requires a `health` entry; `publicPage.test.ts` — "a snapshot containing only a sweep: entry ... renders no fleet card for it" |
| The header host count reflects hosts with health data | ✅ | Same `hostIds` filter; `publicPage.test.ts` — "Hosts (0)" cases for sweep-only and tokens-only hosts |
| The active-sweep count either excludes sweeps with no live host, or those sweeps are visibly grouped as unattributed | ✅ | `activeSweeps` split into attributed/unattributed; unattributed rendered in its own "Unattributed sweeps" table, excluded from "Active sweeps (N)" |
| The mid-run-revoke anomaly (`fleetState.ts:323-326`) remains discoverable | ✅ | `filterRevokedHosts` never touches `activeSweeps`; a revoked host's genuinely in-flight sweeps surface in the "Unattributed sweeps" section — `fleetState.test.ts` and `publicPage.test.ts`'s mid-run-revoke test |
| A revoked host whose best-effort DO cleanup failed does not keep rendering as a live fleet card off stale `health:`/`tokens:` data | ✅ | `fetchLiveFleetSnapshot` cross-references D1's `revoked_at`; `index.test.ts` end-to-end test seeds a host, ingests health, revokes in D1 directly (bypassing the DO cleanup route), and confirms it is absent from `/public/fleet-state` and `/api/fleet-state` |
| Test covers a snapshot containing a `sweep:` entry whose `hostId` has no `health:` entry | ✅ | `publicPage.test.ts` — "unattributed sweeps" describe block |
| Test covers a snapshot where a host's D1 row is revoked but its DO `health:`/`tokens:` entries were never cleaned up | ✅ | `index.test.ts` — "D1-revoked host with un-cleaned-up DO state" describe block |

## Test Plan

- `npm run check` (typecheck + vitest) in `dashboard/`: 242/242 tests pass
  (228 pre-existing + 14 new).
- `npm run check` in `dashboard/web/`: 463/463 tests pass, unmodified (this
  PR does not touch `web/src/*` — see the note below).
- Manually traced the D1-revoke integration test's setup (seed host → ingest
  `host.health` → flip D1 `revoked_at` directly, bypassing
  `handleRevokeHost`'s DO cleanup call entirely) to confirm it reproduces
  exactly the "best-effort cleanup fetch failed" scenario the AC describes.

## Note: production likely runs a third, related mechanism not in scope here

`dashboard.2amlogic.com` serves the built SPA (`web/dist/index.html`) in
production; `publicPage.ts` (fixed here) is only the no-UI-build fallback.
`dashboard/web/src/fleet.ts`'s `buildFleetView` deliberately unions
`snapshot.hosts` and `activeSweeps`' hostIds (its own doc comment: "Keying
off `hosts` alone would silently hide a busy host"), pinned by an existing
test — this is very likely the actual cause of the "4 hosts" figure the
original incident observed. That design is reasonable and intentional; the
narrower gap is that the SPA's headline "N hosts" summary doesn't distinguish
an "unknown"-status (health-less) host from one with real data. Filed #5101
to track that follow-up without touching `web/src/*`'s tested join behavior
in this PR.

Closes #5078