### PR TITLE
fix(dashboard): exclude sweep-only hosts from the SPA fleet-overview host count

### DIFF
--- a/dashboard/web/src/fleet.ts
+++ b/dashboard/web/src/fleet.ts
@@ -84,6 +84,14 @@ export interface FleetView {
   totalSweeps: number;
   /** Hosts in `stale` or `degraded` — the count the overview headline shows. */
   needsAttention: number;
+  /** `hosts.length` minus the hosts known only from `activeSweeps` (status
+   * `"unknown"` — no `host.health`/`tokens.snapshot` ever received). This is
+   * the count the overview headline's "N hosts" shows: a sweep-only host has
+   * no fleet identity to report (no health, no token pool) yet, so counting
+   * it as a member of "the fleet" inflates that number. It still gets a card
+   * (via `hosts`, unchanged) and its sweep still counts toward `totalSweeps`
+   * — this field narrows only the headline's host tally, not visibility. */
+  reportingHosts: number;
 }
 
 /**
@@ -268,8 +276,14 @@ export function buildFleetView(snapshot: FleetSnapshot, now: Date = new Date()):
 
   return {
     hosts,
+    // Deliberately not split into attributed/unattributed: a sweep-only
+    // host's sweeps already render grouped under that host's own card (with
+    // its "unknown" badge making the attribution gap visible there), so the
+    // headline total does not need a second, redundant split to convey the
+    // same information.
     totalSweeps: snapshot.activeSweeps.length,
     needsAttention: hosts.filter((host) => host.status === "stale" || host.status === "degraded").length,
+    reportingHosts: hosts.filter((host) => host.status !== "unknown").length,
   };
 }
 

--- a/dashboard/web/src/views/fleetOverview.ts
+++ b/dashboard/web/src/views/fleetOverview.ts
@@ -253,7 +253,14 @@ export function fleetOverviewView(view: FleetView, now: Date = new Date()): HTML
     el(
       "div",
       { class: "overview__summary", data: { testid: "fleet-summary" } },
-      el("span", {}, `${view.hosts.length} host${view.hosts.length === 1 ? "" : "s"}`),
+      el(
+        "span",
+        {},
+        // `reportingHosts` — not `hosts.length` — so a host known only from
+        // `activeSweeps` (no health/tokens ever received) does not inflate
+        // this count; it still gets a card below, just outside this tally.
+        `${view.reportingHosts} host${view.reportingHosts === 1 ? "" : "s"}`,
+      ),
       el("span", {}, `${view.totalSweeps} active sweep${view.totalSweeps === 1 ? "" : "s"}`),
       el(
         "span",

--- a/dashboard/web/test/fleet.test.ts
+++ b/dashboard/web/test/fleet.test.ts
@@ -114,8 +114,19 @@ describe("buildFleetView", () => {
     const built = view();
     expect(built.totalSweeps).toBe(3);
     // Only the stale host and the truly-at-the-edge degraded host — not the
-    // partially-exhausted-but-healthy one.
+    // partially-exhausted-but-healthy one. Confirms `needsAttention` already
+    // excludes the sweep-only "unknown" host correctly (it filters on
+    // `stale`/`degraded` only).
     expect(built.needsAttention).toBe(2);
+  });
+
+  it("excludes a sweep-only 'unknown' host from reportingHosts, unlike hosts.length (#5101)", () => {
+    const built = view();
+    // 6 hosts total (5 real-health + SWEEP_ONLY_HOST_ID), but only 5 have
+    // ever reported health/tokens — the sweep-only host must not inflate the
+    // "N hosts" headline count, even though it still gets a card via `hosts`.
+    expect(built.hosts).toHaveLength(6);
+    expect(built.reportingHosts).toBe(5);
   });
 
   it("returns an empty view for an empty fleet", () => {
@@ -123,6 +134,7 @@ describe("buildFleetView", () => {
     expect(built.hosts).toEqual([]);
     expect(built.totalSweeps).toBe(0);
     expect(built.needsAttention).toBe(0);
+    expect(built.reportingHosts).toBe(0);
   });
 });
 

--- a/dashboard/web/test/fleetOverview.test.ts
+++ b/dashboard/web/test/fleetOverview.test.ts
@@ -41,9 +41,33 @@ describe("fleetOverviewView", () => {
 
   it("summarizes the fleet above the grid", () => {
     const summary = fleetOverviewView(view(), NOW).querySelector('[data-testid="fleet-summary"]');
-    expect(summary?.textContent).toContain("6 hosts");
+    // 6 hosts total (including the sweep-only "unknown" host), but the
+    // headline shows only the 5 that have ever reported health/tokens
+    // (#5101) — see the dedicated regression test below for the isolated
+    // case.
+    expect(summary?.textContent).toContain("5 hosts");
+    expect(summary?.textContent).not.toContain("6 hosts");
     expect(summary?.textContent).toContain("3 active sweeps");
     expect(summary?.textContent).toContain("2 need");
+  });
+
+  it("excludes a sweep-only 'unknown' host from the 'N hosts' headline while still rendering its card (#5101)", () => {
+    const built = buildFleetView(
+      parseFleetSnapshot({
+        hosts: { real: { health: { record: {}, updatedAt: isoMinutesBefore(1) } } },
+        activeSweeps: [{ hostId: "sweep-only", sweepId: "sweep-1", startedAt: isoMinutesBefore(2) }],
+      }),
+      NOW,
+    );
+    const rendered = fleetOverviewView(built, NOW);
+    const summary = rendered.querySelector('[data-testid="fleet-summary"]');
+
+    // Two hosts render as cards (the real one and the sweep-only one)...
+    const cards = [...rendered.querySelectorAll('[data-testid="host-card"]')];
+    expect(cards.map((card) => card.getAttribute("data-host"))).toEqual(["sweep-only", "real"]);
+    // ...but the headline counts only the one with real health/tokens data.
+    expect(summary?.textContent).toContain("1 host");
+    expect(summary?.textContent).not.toContain("2 host");
   });
 
   it("shows the empty-fleet state, not an error, when no host has reported", () => {


### PR DESCRIPTION
## Summary

The dashboard SPA's fleet-overview headline ("N hosts") counted `view.hosts.length`, which includes hosts known only from `activeSweeps` (status `"unknown"` — no `host.health`/`tokens.snapshot` ever received). A host whose only signal is an in-flight sweep has no real fleet identity to report yet, so counting it as a member of "the fleet" inflated the headline. This mirrors the already-fixed gap on the no-UI-build fallback page (`dashboard/src/publicPage.ts`, #5078/#5102) — this PR closes the same gap on the actual production-serving SPA path (`dashboard/web/src/*`).

## Changes

- `dashboard/web/src/fleet.ts`: added `reportingHosts` to the `FleetView` return shape — the count of hosts whose `status !== "unknown"` — computed in `buildFleetView` alongside the existing `totalSweeps`/`needsAttention`. Left `buildFleetView`'s host union (`hosts`) and card behavior completely untouched, per the issue's explicit constraint.
- `dashboard/web/src/views/fleetOverview.ts`: `fleetOverviewView`'s "N hosts" headline now reads `view.reportingHosts` instead of `view.hosts.length`.
- Documented the reasoned call **not** to split `totalSweeps` into attributed/unattributed: a sweep-only host's sweeps already render grouped under its own card (with its "unknown" badge), so the headline total doesn't need a second, redundant split — the per-card grouping already carries that information for the SPA's card-based layout.
- `dashboard/web/test/fleet.test.ts`: new regression test pinning `reportingHosts` (5 of the fixture's 6 hosts) vs. `hosts.length` (6), plus a `reportingHosts: 0` assertion on the empty-fleet case.
- `dashboard/web/test/fleetOverview.test.ts`: updated the existing summary-line test's expectation from "6 hosts" to "5 hosts" (asserting "6 hosts" is now absent too), and added a dedicated minimal-snapshot regression test asserting the sweep-only host's card still renders while the headline excludes it from the count.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| SPA's fleet-overview headline "N hosts" does not include a host known only from `activeSweeps` | ✅ | `fleetOverviewView` now reads `view.reportingHosts`, which filters `status !== "unknown"` |
| Regression test with a sweep-only host asserts headline excludes it while the card (and sweeps) still render | ✅ | New test in `fleetOverview.test.ts`: `"excludes a sweep-only 'unknown' host from the 'N hosts' headline while still rendering its card (#5101)"` |
| Existing `fleet.test.ts` `"includes a host known only from activeSweeps"` test unmodified/still passing | ✅ | Untouched; `npm test` green (39/39 in `fleet.test.ts`) |
| `needsAttention` already excludes "unknown"-status hosts (pin if uncovered) | ✅ | Already covered by the pre-existing `"counts sweeps and attention-needing hosts"` test (annotated with why, no new test needed per the issue's own curator note) |

## Test Plan

- `cd dashboard/web && npm install && npm run check` (typecheck + full vitest suite) — 33 files / 465 tests pass, including the new/updated cases above.

Closes #5101