### PR TITLE
fix(mcp-loom): update config-resolver fixture path after loom-tools deletion

### DIFF
--- a/mcp-loom/src/shared/config-resolver.test.ts
+++ b/mcp-loom/src/shared/config-resolver.test.ts
@@ -37,7 +37,8 @@ const CONFORMANCE_FIXTURE_DIR = join(
   "..",
   "..",
   "..",
-  "loom-tools",
+  "defaults",
+  "scripts",
   "tests",
   "fixtures",
   "config_resolver"


### PR DESCRIPTION
## Summary

Updates the hardcoded fixture path in the MCP config-resolver conformance test to reference the new location after PR #4971 deleted the `loom-tools/` package and relocated fixtures to `defaults/scripts/tests/fixtures/config_resolver/`.

## Changes

- Changed path segments in `mcp-loom/src/shared/config-resolver.test.ts` from `["..","..","..","loom-tools","tests","fixtures","config_resolver"]` to `["..","..","..","defaults","scripts","tests","fixtures","config_resolver"]`

## Acceptance Criteria Verification

- [x] Cross-language conformance test passes (was failing before this fix)
- [x] All 51 mcp-loom tests pass
- [x] Build completes successfully
- [x] Fixture location verified at new path

## Test Plan

```bash
cd mcp-loom
npm install
npm run build
npm test  # All 51 tests pass, including cross-language conformance
```

Closes #5108