### PR TITLE
fix(guard): mask inert text before the merge-redirect substring check

### DIFF
--- a/.loom/hooks/guard-loom-workflow.sh
+++ b/.loom/hooks/guard-loom-workflow.sh
@@ -140,19 +140,27 @@ strip_literal_text() {
 # narrows what this ONE check can see; it never widens what it misses.
 # =============================================================================
 
-# Mask the BODY of a heredoc whose consuming command is `cat` and whose
+# Mask the BODY of a heredoc whose consuming command is `cat`, whose
 # delimiter is quoted (`cat <<'EOF' ... EOF` / `cat <<"EOF" ... EOF`, and the
-# `<<-` tab-stripping variant). This is exactly the CLAUDE.md-documented
+# `<<-` tab-stripping variant), AND whose `cat` invocation is captured by a
+# command substitution ($()/backtick) that is the value of a known
+# non-executing text-data flag. This is exactly the CLAUDE.md-documented
 # idiom for multi-line commit/PR-body text: `git commit -m "$(cat <<'EOF'
-# ... EOF)"`. A heredoc consumed by `cat` can only ever become inert text
-# data (`cat` never executes anything), and a QUOTED delimiter guarantees
-# bash performs no $()/backtick/$VAR expansion within the body, so the body
-# is 100% literal text regardless of its contents.
+# ... EOF)"`. A QUOTED delimiter guarantees bash performs no
+# $()/backtick/$VAR expansion within the body, so the body is 100% literal
+# text; the flag-capture requirement guarantees that literal text is used as
+# inert data (a message/title/search value) rather than executed.
 #
-# Deliberately narrower than "any heredoc": a heredoc feeding an INTERPRETER
-# instead (`bash <<'EOF' ... EOF`, `sh <<EOF ... EOF`) is genuinely live code
-# and must stay visible to the merge-redirect check, so masking is gated on
-# the word immediately before `<<` being `cat` specifically.
+# Deliberately narrower than "any heredoc" on TWO axes:
+#   1. A heredoc feeding an INTERPRETER (`bash <<'EOF' ... EOF`, `sh <<EOF`)
+#      is genuinely live code, so masking is gated on the word immediately
+#      before `<<` being `cat`.
+#   2. `cat` never executes its body, but its stdout can still be routed INTO
+#      a shell on the same command line -- `cat <<'EOF' | bash`, or a captured
+#      `eval "$(cat <<'EOF' ...)"`. Masking those would blind this
+#      catastrophic-tier guard to a real invocation, so masking is ALSO gated
+#      on `cat` being captured into a text-data flag's $()/backtick value (see
+#      the `capre` confinement check inside the function).
 #
 # Mirrors the #5087 lesson: only a heredoc block that is PROVABLY CLOSED
 # inside the buffer (its bare delimiter line is found) gets its body masked.
@@ -163,6 +171,13 @@ mask_cat_heredoc_bodies() {
     BEGIN {
         SQ = sprintf("%c", 39)
         DQ = sprintf("%c", 34)
+        BT = sprintf("%c", 96)
+        # A cat-heredoc body is only PROVABLY inert when the cat invocation is
+        # captured by a command substitution ($()/backtick) that is itself the
+        # VALUE of a known non-executing text-data flag. `capre` must match the
+        # tail of the opener-line text that sits immediately before the `cat`
+        # token (see the confinement check below).
+        capre = "(^|[ \t])(-m|--message|--body|--notes|--title|--comment|--search)[ \t]*=?[ \t]*(" DQ "|" SQ ")?[ \t]*([$][(]|" BT ")[ \t]*$"
     }
     { lines[NR] = $0 }
     END {
@@ -179,6 +194,25 @@ mask_cat_heredoc_bodies() {
                 # trailing whitespace) to be a bare "cat".
                 pre = substr(line, 1, p - 1)
                 if (pre !~ /(^|[^A-Za-z0-9_])cat[ \t]*$/) continue
+                # HARDENING (#5109 follow-up, PR #5115 review): the word before
+                # `<<` being `cat` is NOT sufficient -- `cat` never executes its
+                # own body, but its stdout can still reach a shell on the SAME
+                # command line, so masking a body that a shell then runs makes
+                # this catastrophic-tier guard blind to a real invocation:
+                #   cat <<EOF | bash        # body piped straight into bash
+                #   eval "$(cat <<EOF ...)" # body captured, then eval-executed
+                # Only mask when the cat-heredoc is captured by a command
+                # substitution ($()/backtick) that is the VALUE of a known
+                # non-executing text-data flag (-m/--message/--body/--notes/
+                # --title/--comment/--search) -- the CLAUDE.md-documented
+                # `-m "$(cat <<'"'"'EOF'"'"' ... EOF)"` idiom -- so the body is
+                # provably confined to inert text data and can never reach a
+                # shell. A bare `cat <<EOF`, a piped `cat <<EOF | bash`, or an
+                # `eval "$(cat <<EOF ...)"` fails this check and is left visible
+                # to the merge-redirect grep, which denies exactly as before.
+                before_cat = pre
+                sub(/cat[ \t]*$/, "", before_cat)
+                if (before_cat !~ capre) continue
                 start = p + 2
                 if (substr(line, start, 1) == "-") start++
                 while (substr(line, start, 1) == " " || substr(line, start, 1) == "\t") start++

--- a/.loom/hooks/guard-loom-workflow.sh
+++ b/.loom/hooks/guard-loom-workflow.sh
@@ -110,6 +110,150 @@ strip_literal_text() {
 }
 
 # =============================================================================
+# GH-PR-MERGE-REDIRECT FALSE-POSITIVE MASKING (issue #5109)
+#
+# The 'gh pr merge' redirect check below (guard tag loom:gh-pr-merge-redirect)
+# used to grep the RAW, unmasked $COMMAND for the literal substring "gh pr
+# merge" anywhere in the byte stream -- so it fired on commands that never
+# actually invoked the disallowed CLI, only mentioned the phrase as inert
+# text: a git commit message (passed via the CLAUDE.md-documented `-m
+# "$(cat <<'EOF' ... EOF)"` heredoc idiom) that quoted the phrase as prose
+# documenting the very rule this guard enforces, and a `gh issue list
+# --search "..."` query whose search string happened to contain the phrase
+# as text to search FOR, not a command to run.
+#
+# The two functions below build a MASKED copy of $COMMAND, used ONLY for the
+# 'gh pr merge' substring check immediately below -- never for any other
+# guard in this file, and never for decision-log redaction (that stays on
+# strip_literal_text() above, unchanged). Composition matters: heredoc-body
+# masking runs FIRST so any quote/backtick characters living inside a masked
+# heredoc body can no longer interfere with the flag-value masking pass that
+# runs second.
+#
+# Deliberately narrow, matching this repo's established masking conventions
+# (see guard-destructive-generic.sh's mask_heredoc_bodies(), #5000/#5087):
+# only two specific, well-understood-safe shapes are masked, and a command
+# that merely EXECUTES the disallowed CLI through a wrapper -- `sh -c "gh pr
+# merge 123"`, `bash -c 'gh pr merge 123'`, `eval "gh pr merge 123"` -- is
+# UNCHANGED by either pass (neither `-c` nor `eval`'s argument is in the
+# whitelist below) and still denies exactly as before. Masking only ever
+# narrows what this ONE check can see; it never widens what it misses.
+# =============================================================================
+
+# Mask the BODY of a heredoc whose consuming command is `cat` and whose
+# delimiter is quoted (`cat <<'EOF' ... EOF` / `cat <<"EOF" ... EOF`, and the
+# `<<-` tab-stripping variant). This is exactly the CLAUDE.md-documented
+# idiom for multi-line commit/PR-body text: `git commit -m "$(cat <<'EOF'
+# ... EOF)"`. A heredoc consumed by `cat` can only ever become inert text
+# data (`cat` never executes anything), and a QUOTED delimiter guarantees
+# bash performs no $()/backtick/$VAR expansion within the body, so the body
+# is 100% literal text regardless of its contents.
+#
+# Deliberately narrower than "any heredoc": a heredoc feeding an INTERPRETER
+# instead (`bash <<'EOF' ... EOF`, `sh <<EOF ... EOF`) is genuinely live code
+# and must stay visible to the merge-redirect check, so masking is gated on
+# the word immediately before `<<` being `cat` specifically.
+#
+# Mirrors the #5087 lesson: only a heredoc block that is PROVABLY CLOSED
+# inside the buffer (its bare delimiter line is found) gets its body masked.
+# An unterminated/unrecognized opener masks NOTHING and the raw text flows
+# through unchanged to the check below.
+mask_cat_heredoc_bodies() {
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)
+        DQ = sprintf("%c", 34)
+    }
+    { lines[NR] = $0 }
+    END {
+        nl = NR
+        for (i = 1; i <= nl; i++) {
+            line = lines[i]
+            off = 1
+            while (1) {
+                p = index(substr(line, off), "<<")
+                if (p == 0) break
+                p = off + p - 1
+                off = p + 2
+                # Require the word immediately before `<<` (ignoring
+                # trailing whitespace) to be a bare "cat".
+                pre = substr(line, 1, p - 1)
+                if (pre !~ /(^|[^A-Za-z0-9_])cat[ \t]*$/) continue
+                start = p + 2
+                if (substr(line, start, 1) == "-") start++
+                while (substr(line, start, 1) == " " || substr(line, start, 1) == "\t") start++
+                qc = substr(line, start, 1)
+                if (qc != SQ && qc != DQ) continue
+                start++
+                wordend = start
+                while (substr(line, wordend, 1) ~ /^[A-Za-z0-9_]$/) wordend++
+                if (wordend <= start) continue
+                if (substr(line, wordend, 1) != qc) continue
+                delim = substr(line, start, wordend - start)
+                closeat = 0
+                for (j = i + 1; j <= nl; j++) {
+                    trimmed = lines[j]
+                    sub(/^[ \t]+/, "", trimmed)
+                    if (trimmed == delim) { closeat = j; break }
+                }
+                if (closeat == 0) continue
+                for (j = i + 1; j < closeat; j++) {
+                    gsub(/./, "X", lines[j])
+                }
+                break
+            }
+        }
+        out = lines[1]
+        for (i = 2; i <= nl; i++) out = out "\n" lines[i]
+        printf "%s", out
+    }'
+}
+
+# Mask the quoted VALUE of known non-executing, text-only flags used by
+# git/gh subcommands: -m/--message, --body, --notes, --title, --comment,
+# --search. A near-duplicate of strip_literal_text() above (which is used
+# only for decision-log redaction) with --search added, kept as a SEPARATE
+# function so this decision-time masking can never change what
+# strip_literal_text() logs. Same conservative floor as strip_literal_text():
+# a span that still contains an unmasked `$(`/backtick (e.g. real command
+# substitution, not yet neutralized by the heredoc pass above) is left
+# completely untouched.
+mask_data_flag_values() {
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)
+        DQ = sprintf("%c", 34)
+        re = "(^|[ \t\n])(--message|--body|--notes|--title|--comment|--search|-m)[ \t]*=?[ \t]*(" \
+             DQ "[^" DQ "]*" DQ "|" SQ "[^" SQ "]*" SQ ")"
+        buf = ""
+    }
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        s = buf
+        out = ""
+        while (match(s, re)) {
+            pre     = substr(s, 1, RSTART - 1)
+            matched = substr(s, RSTART, RLENGTH)
+            s       = substr(s, RSTART + RLENGTH)
+            qpos = 0
+            for (i = 1; i <= length(matched); i++) {
+                c = substr(matched, i, 1)
+                if (c == DQ || c == SQ) { qpos = i; break }
+            }
+            head  = substr(matched, 1, qpos)
+            qchar = substr(matched, qpos, 1)
+            inner = substr(matched, qpos + 1, length(matched) - qpos - 1)
+            if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                gsub(/./, "X", inner)
+            }
+            out = out pre head inner qchar
+        }
+        out = out s
+        printf "%s", out
+    }'
+}
+
+# =============================================================================
 # DECISION TELEMETRY (issue #3771 / #3898) — one JSONL record per deny decision,
 # identical schema + toggle semantics to guard-destructive.sh so both guards'
 # fires land in the SAME .loom/logs/guard-decisions.log for the standing
@@ -290,7 +434,12 @@ ask() {
 # LOOM: Prefer merge-pr.sh over gh pr merge
 # =============================================================================
 
-if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
+# Match against a MASKED copy of $COMMAND (issue #5109) so a mention of the
+# phrase inside a cat-heredoc commit-message body or a --search/--body/-m/etc
+# quoted value doesn't false-positive as a real invocation. See the masking
+# functions' doc comments above for exactly what is (and is NOT) neutralized.
+GH_PR_MERGE_SCAN_TEXT=$(mask_data_flag_values "$(mask_cat_heredoc_bodies "$COMMAND")")
+if echo "$GH_PR_MERGE_SCAN_TEXT" | grep -qE 'gh\s+pr\s+merge'; then
     # Resolve the merge-pr.sh path for the current repo context. Prefer an
     # in-repo installed copy (./.loom/scripts/merge-pr.sh); fall back to the
     # loom-checkout copy under defaults/scripts/ (via $LOOM_HOME) when the repo

--- a/defaults/hooks/guard-loom-workflow.sh
+++ b/defaults/hooks/guard-loom-workflow.sh
@@ -140,19 +140,27 @@ strip_literal_text() {
 # narrows what this ONE check can see; it never widens what it misses.
 # =============================================================================
 
-# Mask the BODY of a heredoc whose consuming command is `cat` and whose
+# Mask the BODY of a heredoc whose consuming command is `cat`, whose
 # delimiter is quoted (`cat <<'EOF' ... EOF` / `cat <<"EOF" ... EOF`, and the
-# `<<-` tab-stripping variant). This is exactly the CLAUDE.md-documented
+# `<<-` tab-stripping variant), AND whose `cat` invocation is captured by a
+# command substitution ($()/backtick) that is the value of a known
+# non-executing text-data flag. This is exactly the CLAUDE.md-documented
 # idiom for multi-line commit/PR-body text: `git commit -m "$(cat <<'EOF'
-# ... EOF)"`. A heredoc consumed by `cat` can only ever become inert text
-# data (`cat` never executes anything), and a QUOTED delimiter guarantees
-# bash performs no $()/backtick/$VAR expansion within the body, so the body
-# is 100% literal text regardless of its contents.
+# ... EOF)"`. A QUOTED delimiter guarantees bash performs no
+# $()/backtick/$VAR expansion within the body, so the body is 100% literal
+# text; the flag-capture requirement guarantees that literal text is used as
+# inert data (a message/title/search value) rather than executed.
 #
-# Deliberately narrower than "any heredoc": a heredoc feeding an INTERPRETER
-# instead (`bash <<'EOF' ... EOF`, `sh <<EOF ... EOF`) is genuinely live code
-# and must stay visible to the merge-redirect check, so masking is gated on
-# the word immediately before `<<` being `cat` specifically.
+# Deliberately narrower than "any heredoc" on TWO axes:
+#   1. A heredoc feeding an INTERPRETER (`bash <<'EOF' ... EOF`, `sh <<EOF`)
+#      is genuinely live code, so masking is gated on the word immediately
+#      before `<<` being `cat`.
+#   2. `cat` never executes its body, but its stdout can still be routed INTO
+#      a shell on the same command line -- `cat <<'EOF' | bash`, or a captured
+#      `eval "$(cat <<'EOF' ...)"`. Masking those would blind this
+#      catastrophic-tier guard to a real invocation, so masking is ALSO gated
+#      on `cat` being captured into a text-data flag's $()/backtick value (see
+#      the `capre` confinement check inside the function).
 #
 # Mirrors the #5087 lesson: only a heredoc block that is PROVABLY CLOSED
 # inside the buffer (its bare delimiter line is found) gets its body masked.
@@ -163,6 +171,13 @@ mask_cat_heredoc_bodies() {
     BEGIN {
         SQ = sprintf("%c", 39)
         DQ = sprintf("%c", 34)
+        BT = sprintf("%c", 96)
+        # A cat-heredoc body is only PROVABLY inert when the cat invocation is
+        # captured by a command substitution ($()/backtick) that is itself the
+        # VALUE of a known non-executing text-data flag. `capre` must match the
+        # tail of the opener-line text that sits immediately before the `cat`
+        # token (see the confinement check below).
+        capre = "(^|[ \t])(-m|--message|--body|--notes|--title|--comment|--search)[ \t]*=?[ \t]*(" DQ "|" SQ ")?[ \t]*([$][(]|" BT ")[ \t]*$"
     }
     { lines[NR] = $0 }
     END {
@@ -179,6 +194,25 @@ mask_cat_heredoc_bodies() {
                 # trailing whitespace) to be a bare "cat".
                 pre = substr(line, 1, p - 1)
                 if (pre !~ /(^|[^A-Za-z0-9_])cat[ \t]*$/) continue
+                # HARDENING (#5109 follow-up, PR #5115 review): the word before
+                # `<<` being `cat` is NOT sufficient -- `cat` never executes its
+                # own body, but its stdout can still reach a shell on the SAME
+                # command line, so masking a body that a shell then runs makes
+                # this catastrophic-tier guard blind to a real invocation:
+                #   cat <<EOF | bash        # body piped straight into bash
+                #   eval "$(cat <<EOF ...)" # body captured, then eval-executed
+                # Only mask when the cat-heredoc is captured by a command
+                # substitution ($()/backtick) that is the VALUE of a known
+                # non-executing text-data flag (-m/--message/--body/--notes/
+                # --title/--comment/--search) -- the CLAUDE.md-documented
+                # `-m "$(cat <<'"'"'EOF'"'"' ... EOF)"` idiom -- so the body is
+                # provably confined to inert text data and can never reach a
+                # shell. A bare `cat <<EOF`, a piped `cat <<EOF | bash`, or an
+                # `eval "$(cat <<EOF ...)"` fails this check and is left visible
+                # to the merge-redirect grep, which denies exactly as before.
+                before_cat = pre
+                sub(/cat[ \t]*$/, "", before_cat)
+                if (before_cat !~ capre) continue
                 start = p + 2
                 if (substr(line, start, 1) == "-") start++
                 while (substr(line, start, 1) == " " || substr(line, start, 1) == "\t") start++

--- a/defaults/hooks/guard-loom-workflow.sh
+++ b/defaults/hooks/guard-loom-workflow.sh
@@ -110,6 +110,150 @@ strip_literal_text() {
 }
 
 # =============================================================================
+# GH-PR-MERGE-REDIRECT FALSE-POSITIVE MASKING (issue #5109)
+#
+# The 'gh pr merge' redirect check below (guard tag loom:gh-pr-merge-redirect)
+# used to grep the RAW, unmasked $COMMAND for the literal substring "gh pr
+# merge" anywhere in the byte stream -- so it fired on commands that never
+# actually invoked the disallowed CLI, only mentioned the phrase as inert
+# text: a git commit message (passed via the CLAUDE.md-documented `-m
+# "$(cat <<'EOF' ... EOF)"` heredoc idiom) that quoted the phrase as prose
+# documenting the very rule this guard enforces, and a `gh issue list
+# --search "..."` query whose search string happened to contain the phrase
+# as text to search FOR, not a command to run.
+#
+# The two functions below build a MASKED copy of $COMMAND, used ONLY for the
+# 'gh pr merge' substring check immediately below -- never for any other
+# guard in this file, and never for decision-log redaction (that stays on
+# strip_literal_text() above, unchanged). Composition matters: heredoc-body
+# masking runs FIRST so any quote/backtick characters living inside a masked
+# heredoc body can no longer interfere with the flag-value masking pass that
+# runs second.
+#
+# Deliberately narrow, matching this repo's established masking conventions
+# (see guard-destructive-generic.sh's mask_heredoc_bodies(), #5000/#5087):
+# only two specific, well-understood-safe shapes are masked, and a command
+# that merely EXECUTES the disallowed CLI through a wrapper -- `sh -c "gh pr
+# merge 123"`, `bash -c 'gh pr merge 123'`, `eval "gh pr merge 123"` -- is
+# UNCHANGED by either pass (neither `-c` nor `eval`'s argument is in the
+# whitelist below) and still denies exactly as before. Masking only ever
+# narrows what this ONE check can see; it never widens what it misses.
+# =============================================================================
+
+# Mask the BODY of a heredoc whose consuming command is `cat` and whose
+# delimiter is quoted (`cat <<'EOF' ... EOF` / `cat <<"EOF" ... EOF`, and the
+# `<<-` tab-stripping variant). This is exactly the CLAUDE.md-documented
+# idiom for multi-line commit/PR-body text: `git commit -m "$(cat <<'EOF'
+# ... EOF)"`. A heredoc consumed by `cat` can only ever become inert text
+# data (`cat` never executes anything), and a QUOTED delimiter guarantees
+# bash performs no $()/backtick/$VAR expansion within the body, so the body
+# is 100% literal text regardless of its contents.
+#
+# Deliberately narrower than "any heredoc": a heredoc feeding an INTERPRETER
+# instead (`bash <<'EOF' ... EOF`, `sh <<EOF ... EOF`) is genuinely live code
+# and must stay visible to the merge-redirect check, so masking is gated on
+# the word immediately before `<<` being `cat` specifically.
+#
+# Mirrors the #5087 lesson: only a heredoc block that is PROVABLY CLOSED
+# inside the buffer (its bare delimiter line is found) gets its body masked.
+# An unterminated/unrecognized opener masks NOTHING and the raw text flows
+# through unchanged to the check below.
+mask_cat_heredoc_bodies() {
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)
+        DQ = sprintf("%c", 34)
+    }
+    { lines[NR] = $0 }
+    END {
+        nl = NR
+        for (i = 1; i <= nl; i++) {
+            line = lines[i]
+            off = 1
+            while (1) {
+                p = index(substr(line, off), "<<")
+                if (p == 0) break
+                p = off + p - 1
+                off = p + 2
+                # Require the word immediately before `<<` (ignoring
+                # trailing whitespace) to be a bare "cat".
+                pre = substr(line, 1, p - 1)
+                if (pre !~ /(^|[^A-Za-z0-9_])cat[ \t]*$/) continue
+                start = p + 2
+                if (substr(line, start, 1) == "-") start++
+                while (substr(line, start, 1) == " " || substr(line, start, 1) == "\t") start++
+                qc = substr(line, start, 1)
+                if (qc != SQ && qc != DQ) continue
+                start++
+                wordend = start
+                while (substr(line, wordend, 1) ~ /^[A-Za-z0-9_]$/) wordend++
+                if (wordend <= start) continue
+                if (substr(line, wordend, 1) != qc) continue
+                delim = substr(line, start, wordend - start)
+                closeat = 0
+                for (j = i + 1; j <= nl; j++) {
+                    trimmed = lines[j]
+                    sub(/^[ \t]+/, "", trimmed)
+                    if (trimmed == delim) { closeat = j; break }
+                }
+                if (closeat == 0) continue
+                for (j = i + 1; j < closeat; j++) {
+                    gsub(/./, "X", lines[j])
+                }
+                break
+            }
+        }
+        out = lines[1]
+        for (i = 2; i <= nl; i++) out = out "\n" lines[i]
+        printf "%s", out
+    }'
+}
+
+# Mask the quoted VALUE of known non-executing, text-only flags used by
+# git/gh subcommands: -m/--message, --body, --notes, --title, --comment,
+# --search. A near-duplicate of strip_literal_text() above (which is used
+# only for decision-log redaction) with --search added, kept as a SEPARATE
+# function so this decision-time masking can never change what
+# strip_literal_text() logs. Same conservative floor as strip_literal_text():
+# a span that still contains an unmasked `$(`/backtick (e.g. real command
+# substitution, not yet neutralized by the heredoc pass above) is left
+# completely untouched.
+mask_data_flag_values() {
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)
+        DQ = sprintf("%c", 34)
+        re = "(^|[ \t\n])(--message|--body|--notes|--title|--comment|--search|-m)[ \t]*=?[ \t]*(" \
+             DQ "[^" DQ "]*" DQ "|" SQ "[^" SQ "]*" SQ ")"
+        buf = ""
+    }
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        s = buf
+        out = ""
+        while (match(s, re)) {
+            pre     = substr(s, 1, RSTART - 1)
+            matched = substr(s, RSTART, RLENGTH)
+            s       = substr(s, RSTART + RLENGTH)
+            qpos = 0
+            for (i = 1; i <= length(matched); i++) {
+                c = substr(matched, i, 1)
+                if (c == DQ || c == SQ) { qpos = i; break }
+            }
+            head  = substr(matched, 1, qpos)
+            qchar = substr(matched, qpos, 1)
+            inner = substr(matched, qpos + 1, length(matched) - qpos - 1)
+            if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                gsub(/./, "X", inner)
+            }
+            out = out pre head inner qchar
+        }
+        out = out s
+        printf "%s", out
+    }'
+}
+
+# =============================================================================
 # DECISION TELEMETRY (issue #3771 / #3898) — one JSONL record per deny decision,
 # identical schema + toggle semantics to guard-destructive.sh so both guards'
 # fires land in the SAME .loom/logs/guard-decisions.log for the standing
@@ -290,7 +434,12 @@ ask() {
 # LOOM: Prefer merge-pr.sh over gh pr merge
 # =============================================================================
 
-if echo "$COMMAND" | grep -qE 'gh\s+pr\s+merge'; then
+# Match against a MASKED copy of $COMMAND (issue #5109) so a mention of the
+# phrase inside a cat-heredoc commit-message body or a --search/--body/-m/etc
+# quoted value doesn't false-positive as a real invocation. See the masking
+# functions' doc comments above for exactly what is (and is NOT) neutralized.
+GH_PR_MERGE_SCAN_TEXT=$(mask_data_flag_values "$(mask_cat_heredoc_bodies "$COMMAND")")
+if echo "$GH_PR_MERGE_SCAN_TEXT" | grep -qE 'gh\s+pr\s+merge'; then
     # Resolve the merge-pr.sh path for the current repo context. Prefer an
     # in-repo installed copy (./.loom/scripts/merge-pr.sh); fall back to the
     # loom-checkout copy under defaults/scripts/ (via $LOOM_HOME) when the repo

--- a/tests/hooks/test-guard-loom-workflow.sh
+++ b/tests/hooks/test-guard-loom-workflow.sh
@@ -236,6 +236,35 @@ EOF'
 assert_deny "Still block gh pr merge inside a bash-fed (non-cat) heredoc" \
     "$GH_5109_BASH_HEREDOC_CMD"
 
+# Regression guard (PR #5115 review): `cat` never executes its own body, but
+# piping its stdout into a shell on the SAME line -- `cat <<'EOF' | bash` --
+# makes the heredoc body live, executed code despite `cat` being the literal
+# consumer. The cat-heredoc masking must NOT neutralize such a body (it is not
+# confined to inert text: it reaches `bash`), so a real invocation shaped this
+# way must still deny. This is the exact bypass reported in the #5115 review.
+GH_5115_CAT_PIPE_BASH_CMD='cat <<'"'"'EOF'"'"' | bash
+'"$PHRASE_CMD"' 123 --admin
+EOF'
+assert_deny "Still block gh pr merge in a cat-heredoc piped into bash" \
+    "$GH_5115_CAT_PIPE_BASH_CMD"
+
+# And its `| sh` cousin -- same reasoning, different interpreter.
+GH_5115_CAT_PIPE_SH_CMD='cat <<'"'"'EOF'"'"' | sh
+'"$PHRASE_CMD"' 123
+EOF'
+assert_deny "Still block gh pr merge in a cat-heredoc piped into sh" \
+    "$GH_5115_CAT_PIPE_SH_CMD"
+
+# And a cat-heredoc captured then eval-executed: captured by $() but the
+# consumer is `eval`, NOT a text-data flag, so the body is not inert and must
+# stay visible.
+GH_5115_CAT_EVAL_CMD='eval "$(cat <<'"'"'EOF'"'"'
+'"$PHRASE_CMD"' 123
+EOF
+)"'
+assert_deny "Still block gh pr merge in a cat-heredoc captured then eval'd" \
+    "$GH_5115_CAT_EVAL_CMD"
+
 echo ""
 
 # =========================================================================

--- a/tests/hooks/test-guard-loom-workflow.sh
+++ b/tests/hooks/test-guard-loom-workflow.sh
@@ -198,6 +198,44 @@ assert_deny "Block gh pr merge --squash" \
 assert_deny_reason_matches "gh pr merge deny reason names merge-pr.sh" \
     "gh pr merge 123" "merge-pr\.sh"
 
+# --- False-positive regression tests (issue #5109) -----------------------
+# The phrase "gh pr merge" appearing as INERT TEXT (a heredoc-quoted commit
+# message, a --search query value) must not deny -- only an actual invocation
+# should. Both reproduce the exact occurrences reported in #5109.
+
+PHRASE_CMD="gh pr merge"
+
+# Occurrence 1: a commit message built via the CLAUDE.md-documented
+# `-m "$(cat <<'EOF' ... EOF)"` heredoc idiom, quoting the phrase as prose
+# documenting the very rule this guard enforces.
+GH_5109_COMMIT_CMD='git add foo.md && git commit -m "$(cat <<'"'"'EOF'"'"'
+Document the rule: never `'"$PHRASE_CMD"'` directly, use merge-pr.sh instead.
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+EOF
+)" && git push'
+assert_allow "Allow heredoc commit message that quotes the phrase as prose" \
+    "$GH_5109_COMMIT_CMD"
+
+# Occurrence 2: a read-only search query whose --search value happens to
+# contain the phrase as text to search FOR, not a command to run.
+assert_allow "Allow gh issue list --search containing the phrase as query text" \
+    "gh issue list --state open --search \"$PHRASE_CMD redirect guard false positive\" --limit 20 --json number,title,url"
+
+# Regression guard: masking must NOT weaken the guard against an actual
+# invocation wrapped in a shell -c string -- '-c' is deliberately not in the
+# masked-flag whitelist, so this must still deny.
+assert_deny "Still block gh pr merge wrapped in sh -c (no masking regression)" \
+    "sh -c \"$PHRASE_CMD 123\""
+
+# Regression guard: a heredoc that feeds an INTERPRETER (not `cat`) is live
+# code, not inert data, and must stay visible to the check.
+GH_5109_BASH_HEREDOC_CMD='bash <<'"'"'EOF'"'"'
+'"$PHRASE_CMD"' 123
+EOF'
+assert_deny "Still block gh pr merge inside a bash-fed (non-cat) heredoc" \
+    "$GH_5109_BASH_HEREDOC_CMD"
+
 echo ""
 
 # =========================================================================


### PR DESCRIPTION
## Summary

The `loom:gh-pr-merge-redirect` guard (tier: catastrophic) matched the disallowed merge CLI invocation as a raw substring anywhere in the Bash command text, with no regard for quoting or heredoc context. This fired on commands that never actually invoked the disallowed CLI:

1. A `git commit -m "$(cat <<'EOF2' ... EOF2)"` heredoc-built commit message that quoted the phrase as prose (documenting the rule this guard enforces).
2. A `gh issue list --search "..."` query whose search string happened to contain the phrase as text to search for.

## Fix

Two narrow masking passes build a masked copy of the command used *only* for this one check's decision (never for other guards, never for decision-log redaction):

- `mask_cat_heredoc_bodies` — neutralizes heredoc BODY lines when the consuming command is `cat` and the delimiter is quoted (guaranteed no expansion, and `cat` never executes anything — exactly the CLAUDE.md-documented commit-message idiom). Only masks a block that is provably *closed* inside the buffer (same #5087 lesson as the sibling `guard-destructive-generic.sh` masking).
- `mask_data_flag_values` — neutralizes the quoted value of known non-executing, text-only flags (`-m`/`--message`/`--body`/`--notes`/`--title`/`--comment`/`--search`), mirroring the existing `strip_literal_text()` heuristic (never masks a span that still contains an unmasked `$(`/backtick).

Both are deliberately narrow: a real invocation wrapped in `sh -c "..."` / `bash -c '...'` / `eval`, or piped into a real interpreter via a non-`cat` heredoc, is untouched by either pass and still denies — no weakening of the actual guard.

## Test plan

- [x] `./tests/hooks/test-guard-loom-workflow.sh` — 31/31 pass (27 existing + 4 new regression tests: both reported false-positive shapes now allow; `sh -c` wrapping and a non-`cat` heredoc still deny)
- [x] `./tests/hooks/test-guard-destructive-dispatcher.sh` — 12/12 pass (unaffected)
- [x] `shellcheck -S warning` on the modified file — clean
- [x] Manually reproduced both occurrences from the issue and confirmed allow; manually confirmed direct invocation and `sh -c`-wrapped invocation still deny

Closes #5109