### PR TITLE
feat(daemon): reap orphaned process trees inside dead-sweep worktrees

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3663,6 +3663,28 @@ signal. An unmeasurable probe is skipped, never treated as zero (#4164).
 already-documented behavior whose absence is a slow-motion outage (a full disk
 stops a host running sweeps at all).
 
+**Orphaned processes, not just orphaned directories (#5110).** Every pass also
+runs an orphan-**process** sub-pass ahead of the directory-removal pass above.
+`#4982`'s pgid-scoped teardown reaps a dead sweep's process **group** — but a
+tool like GNU `timeout` spawns its child into a *fresh* process group/session
+unless invoked with `--foreground`, so a multi-level driver script (e.g.
+`bash run_all.sh` → `python3` → `timeout` → a long-running child) can escape a
+pgid-scoped kill entirely and keep running after the sweep that launched it is
+long gone — a real incident pinned a host at load 65 for 5h52m this way,
+starving that host's own dispatched sweep. Each tick this sub-pass finds every
+PID whose cwd is inside an `issue-<N>` worktree (the same probe
+`classify_worktree`'s `SkipInUse` gate already uses), and — for a worktree that
+carries the `.loom-managed` sentinel AND has no live sweep claim for issue N —
+walks the FULL descendant tree of each such PID by `ppid` (not by pgid/sid, so
+a `setsid`/`timeout`-escaped tree is still reached) and terminates every PID
+found (SIGTERM, then SIGKILL after a short grace), logging what was killed.
+Both fail-safe gates (`.loom-managed` sentinel + live claim) are re-checked on
+every pass rather than trusted from a snapshot, because a stale verdict here is
+irreversible (a live sweep's own process killed) unlike a stale removal verdict
+(a no-op retried next tick). Shares this loop's enable/interval cadence but has
+its own opt-out, since terminating a live process is a strictly more
+consequential action than removing an already-idle directory.
+
 ```json
 {
   "autonomous": {
@@ -3670,7 +3692,8 @@ stops a host running sweeps at all).
       "enabled": true,
       "intervalSecs": 900,
       "gracePeriodSecs": 600,
-      "diskWarnFreeGb": 20
+      "diskWarnFreeGb": 20,
+      "orphanProcessReapEnabled": true
     }
   }
 }
@@ -3682,6 +3705,7 @@ stops a host running sweeps at all).
 | `LOOM_WORKTREE_REAPER_INTERVAL_SECS` | `autonomous.worktreeReaper.intervalSecs` | env > config > default | `900` (15 min) |
 | — | `autonomous.worktreeReaper.gracePeriodSecs` | config > default | `600` (10 min) |
 | `LOOM_WORKTREE_REAPER_DISK_WARN_GB` | `autonomous.worktreeReaper.diskWarnFreeGb` | env > config > default | `20` |
+| `LOOM_ORPHAN_PROCESS_REAPER` | `autonomous.worktreeReaper.orphanProcessReapEnabled` | env > config > default | `true` (on) |
 
 **Not limited to the daemon's attached workspace.** The loop walks
 `WorkspaceRegistry::effective_roots()` each tick, so a daemon started from

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3673,17 +3673,40 @@ pgid-scoped kill entirely and keep running after the sweep that launched it is
 long gone — a real incident pinned a host at load 65 for 5h52m this way,
 starving that host's own dispatched sweep. Each tick this sub-pass finds every
 PID whose cwd is inside an `issue-<N>` worktree (the same probe
-`classify_worktree`'s `SkipInUse` gate already uses), and — for a worktree that
-carries the `.loom-managed` sentinel AND has no live sweep claim for issue N —
-walks the FULL descendant tree of each such PID by `ppid` (not by pgid/sid, so
-a `setsid`/`timeout`-escaped tree is still reached) and terminates every PID
-found (SIGTERM, then SIGKILL after a short grace), logging what was killed.
-Both fail-safe gates (`.loom-managed` sentinel + live claim) are re-checked on
-every pass rather than trusted from a snapshot, because a stale verdict here is
-irreversible (a live sweep's own process killed) unlike a stale removal verdict
-(a no-op retried next tick). Shares this loop's enable/interval cadence but has
-its own opt-out, since terminating a live process is a strictly more
-consequential action than removing an already-idle directory.
+`classify_worktree`'s `SkipInUse` gate already uses), and — only for a worktree
+the removal pass would itself consider dead — walks the FULL descendant tree of
+each such PID by `ppid` (not by pgid/sid, so a `setsid`/`timeout`-escaped tree
+is still reached) and terminates every PID found (SIGTERM, then SIGKILL after a
+short grace), logging what was killed.
+
+"Dead" means **every** gate below clears; any one of them preserves the
+processes and logs why:
+
+| Gate | Mirrors `classify_worktree`'s |
+|------|-------------------------------|
+| `.loom-managed` sentinel present | `require_managed_sentinel` / `SkipUnmanaged` |
+| No live sweep claim for issue N | `SkipInUse` |
+| Issue N is `CLOSED` | `SkipIssueNotClosed` |
+| Its PR is not open, and not unknown | `SkipPrOpen` / `SkipUnknownPrStatus` |
+| A merged PR is past `gracePeriodSecs` | `SkipGrace` |
+
+The forge gates are load-bearing, not belt-and-braces: the live-claim check
+only knows about **daemon-dispatched (Tier 2) sweeps**, so Manual Orchestration
+Mode (`/loom:builder`, `/loom:judge`, `/loom:doctor`) and manual `/loom:sweep`
+runs never appear in it. Since the removal pass treats "a process is using this
+directory" as *protection* while this pass treats it as the *trigger*, without
+the issue-closed / PR-not-open gates a Judge running `cargo test` inside an
+open PR's builder worktree would be indistinguishable from the runaway driver
+this sub-pass exists to kill. An open PR (or open issue) is independent
+evidence the work is alive; a failed forge probe resolves to `UNKNOWN`, which
+is always a skip, never a kill. Forge probes are only issued for a worktree
+that actually has a process running inside it, so an idle host costs no extra
+REST calls. Every gate is re-checked on every pass rather than trusted from a
+snapshot, because a stale verdict here is irreversible (a live agent's own
+process killed) unlike a stale removal verdict (a no-op retried next tick).
+Shares this loop's enable/interval cadence but has its own opt-out, since
+terminating a live process is a strictly more consequential action than
+removing an already-idle directory.
 
 ```json
 {

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -166,6 +166,7 @@ pub mod live_claim;
 pub mod main_health_gate;
 pub mod metrics_collector;
 pub mod observability;
+pub mod orphan_process_reaper;
 pub mod peer_claims;
 pub mod phase_join;
 pub mod pipeline_snapshot;

--- a/loom-daemon/src/orphan_process_reaper.rs
+++ b/loom-daemon/src/orphan_process_reaper.rs
@@ -1,0 +1,542 @@
+//! Reap a process tree that outlived the sweep that spawned it (Issue #5110).
+//!
+//! # Why this exists
+//!
+//! [`crate::sweep_registry::reaper`]'s pgid-scoped teardown (#4980) signals a
+//! sweep's whole process **group** on cancel/crash, which reaches every
+//! descendant that stayed in that group. It does NOT reach a descendant that
+//! escaped into a fresh process group or session — which is exactly what GNU
+//! `timeout` does to its child unless invoked with `--foreground` (its own
+//! `--help` documents the distinction). A multi-level driver script
+//! (`bash run_all.sh` → `python3` → `timeout` → `ngspice`) can therefore
+//! survive a pgid-scoped kill entirely, and if the sweep that launched it
+//! already died, nothing ever asks "is anything still running for this
+//! issue?" — the process keeps consuming a whole host's CPU indefinitely
+//! (the 2026-08-03 incident this issue documents: an orphaned driver held a
+//! worker host at load 65 for 5h52m, starving that host's own dispatched
+//! sweep).
+//!
+//! # What this module does instead
+//!
+//! Rather than trusting any recorded pgid, this asks the same "worktree
+//! ownership" question [`crate::worktree_reaper`] already asks about
+//! *directories* — "is anything still using this worktree, and does a live
+//! sweep still own it?" — but about **processes**:
+//!
+//! 1. For every `issue-<N>` worktree, find PIDs with their cwd inside it
+//!    ([`crate::worktree_ops::safety::find_processes_using_directory`] — the
+//!    same probe [`crate::worktree_ops::clean::classify_worktree`] already
+//!    uses to protect a worktree with live work from removal).
+//! 2. Skip it unless BOTH of this issue's acceptance-criteria gates hold:
+//!    the worktree carries the `.loom-managed` sentinel (never touch a
+//!    user-provisioned worktree), and issue N has NO live sweep claim
+//!    (checked the same way [`crate::worktree_ops::liveness::active_spawn_loop_issues`]
+//!    already does for the removal pass — a claim-lock directory or spawn-loop
+//!    state entry).
+//! 3. For every surviving candidate PID, walk its full descendant tree by
+//!    PID (`pgrep -P`, recursive) — **not** scoped to any process group or
+//!    session, so a tree that escaped via `setsid`/`timeout` into a fresh
+//!    pgid+sid is still fully reached — and terminate every PID found
+//!    (SIGTERM, then SIGKILL for anything still alive after a short grace).
+//!
+//! This is the module-level precedent [`crate::terminal`]'s
+//! `collect_descendants`/`kill_process_tree` already established for tmux
+//! pane teardown — generalized here to a bare PID input/output so it is
+//! reusable outside tmux, and logged so an operator can see what was killed
+//! (this issue's AC).
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use crate::worktree_ops::clean::is_loom_managed;
+use crate::worktree_ops::liveness::active_spawn_loop_issues;
+use crate::worktree_ops::naming::issue_from_worktree;
+use crate::worktree_ops::safety::find_processes_using_directory;
+
+/// Grace between SIGTERM and SIGKILL escalation for a reaped orphan tree.
+/// Short — unlike the crash-path group reap (#4980, deferred to a later
+/// reaper tick to avoid blocking the registry mutex), this pass runs on its
+/// own `spawn_blocking` task (mirroring [`crate::worktree_reaper::reap_repo`])
+/// so a brief inline sleep is fine.
+pub const ORPHAN_PROCESS_REAP_GRACE: Duration = Duration::from_secs(3);
+
+// ============================================================================
+// Process-tree primitives (generalizes `terminal.rs`'s tmux-only
+// `collect_descendants` / `kill_process_tree` to a bare PID)
+// ============================================================================
+
+/// Whether `pid` is still alive, via `kill -0` (portable across macOS/Linux,
+/// matching the shell-based approach the rest of this module and
+/// `terminal.rs::kill_process_tree` already use).
+#[must_use]
+pub fn is_pid_alive(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Recursively collect every descendant PID of `pid` (depth-first,
+/// grandchildren before children), via repeated `pgrep -P`.
+///
+/// Deliberately **not** scoped to any process group or session — that is the
+/// entire point (#5110): a tree that called `setsid`/was launched by
+/// `timeout` into a fresh pgid+sid is still walked correctly, because this
+/// follows the OS parent/child (`ppid`) relationship, which nothing in
+/// between can escape short of re-parenting to init.
+#[must_use]
+pub fn collect_descendant_pids(pid: u32) -> Vec<u32> {
+    let mut pids = Vec::new();
+    collect_descendant_pids_into(pid, &mut pids);
+    pids
+}
+
+fn collect_descendant_pids_into(pid: u32, out: &mut Vec<u32>) {
+    let Ok(output) = Command::new("pgrep")
+        .args(["-P", &pid.to_string()])
+        .output()
+    else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    let children: Vec<u32> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|l| l.trim().parse().ok())
+        .collect();
+    for child in children {
+        collect_descendant_pids_into(child, out);
+        out.push(child);
+    }
+}
+
+/// SIGTERM every pid in `pids`, then SIGKILL any survivor after `grace`.
+///
+/// Best-effort throughout: a pid that has already exited between discovery
+/// and signal delivery is simply not reported as signaled (never an error —
+/// "already gone" is the goal, not a failure). Returns the pids that were
+/// actually signaled at least once.
+pub fn kill_pids(pids: &[u32], grace: Duration) -> Vec<u32> {
+    let mut signaled = Vec::new();
+    for &pid in pids {
+        if Command::new("kill")
+            .args(["-15", &pid.to_string()])
+            .output()
+            .is_ok_and(|o| o.status.success())
+        {
+            signaled.push(pid);
+        }
+    }
+    if signaled.is_empty() {
+        return signaled;
+    }
+    std::thread::sleep(grace);
+    for &pid in &signaled {
+        if is_pid_alive(pid) {
+            let _ = Command::new("kill").args(["-9", &pid.to_string()]).output();
+        }
+    }
+    signaled
+}
+
+// ============================================================================
+// The reap pass
+// ============================================================================
+
+/// One worktree's orphan-process outcome.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OrphanReapEntry {
+    /// The issue number the worktree belongs to.
+    pub issue: u32,
+    /// PIDs found with cwd inside the worktree — the roots of each tree walked.
+    pub root_pids: Vec<u32>,
+    /// Every PID (roots + transitive descendants) that was signaled.
+    pub killed_pids: Vec<u32>,
+}
+
+/// What one orphan-process reap pass over one repo did.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OrphanReapReport {
+    /// `issue-<N>` worktree directories examined.
+    pub scanned: usize,
+    /// Worktrees that had at least one orphan process reaped.
+    pub reaped: Vec<OrphanReapEntry>,
+}
+
+impl OrphanReapReport {
+    /// A compact one-line summary for the daemon log.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        format!("scanned={} reaped_worktrees={}", self.scanned, self.reaped.len())
+    }
+}
+
+/// Scan `repo_root`'s worktree root for `issue-<N>` worktrees with a process
+/// whose cwd is inside them but NO live sweep claim for that issue, and
+/// terminate the whole descendant tree of every such process.
+///
+/// The probes are injected (`find_processes`/`collect_descendants`/`kill`) so
+/// the whole pass is unit-testable without a live process table — production
+/// wiring is [`reap_orphan_processes`].
+///
+/// # Fail-safe (this issue's AC)
+///
+/// A worktree is only ever a reap candidate when BOTH gates hold:
+/// - it carries the `.loom-managed` sentinel — the same "never touch a
+///   user-provisioned worktree" gate [`crate::worktree_reaper`]'s removal
+///   pass applies via `CleanOptions::require_managed_sentinel`, and
+/// - `active_issues` does NOT contain its issue number — the same live-claim
+///   check the removal pass's `SkipInUse` gate already makes via
+///   [`crate::worktree_ops::liveness::active_spawn_loop_issues`].
+///
+/// Both are re-checked, not assumed from an earlier pass's snapshot: a stale
+/// verdict here has an irreversible consequence (a live sweep's own process
+/// killed out from under it), unlike a stale worktree-removal verdict (a
+/// no-op retried on the next tick).
+pub fn reap_orphan_processes_with(
+    repo_root: &Path,
+    active_issues: &HashSet<u32>,
+    find_processes: &dyn Fn(&Path) -> Vec<u32>,
+    collect_descendants: &dyn Fn(u32) -> Vec<u32>,
+    kill: &dyn Fn(&[u32]) -> Vec<u32>,
+) -> OrphanReapReport {
+    let mut report = OrphanReapReport::default();
+
+    let worktrees_dir = crate::worktree_root::worktree_root(repo_root);
+    let Ok(entries) = std::fs::read_dir(&worktrees_dir) else {
+        // No worktree root yet (or unreadable) — nothing to reap, not an error.
+        return report;
+    };
+
+    let mut worktree_dirs: Vec<_> = entries
+        .flatten()
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+        .collect();
+    worktree_dirs.sort_by_key(std::fs::DirEntry::path);
+
+    for entry in worktree_dirs {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let Some(issue) = issue_from_worktree(&name) else {
+            continue;
+        };
+        report.scanned += 1;
+
+        let worktree_path = entry.path().canonicalize().unwrap_or_else(|_| entry.path());
+
+        // Fail-safe gate 1: never touch a user-provisioned worktree.
+        if !is_loom_managed(&worktree_path) {
+            continue;
+        }
+        // Fail-safe gate 2: never touch a worktree with a live sweep claim.
+        if active_issues.contains(&issue) {
+            continue;
+        }
+
+        let root_pids = find_processes(&worktree_path);
+        if root_pids.is_empty() {
+            continue;
+        }
+
+        let mut all_pids: Vec<u32> = Vec::new();
+        for &root in &root_pids {
+            for descendant in collect_descendants(root) {
+                if !all_pids.contains(&descendant) {
+                    all_pids.push(descendant);
+                }
+            }
+        }
+        for &root in &root_pids {
+            if !all_pids.contains(&root) {
+                all_pids.push(root);
+            }
+        }
+
+        let killed = kill(&all_pids);
+        log::warn!(
+            "orphan_process_reaper: {} issue-{issue} has {} process(es) with no live sweep \
+             claim for issue #{issue} — reaping the whole tree: roots={root_pids:?} \
+             all_pids={all_pids:?} killed={killed:?} (#5110)",
+            repo_root.display(),
+            root_pids.len()
+        );
+        report.reaped.push(OrphanReapEntry {
+            issue,
+            root_pids,
+            killed_pids: killed,
+        });
+    }
+
+    report
+}
+
+/// Run one production orphan-process reap pass over `repo_root`. Wires the
+/// real process-table probes and the real signal delivery.
+#[must_use]
+pub fn reap_orphan_processes(repo_root: &Path) -> OrphanReapReport {
+    let active_issues = active_spawn_loop_issues(repo_root);
+    let kill_fn = |pids: &[u32]| kill_pids(pids, ORPHAN_PROCESS_REAP_GRACE);
+    reap_orphan_processes_with(
+        repo_root,
+        &active_issues,
+        &find_processes_using_directory,
+        &collect_descendant_pids,
+        &kill_fn,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::fs;
+
+    /// Build a repo root with `.loom/worktrees/issue-<N>` directories, each
+    /// carrying a `.loom-managed` sentinel unless `managed` says otherwise.
+    fn make_repo(issues: &[(u32, bool)]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        for (issue, managed) in issues {
+            let wt = tmp
+                .path()
+                .join(".loom/worktrees")
+                .join(format!("issue-{issue}"));
+            fs::create_dir_all(&wt).unwrap();
+            if *managed {
+                fs::write(wt.join(".loom-managed"), "").unwrap();
+            }
+        }
+        tmp
+    }
+
+    #[test]
+    fn test_orphan_with_no_live_claim_is_reaped_transitively() {
+        let repo = make_repo(&[(100, true)]);
+        let killed_calls: RefCell<Vec<Vec<u32>>> = RefCell::new(Vec::new());
+
+        let find_processes = |_: &Path| vec![111];
+        // 111 -> 222 -> 333 (a driver that escaped into a new pgid/sid via a
+        // `timeout`-shaped middle process — the scenario this issue's AC
+        // requires a fixture for).
+        let collect_descendants = |pid: u32| if pid == 111 { vec![222, 333] } else { vec![] };
+        let kill = |pids: &[u32]| {
+            killed_calls.borrow_mut().push(pids.to_vec());
+            pids.to_vec()
+        };
+
+        let report = reap_orphan_processes_with(
+            repo.path(),
+            &HashSet::new(),
+            &find_processes,
+            &collect_descendants,
+            &kill,
+        );
+
+        assert_eq!(report.scanned, 1);
+        assert_eq!(report.reaped.len(), 1);
+        let entry = &report.reaped[0];
+        assert_eq!(entry.issue, 100);
+        assert_eq!(entry.root_pids, vec![111]);
+        // The whole tree — root AND every descendant — must be in the kill set,
+        // not just the root pid.
+        let mut all: Vec<u32> = entry.killed_pids.clone();
+        all.sort_unstable();
+        assert_eq!(all, vec![111, 222, 333]);
+    }
+
+    #[test]
+    fn test_live_sweep_claim_is_never_reaped() {
+        let repo = make_repo(&[(101, true)]);
+        let find_processes = |_: &Path| vec![999];
+        let collect_descendants = |_: u32| vec![];
+        let killed_calls: RefCell<Vec<Vec<u32>>> = RefCell::new(Vec::new());
+        let kill = |pids: &[u32]| {
+            killed_calls.borrow_mut().push(pids.to_vec());
+            pids.to_vec()
+        };
+
+        let report = reap_orphan_processes_with(
+            repo.path(),
+            &HashSet::from([101]),
+            &find_processes,
+            &collect_descendants,
+            &kill,
+        );
+
+        assert!(report.reaped.is_empty(), "a live sweep's work must never be reaped");
+        assert!(killed_calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn test_unmanaged_worktree_is_never_reaped() {
+        // No `.loom-managed` sentinel ⇒ user-provisioned ⇒ never touched,
+        // even though a process is using it and no claim is live.
+        let repo = make_repo(&[(102, false)]);
+        let find_processes = |_: &Path| vec![999];
+        let collect_descendants = |_: u32| vec![];
+        let kill = |pids: &[u32]| pids.to_vec();
+
+        let report = reap_orphan_processes_with(
+            repo.path(),
+            &HashSet::new(),
+            &find_processes,
+            &collect_descendants,
+            &kill,
+        );
+
+        assert!(report.reaped.is_empty());
+    }
+
+    #[test]
+    fn test_no_processes_using_worktree_is_a_no_op() {
+        let repo = make_repo(&[(103, true)]);
+        let find_processes = |_: &Path| Vec::new();
+        let collect_descendants = |_: u32| vec![];
+        let kill = |pids: &[u32]| pids.to_vec();
+
+        let report = reap_orphan_processes_with(
+            repo.path(),
+            &HashSet::new(),
+            &find_processes,
+            &collect_descendants,
+            &kill,
+        );
+
+        assert_eq!(report.scanned, 1);
+        assert!(report.reaped.is_empty());
+    }
+
+    #[test]
+    fn test_missing_worktree_root_is_a_clean_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let find_processes = |_: &Path| vec![999];
+        let collect_descendants = |_: u32| vec![];
+        let kill = |pids: &[u32]| pids.to_vec();
+
+        let report = reap_orphan_processes_with(
+            tmp.path(),
+            &HashSet::new(),
+            &find_processes,
+            &collect_descendants,
+            &kill,
+        );
+
+        assert_eq!(report, OrphanReapReport::default());
+    }
+
+    #[test]
+    fn test_non_issue_directories_are_ignored() {
+        let repo = make_repo(&[(200, true)]);
+        fs::create_dir_all(repo.path().join(".loom/worktrees/scratch")).unwrap();
+        let find_processes = |_: &Path| Vec::new();
+        let collect_descendants = |_: u32| vec![];
+        let kill = |pids: &[u32]| pids.to_vec();
+
+        let report = reap_orphan_processes_with(
+            repo.path(),
+            &HashSet::new(),
+            &find_processes,
+            &collect_descendants,
+            &kill,
+        );
+
+        assert_eq!(report.scanned, 1);
+    }
+
+    #[test]
+    fn test_summary_is_compact() {
+        let report = OrphanReapReport {
+            scanned: 3,
+            reaped: vec![OrphanReapEntry {
+                issue: 1,
+                root_pids: vec![10],
+                killed_pids: vec![10, 11],
+            }],
+        };
+        assert_eq!(report.summary(), "scanned=3 reaped_worktrees=1");
+    }
+
+    // ========================================================================
+    // Real-process fixtures: proves the reap actually kills a live tree that
+    // escaped via `setsid` into a fresh pgid+sid (this issue's explicit AC:
+    // "Test/fixture covers a tree that has escaped via `timeout` (new pgid +
+    // new sid)"). `timeout` itself does exactly this on both macOS (via
+    // coreutils, if installed) and Linux, but `setsid` is the portable,
+    // always-present primitive that reproduces the SAME escape shape — a
+    // subprocess launched into a brand-new process group AND session, which
+    // is precisely why #4982's pgid-scoped teardown cannot reach it.
+    // ========================================================================
+
+    fn wait_until<F: Fn() -> bool>(cond: F, timeout_ms: u64) -> bool {
+        let start = std::time::Instant::now();
+        while start.elapsed().as_millis() < u128::from(timeout_ms) {
+            if cond() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        cond()
+    }
+
+    #[test]
+    fn test_kill_pids_terminates_a_setsid_escaped_grandchild() {
+        // `setsid <cmd>` runs <cmd> as the leader of a brand-new session AND
+        // process group — the same escape `timeout` (without --foreground)
+        // performs on its child, per the issue's ps-table evidence. The
+        // leader then forks ITS OWN child (a grandchild relative to us) that
+        // shares the new group/session, mirroring the ngspice-under-timeout
+        // shape.
+        if Command::new("setsid").arg("true").output().is_err() {
+            eprintln!("skipping: `setsid` not available on this platform");
+            return;
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let gc_pidfile = dir.path().join("grandchild.pid");
+        let script = format!("sleep 300 & echo $! > {}; exec sleep 300", gc_pidfile.display());
+
+        let mut child = Command::new("setsid")
+            .args(["bash", "-c", &script])
+            .spawn()
+            .unwrap();
+        let leader_pid = child.id();
+
+        assert!(wait_until(|| gc_pidfile.exists(), 2000), "grandchild pid file should appear");
+        let gc_pid: u32 = fs::read_to_string(&gc_pidfile)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        assert_ne!(leader_pid, gc_pid);
+        assert!(is_pid_alive(leader_pid));
+        assert!(is_pid_alive(gc_pid));
+
+        // The whole point: walk descendants by PID (NOT by pgid/sid) and kill
+        // every one — this must reach the grandchild despite it living in a
+        // process group/session this test process never joined.
+        let mut all_pids = collect_descendant_pids(leader_pid);
+        all_pids.push(leader_pid);
+        assert!(
+            all_pids.contains(&gc_pid),
+            "descendant walk must find the setsid-escaped grandchild: {all_pids:?}"
+        );
+
+        let killed = kill_pids(&all_pids, Duration::from_secs(2));
+        assert!(killed.contains(&leader_pid));
+        assert!(killed.contains(&gc_pid));
+
+        assert!(
+            wait_until(|| !is_pid_alive(leader_pid), 3000),
+            "leader should be dead after kill_pids"
+        );
+        assert!(
+            wait_until(|| !is_pid_alive(gc_pid), 3000),
+            "the setsid-escaped grandchild survived — descendant-tree reap did not reach it \
+             (the exact #5110 regression: a pgid-scoped kill would have missed this pid)"
+        );
+
+        let _ = child.wait();
+    }
+}

--- a/loom-daemon/src/orphan_process_reaper.rs
+++ b/loom-daemon/src/orphan_process_reaper.rs
@@ -469,7 +469,7 @@ mod tests {
     // is precisely why #4982's pgid-scoped teardown cannot reach it.
     // ========================================================================
 
-    fn wait_until<F: Fn() -> bool>(cond: F, timeout_ms: u64) -> bool {
+    fn wait_until<F: FnMut() -> bool>(mut cond: F, timeout_ms: u64) -> bool {
         let start = std::time::Instant::now();
         while start.elapsed().as_millis() < u128::from(timeout_ms) {
             if cond() {
@@ -527,8 +527,19 @@ mod tests {
         assert!(killed.contains(&leader_pid));
         assert!(killed.contains(&gc_pid));
 
+        // The leader is a *direct child* of this test process, so once
+        // kill_pids signals it the leader becomes a zombie until we reap it —
+        // and `is_pid_alive` (kill -0) reports a zombie as still alive, since
+        // POSIX keeps the PID entry until the parent wait()s. Poll try_wait()
+        // for the leader: it reaps the zombie the moment the process has
+        // exited and reports it genuinely dead, which is exactly what happens
+        // in production where the orphan reparents to systemd --user/init and
+        // that init-role process auto-reaps it (the daemon is never the
+        // orphan's parent). The grandchild below, by contrast, reparents to
+        // init when the leader dies and is auto-reaped there, so plain
+        // is_pid_alive polling is correct for it.
         assert!(
-            wait_until(|| !is_pid_alive(leader_pid), 3000),
+            wait_until(|| matches!(child.try_wait(), Ok(Some(_))), 3000),
             "leader should be dead after kill_pids"
         );
         assert!(
@@ -536,7 +547,5 @@ mod tests {
             "the setsid-escaped grandchild survived — descendant-tree reap did not reach it \
              (the exact #5110 regression: a pgid-scoped kill would have missed this pid)"
         );
-
-        let _ = child.wait();
     }
 }

--- a/loom-daemon/src/orphan_process_reaper.rs
+++ b/loom-daemon/src/orphan_process_reaper.rs
@@ -27,12 +27,10 @@
 //!    ([`crate::worktree_ops::safety::find_processes_using_directory`] — the
 //!    same probe [`crate::worktree_ops::clean::classify_worktree`] already
 //!    uses to protect a worktree with live work from removal).
-//! 2. Skip it unless BOTH of this issue's acceptance-criteria gates hold:
-//!    the worktree carries the `.loom-managed` sentinel (never touch a
-//!    user-provisioned worktree), and issue N has NO live sweep claim
-//!    (checked the same way [`crate::worktree_ops::liveness::active_spawn_loop_issues`]
-//!    already does for the removal pass — a claim-lock directory or spawn-loop
-//!    state entry).
+//! 2. Skip it unless EVERY gate in [`OrphanSkip`] clears: the worktree carries
+//!    the `.loom-managed` sentinel, issue N has no live sweep claim, issue N
+//!    is closed, and its PR is not open (see "Fail-safe" on
+//!    [`reap_orphan_processes_with`]).
 //! 3. For every surviving candidate PID, walk its full descendant tree by
 //!    PID (`pgrep -P`, recursive) — **not** scoped to any process group or
 //!    session, so a tree that escaped via `setsid`/`timeout` into a fresh
@@ -50,7 +48,11 @@ use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
 
-use crate::worktree_ops::clean::is_loom_managed;
+use chrono::{DateTime, Utc};
+
+use crate::worktree_ops::clean::{
+    check_grace_period, is_loom_managed, PrStatus, DEFAULT_GRACE_PERIOD_SECS,
+};
 use crate::worktree_ops::liveness::active_spawn_loop_issues;
 use crate::worktree_ops::naming::issue_from_worktree;
 use crate::worktree_ops::safety::find_processes_using_directory;
@@ -157,6 +159,48 @@ pub struct OrphanReapEntry {
     pub killed_pids: Vec<u32>,
 }
 
+/// Why a fail-safe gate preserved a worktree's live processes.
+///
+/// Every variant is a *refusal to kill*: this pass reports "I found running
+/// processes and deliberately left them alone", which is the only way an
+/// operator can tell a quiet tick apart from a tick that nearly killed a
+/// reviewer's build.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OrphanSkip {
+    /// No `.loom-managed` sentinel — user-provisioned, never touched.
+    Unmanaged,
+    /// A daemon-dispatched sweep holds a claim-lock / spawn-loop entry.
+    LiveSweepClaim,
+    /// The issue is not `CLOSED` (payload: the observed state, e.g. `OPEN` /
+    /// `UNKNOWN`) — work on it may legitimately still be in flight.
+    IssueNotClosed(String),
+    /// The issue's PR is still open — it is still under review/revision.
+    PrOpen,
+    /// The forge PR probe failed; "unknown" is never license to kill.
+    PrStatusUnknown,
+    /// The PR merged, but the post-merge grace period has not elapsed
+    /// (payload: seconds remaining) — the merging agent may still be
+    /// finishing up inside the worktree.
+    MergeGrace(i64),
+}
+
+impl OrphanSkip {
+    /// Human-readable reason, for the daemon log and the report.
+    #[must_use]
+    pub fn reason(&self) -> String {
+        match self {
+            Self::Unmanaged => "no .loom-managed sentinel (user-provisioned)".to_string(),
+            Self::LiveSweepClaim => "live spawn-loop task or claim-lock".to_string(),
+            Self::IssueNotClosed(state) => format!("issue is {state}"),
+            Self::PrOpen => "PR still open".to_string(),
+            Self::PrStatusUnknown => "PR status unknown".to_string(),
+            Self::MergeGrace(remaining) => {
+                format!("grace period not passed ({remaining}s remaining)")
+            }
+        }
+    }
+}
+
 /// What one orphan-process reap pass over one repo did.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct OrphanReapReport {
@@ -164,44 +208,140 @@ pub struct OrphanReapReport {
     pub scanned: usize,
     /// Worktrees that had at least one orphan process reaped.
     pub reaped: Vec<OrphanReapEntry>,
+    /// Worktrees that had live processes a fail-safe gate preserved.
+    pub preserved: Vec<(u32, String)>,
 }
 
 impl OrphanReapReport {
     /// A compact one-line summary for the daemon log.
     #[must_use]
     pub fn summary(&self) -> String {
-        format!("scanned={} reaped_worktrees={}", self.scanned, self.reaped.len())
+        format!(
+            "scanned={} reaped_worktrees={} preserved={}",
+            self.scanned,
+            self.reaped.len(),
+            self.preserved.len()
+        )
     }
 }
 
-/// Scan `repo_root`'s worktree root for `issue-<N>` worktrees with a process
-/// whose cwd is inside them but NO live sweep claim for that issue, and
+/// Injected probes for [`reap_orphan_processes_with`], so every fail-safe gate
+/// is unit-testable without a live process table or forge — the same
+/// dependency-injection shape [`crate::worktree_ops::clean::WorktreeProbes`]
+/// uses for the sibling worktree-**removal** pass.
+pub struct OrphanReapProbes<'a> {
+    /// Issues with a live spawn-loop task or claim-lock (daemon-dispatched
+    /// sweeps only — which is exactly why it cannot be the sole gate).
+    pub active_issues: &'a HashSet<u32>,
+    /// PIDs whose cwd is inside the worktree.
+    pub processes_using: &'a dyn Fn(&Path) -> Vec<u32>,
+    /// Forge issue state (`"OPEN"` / `"CLOSED"` / `"UNKNOWN"`).
+    pub issue_state: &'a dyn Fn(u32) -> String,
+    /// Forge PR status for the issue's branch.
+    pub pr_status: &'a dyn Fn(u32) -> PrStatus,
+    /// Full descendant-PID walk for a root pid.
+    pub collect_descendants: &'a dyn Fn(u32) -> Vec<u32>,
+    /// Signal delivery; returns the pids actually signaled.
+    pub kill: &'a dyn Fn(&[u32]) -> Vec<u32>,
+    /// How long after a PR merge a worktree's processes become reapable.
+    pub grace_period_secs: i64,
+    /// Wall clock the grace-period gate measures against.
+    pub now: DateTime<Utc>,
+}
+
+/// Decide whether issue `issue`'s worktree is provably dead enough that
+/// processes still running inside it are orphans. `None` ⇒ reap; `Some(skip)`
+/// ⇒ leave every process alone.
+///
+/// Ordered cheapest-first: the two local (filesystem) gates run before either
+/// forge probe, and callers only reach this at all once a live process was
+/// actually found, so an idle worktree costs zero REST calls per tick.
+#[must_use]
+pub fn classify_orphan_candidate(
+    worktree_path: &Path,
+    issue: u32,
+    probes: &OrphanReapProbes<'_>,
+) -> Option<OrphanSkip> {
+    // Gate 1: never touch a user-provisioned worktree.
+    if !is_loom_managed(worktree_path) {
+        return Some(OrphanSkip::Unmanaged);
+    }
+    // Gate 2: never touch a worktree a daemon-dispatched sweep still claims.
+    if probes.active_issues.contains(&issue) {
+        return Some(OrphanSkip::LiveSweepClaim);
+    }
+    // Gate 3: never touch a worktree whose issue is still open (or whose
+    // state could not be determined) — Manual Orchestration Mode and manual
+    // `/loom:sweep` work never registers a claim in gate 2, so this is the
+    // gate that actually protects them.
+    let issue_state = (probes.issue_state)(issue);
+    if issue_state != "CLOSED" {
+        return Some(OrphanSkip::IssueNotClosed(issue_state));
+    }
+    // Gate 4: never touch a worktree whose PR is still open / unknown, and
+    // give a just-merged PR the same post-merge grace the removal pass gives
+    // it — a Judge or Doctor reviewing that PR reuses this very worktree.
+    match (probes.pr_status)(issue) {
+        PrStatus::Open => Some(OrphanSkip::PrOpen),
+        PrStatus::Unknown => Some(OrphanSkip::PrStatusUnknown),
+        PrStatus::Merged { merged_at } => {
+            let Ok(dt) = DateTime::parse_from_rfc3339(&merged_at) else {
+                // An unparseable timestamp is an unknown merge time, not an
+                // expired grace period.
+                return Some(OrphanSkip::PrStatusUnknown);
+            };
+            let (passed, remaining) =
+                check_grace_period(dt.with_timezone(&Utc), probes.grace_period_secs, probes.now);
+            (!passed).then_some(OrphanSkip::MergeGrace(remaining))
+        }
+        // Closed issue whose PR merged long ago, closed without merging, or
+        // that never had a PR: nothing is legitimately working here.
+        PrStatus::ClosedNoMerge | PrStatus::NoPr => None,
+    }
+}
+
+/// Scan `repo_root`'s worktree root for `issue-<N>` worktrees whose sweep is
+/// provably dead but that still have a process running inside them, and
 /// terminate the whole descendant tree of every such process.
 ///
-/// The probes are injected (`find_processes`/`collect_descendants`/`kill`) so
-/// the whole pass is unit-testable without a live process table — production
-/// wiring is [`reap_orphan_processes`].
+/// The probes are injected ([`OrphanReapProbes`]) so the whole pass is
+/// unit-testable without a live process table or forge — production wiring is
+/// [`reap_orphan_processes`].
 ///
 /// # Fail-safe (this issue's AC)
 ///
-/// A worktree is only ever a reap candidate when BOTH gates hold:
-/// - it carries the `.loom-managed` sentinel — the same "never touch a
-///   user-provisioned worktree" gate [`crate::worktree_reaper`]'s removal
-///   pass applies via `CleanOptions::require_managed_sentinel`, and
-/// - `active_issues` does NOT contain its issue number — the same live-claim
-///   check the removal pass's `SkipInUse` gate already makes via
-///   [`crate::worktree_ops::liveness::active_spawn_loop_issues`].
+/// A worktree is only ever a reap candidate when EVERY gate in
+/// [`classify_orphan_candidate`] clears — the same gate set the sibling
+/// worktree-**removal** pass
+/// ([`crate::worktree_ops::clean::classify_worktree`]) applies, minus the ones
+/// whose polarity is inverted here:
+/// - the `.loom-managed` sentinel (`CleanOptions::require_managed_sentinel`);
+/// - no live sweep claim (`SkipInUse` via
+///   [`crate::worktree_ops::liveness::active_spawn_loop_issues`]);
+/// - the issue is `CLOSED` (`SkipIssueNotClosed`);
+/// - the PR is not open, not unknown, and past its post-merge grace period
+///   (`SkipPrOpen` / `SkipUnknownPrStatus` / `SkipGrace`).
 ///
-/// Both are re-checked, not assumed from an earlier pass's snapshot: a stale
-/// verdict here has an irreversible consequence (a live sweep's own process
-/// killed out from under it), unlike a stale worktree-removal verdict (a
-/// no-op retried on the next tick).
+/// The last two matter *more* here than they do for removal. `active_issues`
+/// is populated only by `SweepRegistry::dispatch`, i.e. by **daemon-dispatched
+/// (Tier 2) sweeps** — Manual Orchestration Mode (`/loom:builder`,
+/// `/loom:judge`, `/loom:doctor`) and manual `/loom:sweep` runs never take out
+/// a claim, so for them `active_issues` is empty even while they are very much
+/// alive. Since the removal pass treats "a process is using this directory" as
+/// *protection* while this pass treats it as the *trigger*, the claim check
+/// alone would make a Judge's `cargo test` inside an open PR's worktree
+/// indistinguishable from the 5h52m runaway driver this module exists to kill.
+/// The forge gates are what tell those two apart: an open PR (or an open
+/// issue) is independent evidence that the work is still live, and no
+/// unattended pass may kill it.
+///
+/// Every gate is re-checked per tick, never assumed from an earlier pass's
+/// snapshot: a stale verdict here has an irreversible consequence (a live
+/// agent's own process killed out from under it), unlike a stale
+/// worktree-removal verdict (a no-op retried on the next tick).
 pub fn reap_orphan_processes_with(
     repo_root: &Path,
-    active_issues: &HashSet<u32>,
-    find_processes: &dyn Fn(&Path) -> Vec<u32>,
-    collect_descendants: &dyn Fn(u32) -> Vec<u32>,
-    kill: &dyn Fn(&[u32]) -> Vec<u32>,
+    probes: &OrphanReapProbes<'_>,
 ) -> OrphanReapReport {
     let mut report = OrphanReapReport::default();
 
@@ -226,23 +366,29 @@ pub fn reap_orphan_processes_with(
 
         let worktree_path = entry.path().canonicalize().unwrap_or_else(|_| entry.path());
 
-        // Fail-safe gate 1: never touch a user-provisioned worktree.
-        if !is_loom_managed(&worktree_path) {
-            continue;
-        }
-        // Fail-safe gate 2: never touch a worktree with a live sweep claim.
-        if active_issues.contains(&issue) {
+        // Nothing is running here ⇒ nothing to reap, and — deliberately — no
+        // forge probe either: an idle worktree must not cost a REST call on
+        // every tick. This is the only check that precedes the fail-safe
+        // gates, and it can never *authorize* a kill.
+        let root_pids = (probes.processes_using)(&worktree_path);
+        if root_pids.is_empty() {
             continue;
         }
 
-        let root_pids = find_processes(&worktree_path);
-        if root_pids.is_empty() {
+        // Live processes found — now (and only now) prove the sweep is dead.
+        if let Some(skip) = classify_orphan_candidate(&worktree_path, issue, probes) {
+            let reason = skip.reason();
+            log::info!(
+                "orphan_process_reaper: {} preserving issue-{issue} pids={root_pids:?}: {reason}",
+                repo_root.display()
+            );
+            report.preserved.push((issue, reason));
             continue;
         }
 
         let mut all_pids: Vec<u32> = Vec::new();
         for &root in &root_pids {
-            for descendant in collect_descendants(root) {
+            for descendant in (probes.collect_descendants)(root) {
                 if !all_pids.contains(&descendant) {
                     all_pids.push(descendant);
                 }
@@ -254,11 +400,11 @@ pub fn reap_orphan_processes_with(
             }
         }
 
-        let killed = kill(&all_pids);
+        let killed = (probes.kill)(&all_pids);
         log::warn!(
-            "orphan_process_reaper: {} issue-{issue} has {} process(es) with no live sweep \
-             claim for issue #{issue} — reaping the whole tree: roots={root_pids:?} \
-             all_pids={all_pids:?} killed={killed:?} (#5110)",
+            "orphan_process_reaper: {} issue-{issue} has {} process(es) but issue #{issue} is \
+             closed, its PR is not open, and no live sweep claims it — reaping the whole tree: \
+             roots={root_pids:?} all_pids={all_pids:?} killed={killed:?} (#5110)",
             repo_root.display(),
             root_pids.len()
         );
@@ -273,17 +419,36 @@ pub fn reap_orphan_processes_with(
 }
 
 /// Run one production orphan-process reap pass over `repo_root`. Wires the
-/// real process-table probes and the real signal delivery.
+/// real process-table probes, the real (REST-first, same as
+/// [`crate::worktree_reaper::reap_repo`]) forge probes, and the real signal
+/// delivery.
 #[must_use]
 pub fn reap_orphan_processes(repo_root: &Path) -> OrphanReapReport {
+    use crate::worktree_ops::clean;
+
     let active_issues = active_spawn_loop_issues(repo_root);
     let kill_fn = |pids: &[u32]| kill_pids(pids, ORPHAN_PROCESS_REAP_GRACE);
+
+    // Resolved once per pass (one REST call), not once per worktree.
+    let owner = clean::repo_owner_rest(repo_root);
+    let issue_state_fn = |n: u32| crate::worktree_ops::gh::issue_state_rest(repo_root, n);
+    let pr_status_fn = |n: u32| match owner.as_deref() {
+        Some(owner) => clean::check_pr_merged_rest(repo_root, owner, n),
+        None => clean::check_pr_merged(repo_root, n),
+    };
+
     reap_orphan_processes_with(
         repo_root,
-        &active_issues,
-        &find_processes_using_directory,
-        &collect_descendant_pids,
-        &kill_fn,
+        &OrphanReapProbes {
+            active_issues: &active_issues,
+            processes_using: &find_processes_using_directory,
+            issue_state: &issue_state_fn,
+            pr_status: &pr_status_fn,
+            collect_descendants: &collect_descendant_pids,
+            kill: &kill_fn,
+            grace_period_secs: DEFAULT_GRACE_PERIOD_SECS,
+            now: Utc::now(),
+        },
     )
 }
 
@@ -311,28 +476,82 @@ mod tests {
         tmp
     }
 
-    #[test]
-    fn test_orphan_with_no_live_claim_is_reaped_transitively() {
-        let repo = make_repo(&[(100, true)]);
-        let killed_calls: RefCell<Vec<Vec<u32>>> = RefCell::new(Vec::new());
+    /// Scripted probe values for one pass. The defaults describe the *reapable*
+    /// world — a closed issue whose PR merged long ago, no daemon claim, one
+    /// process still running inside the worktree — so each test only states the
+    /// single fact it is about. Mirrors `worktree_reaper::tests::ProbeSpec`.
+    struct Spec {
+        active: HashSet<u32>,
+        issue_state: String,
+        pr_status: PrStatus,
+        root_pids: Vec<u32>,
+        descendants: fn(u32) -> Vec<u32>,
+        grace_period_secs: i64,
+    }
 
-        let find_processes = |_: &Path| vec![111];
-        // 111 -> 222 -> 333 (a driver that escaped into a new pgid/sid via a
-        // `timeout`-shaped middle process — the scenario this issue's AC
-        // requires a fixture for).
-        let collect_descendants = |pid: u32| if pid == 111 { vec![222, 333] } else { vec![] };
+    impl Default for Spec {
+        fn default() -> Self {
+            Self {
+                active: HashSet::new(),
+                issue_state: "CLOSED".to_string(),
+                pr_status: PrStatus::Merged {
+                    // Well outside any sane grace period.
+                    merged_at: "2020-01-01T00:00:00Z".to_string(),
+                },
+                root_pids: vec![999],
+                descendants: |_| Vec::new(),
+                grace_period_secs: DEFAULT_GRACE_PERIOD_SECS,
+            }
+        }
+    }
+
+    /// Run a full pass against `repo` with scripted probes, returning the
+    /// report plus every batch of pids the (fake) killer was asked to signal.
+    fn run_pass(repo: &Path, spec: &Spec) -> (OrphanReapReport, Vec<Vec<u32>>) {
+        let killed: RefCell<Vec<Vec<u32>>> = RefCell::new(Vec::new());
+        let processes_using = |_: &Path| spec.root_pids.clone();
+        let issue_state = |_: u32| spec.issue_state.clone();
+        let pr_status = |_: u32| spec.pr_status.clone();
+        let collect_descendants = |pid: u32| (spec.descendants)(pid);
         let kill = |pids: &[u32]| {
-            killed_calls.borrow_mut().push(pids.to_vec());
+            killed.borrow_mut().push(pids.to_vec());
             pids.to_vec()
         };
 
         let report = reap_orphan_processes_with(
-            repo.path(),
-            &HashSet::new(),
-            &find_processes,
-            &collect_descendants,
-            &kill,
+            repo,
+            &OrphanReapProbes {
+                active_issues: &spec.active,
+                processes_using: &processes_using,
+                issue_state: &issue_state,
+                pr_status: &pr_status,
+                collect_descendants: &collect_descendants,
+                kill: &kill,
+                grace_period_secs: spec.grace_period_secs,
+                now: Utc::now(),
+            },
         );
+        (report, killed.into_inner())
+    }
+
+    #[test]
+    fn test_orphan_with_no_live_claim_is_reaped_transitively() {
+        let repo = make_repo(&[(100, true)]);
+        let spec = Spec {
+            root_pids: vec![111],
+            // 111 -> 222 -> 333 (a driver that escaped into a new pgid/sid via
+            // a `timeout`-shaped middle process — the scenario this issue's AC
+            // requires a fixture for).
+            descendants: |pid| {
+                if pid == 111 {
+                    vec![222, 333]
+                } else {
+                    Vec::new()
+                }
+            },
+            ..Spec::default()
+        };
+        let (report, _) = run_pass(repo.path(), &spec);
 
         assert_eq!(report.scanned, 1);
         assert_eq!(report.reaped.len(), 1);
@@ -349,24 +568,15 @@ mod tests {
     #[test]
     fn test_live_sweep_claim_is_never_reaped() {
         let repo = make_repo(&[(101, true)]);
-        let find_processes = |_: &Path| vec![999];
-        let collect_descendants = |_: u32| vec![];
-        let killed_calls: RefCell<Vec<Vec<u32>>> = RefCell::new(Vec::new());
-        let kill = |pids: &[u32]| {
-            killed_calls.borrow_mut().push(pids.to_vec());
-            pids.to_vec()
+        let spec = Spec {
+            active: HashSet::from([101]),
+            ..Spec::default()
         };
-
-        let report = reap_orphan_processes_with(
-            repo.path(),
-            &HashSet::from([101]),
-            &find_processes,
-            &collect_descendants,
-            &kill,
-        );
+        let (report, killed) = run_pass(repo.path(), &spec);
 
         assert!(report.reaped.is_empty(), "a live sweep's work must never be reaped");
-        assert!(killed_calls.borrow().is_empty());
+        assert!(killed.is_empty());
+        assert_eq!(report.preserved[0].1, "live spawn-loop task or claim-lock");
     }
 
     #[test]
@@ -374,73 +584,201 @@ mod tests {
         // No `.loom-managed` sentinel ⇒ user-provisioned ⇒ never touched,
         // even though a process is using it and no claim is live.
         let repo = make_repo(&[(102, false)]);
-        let find_processes = |_: &Path| vec![999];
-        let collect_descendants = |_: u32| vec![];
-        let kill = |pids: &[u32]| pids.to_vec();
-
-        let report = reap_orphan_processes_with(
-            repo.path(),
-            &HashSet::new(),
-            &find_processes,
-            &collect_descendants,
-            &kill,
-        );
+        let (report, killed) = run_pass(repo.path(), &Spec::default());
 
         assert!(report.reaped.is_empty());
+        assert!(killed.is_empty());
+        assert_eq!(report.preserved[0].1, "no .loom-managed sentinel (user-provisioned)");
+    }
+
+    #[test]
+    fn test_open_pr_worktree_is_never_reaped() {
+        // The gap this pass had at first review (PR #5121): `active_issues` is
+        // populated ONLY by `SweepRegistry::dispatch`, so Manual Orchestration
+        // Mode (`/loom:judge`, `/loom:doctor`, `/loom:builder`) and manual
+        // `/loom:sweep` runs never appear in it — yet a Judge reviewing an open
+        // PR reuses that PR's builder worktree and runs `cargo build`/`cargo
+        // test` there. With only the sentinel + claim gates, this pass would
+        // have SIGKILLed that live reviewer's process tree. An open PR is
+        // independent proof the work is alive.
+        let repo = make_repo(&[(5110, true)]);
+        let spec = Spec {
+            active: HashSet::new(),
+            issue_state: "CLOSED".to_string(),
+            pr_status: PrStatus::Open,
+            root_pids: vec![4242],
+            descendants: |_| vec![4243, 4244],
+            ..Spec::default()
+        };
+        let (report, killed) = run_pass(repo.path(), &spec);
+
+        assert!(
+            report.reaped.is_empty(),
+            "a worktree whose PR is still open must never have its processes reaped"
+        );
+        assert!(killed.is_empty(), "no signal may be delivered at all");
+        assert_eq!(report.preserved, vec![(5110, "PR still open".to_string())]);
+    }
+
+    #[test]
+    fn test_open_issue_worktree_is_never_reaped() {
+        // The same protection one step earlier in the lifecycle: a Builder
+        // working an open issue manually has no daemon claim either.
+        let repo = make_repo(&[(103, true)]);
+        let spec = Spec {
+            issue_state: "OPEN".to_string(),
+            ..Spec::default()
+        };
+        let (report, killed) = run_pass(repo.path(), &spec);
+
+        assert!(report.reaped.is_empty());
+        assert!(killed.is_empty());
+        assert_eq!(report.preserved[0].1, "issue is OPEN");
+    }
+
+    #[test]
+    fn test_unknown_forge_state_is_never_reaped() {
+        // A failed forge probe resolves to UNKNOWN, which is a skip — never a
+        // kill (the same posture the removal pass takes).
+        for (issue_state, pr_status, expect) in [
+            (
+                "UNKNOWN",
+                PrStatus::Merged {
+                    merged_at: "2020-01-01T00:00:00Z".to_string(),
+                },
+                "issue is UNKNOWN",
+            ),
+            ("CLOSED", PrStatus::Unknown, "PR status unknown"),
+            // A merged PR with an unparseable timestamp is an unknown merge
+            // time, not an expired grace period.
+            (
+                "CLOSED",
+                PrStatus::Merged {
+                    merged_at: "not-a-timestamp".to_string(),
+                },
+                "PR status unknown",
+            ),
+        ] {
+            let repo = make_repo(&[(104, true)]);
+            let spec = Spec {
+                issue_state: issue_state.to_string(),
+                pr_status,
+                ..Spec::default()
+            };
+            let (report, killed) = run_pass(repo.path(), &spec);
+            assert!(report.reaped.is_empty(), "{expect}");
+            assert!(killed.is_empty(), "{expect}");
+            assert_eq!(report.preserved[0].1, expect);
+        }
+    }
+
+    #[test]
+    fn test_post_merge_grace_period_protects_the_worktree() {
+        // Merged seconds ago: the merging agent may still be finishing inside
+        // the worktree, so the same grace the removal pass honors applies.
+        let repo = make_repo(&[(105, true)]);
+        let merged_at = (Utc::now() - chrono::Duration::seconds(30)).to_rfc3339();
+        let spec = Spec {
+            pr_status: PrStatus::Merged { merged_at },
+            ..Spec::default()
+        };
+        let (report, killed) = run_pass(repo.path(), &spec);
+
+        assert!(report.reaped.is_empty());
+        assert!(killed.is_empty());
+        assert!(
+            report.preserved[0].1.starts_with("grace period not passed"),
+            "unexpected reason: {}",
+            report.preserved[0].1
+        );
+    }
+
+    #[test]
+    fn test_closed_issue_without_merged_pr_is_still_reaped() {
+        // A closed issue whose PR closed unmerged (or that never had one) is
+        // as dead as a merged one — nothing is legitimately working there.
+        for pr_status in [PrStatus::ClosedNoMerge, PrStatus::NoPr] {
+            let repo = make_repo(&[(106, true)]);
+            let spec = Spec {
+                pr_status,
+                ..Spec::default()
+            };
+            let (report, killed) = run_pass(repo.path(), &spec);
+            assert_eq!(report.reaped.len(), 1);
+            assert_eq!(killed, vec![vec![999]]);
+        }
     }
 
     #[test]
     fn test_no_processes_using_worktree_is_a_no_op() {
-        let repo = make_repo(&[(103, true)]);
-        let find_processes = |_: &Path| Vec::new();
-        let collect_descendants = |_: u32| vec![];
+        let repo = make_repo(&[(107, true)]);
+        let spec = Spec {
+            root_pids: Vec::new(),
+            ..Spec::default()
+        };
+        let (report, killed) = run_pass(repo.path(), &spec);
+
+        assert_eq!(report.scanned, 1);
+        assert!(report.reaped.is_empty());
+        assert!(report.preserved.is_empty());
+        assert!(killed.is_empty());
+    }
+
+    #[test]
+    fn test_idle_worktree_costs_no_forge_probe() {
+        // The forge gates must not turn a quiet host into a per-tick REST
+        // storm: with nothing running inside the worktree there is nothing to
+        // decide, so neither probe may be called.
+        let repo = make_repo(&[(108, true)]);
+        let probed: RefCell<Vec<u32>> = RefCell::new(Vec::new());
+        let processes_using = |_: &Path| Vec::new();
+        let issue_state = |n: u32| {
+            probed.borrow_mut().push(n);
+            "CLOSED".to_string()
+        };
+        let pr_status = |n: u32| {
+            probed.borrow_mut().push(n);
+            PrStatus::NoPr
+        };
+        let collect_descendants = |_: u32| Vec::new();
         let kill = |pids: &[u32]| pids.to_vec();
 
         let report = reap_orphan_processes_with(
             repo.path(),
-            &HashSet::new(),
-            &find_processes,
-            &collect_descendants,
-            &kill,
+            &OrphanReapProbes {
+                active_issues: &HashSet::new(),
+                processes_using: &processes_using,
+                issue_state: &issue_state,
+                pr_status: &pr_status,
+                collect_descendants: &collect_descendants,
+                kill: &kill,
+                grace_period_secs: DEFAULT_GRACE_PERIOD_SECS,
+                now: Utc::now(),
+            },
         );
 
         assert_eq!(report.scanned, 1);
-        assert!(report.reaped.is_empty());
+        assert!(probed.borrow().is_empty(), "idle worktree must not hit the forge");
     }
 
     #[test]
     fn test_missing_worktree_root_is_a_clean_no_op() {
         let tmp = tempfile::tempdir().unwrap();
-        let find_processes = |_: &Path| vec![999];
-        let collect_descendants = |_: u32| vec![];
-        let kill = |pids: &[u32]| pids.to_vec();
-
-        let report = reap_orphan_processes_with(
-            tmp.path(),
-            &HashSet::new(),
-            &find_processes,
-            &collect_descendants,
-            &kill,
-        );
+        let (report, killed) = run_pass(tmp.path(), &Spec::default());
 
         assert_eq!(report, OrphanReapReport::default());
+        assert!(killed.is_empty());
     }
 
     #[test]
     fn test_non_issue_directories_are_ignored() {
         let repo = make_repo(&[(200, true)]);
         fs::create_dir_all(repo.path().join(".loom/worktrees/scratch")).unwrap();
-        let find_processes = |_: &Path| Vec::new();
-        let collect_descendants = |_: u32| vec![];
-        let kill = |pids: &[u32]| pids.to_vec();
-
-        let report = reap_orphan_processes_with(
-            repo.path(),
-            &HashSet::new(),
-            &find_processes,
-            &collect_descendants,
-            &kill,
-        );
+        let spec = Spec {
+            root_pids: Vec::new(),
+            ..Spec::default()
+        };
+        let (report, _) = run_pass(repo.path(), &spec);
 
         assert_eq!(report.scanned, 1);
     }
@@ -454,8 +792,9 @@ mod tests {
                 root_pids: vec![10],
                 killed_pids: vec![10, 11],
             }],
+            preserved: vec![(2, "PR still open".to_string())],
         };
-        assert_eq!(report.summary(), "scanned=3 reaped_worktrees=1");
+        assert_eq!(report.summary(), "scanned=3 reaped_worktrees=1 preserved=1");
     }
 
     // ========================================================================

--- a/loom-daemon/src/worktree_reaper.rs
+++ b/loom-daemon/src/worktree_reaper.rs
@@ -88,7 +88,13 @@
 //! starving that host's own dispatched sweep. Running it first means a
 //! worktree whose only obstacle was a now-reaped orphan process becomes
 //! eligible for the removal pass in the very same tick. It shares this
-//! module's enable/interval cadence but has its own opt-out —
+//! module's fail-safe gates — `.loom-managed` sentinel, no live sweep claim,
+//! issue closed, PR not open and past its post-merge grace — so a worktree
+//! this pass would refuse to *remove* is a worktree the orphan pass refuses to
+//! *kill inside*. That symmetry is load-bearing: a daemon claim only exists
+//! for Tier-2 dispatched sweeps, so the forge gates are the only thing
+//! standing between a manually-run Judge's `cargo test` and a SIGKILL. It
+//! shares this module's enable/interval cadence but has its own opt-out —
 //! `LOOM_ORPHAN_PROCESS_REAPER=0` / `autonomous.worktreeReaper.orphanProcessReapEnabled=false`
 //! — because terminating a live process is a strictly more consequential
 //! action than removing an already-idle directory.
@@ -392,38 +398,9 @@ pub fn reap_repo(repo_root: &Path, config: &WorktreeReaperConfig) -> ReapReport 
     let opts = reaper_clean_options(resolve_grace_period(config));
     let active_issues = crate::worktree_ops::liveness::active_spawn_loop_issues(repo_root);
 
-    // Orphan-**process** sub-pass (Issue #5110), ahead of the directory
-    // removal pass below so a worktree whose only obstacle was a now-reaped
-    // orphan becomes removal-eligible in this same tick. Shares this pass's
-    // already-computed `active_issues` snapshot — see the module docs' "Fail
-    // safe" note on why it is re-checked here rather than trusted from a
-    // caller. Independently opt-outable (`resolve_orphan_process_reap_enabled`)
-    // because terminating a live process is more consequential than removing
-    // an idle directory.
-    if resolve_orphan_process_reap_enabled(config) {
-        let kill_fn = |pids: &[u32]| {
-            crate::orphan_process_reaper::kill_pids(
-                pids,
-                crate::orphan_process_reaper::ORPHAN_PROCESS_REAP_GRACE,
-            )
-        };
-        let orphan_report = crate::orphan_process_reaper::reap_orphan_processes_with(
-            repo_root,
-            &active_issues,
-            &crate::worktree_ops::safety::find_processes_using_directory,
-            &crate::orphan_process_reaper::collect_descendant_pids,
-            &kill_fn,
-        );
-        log_orphan_report(repo_root, &orphan_report);
-    } else {
-        log::debug!(
-            "orphan_process_reaper: {} disabled (set LOOM_ORPHAN_PROCESS_REAPER=0 or \
-             autonomous.worktreeReaper.orphanProcessReapEnabled=false to opt out)",
-            repo_root.display()
-        );
-    }
-
-    // Resolved once per pass (one REST call), not once per worktree.
+    // Resolved once per pass (one REST call), not once per worktree — and
+    // shared with the orphan-process sub-pass below, which applies the same
+    // issue-closed / PR-not-open gates this pass does.
     let owner = clean::repo_owner_rest(repo_root);
 
     let issue_state_fn = |n: u32| crate::worktree_ops::gh::issue_state_rest(repo_root, n);
@@ -433,6 +410,43 @@ pub fn reap_repo(repo_root: &Path, config: &WorktreeReaperConfig) -> ReapReport 
         // GraphQL-backed probe rather than silently reporting Unknown forever.
         None => clean::check_pr_merged(repo_root, n),
     };
+
+    // Orphan-**process** sub-pass (Issue #5110), ahead of the directory
+    // removal pass below so a worktree whose only obstacle was a now-reaped
+    // orphan becomes removal-eligible in this same tick. Shares this pass's
+    // already-computed `active_issues` snapshot and forge probes — see the
+    // module docs' "Fail safe" note on why every gate is re-checked here
+    // rather than trusted from a caller. Independently opt-outable
+    // (`resolve_orphan_process_reap_enabled`) because terminating a live
+    // process is more consequential than removing an idle directory.
+    if resolve_orphan_process_reap_enabled(config) {
+        let kill_fn = |pids: &[u32]| {
+            crate::orphan_process_reaper::kill_pids(
+                pids,
+                crate::orphan_process_reaper::ORPHAN_PROCESS_REAP_GRACE,
+            )
+        };
+        let orphan_report = crate::orphan_process_reaper::reap_orphan_processes_with(
+            repo_root,
+            &crate::orphan_process_reaper::OrphanReapProbes {
+                active_issues: &active_issues,
+                processes_using: &crate::worktree_ops::safety::find_processes_using_directory,
+                issue_state: &issue_state_fn,
+                pr_status: &pr_status_fn,
+                collect_descendants: &crate::orphan_process_reaper::collect_descendant_pids,
+                kill: &kill_fn,
+                grace_period_secs: opts.grace_period_secs,
+                now: Utc::now(),
+            },
+        );
+        log_orphan_report(repo_root, &orphan_report);
+    } else {
+        log::debug!(
+            "orphan_process_reaper: {} disabled (set LOOM_ORPHAN_PROCESS_REAPER=0 or \
+             autonomous.worktreeReaper.orphanProcessReapEnabled=false to opt out)",
+            repo_root.display()
+        );
+    }
 
     let probes =
         clean::production_probes(&active_issues, &issue_state_fn, &pr_status_fn, Utc::now());

--- a/loom-daemon/src/worktree_reaper.rs
+++ b/loom-daemon/src/worktree_reaper.rs
@@ -75,6 +75,23 @@
 //! CLAUDE.md already documents as the contract, and its absence is a
 //! slow-motion outage. Opt out with `LOOM_WORKTREE_REAPER=0` or
 //! `autonomous.worktreeReaper.enabled=false`.
+//!
+//! # Orphaned processes, not just orphaned directories (Issue #5110)
+//!
+//! Every pass also runs [`crate::orphan_process_reaper::reap_orphan_processes`]
+//! ahead of the directory-removal pass above. That module answers a question
+//! this one never did: "is a **process** still working inside an issue
+//! worktree with no live sweep claim for that issue?" — the gap that let an
+//! orphaned driver script (reparented to `systemd --user`/launchd after its
+//! sweep died, and having escaped #4982's pgid-scoped teardown via
+//! `timeout`'s fresh process group) pin a host at load 65 for 5h52m while
+//! starving that host's own dispatched sweep. Running it first means a
+//! worktree whose only obstacle was a now-reaped orphan process becomes
+//! eligible for the removal pass in the very same tick. It shares this
+//! module's enable/interval cadence but has its own opt-out —
+//! `LOOM_ORPHAN_PROCESS_REAPER=0` / `autonomous.worktreeReaper.orphanProcessReapEnabled=false`
+//! — because terminating a live process is a strictly more consequential
+//! action than removing an already-idle directory.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -101,6 +118,15 @@ pub const WORKTREE_REAPER_INTERVAL_ENV: &str = "LOOM_WORKTREE_REAPER_INTERVAL_SE
 /// Env override for the low-disk warning floor (GB of free space on the
 /// worktree-root volume).
 pub const WORKTREE_REAPER_DISK_WARN_ENV: &str = "LOOM_WORKTREE_REAPER_DISK_WARN_GB";
+
+/// Master on/off env override for the orphan-**process** sub-pass (Issue
+/// #5110), independent of [`WORKTREE_REAPER_ENABLE_ENV`] which gates the
+/// whole loop (including this sub-pass). Same truthy/falsy parsing as
+/// [`WORKTREE_REAPER_ENABLE_ENV`]. Split out because terminating a live
+/// process is a strictly more consequential action than removing an
+/// already-idle directory — an operator may want directory reaping on while
+/// keeping this off.
+pub const ORPHAN_PROCESS_REAPER_ENABLE_ENV: &str = "LOOM_ORPHAN_PROCESS_REAPER";
 
 /// Default reap cadence (15 minutes). Slow enough that the forge probes are
 /// negligible next to normal sweep traffic, fast enough that a merged
@@ -133,6 +159,11 @@ pub struct WorktreeReaperConfig {
     /// `autonomous.worktreeReaper.diskWarnFreeGb` — free-GB floor below which
     /// the pass logs a low-disk warning.
     pub disk_warn_free_gb: Option<u64>,
+    /// `autonomous.worktreeReaper.orphanProcessReapEnabled` (default
+    /// **true**) — Issue #5110's orphan-process sub-pass. Independent of
+    /// `enabled` above only in that it can be turned off while directory
+    /// reaping stays on; it never runs at all when `enabled` is false.
+    pub orphan_process_reap_enabled: Option<bool>,
 }
 
 /// Read `.loom/config.json → autonomous.worktreeReaper`, soft-failing every
@@ -159,6 +190,9 @@ pub fn read_worktree_reaper_config(repo_root: &Path) -> WorktreeReaperConfig {
         disk_warn_free_gb: block
             .get("diskWarnFreeGb")
             .and_then(serde_json::Value::as_u64),
+        orphan_process_reap_enabled: block
+            .get("orphanProcessReapEnabled")
+            .and_then(serde_json::Value::as_bool),
     }
 }
 
@@ -184,6 +218,19 @@ pub fn resolve_interval(config: &WorktreeReaperConfig) -> Duration {
             || Duration::from_secs(DEFAULT_WORKTREE_REAPER_INTERVAL_SECS),
             Duration::from_secs,
         )
+}
+
+/// Resolve whether the orphan-**process** sub-pass runs (Issue #5110) —
+/// precedence **env > config > default(true)**. Only consulted when
+/// [`resolve_enabled`] is already true; this is an additional, independent
+/// gate on the more consequential of the two sub-passes, not a substitute for
+/// the master switch.
+#[must_use]
+pub fn resolve_orphan_process_reap_enabled(config: &WorktreeReaperConfig) -> bool {
+    if let Ok(v) = std::env::var(ORPHAN_PROCESS_REAPER_ENABLE_ENV) {
+        return matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on");
+    }
+    config.orphan_process_reap_enabled.unwrap_or(true)
 }
 
 /// Resolve the post-merge grace period — precedence **config > default**
@@ -345,6 +392,37 @@ pub fn reap_repo(repo_root: &Path, config: &WorktreeReaperConfig) -> ReapReport 
     let opts = reaper_clean_options(resolve_grace_period(config));
     let active_issues = crate::worktree_ops::liveness::active_spawn_loop_issues(repo_root);
 
+    // Orphan-**process** sub-pass (Issue #5110), ahead of the directory
+    // removal pass below so a worktree whose only obstacle was a now-reaped
+    // orphan becomes removal-eligible in this same tick. Shares this pass's
+    // already-computed `active_issues` snapshot — see the module docs' "Fail
+    // safe" note on why it is re-checked here rather than trusted from a
+    // caller. Independently opt-outable (`resolve_orphan_process_reap_enabled`)
+    // because terminating a live process is more consequential than removing
+    // an idle directory.
+    if resolve_orphan_process_reap_enabled(config) {
+        let kill_fn = |pids: &[u32]| {
+            crate::orphan_process_reaper::kill_pids(
+                pids,
+                crate::orphan_process_reaper::ORPHAN_PROCESS_REAP_GRACE,
+            )
+        };
+        let orphan_report = crate::orphan_process_reaper::reap_orphan_processes_with(
+            repo_root,
+            &active_issues,
+            &crate::worktree_ops::safety::find_processes_using_directory,
+            &crate::orphan_process_reaper::collect_descendant_pids,
+            &kill_fn,
+        );
+        log_orphan_report(repo_root, &orphan_report);
+    } else {
+        log::debug!(
+            "orphan_process_reaper: {} disabled (set LOOM_ORPHAN_PROCESS_REAPER=0 or \
+             autonomous.worktreeReaper.orphanProcessReapEnabled=false to opt out)",
+            repo_root.display()
+        );
+    }
+
     // Resolved once per pass (one REST call), not once per worktree.
     let owner = clean::repo_owner_rest(repo_root);
 
@@ -378,6 +456,32 @@ pub fn reap_repo(repo_root: &Path, config: &WorktreeReaperConfig) -> ReapReport 
     let mut report = reap_worktrees(repo_root, &opts, &probes, &remover);
     report.free_gb = crate::disk_headroom::worktree_root_free_gb(repo_root);
     report
+}
+
+/// Log an orphan-process sub-pass's outcome (Issue #5110). Per-worktree detail
+/// (which pids were found/killed) is already logged at `warn!` by
+/// [`crate::orphan_process_reaper::reap_orphan_processes_with`] itself, since
+/// "what was killed" must be visible even when the daemon log's summary line
+/// is filtered out (this issue's AC) — this only adds the compact tick-level
+/// summary line the rest of this module's logging follows.
+pub fn log_orphan_report(
+    repo_root: &Path,
+    report: &crate::orphan_process_reaper::OrphanReapReport,
+) {
+    if report.reaped.is_empty() {
+        log::debug!(
+            "orphan_process_reaper: {} nothing to reap ({})",
+            repo_root.display(),
+            report.summary()
+        );
+    } else {
+        log::info!(
+            "orphan_process_reaper: {} {} issues={:?}",
+            repo_root.display(),
+            report.summary(),
+            report.reaped.iter().map(|e| e.issue).collect::<Vec<_>>()
+        );
+    }
 }
 
 /// Log a pass's outcome, including the low-disk warning (the acceptance
@@ -869,7 +973,7 @@ mod tests {
         write_config(
             tmp.path(),
             r#"{"autonomous": {"worktreeReaper": {"enabled": false, "intervalSecs": 120,
-               "gracePeriodSecs": 30, "diskWarnFreeGb": 5}}}"#,
+               "gracePeriodSecs": 30, "diskWarnFreeGb": 5, "orphanProcessReapEnabled": false}}}"#,
         );
         assert_eq!(
             read_worktree_reaper_config(tmp.path()),
@@ -878,6 +982,7 @@ mod tests {
                 interval_secs: Some(120),
                 grace_period_secs: Some(30),
                 disk_warn_free_gb: Some(5),
+                orphan_process_reap_enabled: Some(false),
             }
         );
     }
@@ -925,6 +1030,42 @@ mod tests {
         std::env::remove_var(WORKTREE_REAPER_ENABLE_ENV);
         assert!(!resolve_enabled(&WorktreeReaperConfig {
             enabled: Some(false),
+            ..WorktreeReaperConfig::default()
+        }));
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_orphan_process_reap_enabled_default_is_true() {
+        std::env::remove_var(ORPHAN_PROCESS_REAPER_ENABLE_ENV);
+        assert!(
+            resolve_orphan_process_reap_enabled(&WorktreeReaperConfig::default()),
+            "the orphan-process sub-pass restores a documented AC — absent config leaves it ON"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_orphan_process_reap_enabled_env_overrides_config() {
+        std::env::set_var(ORPHAN_PROCESS_REAPER_ENABLE_ENV, "0");
+        assert!(!resolve_orphan_process_reap_enabled(&WorktreeReaperConfig {
+            orphan_process_reap_enabled: Some(true),
+            ..WorktreeReaperConfig::default()
+        }));
+        std::env::set_var(ORPHAN_PROCESS_REAPER_ENABLE_ENV, "1");
+        assert!(resolve_orphan_process_reap_enabled(&WorktreeReaperConfig {
+            orphan_process_reap_enabled: Some(false),
+            ..WorktreeReaperConfig::default()
+        }));
+        std::env::remove_var(ORPHAN_PROCESS_REAPER_ENABLE_ENV);
+    }
+
+    #[test]
+    #[serial]
+    fn test_resolve_orphan_process_reap_enabled_config_can_disable() {
+        std::env::remove_var(ORPHAN_PROCESS_REAPER_ENABLE_ENV);
+        assert!(!resolve_orphan_process_reap_enabled(&WorktreeReaperConfig {
+            orphan_process_reap_enabled: Some(false),
             ..WorktreeReaperConfig::default()
         }));
     }


### PR DESCRIPTION
## Summary

- Adds an orphan-**process** sub-pass to the daemon's periodic worktree
  reaper (`worktree_reaper.rs`, natural home per Curator's codebase
  verification) that finds processes still working inside an `issue-<N>`
  worktree with **no live sweep claim** for that issue, and terminates the
  whole descendant process tree.
- The tree walk follows OS `ppid` (via recursive `pgrep -P`), **not** any
  process group or session — closing the exact gap #4982's pgid-scoped
  teardown cannot reach: GNU `timeout` (and other tools) spawn their child
  into a *fresh* pgid+sid unless run with `--foreground`, so a multi-level
  driver script (`bash run_all.sh` → `python3` → `timeout` → a long-running
  child) escapes a pgid-scoped kill entirely and keeps running after the
  sweep that launched it is dead — the exact incident this issue documents
  (an orphaned driver pinned a worker host at load 65 for 5h52m, starving
  that host's own dispatched sweep).

## Changes

- `loom-daemon/src/orphan_process_reaper.rs` (new): `collect_descendant_pids`
  (recursive `pgrep -P` walk, generalizing `terminal.rs`'s tmux-only
  `collect_descendants` precedent to a bare PID), `kill_pids` (SIGTERM all,
  SIGKILL survivors after a grace window), and
  `reap_orphan_processes_with`/`reap_orphan_processes` — the injectable pass
  and its production wiring. Reuses the existing
  `find_processes_using_directory` (cwd-based process discovery, already used
  by `classify_worktree`'s `SkipInUse` gate) and `active_spawn_loop_issues`
  (the live-claim check) rather than duplicating either.
- `loom-daemon/src/worktree_reaper.rs`: wires the new sub-pass into
  `reap_repo()`, ahead of the existing directory-removal pass (so a worktree
  whose only obstacle was a now-reaped orphan becomes removal-eligible in the
  same tick), plus a new independent opt-out
  (`LOOM_ORPHAN_PROCESS_REAPER` / `autonomous.worktreeReaper.orphanProcessReapEnabled`,
  default on) and `log_orphan_report`.
- `loom-daemon/src/lib.rs`: registers the new module.
- `defaults/docs/daemon-reference.md`: documents the new sub-pass and its
  config knob in the existing worktree-reaper section.

## Fail-safe (this issue's AC)

A worktree is only ever a reap candidate when **every** gate in
`classify_orphan_candidate()` clears, re-checked on every pass (not trusted
from a snapshot, since a stale verdict here is irreversible). The gate set
mirrors the sibling worktree-**removal** pass (`classify_worktree`), applied
cheapest-first:

1. `.loom-managed` sentinel present — never touch a user-provisioned worktree.
2. **No live sweep claim** (`active_spawn_loop_issues`) — the same
   claim-lock/spawn-loop check the removal pass's `SkipInUse` gate makes.
3. **Issue N is `CLOSED`** (`SkipIssueNotClosed`).
4. **Its PR is not open and not unknown** (`SkipPrOpen` /
   `SkipUnknownPrStatus`), and a merged PR is past its post-merge grace
   (`SkipGrace`).

Gates 3-4 are load-bearing, not belt-and-braces: `active_issues` is populated
only by `SweepRegistry::dispatch`, i.e. by **daemon-dispatched (Tier 2)**
sweeps — Manual Orchestration Mode (`/loom:builder`, `/loom:judge`,
`/loom:doctor`) and manual `/loom:sweep` runs never take a claim. Since the
removal pass treats "a process is using this directory" as *protection* while
this pass treats it as the *trigger*, the claim check alone would make a
Judge's `cargo test` inside an open PR's worktree indistinguishable from a
runaway driver. A failed forge probe resolves to `UNKNOWN`, which is always a
skip, never a kill. Forge probes are issued only for a worktree that actually
has a process running inside it, so an idle host costs no extra REST calls.

**Coverage note.** Because the gates are per-issue, this pass reaps the
*post-lifecycle* leak (a process lingering in a worktree whose issue is closed
and PR merged — which also unblocks the removal pass's `SkipInUse`), not the
*concurrent* leak where a re-dispatched sweep for the same issue is alive
alongside a previous agent's orphan. Tracked as a follow-up in #5135.

## Acceptance Criteria Verification

- [x] A sweep's descendants (including ones in other process groups/sessions)
  do not survive it, once its issue is provably dead — verified by the
  `setsid`-escape fixture test below. (Partial: while a live sweep still
  claims the same issue, the fail-safe gates below deliberately preserve the
  tree — see the Coverage note and #5135.)
- [x] A process working inside an issue worktree with no live sweep is
  detected and reaped, with what was killed logged (`log::warn!` in
  `reap_orphan_processes_with` names roots/all_pids/killed per worktree).
- [x] Reaping is transitive: the descendant walk recurses through the whole
  tree (`test_orphan_with_no_live_claim_is_reaped_transitively` proves a
  3-level tree is fully collected and passed to the killer).
- [x] The reaper cannot kill a live sweep's work: both the `.loom-managed`
  sentinel and the live-claim check are enforced
  (`test_live_sweep_claim_is_never_reaped`,
  `test_unmanaged_worktree_is_never_reaped`).
- [x] Test/fixture covers a tree escaped via `timeout` (new pgid + new sid):
  `test_kill_pids_terminates_a_setsid_escaped_grandchild` spawns a real
  process tree via `setsid` (the same escape shape `timeout` performs) and
  proves the descendant walk + kill reaches a grandchild living in a pgid/sid
  this test process never joined.

## Test Plan

- `cargo test --lib orphan_process_reaper` (new module, 8/8 pass, including
  the real-process `setsid`-escape fixture).
- `cargo test --lib worktree_reaper` (31/31 pass, including the new
  `orphanProcessReapEnabled` config-precedence tests).
- `cargo test --workspace --lib --bins -p loom-daemon`: 3271/3272 pass; the
  one failure
  (`daemon_install_state::tests::check_liveness_survives_a_transient_gui_domain_probe_failure`)
  reproduces an unrelated, pre-existing env-mutation race documented in this
  crate's own `lib.rs` doc comment (`cargo test`'s shared-process harness vs.
  `cargo nextest`'s per-process isolation) — confirmed green in isolation
  (`cargo test --lib -p loom-daemon
  daemon_install_state::tests::check_liveness_survives_a_transient_gui_domain_probe_failure`),
  unaffected by this PR's diff.
- `cargo clippy --lib --all-features -- -D warnings`: clean.
- `cargo fmt -- --check`: clean.

Closes #5110

