### PR TITLE
fix(dashboard): exclude sweep-only hosts from the SPA's fleet-overview headline count

### DIFF
--- a/dashboard/web/src/fleet.ts
+++ b/dashboard/web/src/fleet.ts
@@ -81,8 +81,29 @@ export interface HostView {
 
 export interface FleetView {
   hosts: HostView[];
+  /** Hosts with a real `health`/`tokens` entry — `hosts.length` minus those
+   * known only from `activeSweeps` (`status === "unknown"`, see the module
+   * doc's "union" note). This, not `hosts.length`, is what the overview
+   * headline's "N hosts" count uses (#5101): `hosts` deliberately still
+   * includes sweep-only hosts (and their cards), so counting `hosts.length`
+   * in the headline would tell an operator the fleet has more reporting
+   * hosts than it does. Mirrors the equivalent fix in
+   * `dashboard/src/publicPage.ts`'s `renderFleetOverview` (#5078).
+   *
+   * `totalSweeps` is deliberately NOT split the same way: unlike the public
+   * page's flat table (which needed a second "unattributed sweeps" table to
+   * keep a sweep-only host's sweeps discoverable), every sweep here already
+   * renders under its own host's card — including a sweep-only host's own
+   * card — so the per-card grouping already answers "whose sweep is this",
+   * and splitting the headline number too would only add a second count to
+   * reconcile against the cards below it.
+   */
+  reportingHosts: number;
   totalSweeps: number;
-  /** Hosts in `stale` or `degraded` — the count the overview headline shows. */
+  /** Hosts in `stale` or `degraded` — the count the overview headline shows.
+   * `"unknown"` hosts are excluded here too (STATUS_ORDER treats them as
+   * their own bucket, not `stale`/`degraded`) — see the "excludes sweep-only
+   * hosts" test in `fleet.test.ts`. */
   needsAttention: number;
 }
 
@@ -268,6 +289,7 @@ export function buildFleetView(snapshot: FleetSnapshot, now: Date = new Date()):
 
   return {
     hosts,
+    reportingHosts: hosts.filter((host) => host.status !== "unknown").length,
     totalSweeps: snapshot.activeSweeps.length,
     needsAttention: hosts.filter((host) => host.status === "stale" || host.status === "degraded").length,
   };

--- a/dashboard/web/src/views/fleetOverview.ts
+++ b/dashboard/web/src/views/fleetOverview.ts
@@ -253,7 +253,11 @@ export function fleetOverviewView(view: FleetView, now: Date = new Date()): HTML
     el(
       "div",
       { class: "overview__summary", data: { testid: "fleet-summary" } },
-      el("span", {}, `${view.hosts.length} host${view.hosts.length === 1 ? "" : "s"}`),
+      el(
+        "span",
+        {},
+        `${view.reportingHosts} host${view.reportingHosts === 1 ? "" : "s"}`,
+      ),
       el("span", {}, `${view.totalSweeps} active sweep${view.totalSweeps === 1 ? "" : "s"}`),
       el(
         "span",

--- a/dashboard/web/test/fleet.test.ts
+++ b/dashboard/web/test/fleet.test.ts
@@ -114,13 +114,42 @@ describe("buildFleetView", () => {
     const built = view();
     expect(built.totalSweeps).toBe(3);
     // Only the stale host and the truly-at-the-edge degraded host — not the
-    // partially-exhausted-but-healthy one.
+    // partially-exhausted-but-healthy one, and not the sweep-only "unknown"
+    // host either — see the dedicated #5101 test below.
     expect(built.needsAttention).toBe(2);
+  });
+
+  // #5101: the SPA's fleet-overview headline uses `reportingHosts`, not
+  // `hosts.length`, so a host known only from activeSweeps ("unknown"
+  // status) does not inflate the "N hosts" count — while still remaining in
+  // `hosts` (and rendering its own card, per the module doc's union rule).
+  it("excludes sweep-only 'unknown' hosts from reportingHosts, but not from hosts", () => {
+    const built = view();
+    expect(built.hosts).toHaveLength(6);
+    expect(built.reportingHosts).toBe(5);
+    expect(findHost(built, SWEEP_ONLY_HOST_ID)?.status).toBe("unknown");
+  });
+
+  // Pin: needsAttention (stale/degraded only) already excludes "unknown"
+  // hosts — STATUS_ORDER and the needsAttention filter both treat "unknown"
+  // as its own bucket, distinct from stale/degraded (#5101).
+  it("excludes sweep-only 'unknown' hosts from needsAttention", () => {
+    const built = buildFleetView(
+      parseFleetSnapshot({
+        hosts: {},
+        activeSweeps: [{ hostId: "sweep-only", sweepId: "s1" }],
+      }),
+      NOW,
+    );
+    expect(findHost(built, "sweep-only")?.status).toBe("unknown");
+    expect(built.needsAttention).toBe(0);
+    expect(built.reportingHosts).toBe(0);
   });
 
   it("returns an empty view for an empty fleet", () => {
     const built = buildFleetView({ hosts: {}, activeSweeps: [] }, NOW);
     expect(built.hosts).toEqual([]);
+    expect(built.reportingHosts).toBe(0);
     expect(built.totalSweeps).toBe(0);
     expect(built.needsAttention).toBe(0);
   });

--- a/dashboard/web/test/fleetOverview.test.ts
+++ b/dashboard/web/test/fleetOverview.test.ts
@@ -41,9 +41,25 @@ describe("fleetOverviewView", () => {
 
   it("summarizes the fleet above the grid", () => {
     const summary = fleetOverviewView(view(), NOW).querySelector('[data-testid="fleet-summary"]');
-    expect(summary?.textContent).toContain("6 hosts");
+    // 5, not 6: SWEEP_ONLY_HOST_ID has no health/tokens entry — it is known
+    // only from activeSweeps (status "unknown") — so it is excluded from the
+    // headline "N hosts" count even though it still gets a card (#5101).
+    expect(summary?.textContent).toContain("5 hosts");
     expect(summary?.textContent).toContain("3 active sweeps");
     expect(summary?.textContent).toContain("2 need");
+  });
+
+  // #5101: the headline "N hosts" count must not include a host known only
+  // from activeSweeps, even though its card (and its sweeps) still render.
+  it("excludes a sweep-only host from the headline host count, but still renders its card", () => {
+    const rendered = fleetOverviewView(view(), NOW);
+    const summary = rendered.querySelector('[data-testid="fleet-summary"]');
+    expect(summary?.textContent).toContain("5 hosts");
+    expect(summary?.textContent).not.toContain("6 hosts");
+
+    const sweepOnlyCard = rendered.querySelector(`[data-host="${SWEEP_ONLY_HOST_ID}"]`);
+    expect(sweepOnlyCard).not.toBeNull();
+    expect(sweepOnlyCard?.querySelectorAll(".card__sweep")).toHaveLength(1);
   });
 
   it("shows the empty-fleet state, not an error, when no host has reported", () => {


### PR DESCRIPTION
## Summary

`dashboard/web/src/fleet.ts`'s `buildFleetView` deliberately unions hosts known from `snapshot.hosts` with hosts known only from `activeSweeps` (status `"unknown"`) — that union is unchanged, still documented, and still tested (see `fleet.test.ts`'s "includes a host known only from activeSweeps" test, preserved as-is).

The bug was narrower: `dashboard/web/src/views/fleetOverview.ts`'s `fleetOverviewView` headline ("N hosts" / "M active sweeps") used `view.hosts.length`, which counted those unknown-status hosts too, inflating the "N hosts" count on the production SPA (`dashboard.2amlogic.com`).

- Adds `FleetView.reportingHosts` — the count of hosts with a real `health`/`tokens` entry (`status !== "unknown"`) — and uses it for the headline's "N hosts" text instead of `hosts.length`.
- `totalSweeps` is deliberately left unsplit. Unlike `dashboard/src/publicPage.ts`'s flat sweep table (which needed a second "unattributed sweeps" table to keep sweep-only hosts discoverable — #5078), the SPA's card-based layout already groups every sweep, including a sweep-only host's, under its own card. Reasoning documented inline on `FleetView.reportingHosts`.
- Verified `needsAttention` already excludes `"unknown"`-status hosts (it only counts `stale`/`degraded`) and pinned that with a dedicated regression test.

## Test plan

- [x] `dashboard/web/test/fleet.test.ts`: added `reportingHosts` coverage (multi-host fixture: 6 hosts total, 5 reporting) and a dedicated test pinning that `needsAttention` excludes `"unknown"` hosts.
- [x] `dashboard/web/test/fleetOverview.test.ts`: updated the existing headline-summary test (now "5 hosts", not "6 hosts") and added a regression test asserting the sweep-only host's card (and its sweep) still renders while the headline excludes it.
- [x] `dashboard/web/test/fleet.test.ts`'s "includes a host known only from activeSweeps" test is unchanged and still passes.
- [x] `npm run check` (typecheck + vitest) in `dashboard/web` — 33 files, 466 tests, all passing.

Closes #5101

🤖 Generated with [Claude Code](https://claude.com/claude-code)