### PR TITLE
feat(observability): backfill sweep.completed/outcome for restart-adopted sweeps

### DIFF
--- a/.loom/docs/observability.md
+++ b/.loom/docs/observability.md
@@ -90,6 +90,36 @@ field-by-field reference, the `visibility` anti-leak contract, and the local
 exporter is configured**):
 [`.loom/docs/telemetry-schema.md`](telemetry-schema.md).
 
+### Backfill: the local journal is the export queue-of-record (#5084)
+
+The live collector can only attach the correct `sweep_id` to a terminal
+`sweep.completed`/`sweep.outcome` record by having observed that sweep's
+*own* dispatch event earlier in the same daemon process. A sweep **adopted
+across a daemon restart** was dispatched by the previous process, so this
+falls through to a synthesized `unknown-issue-{N}` id — the record can still
+export, but under an id nothing else can query it by, which is what produced
+the "sweeps that finished were silently missing from the backend" incident
+this issue documents.
+
+`loom-daemon/src/observability/backfill.rs` fixes this at the root: the local
+`sweep-outcome-telemetry.jsonl` journal above is written unconditionally at
+every terminal transition — with the *real* `sweep_id`, independent of
+whether the live collector saw the dispatch — so a backfill pass (run once at
+collector startup, then every `SNAPSHOT_INTERVAL`) treats it as the queue of
+record. It re-offers any envelope not yet handed to the export queue
+(tracked by a small on-disk cursor, `observability-backfill-state.json`) —
+self-healing *any* lost export, not just the restart-adoption case (a
+transport failure or a queue drop recovers the same way). `loom-daemon
+sweep-outcomes --pending-export` reports how many local records have not yet
+been attempted, so the backlog is visible rather than silent.
+
+True idempotency — a re-offered record must never double-count — is enforced
+on the **backend**, not the daemon: `dashboard/migrations/0002_…sql` adds a
+partial `UNIQUE(kind, sweep_id)` index scoped to exactly `sweep.completed`/
+`sweep.outcome`, and `/ingest` uses `INSERT OR IGNORE`, so a duplicate is
+silently absorbed rather than inserted twice. The daemon-side cursor is only
+an efficiency optimization against needless re-sends.
+
 ## 3. Exporters: HTTPS (default) or OTLP (opt-in)
 
 The default exporter is `HttpsExporter` — JSON-over-HTTPS `POST /ingest`,

--- a/dashboard/migrations/0002_idempotent_terminal_records.sql
+++ b/dashboard/migrations/0002_idempotent_terminal_records.sql
@@ -1,0 +1,29 @@
+-- Idempotent terminal-record ingest (Issue #5084).
+--
+-- `sweep.completed` / `sweep.outcome` are each written exactly once per
+-- sweep by the daemon's own reaper — but the daemon-side backfill drain
+-- (loom-daemon/src/observability/backfill.rs) is only an *efficiency*
+-- optimization against re-offering an already-queued record; it is not the
+-- correctness mechanism. A crash between enqueueing a backfilled batch and
+-- persisting the advanced cursor re-offers the same record on the next
+-- pass, and a transport retry can do the same for a live-observed record.
+-- Without a constraint here, either would silently double the row for that
+-- sweep in `records` (and double-count it in any aggregate query over the
+-- table).
+--
+-- A partial UNIQUE index — scoped to exactly the two kinds that are emitted
+-- once per sweep — is the backend-side guarantee: `INSERT OR IGNORE`
+-- (src/index.ts's ingest handler) silently absorbs a duplicate `(kind,
+-- sweep_id)` pair instead of inserting a second row, however many times a
+-- backfill pass or retry re-sends it. Every other `kind` (`sweep.started`,
+-- `sweep.phase`, `tokens.snapshot`, `host.health`, …) is untouched — some
+-- are legitimately emitted many times per sweep/host (`sweep.phase` once
+-- per lifecycle phase) or carry no `sweep_id` at all (the host-level
+-- kinds), and SQLite's partial-index WHERE clause means the constraint
+-- never applies to their rows.
+--
+-- NULL `sweep_id` values are exempt from uniqueness by SQL's own NULL != NULL
+-- rule, so this is safe even though `sweep_id` is nullable on the column.
+CREATE UNIQUE INDEX idx_records_terminal_sweep_once
+  ON records (kind, sweep_id)
+  WHERE kind IN ('sweep.completed', 'sweep.outcome');

--- a/dashboard/src/index.ts
+++ b/dashboard/src/index.ts
@@ -259,8 +259,19 @@ async function handleIngest(request: Request, env: Env): Promise<Response> {
   const nowIso = new Date().toISOString();
   const statements = envelopes.map((envelope) => {
     const fields = extractRecordFields(envelope.record);
+    // `OR IGNORE` (Issue #5084): `idx_records_terminal_sweep_once`
+    // (migrations/0002) enforces a partial UNIQUE(kind, sweep_id) for
+    // exactly `sweep.completed`/`sweep.outcome` — the two kinds a sweep
+    // emits once, ever. A re-sent record for a sweep already ingested
+    // (the daemon-side backfill drain's cursor is an efficiency
+    // optimization, not a correctness guarantee — see
+    // `loom-daemon/src/observability/backfill.rs`'s module doc) is
+    // silently absorbed here instead of duplicating the row. Every other
+    // `kind` has no matching unique index, so this is a no-op change for
+    // them — `INSERT OR IGNORE` behaves exactly like `INSERT` when there is
+    // no conflicting constraint.
     return env.DB.prepare(
-      `INSERT INTO records
+      `INSERT OR IGNORE INTO records
          (schema_version, emitted_at, host_id, kind, repo, visibility, issue, sweep_id, payload, ingested_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).bind(

--- a/dashboard/test/ingest.test.ts
+++ b/dashboard/test/ingest.test.ts
@@ -1,7 +1,15 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import worker from "../src/index";
-import { hostHealthEnvelope, revokeHost, seedHost, sweepStartedEnvelope } from "./testHelpers";
+import {
+  hostHealthEnvelope,
+  revokeHost,
+  seedHost,
+  sweepCompletedEnvelope,
+  sweepOutcomeEnvelope,
+  sweepPhaseEnvelope,
+  sweepStartedEnvelope,
+} from "./testHelpers";
 
 function ingestRequest(body: unknown, authHeader?: string): Request {
   const headers: Record<string, string> = { "content-type": "application/json" };
@@ -197,6 +205,70 @@ describe("POST /ingest — visibility fail-safe default", () => {
     expect(response.status).toBe(200);
     const rows = await recordsForHost("host-abc");
     expect(rows[0]?.visibility).toBe("public");
+  });
+});
+
+describe("POST /ingest — idempotent terminal records (Issue #5084)", () => {
+  it("re-ingesting the same sweep.completed record does not double-count it", async () => {
+    const envelope = sweepCompletedEnvelope();
+    const first = await callWorker(ingestRequest([envelope], "Bearer abc-ingest-key"));
+    expect(first.status).toBe(200);
+    expect(await first.json()).toEqual({ accepted: 1, host_id: "host-abc" });
+
+    // A backfill re-offer or a transport-retry resend of the EXACT same
+    // record — same kind, same sweep_id. Must still ack 2xx, not surface as
+    // a client error.
+    const second = await callWorker(ingestRequest([envelope], "Bearer abc-ingest-key"));
+    expect(second.status).toBe(200);
+
+    const rows = await recordsForHost("host-abc");
+    expect(rows.filter((r) => r.kind === "sweep.completed")).toHaveLength(1);
+  });
+
+  it("re-ingesting the same sweep.outcome record does not double-count it", async () => {
+    const envelope = sweepOutcomeEnvelope();
+    await callWorker(ingestRequest([envelope], "Bearer abc-ingest-key"));
+    await callWorker(ingestRequest([envelope], "Bearer abc-ingest-key"));
+
+    const rows = await recordsForHost("host-abc");
+    expect(rows.filter((r) => r.kind === "sweep.outcome")).toHaveLength(1);
+  });
+
+  it("a duplicate sweep.completed does not block the REST of a mixed batch from persisting", async () => {
+    const completed = sweepCompletedEnvelope();
+    await callWorker(ingestRequest([completed], "Bearer abc-ingest-key"));
+
+    // Re-send the same completed record alongside a genuinely new one —
+    // `INSERT OR IGNORE` is per-statement, so the duplicate is dropped and
+    // the new health record still lands in the same batch transaction.
+    const response = await callWorker(
+      ingestRequest([completed, hostHealthEnvelope()], "Bearer abc-ingest-key"),
+    );
+    expect(response.status).toBe(200);
+
+    const rows = await recordsForHost("host-abc");
+    expect(rows.filter((r) => r.kind === "sweep.completed")).toHaveLength(1);
+    expect(rows.filter((r) => r.kind === "host.health")).toHaveLength(1);
+  });
+
+  it("does NOT dedupe sweep.phase — a sweep legitimately emits many, one per lifecycle phase", async () => {
+    const builder = sweepPhaseEnvelope({ phase: "builder" });
+    const judge = sweepPhaseEnvelope({ phase: "judge", entered_at: "2026-07-30T12:20:00Z" });
+    await callWorker(ingestRequest([builder], "Bearer abc-ingest-key"));
+    await callWorker(ingestRequest([judge], "Bearer abc-ingest-key"));
+
+    const rows = await recordsForHost("host-abc");
+    expect(rows.filter((r) => r.kind === "sweep.phase")).toHaveLength(2);
+  });
+
+  it("does not dedupe two DIFFERENT sweeps' sweep.completed records", async () => {
+    const first = sweepCompletedEnvelope({ sweep_id: "sweep-issue-1-0", issue: 1 });
+    const secondSweep = sweepCompletedEnvelope({ sweep_id: "sweep-issue-2-0", issue: 2 });
+    await callWorker(ingestRequest([first], "Bearer abc-ingest-key"));
+    await callWorker(ingestRequest([secondSweep], "Bearer abc-ingest-key"));
+
+    const rows = await recordsForHost("host-abc");
+    expect(rows.filter((r) => r.kind === "sweep.completed")).toHaveLength(2);
   });
 });
 

--- a/loom-daemon/src/cli/misc_cmds.rs
+++ b/loom-daemon/src/cli/misc_cmds.rs
@@ -336,14 +336,35 @@ pub(crate) fn handle_sweep_outcomes_command(
     result_filter: Option<&str>,
     records_mode: bool,
     limit: Option<usize>,
+    pending_export: bool,
     json: bool,
 ) -> Result<()> {
+    use loom_daemon::observability::backfill;
     use loom_daemon::sweep_outcomes;
     use loom_daemon::telemetry;
     use loom_daemon::worktree_ops::repo;
 
     let repo_root = repo::resolve_repo_root(workspace)?;
     let path = sweep_outcomes::default_outcome_telemetry_path(&repo_root);
+
+    if pending_export {
+        let pending = backfill::pending_count(&repo_root);
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({ "pending_export": pending }))?
+            );
+        } else if pending == 0 {
+            println!("0 local outcome record(s) pending export — the backfill drain is caught up.");
+        } else {
+            println!(
+                "{pending} local outcome record(s) recorded at {} but not yet attempted for export \
+                 (Issue #5084 — self-heals on the daemon's next backfill pass).",
+                path.display()
+            );
+        }
+        return Ok(());
+    }
 
     let result_filter: Option<telemetry::SweepResult> =
         result_filter.map(parse_sweep_result_arg).transpose()?;

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -853,6 +853,16 @@ enum Commands {
         #[arg(long, value_name = "N")]
         limit: Option<usize>,
 
+        /// Print how many locally-journaled records the observability
+        /// exporter has not yet attempted to send to the backend (Issue
+        /// #5084) instead of the summary/records output — every other flag
+        /// except `--json`/`--workspace` is ignored in this mode. This is the
+        /// AC's "N local outcomes not yet in the backend" measurability
+        /// gauge: `0` means the backfill drain (see
+        /// `.loom/docs/observability.md`) is caught up.
+        #[arg(long = "pending-export")]
+        pending_export: bool,
+
         /// Emit machine-readable JSON instead of the human-readable table.
         #[arg(long)]
         json: bool,
@@ -2020,6 +2030,7 @@ fn handle_cli_command(command: Commands) -> Result<()> {
             result,
             records,
             limit,
+            pending_export,
             json,
         } => handle_sweep_outcomes_command(
             &workspace,
@@ -2027,6 +2038,7 @@ fn handle_cli_command(command: Commands) -> Result<()> {
             result.as_deref(),
             records,
             limit,
+            pending_export,
             json,
         ),
         Commands::Stats {

--- a/loom-daemon/src/observability/backfill.rs
+++ b/loom-daemon/src/observability/backfill.rs
@@ -1,0 +1,569 @@
+//! Local-journal backfill for `sweep.completed` / `sweep.outcome` telemetry
+//! (Issue #5084).
+//!
+//! ## Problem
+//!
+//! [`super::collector`]'s live event-bus pipeline is the *only* path that
+//! ever pushes a `sweep.completed`/`sweep.outcome` envelope onto the export
+//! [`super::queue::DurableQueue`], and it can only attach the correct
+//! `sweep_id` to a terminal `Event::SweepExited`/`Event::SweepCrashed` via an
+//! in-memory `issue -> sweep_id` map populated by observing that sweep's own
+//! `Event::SweepGlobalDispatch` earlier in **this process's** lifetime
+//! ([`super::collector::DispatchState`]). A sweep **adopted across a daemon
+//! restart** was dispatched by the previous process — this process never saw
+//! its dispatch event — so the terminal event's mapping falls back to a
+//! synthesized `unknown-issue-{N}` id (see
+//! [`super::collector::map_event_to_records`]). The record can still be
+//! pushed and exported, but under the wrong id, so any query keyed on the
+//! real `sweep_id` (the dashboard's `sweep:<sweepId>` Durable Object deletion
+//! included) finds nothing — the silent under-count and leaked `sweep:` entry
+//! #5084 documents.
+//!
+//! ## Fix: the local outcome-telemetry journal is the queue of record
+//!
+//! [`crate::sweep_outcomes::append_outcome_telemetry`] already durably
+//! records one `sweep.outcome` envelope, carrying the *correct* `sweep_id`
+//! (read straight off the registry entry the reaper is holding, never from
+//! the event-bus dispatch-tracking map), for **every** terminal transition —
+//! restart-adopted or not — independent of whether the live event-bus
+//! collector even observed the matching dispatch. This module treats that
+//! journal as the export queue-of-record: a backfill pass reads every
+//! envelope not yet attempted, synthesizes the paired `sweep.completed`
+//! record the journal does not separately store (see
+//! [`synthesize_completed`]), and pushes both onto the
+//! [`super::queue::DurableQueue`] for the existing sender/exporter to drain —
+//! the same path a live-observed terminal event already uses, so no new
+//! egress code is needed.
+//!
+//! This is deliberately more general than "fix restart adoption": *any* lost
+//! export (a transport failure, a queue drop, a daemon killed before its own
+//! collector task got scheduled) self-heals on the next backfill pass, since
+//! the local journal is unconditionally written by the reaper's terminal
+//! transition and never depends on the export pipeline succeeding.
+//!
+//! ## Idempotency
+//!
+//! A daemon-side cursor ([`BackfillState`]) tracks the newest `emitted_at`
+//! already handed to the queue, persisted to disk so a restart does not
+//! re-walk the whole journal — but this is an efficiency optimization, **not**
+//! the correctness mechanism: a crash between enqueueing a batch and
+//! persisting the advanced cursor re-offers the same records on the next
+//! pass. True idempotency (never double-counted in the backend) is the
+//! backend's job — the `records` table's partial unique index on
+//! `(kind, sweep_id)` for `sweep.completed`/`sweep.outcome` plus
+//! `INSERT OR IGNORE` (see `dashboard/migrations`) — so a re-sent record is
+//! silently absorbed rather than duplicated, however many times a backfill
+//! pass re-offers it.
+//!
+//! ## Measurability
+//!
+//! [`pending_count`] answers "how many local outcome records has this daemon
+//! not yet attempted to export" — the AC's "N local outcomes not yet in the
+//! backend" gauge — without a round trip to the backend (this daemon has no
+//! query-back channel to it). It performs the same computation
+//! [`run_backfill_pass`] uses to decide what to enqueue, exposed separately
+//! for `loom-daemon sweep-outcomes --pending-export`.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::sweep_outcomes;
+use crate::telemetry::{self, TelemetryEnvelope, TelemetryRecord};
+use crate::workspace_pool::WorkspacePool;
+
+use super::queue::DurableQueue;
+
+/// Env var overriding the backfill cursor state path (test seam), mirroring
+/// [`crate::sweep_outcomes::OUTCOME_TELEMETRY_JOURNAL_PATH_ENV`].
+pub const BACKFILL_STATE_PATH_ENV: &str = "LOOM_OBSERVABILITY_BACKFILL_STATE_PATH";
+
+/// Default filename under `<workspace_root>/.loom/logs/`.
+pub const BACKFILL_STATE_FILENAME: &str = "observability-backfill-state.json";
+
+/// Resolve the default backfill cursor path: [`BACKFILL_STATE_PATH_ENV`]
+/// override (non-empty), else
+/// `<workspace_root>/.loom/logs/observability-backfill-state.json`.
+#[must_use]
+pub fn default_backfill_state_path(workspace_root: &Path) -> PathBuf {
+    if let Ok(path) = std::env::var(BACKFILL_STATE_PATH_ENV) {
+        if !path.is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+    workspace_root
+        .join(".loom")
+        .join("logs")
+        .join(BACKFILL_STATE_FILENAME)
+}
+
+/// Persisted backfill progress cursor: the newest `emitted_at` of a
+/// telemetry-journal envelope this daemon has already handed to the export
+/// queue. `None` means "nothing backfilled yet" (a fresh workspace, or a
+/// missing/corrupt state file — see [`load_state`]).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+pub struct BackfillState {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_backfilled_emitted_at: Option<DateTime<Utc>>,
+}
+
+/// Load `path`'s cursor, defaulting to "nothing backfilled yet" on a
+/// missing/corrupt file — matches every other journal reader's soft-fail
+/// contract in this crate (a corrupt cursor degrades to "reprocess
+/// everything", which the backend's idempotent ingest absorbs harmlessly,
+/// rather than crashing the collector).
+#[must_use]
+pub fn load_state(path: &Path) -> BackfillState {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|contents| serde_json::from_str(&contents).ok())
+        .unwrap_or_default()
+}
+
+/// Persist `state` to `path` atomically (temp file + rename, mirroring
+/// [`crate::observability::queue::persist_to`]), creating parent directories
+/// as needed. Best-effort: a write failure is logged and swallowed — the next
+/// pass simply re-offers already-queued records, which the backend's
+/// idempotent ingest absorbs harmlessly.
+pub fn save_state(path: &Path, state: &BackfillState) {
+    if let Some(parent) = path.parent() {
+        if let Err(error) = std::fs::create_dir_all(parent) {
+            log::warn!(
+                "observability: could not create backfill state dir {}: {error}",
+                parent.display()
+            );
+            return;
+        }
+    }
+    let json = match serde_json::to_string(state) {
+        Ok(json) => json,
+        Err(error) => {
+            log::warn!("observability: failed to serialize backfill state: {error}");
+            return;
+        }
+    };
+    let temporary = path.with_extension(format!("json.tmp-{}", std::process::id()));
+    if let Err(error) = std::fs::write(&temporary, json) {
+        log::warn!(
+            "observability: failed to write backfill state {}: {error}",
+            temporary.display()
+        );
+        return;
+    }
+    if let Err(error) = std::fs::rename(&temporary, path) {
+        log::warn!(
+            "observability: failed to persist backfill state to {}: {error}",
+            path.display()
+        );
+    }
+}
+
+/// The telemetry-journal envelopes not yet handed to the export queue per
+/// `state`'s cursor, in journal (chronological) order.
+#[must_use]
+fn pending_envelopes(
+    telemetry_journal_path: &Path,
+    state: &BackfillState,
+) -> Vec<TelemetryEnvelope> {
+    sweep_outcomes::read_all_outcome_telemetry(telemetry_journal_path)
+        .into_iter()
+        .filter(|envelope| match state.last_backfilled_emitted_at {
+            Some(cursor) => envelope.emitted_at > cursor,
+            None => true,
+        })
+        .collect()
+}
+
+/// How many local outcome-telemetry records under `workspace_root` have not
+/// yet been attempted for export (AC "the gap is measurable"). Reads the
+/// on-disk cursor fresh each call — cheap relative to its callers' cadence (a
+/// CLI invocation, or once per [`super::SNAPSHOT_INTERVAL`]).
+#[must_use]
+pub fn pending_count(workspace_root: &Path) -> usize {
+    let telemetry_path = sweep_outcomes::default_outcome_telemetry_path(workspace_root);
+    let state_path = default_backfill_state_path(workspace_root);
+    let state = load_state(&state_path);
+    pending_envelopes(&telemetry_path, &state).len()
+}
+
+/// Synthesize the paired `sweep.completed` record a `sweep.outcome` envelope
+/// implies. The telemetry journal only ever stores the outcome shape (see the
+/// `sweep_outcomes` module doc for why they are separate journals), so the
+/// completed record has to be rebuilt here rather than read back verbatim.
+/// `completed_at` reuses the envelope's own `emitted_at`:
+/// `SweepRegistry::append_outcome_telemetry_journal` stamps the envelope with
+/// `Utc::now()` synchronously inside the same terminal-transition call that
+/// determined the outcome, so the two are the same instant to journal-write
+/// precision.
+fn synthesize_completed(
+    envelope: &TelemetryEnvelope,
+    outcome: &telemetry::SweepOutcomeRecord,
+) -> TelemetryEnvelope {
+    TelemetryEnvelope {
+        schema_version: envelope.schema_version,
+        emitted_at: envelope.emitted_at,
+        host_id: envelope.host_id.clone(),
+        record: TelemetryRecord::SweepCompleted(telemetry::SweepCompletedRecord {
+            repo: outcome.repo.clone(),
+            visibility: outcome.visibility,
+            issue: outcome.issue,
+            sweep_id: outcome.sweep_id.clone(),
+            completed_at: envelope.emitted_at,
+            result: outcome.result,
+        }),
+    }
+}
+
+/// Run one backfill pass for a single workspace root: enqueue every pending
+/// `sweep.outcome` record (paired with a [`synthesize_completed`]d
+/// `sweep.completed`) onto `queue`, then advance and persist the cursor.
+/// Returns the number of `sweep.outcome` records processed (the number of
+/// envelopes pushed onto `queue` is twice this, for the paired `completed` +
+/// `outcome` records).
+pub fn run_backfill_pass(workspace_root: &Path, queue: &DurableQueue) -> usize {
+    let telemetry_path = sweep_outcomes::default_outcome_telemetry_path(workspace_root);
+    let state_path = default_backfill_state_path(workspace_root);
+    let mut state = load_state(&state_path);
+    let pending = pending_envelopes(&telemetry_path, &state);
+    if pending.is_empty() {
+        return 0;
+    }
+    let mut newest = state.last_backfilled_emitted_at;
+    for envelope in &pending {
+        match &envelope.record {
+            TelemetryRecord::SweepOutcome(outcome) => {
+                queue.push(synthesize_completed(envelope, outcome));
+                queue.push(envelope.clone());
+            }
+            // Forward-compatible: the telemetry journal today only ever
+            // carries `sweep.outcome` (see `read_all_sweep_outcomes`'s doc),
+            // but a future kind sharing the file should still be exported by
+            // this backfill path rather than silently dropped.
+            _ => queue.push(envelope.clone()),
+        }
+        newest =
+            Some(newest.map_or(envelope.emitted_at, |current| current.max(envelope.emitted_at)));
+    }
+    state.last_backfilled_emitted_at = newest;
+    save_state(&state_path, &state);
+    log::info!(
+        "observability: backfilled {} local outcome record(s) for {} onto the export queue",
+        pending.len(),
+        workspace_root.display()
+    );
+    pending.len()
+}
+
+/// Run a backfill pass across every workspace this daemon knows about:
+/// `primary_workspace_root` (the daemon's own managed root, included even if
+/// not yet provisioned in `workspace_pool` — e.g. no sweep dispatched there
+/// yet in this process) plus every additional repo
+/// [`WorkspacePool::provisioned_registries`] currently tracks. Mirrors the
+/// same "iterate every provisioned root" pattern
+/// [`super::collector::collect_active_sweep_ids`] and
+/// [`super::collector::collect_managed_repos`] already use — a multi-repo
+/// daemon's backfill must cover every repo's own local journal, not just the
+/// primary one (the reported incident spanned repos, not just issues within
+/// one).
+pub fn run_backfill_pass_all(
+    primary_workspace_root: &Path,
+    workspace_pool: &WorkspacePool,
+    queue: &DurableQueue,
+) -> usize {
+    let mut roots: Vec<PathBuf> = vec![primary_workspace_root.to_path_buf()];
+    for registry in workspace_pool.provisioned_registries() {
+        let root = registry
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .config()
+            .workspace_root
+            .clone();
+        if !roots.contains(&root) {
+            roots.push(root);
+        }
+    }
+    roots
+        .iter()
+        .map(|root| run_backfill_pass(root, queue))
+        .sum()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::event_bus::EventBus;
+    use serial_test::serial;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    fn outcome_envelope(issue: u32, sweep_id: &str, host_id: &str) -> TelemetryEnvelope {
+        TelemetryEnvelope::new(
+            host_id,
+            TelemetryRecord::SweepOutcome(telemetry::SweepOutcomeRecord {
+                repo: "rjwalters/loom".to_string(),
+                visibility: telemetry::RepoVisibility::Public,
+                issue,
+                sweep_id: sweep_id.to_string(),
+                model: Some("opus".to_string()),
+                effort: None,
+                config: std::collections::BTreeMap::new(),
+                phase_durations: Vec::new(),
+                total_duration_sec: 42,
+                result: telemetry::SweepResult::Success,
+                pr_number: Some(100 + issue),
+            }),
+        )
+    }
+
+    #[test]
+    fn pending_envelopes_with_no_cursor_returns_everything() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweep-outcome-telemetry.jsonl");
+        sweep_outcomes::append_outcome_telemetry(
+            &path,
+            &outcome_envelope(1, "sweep-issue-1-0", "host-a"),
+        )
+        .unwrap();
+        sweep_outcomes::append_outcome_telemetry(
+            &path,
+            &outcome_envelope(2, "sweep-issue-2-0", "host-a"),
+        )
+        .unwrap();
+
+        let pending = pending_envelopes(&path, &BackfillState::default());
+        assert_eq!(pending.len(), 2);
+    }
+
+    #[test]
+    fn pending_envelopes_excludes_everything_at_or_before_the_cursor() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sweep-outcome-telemetry.jsonl");
+        let first = outcome_envelope(1, "sweep-issue-1-0", "host-a");
+        sweep_outcomes::append_outcome_telemetry(&path, &first).unwrap();
+        sweep_outcomes::append_outcome_telemetry(
+            &path,
+            &outcome_envelope(2, "sweep-issue-2-0", "host-a"),
+        )
+        .unwrap();
+
+        let state = BackfillState {
+            last_backfilled_emitted_at: Some(first.emitted_at),
+        };
+        let pending = pending_envelopes(&path, &state);
+        assert_eq!(pending.len(), 1, "only the envelope strictly after the cursor is pending");
+        match &pending[0].record {
+            TelemetryRecord::SweepOutcome(r) => assert_eq!(r.issue, 2),
+            other => panic!("unexpected record {other:?}"),
+        }
+    }
+
+    #[test]
+    fn state_round_trips_through_save_and_load() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("backfill-state.json");
+        assert_eq!(load_state(&path), BackfillState::default(), "missing file -> default state");
+
+        let state = BackfillState {
+            last_backfilled_emitted_at: Some(Utc::now()),
+        };
+        save_state(&path, &state);
+        assert_eq!(load_state(&path), state);
+    }
+
+    #[test]
+    fn load_state_of_a_corrupt_file_degrades_to_default() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("backfill-state.json");
+        std::fs::write(&path, "{ not json }").unwrap();
+        assert_eq!(load_state(&path), BackfillState::default());
+    }
+
+    #[test]
+    fn default_backfill_state_path_is_under_loom_logs() {
+        let workspace = Path::new("/workspace/repo");
+        let path = default_backfill_state_path(workspace);
+        assert_eq!(
+            path,
+            workspace
+                .join(".loom")
+                .join("logs")
+                .join(BACKFILL_STATE_FILENAME)
+        );
+    }
+
+    /// AC: a sweep adopted across a daemon restart — no
+    /// `Event::SweepGlobalDispatch` ever observed in this process, only the
+    /// local journal record — still produces a matching `sweep.completed` +
+    /// `sweep.outcome` pair on the export queue, carrying the REAL sweep id
+    /// (never the collector's `unknown-issue-{N}` fallback).
+    #[test]
+    #[serial]
+    fn backfill_pushes_a_completed_and_outcome_pair_with_the_real_sweep_id() {
+        let dir = tempdir().unwrap();
+        std::env::set_var(
+            sweep_outcomes::OUTCOME_TELEMETRY_JOURNAL_PATH_ENV,
+            dir.path().join("telemetry.jsonl"),
+        );
+        std::env::set_var(super::BACKFILL_STATE_PATH_ENV, dir.path().join("cursor.json"));
+
+        sweep_outcomes::append_outcome_telemetry(
+            &sweep_outcomes::default_outcome_telemetry_path(dir.path()),
+            &outcome_envelope(4989, "sweep-issue-4989-restart-adopted", "robb-studio"),
+        )
+        .unwrap();
+
+        let queue = DurableQueue::open(dir.path().join("queue.jsonl"), 10);
+        let processed = run_backfill_pass(dir.path(), &queue);
+
+        std::env::remove_var(sweep_outcomes::OUTCOME_TELEMETRY_JOURNAL_PATH_ENV);
+        std::env::remove_var(super::BACKFILL_STATE_PATH_ENV);
+
+        assert_eq!(processed, 1);
+        let batch = queue.peek_batch(10);
+        assert_eq!(batch.len(), 2, "one sweep.completed + one sweep.outcome");
+        match &batch[0].record {
+            TelemetryRecord::SweepCompleted(r) => {
+                assert_eq!(r.sweep_id, "sweep-issue-4989-restart-adopted");
+                assert_eq!(r.issue, 4989);
+                assert_eq!(r.result, telemetry::SweepResult::Success);
+            }
+            other => panic!("expected SweepCompleted first, got {other:?}"),
+        }
+        match &batch[1].record {
+            TelemetryRecord::SweepOutcome(r) => {
+                assert_eq!(r.sweep_id, "sweep-issue-4989-restart-adopted");
+            }
+            other => panic!("expected SweepOutcome second, got {other:?}"),
+        }
+    }
+
+    /// AC: backfill is idempotent at the daemon-side cursor level — a second
+    /// pass with no new journal entries enqueues nothing more.
+    #[test]
+    #[serial]
+    fn a_second_pass_with_no_new_entries_enqueues_nothing() {
+        let dir = tempdir().unwrap();
+        let telemetry_path = dir.path().join("telemetry.jsonl");
+        sweep_outcomes::append_outcome_telemetry(
+            &telemetry_path,
+            &outcome_envelope(1, "sweep-issue-1-0", "host-a"),
+        )
+        .unwrap();
+
+        std::env::set_var(sweep_outcomes::OUTCOME_TELEMETRY_JOURNAL_PATH_ENV, &telemetry_path);
+        std::env::set_var(super::BACKFILL_STATE_PATH_ENV, dir.path().join("cursor.json"));
+
+        let queue = DurableQueue::open(dir.path().join("queue.jsonl"), 10);
+        let first_pass = run_backfill_pass(dir.path(), &queue);
+        assert_eq!(first_pass, 1);
+        queue.ack(queue.len()); // simulate a successful export drain
+
+        let second_pass = run_backfill_pass(dir.path(), &queue);
+
+        std::env::remove_var(sweep_outcomes::OUTCOME_TELEMETRY_JOURNAL_PATH_ENV);
+        std::env::remove_var(super::BACKFILL_STATE_PATH_ENV);
+
+        assert_eq!(second_pass, 0, "the already-backfilled entry must not be re-enqueued");
+        assert!(queue.is_empty());
+    }
+
+    /// AC: newly appended journal entries ARE picked up on a subsequent pass
+    /// — the cursor advances forward, it does not stall after the first run.
+    #[test]
+    #[serial]
+    fn a_later_pass_picks_up_newly_appended_entries() {
+        let dir = tempdir().unwrap();
+        let telemetry_path = dir.path().join("telemetry.jsonl");
+        std::env::set_var(sweep_outcomes::OUTCOME_TELEMETRY_JOURNAL_PATH_ENV, &telemetry_path);
+        std::env::set_var(super::BACKFILL_STATE_PATH_ENV, dir.path().join("cursor.json"));
+
+        sweep_outcomes::append_outcome_telemetry(
+            &telemetry_path,
+            &outcome_envelope(1, "sweep-issue-1-0", "host-a"),
+        )
+        .unwrap();
+        let queue = DurableQueue::open(dir.path().join("queue.jsonl"), 10);
+        assert_eq!(run_backfill_pass(dir.path(), &queue), 1);
+        queue.ack(queue.len());
+
+        sweep_outcomes::append_outcome_telemetry(
+            &telemetry_path,
+            &outcome_envelope(2, "sweep-issue-2-0", "host-a"),
+        )
+        .unwrap();
+        let second_pass = run_backfill_pass(dir.path(), &queue);
+
+        std::env::remove_var(sweep_outcomes::OUTCOME_TELEMETRY_JOURNAL_PATH_ENV);
+        std::env::remove_var(super::BACKFILL_STATE_PATH_ENV);
+
+        assert_eq!(second_pass, 1);
+        assert_eq!(queue.len(), 2);
+    }
+
+    /// AC ("measurable"): [`pending_count`] reflects exactly what the next
+    /// backfill pass would enqueue, before and after a pass runs.
+    #[test]
+    #[serial]
+    fn pending_count_tracks_the_backfill_cursor() {
+        let dir = tempdir().unwrap();
+        std::env::set_var(
+            sweep_outcomes::OUTCOME_TELEMETRY_JOURNAL_PATH_ENV,
+            dir.path().join("telemetry.jsonl"),
+        );
+        std::env::set_var(super::BACKFILL_STATE_PATH_ENV, dir.path().join("cursor.json"));
+
+        assert_eq!(pending_count(dir.path()), 0, "no journal yet -> nothing pending");
+
+        sweep_outcomes::append_outcome_telemetry(
+            &sweep_outcomes::default_outcome_telemetry_path(dir.path()),
+            &outcome_envelope(1, "sweep-issue-1-0", "host-a"),
+        )
+        .unwrap();
+        assert_eq!(pending_count(dir.path()), 1);
+
+        let queue = DurableQueue::open(dir.path().join("queue.jsonl"), 10);
+        run_backfill_pass(dir.path(), &queue);
+        assert_eq!(pending_count(dir.path()), 0, "a completed pass clears the backlog");
+
+        std::env::remove_var(sweep_outcomes::OUTCOME_TELEMETRY_JOURNAL_PATH_ENV);
+        std::env::remove_var(super::BACKFILL_STATE_PATH_ENV);
+    }
+
+    /// AC: `run_backfill_pass_all` covers every repo the pool has
+    /// provisioned, not just the primary workspace root — a multi-repo
+    /// daemon's adopted sweeps can live in a sibling repo's own journal.
+    #[tokio::test]
+    #[serial]
+    async fn run_backfill_pass_all_covers_every_provisioned_workspace() {
+        let dir = tempdir().unwrap();
+        let primary = dir.path().join("primary");
+        let sibling = dir.path().join("sibling");
+        std::fs::create_dir_all(&primary).unwrap();
+        std::fs::create_dir_all(&sibling).unwrap();
+
+        sweep_outcomes::append_outcome_telemetry(
+            &sweep_outcomes::default_outcome_telemetry_path(&primary),
+            &outcome_envelope(1, "sweep-issue-1-0", "host-a"),
+        )
+        .unwrap();
+        sweep_outcomes::append_outcome_telemetry(
+            &sweep_outcomes::default_outcome_telemetry_path(&sibling),
+            &outcome_envelope(2, "sweep-issue-2-0", "host-a"),
+        )
+        .unwrap();
+
+        let pool = WorkspacePool::new(Arc::new(EventBus::new()), tokio::runtime::Handle::current());
+        let registry = crate::sweep_registry::SweepRegistry::new(
+            crate::sweep_registry::SweepRegistryConfig::new(sibling.clone()),
+        );
+        pool.seed(sibling.clone(), Arc::new(std::sync::Mutex::new(registry)));
+
+        let queue = DurableQueue::open(dir.path().join("queue.jsonl"), 10);
+        let processed = run_backfill_pass_all(&primary, &pool, &queue);
+
+        assert_eq!(processed, 2, "one outcome from each of the two workspaces");
+        assert_eq!(queue.len(), 4, "two completed + two outcome envelopes");
+    }
+}

--- a/loom-daemon/src/observability/collector.rs
+++ b/loom-daemon/src/observability/collector.rs
@@ -109,6 +109,15 @@ async fn run_collector(
     let mut slug_cache: HashMap<String, String> = HashMap::new();
     let mut snapshot_timer = tokio::time::interval(snapshot_interval);
     snapshot_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    // First-boot backfill (Issue #5084): run once immediately, before the
+    // first snapshot tick, so a sweep adopted across a daemon restart does
+    // not wait a full `snapshot_interval` (5 minutes) for its terminal
+    // record to reach the export queue. Blocking here is fine — this is a
+    // bounded, local-disk-only read (no network, no `gh`) and runs once at
+    // task startup.
+    run_backfill(&queue, &workspace_root, &workspace_pool).await;
+
     loop {
         tokio::select! {
             biased;
@@ -144,8 +153,42 @@ async fn run_collector(
                     &mut slug_cache,
                 )
                 .await;
+                // Periodic backfill (Issue #5084), same cadence as the host
+                // snapshot: self-heals any terminal record the live
+                // event-bus path missed or mis-attributed, not just the
+                // first-boot case above (e.g. a sweep whose terminal
+                // transition raced this task's own startup).
+                run_backfill(&queue, &workspace_root, &workspace_pool).await;
             }
         }
+    }
+}
+
+/// Run one [`super::backfill::run_backfill_pass_all`] pass, dispatched
+/// through `spawn_blocking` (Issue #5084): the backfill path is synchronous
+/// disk I/O (journal reads, queue pushes, cursor persistence) with no `.await`
+/// points of its own, so running it inline on the collector's async task
+/// would block that task's executor thread for the duration — `spawn_blocking`
+/// keeps it off the reactor, mirroring how [`sample_host_health`] already
+/// dispatches its own blocking CPU probe.
+async fn run_backfill(
+    queue: &Arc<DurableQueue>,
+    workspace_root: &Path,
+    workspace_pool: &Arc<WorkspacePool>,
+) {
+    let queue = queue.clone();
+    let workspace_root = workspace_root.to_path_buf();
+    let workspace_pool = workspace_pool.clone();
+    let processed = tokio::task::spawn_blocking(move || {
+        super::backfill::run_backfill_pass_all(&workspace_root, &workspace_pool, &queue)
+    })
+    .await
+    .unwrap_or_else(|error| {
+        log::warn!("observability: backfill task panicked: {error}");
+        0
+    });
+    if processed > 0 {
+        log::info!("observability: backfill pass enqueued {processed} previously-unexported sweep outcome(s)");
     }
 }
 
@@ -1503,6 +1546,11 @@ mod tests {
             ),
             cli_build_commit: "unknown".to_string(),
             work_finder_log_tick_age_secs: None,
+            // Pre-existing pipeline check: `HealthInputs` gained this field
+            // in #5097 after this fixture was added in #5098 — `None` (gh
+            // available) matches every other axis this fixture already
+            // documents as healthy.
+            gh_unavailable: None,
         }
     }
 

--- a/loom-daemon/src/observability/mod.rs
+++ b/loom-daemon/src/observability/mod.rs
@@ -20,6 +20,15 @@
 //!   with an existing OpenTelemetry stack, selected via
 //!   `observability.exporter = "otlp"` ([`resolve_exporter`]). Off by
 //!   default; [`exporter::HttpsExporter`] stays the default sink.
+//! - [`backfill`] (Issue #5084) — the local `sweep-outcome-telemetry.jsonl`
+//!   journal ([`crate::sweep_outcomes`]) is written unconditionally at every
+//!   sweep's terminal transition, independent of whether [`collector`]'s
+//!   live event-bus pipeline observed it. `backfill` treats that journal as
+//!   the export queue-of-record: it periodically pushes any record the queue
+//!   has not yet been offered onto [`queue::DurableQueue`] alongside a
+//!   synthesized `sweep.completed`, so a sweep adopted across a daemon
+//!   restart (whose dispatch this process never saw) still exports under its
+//!   real `sweep_id` instead of being silently under-counted.
 //!
 //! # Off by default (FLAGS-OFF posture)
 //!
@@ -64,6 +73,7 @@
 //! variant in this module tree names the *file path*, never the key
 //! contents.
 
+pub mod backfill;
 pub mod collector;
 pub mod exporter;
 #[cfg(feature = "otlp")]


### PR DESCRIPTION
## Summary

Sweeps adopted across a daemon restart wrote their terminal outcome to the
local journal (`.loom/logs/sweep-outcome-telemetry.jsonl`, #4704) but never
reliably exported `sweep.completed`/`sweep.outcome` to the observability
backend: the live event-bus collector can only attach the *correct*
`sweep_id` to a terminal event by having observed that sweep's own dispatch
event earlier in the same daemon process — a restart-adopted sweep's dispatch
happened in the *previous* process, so the terminal record fell back to a
synthesized `unknown-issue-{N}` id. The record could still export, but under
an id nothing else could query it by, so any per-sweep backend query (D1, and
the dashboard's `sweep:<sweepId>` Durable Object cleanup) found nothing —
matching the reported incident (six lost outcome records across three
restarts, and a phantom-dashboard-card leak, #5078).

## Changes

- **`loom-daemon/src/observability/backfill.rs`** (new): treats the durable
  `sweep-outcome-telemetry.jsonl` journal as the export queue-of-record — it
  already carries the *correct* `sweep_id` for every terminal transition,
  independent of whether the live collector saw the matching dispatch. A
  backfill pass reads every journal envelope not yet handed to the export
  queue (tracked by a small on-disk cursor,
  `observability-backfill-state.json`), synthesizes the paired
  `sweep.completed` record (the journal only stores the `sweep.outcome`
  shape), and pushes both onto the existing `DurableQueue` for the
  unmodified sender/exporter to drain.
- **`loom-daemon/src/observability/collector.rs`**: runs the backfill pass
  once at collector startup (so a restart-adopted sweep's record does not
  wait a full snapshot interval) and again on every snapshot tick, across
  every workspace the daemon manages (`WorkspacePool::provisioned_registries`
  — a multi-repo daemon's adopted sweeps can live in a sibling repo's own
  journal, not just the primary workspace).
- **`loom-daemon/src/main.rs` + `src/cli/misc_cmds.rs`**: `loom-daemon
  sweep-outcomes --pending-export` reports how many local records the
  backfill drain has not yet attempted — the AC's "N local outcomes not yet
  in the backend" measurability gauge, so this cannot regress silently.
- **`dashboard/migrations/0002_idempotent_terminal_records.sql`** +
  **`dashboard/src/index.ts`**: true idempotency is enforced on the
  backend, not the daemon (the daemon-side cursor is only an efficiency
  optimization). A partial `UNIQUE(kind, sweep_id)` index scoped to exactly
  `sweep.completed`/`sweep.outcome`, plus `/ingest` switching to
  `INSERT OR IGNORE`, silently absorbs a re-offered record instead of
  duplicating the row — covers both the daemon-side backfill re-offer case
  and a plain transport-retry resend.
- **`.loom/docs/observability.md`**: documents the backfill mechanism and
  the backend-side idempotency contract.
- Fixed a pre-existing compile error in `collector.rs`'s own test module
  (`HealthInputs` gained a `gh_unavailable` field in #5097 after a fixture
  in #5098 was merged without it) — blocked `cargo test --lib` outright, so
  I added the one missing field to get back to a compiling baseline.

## Acceptance Criteria Verification

- [x] A sweep adopted across a daemon restart still produces
      `sweep.completed` and `sweep.outcome` in the backend when it
      finishes — the backfill pass reads the always-written local journal,
      independent of whether this process observed the dispatch. Covered by
      `backfill_pushes_a_completed_and_outcome_pair_with_the_real_sweep_id`
      (asserts the real `sweep_id`, never `unknown-issue-{N}`).
- [x] Outcome records present in the local journal but absent from the
      backend are eventually exported, not silently stranded — first-boot
      pass at collector startup, plus every snapshot tick thereafter.
- [x] Backfill is idempotent — re-exporting an already-ingested outcome
      does not double-count: backend partial unique index +
      `INSERT OR IGNORE` (migration 0002), verified by 5 new dashboard
      tests including exact-duplicate re-ingest and a duplicate mixed into
      a fresh batch.
- [x] A `sweep:` DO entry is not leaked for a sweep whose completion was
      observed locally — `sweep.completed` now reliably reaches
      `fleetState.ts`'s existing deletion path under the real `sweep_id`.
- [x] The gap is measurable — `loom-daemon sweep-outcomes --pending-export`
      (text and `--json`), backed by `pending_count`, which is exactly the
      count the next backfill pass would enqueue.
- [x] The six outcomes lost in the reported incident: this PR makes the
      mechanism correct and idempotent going forward (per the curator's
      note, no live backfill run against production data was required for
      this issue) — a daemon picking up this build will backfill any of
      those six still sitting in `sweep-outcome-telemetry.jsonl` on its next
      collector startup.

## Test Plan

- `cargo test --lib` (loom-daemon): 3261 passed, 0 failed — includes 10 new
  tests in `observability::backfill` plus the pre-existing suite unaffected.
- `cargo clippy --lib --bins --tests --all-features -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `npm test` (dashboard, `vitest run` via `pretest`): 250 passed (10 files),
  including 5 new idempotency tests in `test/ingest.test.ts` (exact-duplicate
  `sweep.completed`/`sweep.outcome`, duplicate-mixed-into-a-fresh-batch,
  `sweep.phase` correctly NOT deduped, two distinct sweeps' `sweep.completed`
  correctly NOT deduped).
- `npx tsc --noEmit` (dashboard): clean.
- Manual CLI verification: `loom-daemon sweep-outcomes --workspace <dir>
  --pending-export` against an empty journal (`0 ... caught up`) and a
  seeded journal (`1 local outcome record(s) ... not yet attempted`), both
  text and `--json`.

Closes #5084