### PR TITLE
fix(daemon): correct stale bootout-kills-sweeps claim, add settle/retry/verify to the launchd relaunch path

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -5194,16 +5194,29 @@ exits **6** rather than reporting a half-update. It does **not** tell you to
 `launchctl bootstrap` the existing plist — that plist is stale by construction
 (no `KeepAlive:{SuccessfulExit:true}`, no `LOOM_DAEMON_SUPERVISOR`), so
 bootstrapping it relaunches *unsupervised* and every subsequent roll refuses
-identically forever, and its `launchctl bootout` tears down the whole job tree
-(in-flight sweep children are direct children of the launchd job, so they are
-killed). Instead, `--relaunch` (or `LOOM_DAEMON_UPDATE_RELAUNCH=1`) re-renders
-the plist via `loom-daemon-start.sh` — installing both supervised keys — while
+identically forever. (A bare `launchctl bootout` of that plist no longer kills
+in-flight sweeps on a current build, #5081 — every sweep is spawned in its own
+process group, `process_group(0)` since #3800, which bootout's job-tree
+teardown does not reach, so it reparents to pid 1 and keeps running; this
+corrects guidance that was accurate before #3800 but had gone stale.) Instead,
+`--relaunch` (or `LOOM_DAEMON_UPDATE_RELAUNCH=1`) re-renders the plist via
+`loom-daemon-start.sh` — installing both supervised keys — while
 **preserving the live plist's `LOOM_*`/token `EnvironmentVariables`** (read with
 `plutil` + `jq`, `PATH`/`HOME`/`LOOM_DAEMON_SUPERVISOR` excluded so autonomy
 flags never silently narrow to FLAGS-OFF, #4011), and stops the old daemon
-**gracefully with `SIGTERM`** so sweep children reparent and keep working. The
-default path stays exit-6 (no `--relaunch`) so the sweep-disrupting relaunch is
-always a consented action.
+**gracefully with `SIGTERM`** rather than a bootout (belt-and-braces against a
+double teardown, since `loom-daemon-start.sh`'s own launchd block below
+bootouts the loaded job again before re-bootstrapping). The default path stays
+exit-6 (no `--relaunch`) so a plist-env-changing relaunch is always a
+consented action. `loom-daemon-start.sh`'s bootout+bootstrap sequence itself
+settles after bootout, retries the bootstrap step if it hits the async
+bootout/bootstrap race (`Bootstrap failed: 5: Input/output error`, #5081 —
+`bootout` returns before the kernel finishes tearing the job down, so an
+immediate `bootstrap` can fail even against a valid plist), and verifies the
+relaunched job's live pid **and** reported `EnvironmentVariables` before
+reporting success — see `LOOM_DAEMON_BOOTOUT_SETTLE_SECS` /
+`LOOM_DAEMON_BOOTSTRAP_RETRY_ATTEMPTS` / `LOOM_DAEMON_BOOTSTRAP_RETRY_SECS` in
+`loom-daemon-start.sh --help`.
 
 **Staleness detection** is primary-local, zero-network: it compares the git
 commit **baked into** the currently-resolved `loom-daemon` binary (embedded at

--- a/defaults/docs/machine-dispatcher.md
+++ b/defaults/docs/machine-dispatcher.md
@@ -234,11 +234,14 @@ confusing than useful in machine mode.
 
 `loom restart` mirrors `start`/`stop` — same collision guard — and prefers a
 **drain-and-roll** restart: it first tries the daemon's own supervised restart
-IPC (`loom-daemon restart`, #4077), which never tears down in-flight sweep
-children (unlike a `launchctl bootout`). If that is unavailable (not
+IPC (`loom-daemon restart`, #4077), which can apply a code update without
+touching the loaded launchd job at all. If that is unavailable (not
 launchd-managed) or refused (not currently running, or a pre-#4077 binary), it
 falls back to a plain stop-then-start via the same checkout-resolved
-lifecycle-script delegates.
+lifecycle-script delegates — on launchd this does bootout+bootstrap the job,
+which no longer tears down in-flight sweeps on a current build (every sweep
+runs in its own process group, #5081), though it still cannot apply a plist
+`EnvironmentVariables` change without that reload (#4995).
 
 ### Sweep dispatch on a multi-repo worker host (#4299)
 

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -104,6 +104,21 @@
 #                        a host that needs one or two additional dirs (e.g. a
 #                        project-local toolchain) without inheriting the WHOLE
 #                        invoking shell's interactive PATH.
+#   LOOM_DAEMON_BOOTOUT_SETTLE_SECS  macOS/launchd only (#5081): max seconds to
+#                        poll `launchctl print` after a `bootout`, waiting for
+#                        the old job to actually leave the bootstrap namespace,
+#                        before attempting `bootstrap` (default 5). `bootout`
+#                        is asynchronous; an immediate `bootstrap` can race it
+#                        and fail with "Bootstrap failed: 5: Input/output
+#                        error" even against a valid plist.
+#   LOOM_DAEMON_BOOTSTRAP_RETRY_ATTEMPTS  macOS/launchd only (#5081): max
+#                        `launchctl bootstrap` attempts when it keeps failing
+#                        with that same async-race I/O error (default 4).
+#                        Never retries on any OTHER bootstrap failure (a
+#                        genuinely bad plist/permission problem a retry cannot
+#                        fix).
+#   LOOM_DAEMON_BOOTSTRAP_RETRY_SECS  macOS/launchd only (#5081): seconds to
+#                        sleep between bootstrap retries (default 2).
 #   LOOM_MACHINE_CHECKOUT  Machine mode (Epic #3835 Phase 3b, #4229): set by
 #                        the `scripts/loom` dispatcher to the resolved
 #                        ~/.local/share/loom checkout before it execs this
@@ -220,6 +235,17 @@ fi
 if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/canonical-daemon-path.sh" ]]; then
     # shellcheck source=../lib/canonical-daemon-path.sh
     source "$_LOOM_LAUNCHD_LIB_DIR/canonical-daemon-path.sh"
+fi
+# verify_launchd_env_applied() (#5081) — post-bootstrap check that the
+# launchd job actually reports the freshly-rendered plist's
+# EnvironmentVariables, used by the launchd start path below to catch a
+# "bootstrap succeeded, pid is alive, but the env is somehow still stale"
+# outcome rather than silently reporting success. Shared with
+# loom-daemon-update.sh via lib/daemon-env-harvest.sh (#4581) so both call
+# sites agree on how a plist's env is read back.
+if [[ -r "$_LOOM_LAUNCHD_LIB_DIR/daemon-env-harvest.sh" ]]; then
+    # shellcheck source=../lib/daemon-env-harvest.sh
+    source "$_LOOM_LAUNCHD_LIB_DIR/daemon-env-harvest.sh"
 fi
 
 # resolve_plist_path() — the deterministic PATH baked into every rendered
@@ -1581,18 +1607,51 @@ if [[ "$USE_LAUNCHD" == "true" ]]; then
     # Reload with the freshly-rendered plist every time -- a job left loaded
     # from a prior invocation (possibly with different flags/env) must not
     # silently keep running its OLD definition.
+    #
+    # `launchctl bootout` is ASYNCHRONOUS (#5081): it returns before the
+    # kernel has actually finished tearing the old job down, so an immediate
+    # `bootstrap` can race that teardown and fail with "Bootstrap failed: 5:
+    # Input/output error" (EIO) even though the plist is perfectly valid --
+    # leaving NO job loaded and the daemon down until a retry. (This is
+    # unrelated to whether bootout kills in-flight SWEEPS -- it no longer does,
+    # since #3800 gives every sweep its own process group -- this is purely
+    # about the bootout/bootstrap race on the job itself.) Settle briefly
+    # after bootout (poll `launchctl print` until the job is actually gone,
+    # bounded by LOOM_DAEMON_BOOTOUT_SETTLE_SECS), and retry bootstrap
+    # specifically on that EIO shape (never on other failures, which are
+    # genuine plist/permission problems a retry cannot fix) rather than
+    # reporting a half-applied update.
     if launchctl print "$LAUNCHD_SERVICE" >/dev/null 2>&1; then
         launchctl bootout "$LAUNCHD_SERVICE" >/dev/null 2>&1 || true
+        BOOTOUT_SETTLE_SECS="${LOOM_DAEMON_BOOTOUT_SETTLE_SECS:-5}"
+        _bootout_settle_deadline=$((SECONDS + BOOTOUT_SETTLE_SECS))
+        while launchctl print "$LAUNCHD_SERVICE" >/dev/null 2>&1; do
+            [[ $SECONDS -ge $_bootout_settle_deadline ]] && break
+            sleep 0.2
+        done
     fi
 
     BOOTSTRAP_ERR="$START_LOG.bootstrap-err"
-    if ! launchctl bootstrap "$LAUNCHD_DOMAIN" "$PLIST_FILE" 2>"$BOOTSTRAP_ERR"; then
-        err "launchctl bootstrap failed for $LAUNCHD_SERVICE:"
+    BOOTSTRAP_MAX_ATTEMPTS="${LOOM_DAEMON_BOOTSTRAP_RETRY_ATTEMPTS:-4}"
+    BOOTSTRAP_RETRY_SLEEP_SECS="${LOOM_DAEMON_BOOTSTRAP_RETRY_SECS:-2}"
+    _bootstrap_attempt=0
+    while :; do
+        _bootstrap_attempt=$((_bootstrap_attempt + 1))
+        if launchctl bootstrap "$LAUNCHD_DOMAIN" "$PLIST_FILE" 2>"$BOOTSTRAP_ERR"; then
+            rm -f "$BOOTSTRAP_ERR"
+            break
+        fi
+        if grep -qE '(^|[^0-9])5: Input/output error' "$BOOTSTRAP_ERR" 2>/dev/null \
+            && [[ "$_bootstrap_attempt" -lt "$BOOTSTRAP_MAX_ATTEMPTS" ]]; then
+            warn "launchctl bootstrap hit the async-bootout race (EIO) for $LAUNCHD_SERVICE -- attempt ${_bootstrap_attempt}/${BOOTSTRAP_MAX_ATTEMPTS}, settling ${BOOTSTRAP_RETRY_SLEEP_SECS}s and retrying (#5081)."
+            sleep "$BOOTSTRAP_RETRY_SLEEP_SECS"
+            continue
+        fi
+        err "launchctl bootstrap failed for $LAUNCHD_SERVICE (attempt ${_bootstrap_attempt}/${BOOTSTRAP_MAX_ATTEMPTS}):"
         cat "$BOOTSTRAP_ERR" >&2 2>/dev/null || true
         rm -f "$BOOTSTRAP_ERR"
         exit 1
-    fi
-    rm -f "$BOOTSTRAP_ERR"
+    done
 
     # RunAtLoad=true means bootstrap alone would already start it, but we
     # kickstart -k explicitly anyway so THIS invocation deterministically wins
@@ -1622,6 +1681,26 @@ if [[ "$USE_LAUNCHD" == "true" ]]; then
         warn "If another daemon is already listening on the socket, stop it first"
         warn "(./.loom/scripts/cli/loom-daemon-stop.sh) and retry."
         exit 1
+    fi
+
+    # Post-condition (#5081): a successful bootstrap + a live pid do not, by
+    # themselves, prove the freshly-rendered plist's EnvironmentVariables
+    # actually took effect -- launchd's own "environment = { ... }" block
+    # (from `launchctl print`) is the only authoritative source for what the
+    # running process actually received. Verify it before reporting success,
+    # rather than silently returning a daemon that is alive but still running
+    # under some stale/unexpected env.
+    if declare -f verify_launchd_env_applied >/dev/null 2>&1; then
+        _env_verify_out=$(verify_launchd_env_applied "$LAUNCHD_SERVICE" "$PLIST_FILE" 2>&1)
+        _env_verify_rc=$?
+        if [[ "$_env_verify_rc" -eq 1 ]]; then
+            err "loom-daemon is running (pid ${daemon_pid}) under launchd, but its reported environment does NOT match the freshly-rendered plist -- refusing to report success (#5081)."
+            printf '%s\n' "$_env_verify_out" >&2
+            exit 1
+        elif [[ "$_env_verify_rc" -ne 0 ]]; then
+            warn "Could not verify the running job's env against the plist (plutil/jq unavailable?) -- proceeding, but the env change is unconfirmed:"
+            printf '%s\n' "$_env_verify_out" | while IFS= read -r _line; do warn "  $_line"; done
+        fi
     fi
 
     # Redundant since #4774 -- the daemon claims $PID_FILE itself immediately

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -93,11 +93,24 @@
 # exact #4011 silent-autonomy-loss class this closes. The old advice to bootstrap
 # the EXISTING plist was itself a bug (#4118): it relaunched under the STALE plist
 # (no KeepAlive:SuccessfulExit, no LOOM_DAEMON_SUPERVISOR), so every subsequent
-# roll hit the same exit 6 forever, and its bootout killed in-flight sweeps
-# (sweep children are direct children of the launchd job). --relaunch re-renders
-# via loom-daemon-start.sh (installing the supervised keys) while preserving the
-# live plist's LOOM_* autonomy env, and SIGTERMs the daemon so sweep children
-# reparent instead of being torn down with the job.
+# roll hit the same exit 6 forever. It was ALSO documented (here, through
+# 2026-08-03) as killing in-flight sweeps via bootout tearing down the job tree
+# — that claim is STALE (#5081): since #3800 (2026-07-22) every sweep is spawned
+# as its OWN process group (`Command::process_group(0)`), and launchd's bootout
+# tears down the job's process group specifically, so a detached sweep is never
+# reached by it — it reparents to pid 1 and keeps running. Confirmed both by
+# code (dispatch.rs, `#4980`'s persisted pgid relies on this same fact) and by
+# observation (three bootout+bootstrap cycles on 2026-08-03, #5081). --relaunch
+# is still the recommended path here, but for a DIFFERENT reason: `launchctl
+# bootout` is asynchronous, and a hand-run bootstrap immediately after it can
+# race the still-in-progress teardown and fail with "Bootstrap failed: 5:
+# Input/output error", leaving the daemon down until a retry. --relaunch
+# re-renders via loom-daemon-start.sh (installing the supervised keys) while
+# preserving the live plist's LOOM_* autonomy env; loom-daemon-start.sh's own
+# bootout+bootstrap sequence settles after bootout, retries the bootstrap step
+# on that specific race, and verifies the relaunched job's live pid + reported
+# environment before reporting success (#5081) — a hand-typed bootout+bootstrap
+# gets none of that safety net.
 #
 # systemd --user-managed daemons (Linux, #4260 sub-issue C): the exact same
 # ownership-tiering + supervised-restart contract, ported to the systemd --user
@@ -1837,11 +1850,17 @@ log_systemd_diagnostics() {
 # EXISTING plist. That plist is stale by construction (it is the pre-#4077 file
 # that caused the refused restart) — bootstrapping it relaunches WITHOUT
 # KeepAlive:SuccessfulExit and WITHOUT LOOM_DAEMON_SUPERVISOR, so the next roll
-# refuses identically, forever; and its `launchctl bootout` tears down the whole
-# job tree, killing in-flight sweeps (they are direct children of the launchd
-# job). The correct fix is to RE-RENDER the plist via loom-daemon-start.sh (which
-# hardcodes the two supervised keys), preserving the live plist's autonomy/auth
-# env, and to stop the old daemon gracefully so sweep children reparent.
+# refuses identically, forever. The correct fix is to RE-RENDER the plist via
+# loom-daemon-start.sh (which hardcodes the two supervised keys), preserving
+# the live plist's autonomy/auth env.
+#
+# `launchctl bootout` itself no longer needs to be avoided for sweep safety
+# (#5081): a bare bootout does not kill in-flight sweeps on a current build —
+# see the top-of-file note near #4118 for why. This function still stops the
+# old daemon with a graceful SIGTERM rather than calling bootout directly,
+# both to avoid double-tearing-down the job (loom-daemon-start.sh's own
+# launchd block below already bootouts the loaded job before re-bootstrapping)
+# and so a daemon that predates this fix keeps behaving safely either way.
 
 # harvest_plist_env is defined in lib/daemon-env-harvest.sh (#4581, sourced
 # near the top of this script) — shared with scripts/loom's loom_cmd_restart()
@@ -1873,15 +1892,18 @@ perform_relaunch() {
     done <<< "$harvested"
     echo "Preserved ${count} LOOM_*/token env var(s) from the live plist across the re-render (PATH/HOME/LOOM_DAEMON_SUPERVISOR excluded by design)."
 
-    # 2. Stop the old daemon GRACEFULLY so its sweep children reparent and keep
-    #    working, instead of `launchctl bootout` tearing down the whole job tree.
-    #    kill -TERM makes the daemon exit non-zero, so the stale plist's
-    #    KeepAlive=false does not relaunch it — start.sh below installs the fresh,
-    #    supervised plist and bootstraps the new process.
+    # 2. Stop the old daemon GRACEFULLY with SIGTERM rather than calling
+    #    `launchctl bootout` directly here (bootout itself no longer kills
+    #    in-flight sweeps, #5081 — this is belt-and-braces against a double
+    #    bootout, since loom-daemon-start.sh's launchd block below bootouts the
+    #    loaded job again before re-bootstrapping). kill -TERM makes the daemon
+    #    exit non-zero, so the stale plist's KeepAlive=false does not relaunch
+    #    it — start.sh below installs the fresh, supervised plist and
+    #    bootstraps the new process (with its own settle/retry/verify, #5081).
     local daemon_pid
     daemon_pid=$(launchd_job_pid)
     if [[ -n "$daemon_pid" ]] && kill -0 "$daemon_pid" 2>/dev/null; then
-        echo "Sending SIGTERM to the running daemon (pid ${daemon_pid}) — sweep children reparent and keep working (NOT bootout, which would kill them)."
+        echo "Sending SIGTERM to the running daemon (pid ${daemon_pid}) — sweep children reparent and keep working; in-flight sweeps are not otherwise at risk here (bootout no longer kills them either, #5081)."
         kill -TERM "$daemon_pid" 2>/dev/null || true
         local _waited
         for _waited in 1 2 3 4 5; do
@@ -2280,7 +2302,7 @@ if [[ "$NO_RESTART" == "true" ]]; then
             echo "  $PROVISION_TARGET restart      (graceful: supervised in-place relaunch, in-flight sweeps preserved)"
             echo "If that binary predates #4077 and refuses the restart, re-render + relaunch under supervision:"
             echo "  loom-daemon-update.sh --relaunch   (preserves the live plist's LOOM_* env; SIGTERMs the daemon so sweep children reparent)"
-            echo "Do NOT 'launchctl bootout $LAUNCHD_SERVICE' by hand — bootout tears down the whole job tree and KILLS in-flight sweeps (they are direct children of the launchd job)."
+            echo "'launchctl bootout $LAUNCHD_SERVICE' no longer kills in-flight sweeps on a current build (#5081 — each sweep runs in its own process group and reparents to pid 1), but a hand-run bootout+bootstrap can still race and leave the daemon down (bootout is asynchronous); prefer --relaunch above, which settles/retries/verifies the relaunch safely."
         elif [[ "$DAEMON_MANAGER" == "systemd" ]]; then
             echo "The running (systemd-managed) daemon is still the PRE-update binary. Restart it with:"
             echo "  $PROVISION_TARGET restart      (graceful: supervised in-place relaunch, in-flight sweeps preserved)"
@@ -2375,14 +2397,18 @@ if [[ "$DAEMON_MANAGER" == "launchd" ]]; then
     err "autonomy env — run:"
     err "  loom-daemon-update.sh --relaunch      (or: LOOM_DAEMON_UPDATE_RELAUNCH=1 loom-daemon-update.sh)"
     err ""
-    err "WARNING: do NOT 'launchctl bootout $LAUNCHD_SERVICE' by hand to force this."
-    err "bootout tears down the whole job tree, and in-flight sweep children are DIRECT"
-    err "children of the launchd job, so it TERMINATES every running sweep — stranding"
-    err "loom:building labels and leaving worktrees behind. --relaunch above instead stops"
-    err "the daemon gracefully (SIGTERM) so sweep children reparent and keep working."
-    err "If you must relaunch by hand, prefer the graceful sequence over bootout+bootstrap:"
-    err "  kill -TERM ${daemon_pid_hint:-<daemon-pid>}   # daemon exits non-zero; children reparent; not relaunched (stale plist KeepAlive=false)"
-    err "  $START_SCRIPT                                  # re-render + bootstrap the supervised plist"
+    err "NOTE (#5081): a bare 'launchctl bootout $LAUNCHD_SERVICE' no longer terminates"
+    err "in-flight sweeps on a current build — every sweep runs in its own process group"
+    err "(process_group(0), #3800), which bootout's job-tree teardown does not reach; it"
+    err "reparents to pid 1 and keeps running. --relaunch above is still the recommended"
+    err "path, but for a different reason: hand-running bootout immediately followed by a"
+    err "plain bootstrap can race (bootout is asynchronous) and fail with 'Bootstrap"
+    err "failed: 5: Input/output error', leaving the daemon down until a retry — start.sh"
+    err "settles after bootout, retries on that race, and verifies the relaunched job's"
+    err "live pid + env before reporting success, none of which a hand-typed sequence gets."
+    err "If you must relaunch by hand anyway, prefer the graceful sequence below:"
+    err "  kill -TERM ${daemon_pid_hint:-<daemon-pid>}   # daemon exits non-zero; sweep children reparent regardless; not relaunched (stale plist KeepAlive=false)"
+    err "  $START_SCRIPT                                  # re-render + reload the supervised plist (settles/retries/verifies, #5081)"
     exit 6
 fi
 

--- a/defaults/scripts/lib/daemon-env-harvest.sh
+++ b/defaults/scripts/lib/daemon-env-harvest.sh
@@ -39,6 +39,41 @@
 # Callers decide what "harvest failed" means for them (loom-daemon-update.sh's
 # perform_relaunch/perform_systemd_relaunch treat it as a hard abort; see
 # scripts/loom's loom_cmd_restart() for the equivalent bare-exec-fallback use).
+#
+# Three more functions (#5081) close the OTHER half of the plist-env-change
+# story: after a bootout+bootstrap, prove the freshly-rendered plist's
+# EnvironmentVariables actually took effect, instead of trusting a successful
+# `launchctl bootstrap` + a live pid alone (which says nothing about whether
+# the job's REPORTED env matches what was just written):
+#
+#   extract_launchd_print_env <print_output>
+#     Pure text parser (no `launchctl` call of its own — takes ALREADY-
+#     CAPTURED `launchctl print <service>` output as its one argument, so it
+#     is trivially unit-testable against canned text). Echoes "<key>\t<value>"
+#     lines parsed out of the "environment = { KEY => value ... }" block
+#     `launchctl print` reports for a loaded job — the merged env launchd
+#     actually handed the running process, and the only authoritative source
+#     for "did the new plist's env take effect" (the plist file itself only
+#     says what SHOULD have been applied).
+#
+#   launchd_env_matches_plist <plist> <print_output>
+#     Compares EVERY key in <plist>'s EnvironmentVariables dict (not just the
+#     LOOM_*/token subset harvest_plist_env extracts — this checks the WHOLE
+#     dict, including PATH/HOME/LOOM_DAEMON_SUPERVISOR) against
+#     extract_launchd_print_env's parse of <print_output>. Returns 0 when
+#     every key matches, 1 (with a stderr diagnostic naming the first
+#     missing/mismatched key) otherwise, 2 when plutil/jq are unavailable or
+#     the plist is unparseable — same contract as harvest_plist_env. Takes
+#     the print output as a plain argument (not a live service name) so it,
+#     too, is testable without a real `launchctl`.
+#
+#   verify_launchd_env_applied <service> <plist>
+#     The live wrapper: runs `launchctl print <service>` itself and hands the
+#     result to launchd_env_matches_plist. Returns 1 (with a stderr
+#     diagnostic) when the job cannot even be printed (not loaded/running),
+#     in addition to launchd_env_matches_plist's own return contract. This is
+#     the function loom-daemon-start.sh's launchd path calls as its final
+#     post-bootstrap post-condition.
 
 harvest_plist_env() {
     local plist="$1"
@@ -85,4 +120,66 @@ harvest_unit_env() {
             *) continue ;;
         esac
     done < "$unit_path"
+}
+
+extract_launchd_print_env() {
+    local print_output="$1"
+    printf '%s\n' "$print_output" | awk '
+        /^[[:space:]]*environment = \{/ { in_env=1; next }
+        in_env && /^[[:space:]]*\}[[:space:]]*$/ { in_env=0; next }
+        in_env {
+            line=$0
+            sub(/^[[:space:]]+/, "", line)
+            idx = index(line, " => ")
+            if (idx > 0) {
+                key = substr(line, 1, idx - 1)
+                val = substr(line, idx + 4)
+                print key "\t" val
+            }
+        }
+    '
+}
+
+launchd_env_matches_plist() {
+    local plist="$1" print_output="$2"
+    if [[ ! -f "$plist" ]]; then
+        echo "Cannot verify launchd env: plist not found at $plist" >&2
+        return 2
+    fi
+    if ! command -v plutil >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+        echo "Cannot verify launchd env: plutil and jq are both required on the macOS launchd path." >&2
+        return 2
+    fi
+    local expected_json
+    expected_json=$(plutil -convert json -o - "$plist" 2>/dev/null) || {
+        echo "Cannot verify launchd env: plist at $plist is not parseable by plutil." >&2
+        return 2
+    }
+    local actual_env
+    actual_env="$(extract_launchd_print_env "$print_output")"
+    local key expected_value actual_value mismatches=0
+    while IFS= read -r key; do
+        [[ -z "$key" ]] && continue
+        expected_value=$(printf '%s' "$expected_json" | jq -r --arg k "$key" '.EnvironmentVariables[$k] // ""')
+        if ! actual_value=$(printf '%s\n' "$actual_env" | awk -F'\t' -v k="$key" '$1 == k { print $2; found=1; exit } END { if (!found) exit 1 }'); then
+            echo "launchd env verification: key '${key}' is in the plist but missing from the running job's reported environment." >&2
+            mismatches=$((mismatches + 1))
+            continue
+        fi
+        if [[ "$actual_value" != "$expected_value" ]]; then
+            echo "launchd env verification: key '${key}' expected [${expected_value}] but the running job reports [${actual_value}]." >&2
+            mismatches=$((mismatches + 1))
+        fi
+    done < <(printf '%s' "$expected_json" | jq -r '.EnvironmentVariables // {} | keys[]')
+    [[ "$mismatches" -eq 0 ]]
+}
+
+verify_launchd_env_applied() {
+    local service="$1" plist="$2"
+    local print_output
+    print_output=$(launchctl print "$service" 2>/dev/null) || {
+        echo "Cannot verify launchd env: 'launchctl print ${service}' failed (job not loaded/running)." >&2
+        return 1
+    }
+    launchd_env_matches_plist "$plist" "$print_output"
 }

--- a/defaults/scripts/tests/test-loom-daemon-start.sh
+++ b/defaults/scripts/tests/test-loom-daemon-start.sh
@@ -1438,6 +1438,217 @@ else
     echo "  (skipping real-systemd #4862 regression: no reachable 'systemctl --user' manager on this host)"
 fi
 
+# ===================================================================
+# Real launchd bootout+bootstrap path (#5081): settle/retry on the async
+# EIO race ("Bootstrap failed: 5: Input/output error"), and a post-bootstrap
+# check that the running job's REPORTED env actually matches the
+# freshly-rendered plist. Only meaningful on Darwin (the launchd path is
+# Darwin-gated). `LOOM_LAUNCHD_DOMAIN` is pinned so resolve_launchd_domain()
+# never probes `launchctl print gui/<uid>` itself, and HOME is sandboxed so
+# the rendered plist never lands in the operator's real
+# ~/Library/LaunchAgents -- this suite must never touch real launchd state.
+# ===================================================================
+if [[ "$(uname -s)" == "Darwin" ]]; then
+
+LD5081_LABEL="com.example.loom-sandbox-5081-$$"
+LD5081_DOMAIN="user/$(id -u)"
+LD5081_SERVICE="${LD5081_DOMAIN}/${LD5081_LABEL}"
+
+# write_smart_launchd_bin <bin_dir> <bootstrap_log> <state_dir> <eio_failures> <mismatch:0|1>
+#
+# A launchctl stub that reflects a REAL bootstrap outcome instead of a
+# hardcoded fake: `bootstrap` records the plist path it was handed (and, for
+# the first <eio_failures> calls, fails with the EXACT text real launchd
+# reports for the #5081 async race); `print` — for OUR service only — reports
+# a REAL backgrounded process's pid (read from <state_dir>/real.pid, so the
+# script's own `kill -0` liveness check succeeds) plus an
+# "environment = { KEY => value ... }" block built from the LAST bootstrapped
+# plist via plutil+jq, mirroring real `launchctl print` output byte-for-byte
+# closely enough for extract_launchd_print_env to parse. <mismatch>=1
+# corrupts the reported LOOM_SOCKET_PATH value so a verification-FAILURE path
+# can be exercised. Any OTHER service (e.g. the watchdog's own label) reports
+# "not loaded" (print exits 1); bootout/kickstart are unconditional no-ops
+# for every service.
+write_smart_launchd_bin() {
+    local bin_dir="$1" bootstrap_log="$2" state_dir="$3" eio_failures="$4" mismatch="${5:-0}"
+    mkdir -p "$bin_dir" "$state_dir"
+    : > "$bootstrap_log"
+    echo 0 > "$state_dir/bootstrap-attempts"
+    rm -f "$state_dir/bootstrapped-plist-path"
+    cat > "$bin_dir/launchctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "${bootstrap_log}"
+service_arg="\${2:-}"
+case "\${1:-}" in
+  print)
+    if [[ "\$service_arg" == "${LD5081_SERVICE}" && -f "${state_dir}/bootstrapped-plist-path" ]]; then
+      plist_path="\$(cat "${state_dir}/bootstrapped-plist-path")"
+      real_pid="\$(cat "${state_dir}/real.pid" 2>/dev/null)"
+      echo "	pid = \${real_pid}"
+      echo "	environment = {"
+      if [[ "${mismatch}" == "1" ]]; then
+        plutil -convert json -o - "\$plist_path" 2>/dev/null | jq -r '.EnvironmentVariables // {} | to_entries[] | "\t\t" + .key + " => " + (.value|tostring)' | awk -F' => ' -v OFS=' => ' '{ if (\$1 ~ /LOOM_SOCKET_PATH\$/) { \$2 = "WRONG-VALUE-INJECTED-BY-TEST" }; print }'
+      else
+        plutil -convert json -o - "\$plist_path" 2>/dev/null | jq -r '.EnvironmentVariables // {} | to_entries[] | "\t\t" + .key + " => " + (.value|tostring)'
+      fi
+      echo "	}"
+      exit 0
+    fi
+    exit 1
+    ;;
+  bootout)
+    rm -f "${state_dir}/bootstrapped-plist-path"
+    exit 0
+    ;;
+  bootstrap)
+    plist_path="\$3"
+    attempts="\$(cat "${state_dir}/bootstrap-attempts" 2>/dev/null || echo 0)"
+    attempts=\$((attempts + 1))
+    echo "\$attempts" > "${state_dir}/bootstrap-attempts"
+    if [[ "\$attempts" -le "${eio_failures}" ]]; then
+      echo "Bootstrap failed: 5: Input/output error" >&2
+      exit 5
+    fi
+    echo "\$plist_path" > "${state_dir}/bootstrapped-plist-path"
+    exit 0
+    ;;
+  kickstart) exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+    chmod +x "$bin_dir/launchctl"
+}
+
+LD5081_FAKE_BIN="$WORKDIR/fake-loom-daemon-5081"
+cat > "$LD5081_FAKE_BIN" <<'EOF'
+#!/usr/bin/env bash
+sleep 60
+EOF
+chmod +x "$LD5081_FAKE_BIN"
+
+# T1. Clean bootstrap (no EIO race) -> exits 0, env verification passes
+#     against the real, freshly-rendered plist.
+LD1_HOME="$WORKDIR/ld1-home"
+LD1_BIN="$WORKDIR/ld1-launchctl-bin"
+LD1_STATE="$WORKDIR/ld1-state"
+mkdir -p "$LD1_HOME"
+write_smart_launchd_bin "$LD1_BIN" "$WORKDIR/ld1.log" "$LD1_STATE" 0 0
+sleep 60 >/dev/null 2>&1 &
+LD1_REAL_PID=$!
+bg_proc_track "$LD1_REAL_PID"
+echo "$LD1_REAL_PID" > "$LD1_STATE/real.pid"
+out1=$( PATH="$LD1_BIN:$PATH" HOME="$LD1_HOME" LOOM_DAEMON_BIN="$LD5081_FAKE_BIN" \
+    LOOM_LAUNCHD_LABEL="$LD5081_LABEL" LOOM_LAUNCHD_DOMAIN="$LD5081_DOMAIN" \
+    LOOM_SOCKET_PATH="$LD1_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$LD1_HOME/.loom/autonomy-desired" \
+    LOOM_WATCHDOG_LABEL="com.example.loom-sandbox-5081-wd-$$" \
+    bash "$START_SCRIPT" 2>&1 )
+rc1=$?
+kill "$LD1_REAL_PID" 2>/dev/null || true
+assert_eq "0" "$rc1" "launchd path (#5081): clean bootstrap + matching env -> exit 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$rc1" -eq 0 ]] && ! echo "$out1" | grep -qi 'does NOT match'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} launchd path (#5081): env verification passes against the real rendered plist"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} launchd path (#5081): env verification passes against the real rendered plist"
+    echo "  output: $out1"
+fi
+
+# T2. Bootstrap fails with the EIO race exactly once, then succeeds on retry
+#     -> exit 0, and the output names the retry.
+LD2_HOME="$WORKDIR/ld2-home"
+LD2_BIN="$WORKDIR/ld2-launchctl-bin"
+LD2_STATE="$WORKDIR/ld2-state"
+mkdir -p "$LD2_HOME"
+write_smart_launchd_bin "$LD2_BIN" "$WORKDIR/ld2.log" "$LD2_STATE" 1 0
+sleep 60 >/dev/null 2>&1 &
+LD2_REAL_PID=$!
+bg_proc_track "$LD2_REAL_PID"
+echo "$LD2_REAL_PID" > "$LD2_STATE/real.pid"
+out2=$( PATH="$LD2_BIN:$PATH" HOME="$LD2_HOME" LOOM_DAEMON_BIN="$LD5081_FAKE_BIN" \
+    LOOM_LAUNCHD_LABEL="$LD5081_LABEL" LOOM_LAUNCHD_DOMAIN="$LD5081_DOMAIN" \
+    LOOM_SOCKET_PATH="$LD2_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$LD2_HOME/.loom/autonomy-desired" \
+    LOOM_WATCHDOG_LABEL="com.example.loom-sandbox-5081-wd-$$" \
+    LOOM_DAEMON_BOOTSTRAP_RETRY_SECS=0 \
+    bash "$START_SCRIPT" 2>&1 )
+rc2=$?
+kill "$LD2_REAL_PID" 2>/dev/null || true
+assert_eq "0" "$rc2" "launchd path (#5081): one EIO bootstrap failure, retry succeeds -> exit 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out2" | grep -qi 'async-bootout race' && echo "$out2" | grep -q 'attempt 1/'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} launchd path (#5081): EIO retry is logged"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} launchd path (#5081): EIO retry is logged"
+    echo "  output: $out2"
+fi
+
+# T3. Bootstrap keeps failing with the EIO race past the retry ceiling ->
+#     exit 1, loudly, and NEVER a false "started" success.
+LD3_HOME="$WORKDIR/ld3-home"
+LD3_BIN="$WORKDIR/ld3-launchctl-bin"
+LD3_STATE="$WORKDIR/ld3-state"
+mkdir -p "$LD3_HOME"
+write_smart_launchd_bin "$LD3_BIN" "$WORKDIR/ld3.log" "$LD3_STATE" 99 0
+out3=$( PATH="$LD3_BIN:$PATH" HOME="$LD3_HOME" LOOM_DAEMON_BIN="$LD5081_FAKE_BIN" \
+    LOOM_LAUNCHD_LABEL="$LD5081_LABEL" LOOM_LAUNCHD_DOMAIN="$LD5081_DOMAIN" \
+    LOOM_SOCKET_PATH="$LD3_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$LD3_HOME/.loom/autonomy-desired" \
+    LOOM_WATCHDOG_LABEL="com.example.loom-sandbox-5081-wd-$$" \
+    LOOM_DAEMON_BOOTSTRAP_RETRY_ATTEMPTS=2 LOOM_DAEMON_BOOTSTRAP_RETRY_SECS=0 \
+    bash "$START_SCRIPT" 2>&1 )
+rc3=$?
+assert_eq "1" "$rc3" "launchd path (#5081): EIO race persists past the retry ceiling -> exit 1"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out3" | grep -qi 'bootstrap failed' && ! echo "$out3" | grep -qi 'started under launchd'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} launchd path (#5081): exhausted EIO retries never report a false success"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} launchd path (#5081): exhausted EIO retries never report a false success"
+    echo "  output: $out3"
+fi
+
+# T4. Bootstrap + kickstart succeed, pid is alive, but the running job's
+#     REPORTED env does not match the freshly-rendered plist -> exit 1, named
+#     as an env mismatch (#5081's "never silently return a wrong env" AC),
+#     never a false "started" success either.
+LD4_HOME="$WORKDIR/ld4-home"
+LD4_BIN="$WORKDIR/ld4-launchctl-bin"
+LD4_STATE="$WORKDIR/ld4-state"
+mkdir -p "$LD4_HOME"
+write_smart_launchd_bin "$LD4_BIN" "$WORKDIR/ld4.log" "$LD4_STATE" 0 1
+sleep 60 >/dev/null 2>&1 &
+LD4_REAL_PID=$!
+bg_proc_track "$LD4_REAL_PID"
+echo "$LD4_REAL_PID" > "$LD4_STATE/real.pid"
+out4=$( PATH="$LD4_BIN:$PATH" HOME="$LD4_HOME" LOOM_DAEMON_BIN="$LD5081_FAKE_BIN" \
+    LOOM_LAUNCHD_LABEL="$LD5081_LABEL" LOOM_LAUNCHD_DOMAIN="$LD5081_DOMAIN" \
+    LOOM_SOCKET_PATH="$LD4_HOME/.loom/loom-daemon.sock" \
+    LOOM_AUTONOMY_MARKER="$LD4_HOME/.loom/autonomy-desired" \
+    LOOM_WATCHDOG_LABEL="com.example.loom-sandbox-5081-wd-$$" \
+    bash "$START_SCRIPT" 2>&1 )
+rc4=$?
+kill "$LD4_REAL_PID" 2>/dev/null || true
+assert_eq "1" "$rc4" "launchd path (#5081): env mismatch after a successful bootstrap -> exit 1"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out4" | grep -qi 'does NOT match' && echo "$out4" | grep -qi 'LOOM_SOCKET_PATH' && ! echo "$out4" | grep -qi 'started under launchd'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} launchd path (#5081): env mismatch is named and never reported as a false success"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} launchd path (#5081): env mismatch is named and never reported as a false success"
+    echo "  output: $out4"
+fi
+
+else
+    echo "  (skipping real launchd bootout/bootstrap #5081 regression: not running on Darwin)"
+fi
+
 # ---------- summary ----------
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -1620,8 +1620,12 @@ fi
 #     socket). Without --relaunch the updater must exit NON-ZERO (6) and print
 #     the CORRECTED fallback: it names the `--relaunch` re-render path (NOT a
 #     bare `launchctl bootstrap` of the stale plist, which was the #4118 bug),
-#     warns that `launchctl bootout` terminates in-flight sweeps (AC4), and
-#     prefers a graceful `kill -TERM`.
+#     mentions `launchctl bootout` and a graceful `kill -TERM` (AC4) — as of
+#     #5081, bootout no longer terminates in-flight sweeps on a current build
+#     (every sweep holds its own process group, #3800), so the warning is now
+#     about the async bootout/bootstrap race leaving the daemon down, not
+#     about sweep safety; `kill -TERM` is still named as the graceful,
+#     settled/retried/verified path.
 # ============================================================
 W16="$BASE_WORKDIR/w16"
 new_fixture "$W16"
@@ -1652,15 +1656,17 @@ else
     echo -e "${RED}✗${NC} refused restart names --relaunch, never a bare bootstrap of the stale plist"
     echo "  output: $out16"
 fi
-# (b) AC4: warns that bootout terminates in-flight sweeps + prefers kill -TERM.
+# (b) AC4: mentions bootout + sweeps (the #5081-corrected framing: bootout no
+#     longer kills in-flight sweeps, but hand-running it can still race the
+#     async teardown) and still prefers a graceful `kill -TERM` fallback.
 TESTS_RUN=$((TESTS_RUN + 1))
 if echo "$out16" | grep -qi 'bootout' && echo "$out16" | grep -qi 'sweep' \
     && echo "$out16" | grep -q 'kill -TERM'; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "${GREEN}✓${NC} refused restart warns bootout kills in-flight sweeps + prefers kill -TERM (AC4)"
+    echo -e "${GREEN}✓${NC} refused restart mentions bootout+sweeps (#5081-corrected) + prefers kill -TERM (AC4)"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "${RED}✗${NC} refused restart warns bootout kills in-flight sweeps + prefers kill -TERM (AC4)"
+    echo -e "${RED}✗${NC} refused restart mentions bootout+sweeps (#5081-corrected) + prefers kill -TERM (AC4)"
     echo "  output: $out16"
 fi
 
@@ -1875,7 +1881,10 @@ fi # end plutil-availability guard for scenarios 21-22
 # ============================================================
 # 23. --no-restart on a launchd host does NOT print a bare `launchctl bootstrap`
 #     of the stale plist (the second #4118 stale-advice site): it names the
-#     --relaunch re-render path and warns that bootout kills in-flight sweeps.
+#     --relaunch re-render path and mentions bootout + sweeps (#5081-corrected
+#     framing: bootout no longer kills in-flight sweeps on a current build,
+#     but the async bootout/bootstrap race is still a reason to prefer
+#     --relaunch's settled/retried/verified sequence over a hand-run one).
 # ============================================================
 W23="$BASE_WORKDIR/w23"
 new_fixture "$W23"
@@ -1898,10 +1907,10 @@ if echo "$out23" | grep -q -- '--relaunch' \
     && ! echo "$out23" | grep -qi 'launchctl bootstrap' \
     && echo "$out23" | grep -qi 'bootout' && echo "$out23" | grep -qi 'sweep'; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "${GREEN}✓${NC} --no-restart names --relaunch, no bare bootstrap, warns bootout kills sweeps"
+    echo -e "${GREEN}✓${NC} --no-restart names --relaunch, no bare bootstrap, mentions bootout+sweeps (#5081-corrected)"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "${RED}✗${NC} --no-restart names --relaunch, no bare bootstrap, warns bootout kills sweeps"
+    echo -e "${RED}✗${NC} --no-restart names --relaunch, no bare bootstrap, mentions bootout+sweeps (#5081-corrected)"
     echo "  output: $out23"
 fi
 


### PR DESCRIPTION
## Summary

- Corrects a now-stale in-repo claim that `launchctl bootout` kills in-flight sweeps: since #3800 every sweep is spawned in its own process group (`process_group(0)`, also relied on by #4982's pgid-based reaping), so bootout's job-tree teardown never reaches a detached sweep — it reparents to pid 1 and keeps running. Confirmed against the code and against the three-cycle observation in #5081.
- Adds a supported, tested procedure for applying a plist env change without the daemon going down on a race: `loom-daemon-start.sh`'s launchd bootout+bootstrap sequence now settles after bootout, retries the bootstrap step specifically on the async `Bootstrap failed: 5: Input/output error` race, and verifies the relaunched job's live pid + reported `EnvironmentVariables` before reporting success.
- Updates the tests that assert on the (previously stale) warning text so the docs and the tests agree.

## Changes

- `defaults/scripts/cli/loom-daemon-update.sh` — corrects the three comment/warning sites (`#4118` top-of-file note, `perform_relaunch()` doc comment + in-function comments, `--no-restart`/refused-restart warning text) to state the accurate, current reasoning: bootout no longer kills in-flight sweeps, but a hand-run bootout immediately followed by bootstrap can still race and leave the daemon down — `--relaunch` remains the recommended path because it drives `loom-daemon-start.sh`'s settled/retried/verified sequence instead of a raw bootout+bootstrap.
- `defaults/scripts/cli/loom-daemon-start.sh` — new `LOOM_DAEMON_BOOTOUT_SETTLE_SECS` (default 5), `LOOM_DAEMON_BOOTSTRAP_RETRY_ATTEMPTS` (default 4), `LOOM_DAEMON_BOOTSTRAP_RETRY_SECS` (default 2) env knobs (documented in the `--help` banner); the launchd bootout+bootstrap block now polls `launchctl print` until the old job is actually gone (bounded settle) before bootstrapping, and retries bootstrap only on the exact async-race `EIO` failure text (never on any other bootstrap failure, which is a genuine plist/permission problem a retry cannot fix); a new post-bootstrap post-condition calls `verify_launchd_env_applied` and refuses to report success if the running job's reported env does not match the freshly-rendered plist.
- `defaults/scripts/lib/daemon-env-harvest.sh` — three new functions: `extract_launchd_print_env` (pure text parser of `launchctl print` output, unit-testable against canned text), `launchd_env_matches_plist` (compares every key in a plist's `EnvironmentVariables` against parsed `launchctl print` output), and `verify_launchd_env_applied` (the live wrapper `loom-daemon-start.sh` calls).
- `defaults/scripts/tests/test-loom-daemon-start.sh` — new real-launchd-stub regression suite (Darwin-gated, sandboxed `HOME`/`LOOM_LAUNCHD_DOMAIN`) covering: clean bootstrap + passing env verification; one EIO failure then a successful retry; EIO race persisting past the retry ceiling (exit 1, never a false success); and a successful bootstrap with a mismatched running env (exit 1, names the mismatched key, never a false success).
- `defaults/scripts/tests/test-loom-daemon-update.sh` — updates the descriptive comments/echo text on the two launchd-refused-restart tests (AC4, `--no-restart`) that previously asserted "warns bootout kills in-flight sweeps" to the corrected framing; the underlying grep assertions were already substring-based and continue to hold against the corrected script output (verified: 216/216 passing before and after).
- `defaults/docs/daemon-reference.md`, `defaults/docs/machine-dispatcher.md` — the equivalent operator-doc claims corrected to match the code, and the new settle/retry/verify behavior documented.

## Acceptance Criteria Verification

- [x] The in-repo claim about bootout and in-flight sweeps matches observed behaviour on a current build — corrected in all 3 script comment sites + the 2 operator docs that restated it, backed by the code (`process_group(0)` since #3800/#4982) and the observed reparenting-to-pid-1 behavior described in the issue.
- [x] A documented, tested procedure exists for changing a plist env var, and it does not leave the daemon down on a race — `--relaunch` → `loom-daemon-start.sh`'s settle+retry+verify sequence, documented in both scripts' comment banners and `daemon-reference.md`, covered by the new 4-scenario test suite in `test-loom-daemon-start.sh`.
- [x] Any bootout+bootstrap in tooling settles/retries and verifies a running pid with the expected env — implemented in `loom-daemon-start.sh`'s launchd start block.
- [x] Tests asserting the stale warning are updated in the same change — `test-loom-daemon-update.sh`'s two launchd-warning tests reworded to the corrected framing; `test-loom-daemon-start.sh` gets the new settle/retry/verify regression suite.

## Test Plan

- `bash defaults/scripts/tests/test-loom-daemon-start.sh` — 80/80 passed (includes the 8 new `#5081` launchd bootout+bootstrap scenarios).
- `bash defaults/scripts/tests/test-loom-daemon-update.sh` — 216/216 passed (before and after the descriptive-text edits, confirming the grep assertions still hold against the corrected wording).
- `shellcheck -x` on all 3 modified/added `.sh` library/CLI files — no new warnings versus the `origin/main` baseline (pre-existing `SC2329`/`SC1091` info-level notices only).

Closes #5081
