### PR TITLE
fix(dashboard): re-provision a revoked host_id via an atomic upsert

### DIFF
--- a/.loom/docs/observability.md
+++ b/.loom/docs/observability.md
@@ -301,8 +301,11 @@ here:
 - Revoking the old key (step 6) while sweep entries still reference the old
   `host_id` and are active or orphaned can leave a phantom fleet member on
   the dashboard until those entries clear — #5078.
-- Re-provisioning a previously-revoked `host_id` (e.g. reusing the old name
-  later) currently 409s with no override — #5082.
+Reusing a previously-revoked `host_id` (e.g. reclaiming the old name later)
+used to 409 with no override; `POST /admin/hosts` now re-provisions a revoked
+host in place — minting a new key and clearing the revocation atomically, never
+reviving the dead one — and only 409s for a host that is currently live
+(#5082).
 
 ## Map of every detail doc
 

--- a/dashboard/docs/deploy-runbook.md
+++ b/dashboard/docs/deploy-runbook.md
@@ -370,10 +370,12 @@ below.
 
 ### Rotating an ingest key
 
-`POST /admin/hosts` refuses a `host_id` that already exists (`409`), so
-rotation is a two-move operation. Pick whichever fits:
+`POST /admin/hosts` refuses a `host_id` that is currently **live** (`409`), so
+rotation is a two-move operation. A **revoked** `host_id` is re-provisionable
+(issue #5082) — the re-provision replaces the dead key rather than reviving it,
+so no raw SQL is involved either way. Pick whichever fits:
 
-**A. Rolling rotation (no raw SQL, brief dual-identity window)** — provision a
+**A. Rolling rotation (brief dual-identity window, no `401`s)** — provision a
 successor identity, cut the host over, then revoke the old one:
 
 ```bash
@@ -385,17 +387,16 @@ curl -sS -X POST "$BASE/admin/hosts/my-laptop/revoke" -H "authorization: Bearer 
 
 Historical rows keep the old `host_id`; new rows use the new one.
 
-**B. In-place rotation (same `host_id`, needs one D1 statement)** — delete the
-host row, then re-provision the same id with a fresh key:
+**B. In-place rotation (same `host_id`)** — revoke the host, then re-provision
+the same id, which mints a fresh key and clears the revocation atomically:
 
 ```bash
-npx wrangler d1 execute loom-observability --remote \
-  --command "DELETE FROM hosts WHERE host_id = 'my-laptop'"
+curl -sS -X POST "$BASE/admin/hosts/my-laptop/revoke" -H "authorization: Bearer $ADMIN"
 curl -sS -X POST "$BASE/admin/hosts" -H "authorization: Bearer $ADMIN" \
   -H 'content-type: application/json' -d '{"host_id":"my-laptop"}'
 ```
 
-Between the delete and the daemon picking up the new key, that host's pushes
+Between the revoke and the daemon picking up the new key, that host's pushes
 get `401` — they are **not lost**: the daemon's durable queue retries with
 backoff and drains once the new key is in place (up to `queueCapacity`).
 

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -333,16 +333,37 @@ async function handleCreateHost(request: Request, env: Env): Promise<Response> {
     return jsonError(400, "host_id is required");
   }
 
-  const existing = await env.DB.prepare("SELECT host_id FROM hosts WHERE host_id = ?").bind(hostId).first();
-  if (existing) {
-    return jsonError(409, `host_id "${hostId}" already exists`);
-  }
-
   const key = typeof body.key === "string" && body.key.length > 0 ? body.key : generateIngestKey();
   const keyHash = await hashIngestKey(key);
-  await env.DB.prepare("INSERT INTO hosts (host_id, key_hash, created_at, revoked_at) VALUES (?, ?, ?, NULL)")
+
+  // A *revoked* host_id must be re-provisionable without hand-editing D1
+  // (#5082): a revoked row is a dead credential, but `host_id` is the primary
+  // key, so it would otherwise reserve the name forever. This single statement
+  // both creates a brand-new host and re-mints a retired one:
+  //
+  //   - live row  → `DO UPDATE ... WHERE hosts.revoked_at IS NOT NULL` does not
+  //     match, so nothing changes and `meta.changes` is 0 ⇒ 409 (accidental
+  //     re-minting of an *active* host still fails).
+  //   - revoked row → the conflict target matches and the row is rewritten with
+  //     the NEW `key_hash` and a cleared `revoked_at`. The old (revoked) hash is
+  //     replaced, never reactivated, and `created_at` is restamped because the
+  //     row now describes a freshly minted credential.
+  //
+  // It is an upsert rather than DELETE + INSERT precisely so there is no window
+  // in which the host row is absent.
+  const result = await env.DB.prepare(
+    `INSERT INTO hosts (host_id, key_hash, created_at, revoked_at) VALUES (?, ?, ?, NULL)
+     ON CONFLICT(host_id) DO UPDATE SET
+       key_hash = excluded.key_hash,
+       created_at = excluded.created_at,
+       revoked_at = NULL
+     WHERE hosts.revoked_at IS NOT NULL`,
+  )
     .bind(hostId, keyHash, new Date().toISOString())
     .run();
+  if ((result.meta.changes ?? 0) === 0) {
+    return jsonError(409, `host_id "${hostId}" already exists`);
+  }
 
   // The plaintext key is returned exactly once, here — only its hash is
   // ever persisted, so this response is the operator's only chance to

--- a/dashboard/test/ingest.test.ts
+++ b/dashboard/test/ingest.test.ts
@@ -293,6 +293,73 @@ describe("POST /admin/hosts — host provisioning", () => {
     );
     expect(response.status).toBe(409);
   });
+
+  // Issue #5082: a revoked host_id used to be reserved forever, so renaming or
+  // re-keying a retired host required hand-editing production D1.
+  it("re-provisions a revoked host_id, and the pre-revoke key stays dead", async () => {
+    await revokeHost(env.DB, "host-abc");
+
+    const response = await callWorker(
+      new Request("https://ingest.example/admin/hosts", {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer test-admin-token" },
+        body: JSON.stringify({ host_id: "host-abc" }),
+      }),
+    );
+    expect(response.status).toBe(201);
+    const { ingest_key: newKey } = (await response.json()) as { ingest_key: string };
+    expect(newKey).not.toBe("abc-ingest-key");
+
+    // The revoked credential must never be resurrected — only replaced.
+    const oldKeyResponse = await callWorker(ingestRequest([sweepStartedEnvelope()], "Bearer abc-ingest-key"));
+    expect(oldKeyResponse.status).toBe(401);
+
+    const newKeyResponse = await callWorker(
+      ingestRequest([sweepStartedEnvelope({ sweep_id: "sweep-reprovisioned" })], `Bearer ${newKey}`),
+    );
+    expect(newKeyResponse.status).toBe(200);
+    expect(await recordsForHost("host-abc")).toHaveLength(1);
+  });
+
+  it("re-provisions a revoked host_id in place, without deleting the row first", async () => {
+    const before = (await env.DB.prepare("SELECT key_hash FROM hosts WHERE host_id = 'host-abc'").first()) as {
+      key_hash: string;
+    };
+    await revokeHost(env.DB, "host-abc");
+
+    const response = await callWorker(
+      new Request("https://ingest.example/admin/hosts", {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer test-admin-token" },
+        body: JSON.stringify({ host_id: "host-abc" }),
+      }),
+    );
+    expect(response.status).toBe(201);
+
+    // Exactly one row, updated in place (upsert) rather than delete + insert:
+    // the key_hash is replaced and revoked_at is cleared.
+    const { results } = await env.DB.prepare("SELECT key_hash, revoked_at FROM hosts WHERE host_id = 'host-abc'").all();
+    expect(results).toHaveLength(1);
+    const row = results[0] as { key_hash: string; revoked_at: string | null };
+    expect(row.revoked_at).toBeNull();
+    expect(row.key_hash).not.toBe(before.key_hash);
+  });
+
+  it("honors an explicit key when re-provisioning a revoked host_id", async () => {
+    await revokeHost(env.DB, "host-abc");
+
+    const response = await callWorker(
+      new Request("https://ingest.example/admin/hosts", {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer test-admin-token" },
+        body: JSON.stringify({ host_id: "host-abc", key: "abc-rotated-key" }),
+      }),
+    );
+    expect(response.status).toBe(201);
+
+    const rotatedResponse = await callWorker(ingestRequest([sweepStartedEnvelope()], "Bearer abc-rotated-key"));
+    expect(rotatedResponse.status).toBe(200);
+  });
 });
 
 describe("POST /admin/hosts/:hostId/revoke", () => {


### PR DESCRIPTION
## Summary

`POST /admin/hosts` refused any `host_id` that had ever existed — including one whose key was **revoked** — because the existence check was a plain primary-key lookup with no `revoked_at` filter. Reclaiming a retired name (the 2026-08-03 `robb-studio` rename) therefore required a hand-written `DELETE` against production D1.

The pre-check + `INSERT` is replaced by a single atomic upsert:

```sql
INSERT INTO hosts (host_id, key_hash, created_at, revoked_at) VALUES (?, ?, ?, NULL)
ON CONFLICT(host_id) DO UPDATE SET
  key_hash = excluded.key_hash,
  created_at = excluded.created_at,
  revoked_at = NULL
WHERE hosts.revoked_at IS NOT NULL
```

A **live** row does not match the `DO UPDATE` guard, so `meta.changes` is 0 and the route still returns 409. A **revoked** row is rewritten in place with the new `key_hash` and a cleared `revoked_at` — the dead credential is replaced, never reactivated. Because it is an upsert rather than DELETE + INSERT, there is no window in which the host row is absent, and the TOCTOU gap between the old check and the old write is gone as well.

## Changes

- `dashboard/src/index.ts` — `handleCreateHost`: drop the unfiltered `SELECT` existence check; issue the guarded upsert above and return 409 when it reports zero changes. `created_at` is restamped because the row now describes a freshly minted credential.
- `dashboard/test/ingest.test.ts` — three regression tests in the existing `POST /admin/hosts — host provisioning` block.
- `dashboard/docs/deploy-runbook.md` — "Rotating an ingest key" option B is now revoke-then-reprovision (no `wrangler d1 execute ... DELETE`), and option A's framing corrected to "currently live".
- `.loom/docs/observability.md` — the host-rename "Known gaps" entry for #5082 now describes the shipped behavior. (Edited in the installed copy because that is where the content lives — the rename runbook was added there only, by #5099; there is no `defaults/docs/` counterpart to edit.)

## Acceptance Criteria Verification

- [x] **A previously revoked `host_id` can be re-provisioned through the admin API, with no manual D1 mutation** — `re-provisions a revoked host_id, and the pre-revoke key stays dead` asserts `201` where `main` returns `409`.
- [x] **The old `key_hash` is replaced, never reactivated** — same test: `POST /ingest` with the pre-revoke key returns `401` after re-provisioning, while the newly returned key returns `200` and its record lands under the same `host_id`.
- [x] **No window exists where the host row is absent (atomic upsert, not delete + insert)** — a single statement; `re-provisions a revoked host_id in place, without deleting the row first` asserts exactly one row survives, with `revoked_at IS NULL` and a `key_hash` different from the pre-revoke hash.
- [x] **The 409 remains for a currently live `host_id`** — the pre-existing `rejects creating a duplicate host_id` test (live `host-abc` fixture) still passes unchanged; the guard is enforced by `WHERE hosts.revoked_at IS NOT NULL` in SQL rather than by a separate read, so it also holds under concurrent provisions.
- [x] **Test covers provision → revoke → re-provision, and the first key no longer authenticates** — as above, plus `honors an explicit key when re-provisioning a revoked host_id` for the operator-supplied-key path.

## Test Plan

- [x] `npm run check` in `dashboard/` (typecheck + vitest): **231 passed / 10 files**, exit 0.
- [x] Negative control — reverted `src/index.ts` to `main` and re-ran `test/ingest.test.ts`: the 3 new tests fail (`409` instead of `201`), the other 22 pass. The tests genuinely gate the fix.
- [x] `tsc --noEmit` clean.
- [x] Manual verification: N/A — `dashboard/test/` runs against a real D1 binding via `apply-migrations.ts`, not a mock, so the upsert is exercised against actual SQLite semantics (including the skipped-`DO UPDATE` `changes = 0` behavior the 409 path depends on).

Closes #5082
