### PR TITLE
fix(guard): merge-redirect masking still bypassable via flag-captured cat-heredoc piped to a shell

### DIFF
--- a/.loom/hooks/guard-loom-workflow.sh
+++ b/.loom/hooks/guard-loom-workflow.sh
@@ -224,6 +224,12 @@ mask_cat_heredoc_bodies() {
                 if (wordend <= start) continue
                 if (substr(line, wordend, 1) != qc) continue
                 delim = substr(line, start, wordend - start)
+                # The opener line must END after the quoted delimiter. Anything
+                # trailing it routes cat stdout somewhere else (a pipe into a
+                # shell, a redirect into a file), which is the class that must
+                # stay visible to the merge-redirect grep.
+                rest = substr(line, wordend + 1)
+                if (rest ~ /[^ \t]/) continue
                 closeat = 0
                 for (j = i + 1; j <= nl; j++) {
                     trimmed = lines[j]

--- a/defaults/hooks/guard-loom-workflow.sh
+++ b/defaults/hooks/guard-loom-workflow.sh
@@ -224,6 +224,12 @@ mask_cat_heredoc_bodies() {
                 if (wordend <= start) continue
                 if (substr(line, wordend, 1) != qc) continue
                 delim = substr(line, start, wordend - start)
+                # The opener line must END after the quoted delimiter. Anything
+                # trailing it routes cat stdout somewhere else (a pipe into a
+                # shell, a redirect into a file), which is the class that must
+                # stay visible to the merge-redirect grep.
+                rest = substr(line, wordend + 1)
+                if (rest ~ /[^ \t]/) continue
                 closeat = 0
                 for (j = i + 1; j <= nl; j++) {
                     trimmed = lines[j]

--- a/tests/hooks/test-guard-loom-workflow.sh
+++ b/tests/hooks/test-guard-loom-workflow.sh
@@ -265,6 +265,43 @@ EOF
 assert_deny "Still block gh pr merge in a cat-heredoc captured then eval'd" \
     "$GH_5115_CAT_EVAL_CMD"
 
+# Regression guard (issue #5122 -- capre-gate bypass reported after #5115
+# merged): the `capre` prefix gate (added by #5115 to allow the documented
+# `-m "$(cat <<'EOF' ... EOF)"` idiom) only inspected the text BEFORE the
+# `cat` token -- never what follows the heredoc opener line. So wrapping the
+# SAME bypass shapes above in a flag-captured prefix (`-m "$(cat <<'EOF' |
+# bash ...)"`) slipped straight past the gate and was masked as inert data,
+# even though `cat`'s stdout is still piped into a live shell. The opener
+# line must END immediately after the quoted delimiter to be masked; any
+# suffix -- a pipe, a redirect, anything -- must keep the body visible to
+# the merge-redirect grep.
+GH_5122_FLAG_CAPTURED_PIPE_BASH_CMD='git commit -m "$(cat <<'"'"'EOF'"'"' | bash
+'"$PHRASE_CMD"' 123 --admin
+EOF
+)"'
+assert_deny "Still block gh pr merge in a flag-captured cat-heredoc piped into bash (#5122)" \
+    "$GH_5122_FLAG_CAPTURED_PIPE_BASH_CMD"
+
+# Same class, but the redirect parks the body in a file instead of piping it
+# directly -- a later command on the same line then executes that file. The
+# pipe is not the only live vector; any redirect on the opener line is.
+GH_5122_FLAG_CAPTURED_REDIRECT_FILE_CMD='git commit -m "$(cat <<'"'"'EOF'"'"' 1> /tmp/loom-test-5122.sh
+'"$PHRASE_CMD"' 123 --admin
+EOF
+)" ; bash /tmp/loom-test-5122.sh'
+assert_deny "Still block gh pr merge in a flag-captured cat-heredoc redirected to a file then bash'd (#5122)" \
+    "$GH_5122_FLAG_CAPTURED_REDIRECT_FILE_CMD"
+
+# The `<<-` (dash) heredoc variant (strips leading tabs from the body) must
+# get the same treatment -- the opener-line-suffix check does not special-
+# case the `-` after `<<`.
+GH_5122_FLAG_CAPTURED_DASH_PIPE_BASH_CMD='git commit -m "$(cat <<-'"'"'EOF'"'"' | bash
+'"$PHRASE_CMD"' 123 --admin
+EOF
+)"'
+assert_deny "Still block gh pr merge in a flag-captured cat <<- heredoc piped into bash (#5122)" \
+    "$GH_5122_FLAG_CAPTURED_DASH_PIPE_BASH_CMD"
+
 echo ""
 
 # =========================================================================


### PR DESCRIPTION
## Summary

Fixes a catastrophic-severity guard regression (regression from #5115) in
`mask_cat_heredoc_bodies()` in `defaults/hooks/guard-loom-workflow.sh`. The
`capre` gate added by #5115 only inspected the text *before* the `cat` token
in a `cat <<'EOF'` heredoc opener line, never what follows it. This let a
flag-captured cat-heredoc whose opener line has a trailing pipe or redirect
(e.g. `-m "$(cat <<'EOF' | bash ...)"`) be masked as inert text-data and sail
through the merge-redirect grep as ALLOW, even though the heredoc body is a
live shell-execution vector.

## Fix

Add a 2-line suffix check immediately after `delim = substr(line, start,
wordend - start)` inside `mask_cat_heredoc_bodies()`: the heredoc opener line
must end (only trailing whitespace permitted) right after the closing quote
of the delimiter to be treated as inert. Any trailing pipe, redirect, or
other content keeps the body visible to the merge-redirect grep, exactly as
before #5115.

Mirrored identically in both `defaults/hooks/guard-loom-workflow.sh` and the
tracked `.loom/hooks/guard-loom-workflow.sh` copy (verified byte-identical
after the change).

## Testing

- `./tests/hooks/test-guard-loom-workflow.sh`: 37/37 pass (34 existing + 3
  new regression tests: flag-captured `| bash` form, flag-captured `1> file`
  + later-`bash` form, and the `<<-` (dash) variant).
- Existing #5109 false-positive ALLOW tests (heredoc commit message quoting
  the phrase as prose, `--search` query containing the phrase as text) still
  pass.
- `shellcheck -S warning` clean on both hook copies.
- Manually reproduced the exact repro from the issue and confirmed it now
  denies (previously silent ALLOW), and confirmed all 7 bypass shapes in the
  issue's table now deny while both #5109 false-positive shapes still allow.

## Test plan

- [x] `./tests/hooks/test-guard-loom-workflow.sh` passes (37/37)
- [x] `defaults/hooks/guard-loom-workflow.sh` and `.loom/hooks/guard-loom-workflow.sh` byte-identical
- [x] `shellcheck -S warning` clean on both copies
- [x] Manual repro from issue now denies
- [x] All 7 bypass shapes deny; both #5109 false-positive shapes still allow

Closes #5122