### PR TITLE
feat(daemon): report positive telemetry-export liveness in status and health

### DIFF
--- a/defaults/docs/observability.md
+++ b/defaults/docs/observability.md
@@ -135,6 +135,60 @@ published and the `observability` health section stays silent. Choosing OTLP
 therefore trades this particular misconfiguration guardrail away; keep the
 default `"https"` sink if you want it.
 
+## 3b. Confirming telemetry is actually flowing
+
+`loom-daemon health`'s `observability` section is **anomaly-only** by design
+(issue #4830): it renders when something is wrong and stays silent otherwise.
+That is the right call for a surface whose value is that every printed line is
+worth reading — but on its own it left three very different hosts looking
+identical (no section at all): one exporting perfectly, one with observability
+disabled, and one that was configured, running, and had **never successfully
+exported anything**. A `~/.loom/logs/observability-queue.jsonl` of 0 bytes is
+equally consistent with "drained cleanly" and "nothing was ever enqueued", so
+confirming the healthy case meant grepping `daemon.log` for the *absence* of a
+warning.
+
+`loom-daemon status` now states the answer positively (issue #5083):
+
+```
+Observability: OK — last export 12s ago, 3481 record(s) as host_id=robb-studio → https://…/ingest
+```
+
+The same facts are machine-readable under `observability_export` in
+`loom-daemon status --json`, so a watch loop can assert health instead of
+inferring it from silence:
+
+```bash
+loom-daemon status --json | jq -e '.observability_export.state == "healthy"'
+```
+
+| `state` | Meaning | Rendered as |
+|---|---|---|
+| `disabled` | Exporter not running: `enabled=false`, or enabled but under-configured (no endpoint / no readable ingest key / `otlp` without the Cargo feature) | `Observability: disabled …` |
+| `starting` | Running, nothing acked yet, still inside the grace window (3 × `flushIntervalSecs`, floored at 10 min) — a just-rolled daemon, not a fault | `Observability: starting …` |
+| `never_exported` | Running well past the grace window and **no batch has ever been acked** — the silent failure mode | `Observability: NEVER EXPORTED …` |
+| `healthy` | Batches are being acked and the ids agree | `Observability: OK …` |
+| `host_id_mismatch` | Batches are being acked, but under a different `host_id` than this daemon reports for itself (the #4830 condition, §3 above) | `Observability: HOST-ID MISMATCH …` |
+| `failing` | The most recent flush attempt errored; the queue is retrying with backoff | `Observability: FAILING …` |
+
+`observability_export` also carries `host_id`, `endpoint`, `exporter`,
+`started_at`, `last_success_at`, `last_failure_at`, `last_failure_detail`,
+`records_exported`, `consecutive_failures`, and `flush_interval_secs`. A `null`
+`observability_export` means the daemon binary predates #5083 — "cannot tell",
+never "disabled"; restart the daemon onto a current binary.
+
+The health section keeps its anomaly-only contract. It now recognizes two
+additional *non-green* conditions — `never_exported` and `failing` — which are
+anomalies by the same rule that already admitted `host_id_mismatch`; `healthy`,
+`starting`, and `disabled` still render nothing at all. When a section does
+render, its `detail` payload carries the full `observability_export` record, so
+a machine consumer of `loom-daemon health --json` gets the positive facts too.
+
+**Note on scope**: this is a *transport-level* signal — it answers "are batches
+being acked", not "is every record kind being enqueued". A host can report
+`healthy` while a specific record kind is silently never queued (e.g. issue
+#5084); the two checks are complementary.
+
 ## 4. The backend: deploy your own Cloudflare Worker
 
 The Phase-2 backend is a Cloudflare Worker (D1 for durable history, a

--- a/loom-daemon/src/cli/status.rs
+++ b/loom-daemon/src/cli/status.rs
@@ -806,6 +806,7 @@ pub(crate) mod status_client_tests {
             daemon_build_commit: Some("18887b5c".to_string()),
             work_finder_interval_secs: Some(60),
             observability_host_id_mismatch: None,
+            observability_export: None,
         }
     }
 

--- a/loom-daemon/src/cli/status_render.rs
+++ b/loom-daemon/src/cli/status_render.rs
@@ -176,6 +176,15 @@ pub(crate) fn build_status_json_value(
         // reports for itself, so its telemetry is being filed under the wrong
         // host. `null` in the common case (ids agree, or no exporter running).
         "observability_host_id_mismatch": report.observability_host_id_mismatch,
+        // Positive export-liveness signal (#5083). Unlike the anomaly-only
+        // field above, this is non-null for any daemon of this vintage and
+        // always carries a `state`, so a watch loop can assert health rather
+        // than infer it from the absence of a warning:
+        //   loom-daemon status --json \
+        //     | jq -e '.observability_export.state == "healthy"'
+        // States: disabled | starting | never_exported | healthy |
+        // host_id_mismatch | failing. `null` only from a pre-#5083 daemon.
+        "observability_export": report.observability_export,
         "dynamic_cap": {
             "token_pool_size": report.token_pool_size,
             // The directory the daemon resolved for the pool above (#4292) —
@@ -689,6 +698,85 @@ fn render_preflight_advisory_line(report: &DaemonStatusReport) -> Option<String>
     ))
 }
 
+/// The `Observability: …` telemetry-export line (Issue #5083) — always
+/// rendered, because the whole point is that "healthy" must be *stated*, not
+/// inferred from the absence of a warning.
+///
+/// Split out of [`print_status_human`] so every state is unit-testable without
+/// capturing process stdout, mirroring [`render_admission_brake_line`]. `now`
+/// is passed in (rather than read here) so the tests are deterministic.
+///
+/// `status = None` means a pre-#5083 daemon binary that never computed one —
+/// reported as `unknown`, never silently as `disabled`, which would be an
+/// invented fact about a daemon that said nothing.
+fn render_observability_line(
+    status: Option<&loom_daemon::types::ObservabilityExportStatus>,
+    now: DateTime<Utc>,
+) -> String {
+    use loom_daemon::health::format_window;
+    use loom_daemon::types::ObservabilityExportState as State;
+
+    let Some(s) = status else {
+        return "Observability: unknown (older daemon binary — restart to pick up #5083)"
+            .to_string();
+    };
+    let host = s.host_id.as_deref().unwrap_or("unknown-host");
+    let endpoint = s.endpoint.as_deref().unwrap_or("(no endpoint)");
+    let uptime = s
+        .uptime_secs(now)
+        .map_or_else(|| "?".to_string(), format_window);
+    let last_success = s
+        .last_success_age_secs(now)
+        .map_or_else(|| "never".to_string(), |age| format!("{} ago", format_window(age)));
+    // Re-derived rather than trusting the daemon-stamped `state`, so a status
+    // payload that sat in a pipe for a while still reads correctly across the
+    // grace boundary — `classify` is the single shared rule (`types.rs`).
+    match s.classify(now) {
+        State::Disabled => {
+            "Observability: disabled (no telemetry export — set observability.enabled=true to opt in)"
+                .to_string()
+        }
+        State::Starting => format!(
+            "Observability: starting — exporter up {uptime} as host_id={host}, no batch acked yet \
+             (first flush due within {}s) → {endpoint}",
+            s.flush_interval_secs.unwrap_or(0)
+        ),
+        State::NeverExported => format!(
+            "Observability: NEVER EXPORTED — running {uptime} as host_id={host} and no batch has \
+             EVER been acked; telemetry is not reaching {endpoint}{}",
+            s.last_failure_detail
+                .as_deref()
+                .map_or_else(String::new, |d| format!(" (last error: {d})")),
+        ),
+        State::Healthy => format!(
+            "Observability: OK — last export {last_success}, {} record(s) as host_id={host} → {endpoint}",
+            s.records_exported
+        ),
+        State::HostIdMismatch => format!(
+            "Observability: HOST-ID MISMATCH — telemetry is landing under host_id={}, not {host} \
+             (last export {last_success}, {} record(s)) → {endpoint}",
+            s.ingest_host_id.as_deref().unwrap_or("unknown"),
+            s.records_exported
+        ),
+        State::Failing => format!(
+            "Observability: FAILING — {} consecutive failed flush(es) as host_id={host}, last \
+             success {last_success} → {endpoint}{}",
+            s.consecutive_failures,
+            s.last_failure_detail
+                .as_deref()
+                .map_or_else(String::new, |d| format!(" (last error: {d})")),
+        ),
+        // Only reachable from a NEWER daemon reporting a state this build does
+        // not know. Say so plainly rather than collapsing it into one of the
+        // known states — the same "degrade legibly, never mislabel" posture the
+        // Safehouse block takes for an unknown state string (#4464).
+        State::Unrecognized => format!(
+            "Observability: unrecognized state from a newer daemon binary (host_id={host}) — \
+             upgrade this client to read it"
+        ),
+    }
+}
+
 /// The standalone `Admission brake: …` status line (#4903), or `None` when no
 /// brake is registered (older daemon / never registered) — which renders
 /// nothing at all, the zero-behavior-change baseline the host breaker's line
@@ -1107,6 +1195,17 @@ pub(crate) fn print_status_human(
             println!("Safehouse:     unknown (older daemon binary — restart to pick up #4345)")
         }
     }
+
+    // Telemetry export liveness (#5083): the positive counterpart to the
+    // host-id mismatch WARNING printed further up. Before this, "exporting
+    // fine", "observability disabled", and "configured but silently never
+    // exported" were all rendered as the same thing — nothing — and telling
+    // them apart meant grepping `daemon.log` for the *absence* of a warning.
+    // Same shape as the Safehouse block above, for the same reason.
+    println!(
+        "{}",
+        render_observability_line(report.observability_export.as_ref(), Utc::now())
+    );
 
     // Watchdog protection state (#4354): this daemon is answering, so it is
     // alive — but is anything positioned to notice when it *stops* being? Before
@@ -1904,8 +2003,9 @@ mod status_protection_tests {
     //! (#4069): the reachable payload carries `protection` and never
     //! `install_state`, and `protection` is wire-compatible-nullable so a host
     //! where no loom dir resolves still emits a well-formed payload.
-    use super::build_status_json_value;
+    use super::{build_status_json_value, render_observability_line};
     use crate::cli::status::status_client_tests::sample_report;
+    use chrono::{DateTime, Utc};
     use loom_daemon::daemon_install_state::{ProtectionReport, ProtectionState, WatchdogJob};
     use std::path::PathBuf;
 
@@ -2022,6 +2122,143 @@ mod status_protection_tests {
         assert_eq!(m["daemon_host_id"], "robb-studio");
         assert_eq!(m["ingest_host_id"], "robb-pro");
         assert!(m["first_seen_at"].is_string());
+    }
+
+    // ===================================================================
+    // Telemetry export liveness (#5083)
+    // ===================================================================
+
+    fn render_now() -> DateTime<Utc> {
+        "2026-08-03T12:00:00Z".parse().unwrap()
+    }
+
+    /// A running HTTPS exporter, up four hours, that has never been touched by
+    /// a flush attempt — the base the individual states mutate from.
+    fn export_status(
+        mutate: impl FnOnce(&mut loom_daemon::types::ObservabilityExportStatus),
+    ) -> loom_daemon::types::ObservabilityExportStatus {
+        let mut status = loom_daemon::types::ObservabilityExportStatus {
+            state: loom_daemon::types::ObservabilityExportState::Starting,
+            host_id: Some("robb-studio".to_string()),
+            ingest_host_id: None,
+            endpoint: Some("https://dashboard.example/ingest".to_string()),
+            exporter: Some("https".to_string()),
+            started_at: Some(render_now() - chrono::Duration::hours(4)),
+            last_success_at: None,
+            last_failure_at: None,
+            last_failure_detail: None,
+            records_exported: 0,
+            consecutive_failures: 0,
+            flush_interval_secs: Some(30),
+        };
+        mutate(&mut status);
+        status
+    }
+
+    #[test]
+    fn observability_line_states_health_positively_with_the_host_id() {
+        // AC1: an operator can confirm telemetry is flowing, and under which
+        // host_id, without reading logs.
+        let status = export_status(|e| {
+            e.last_success_at = Some(render_now() - chrono::Duration::seconds(12));
+            e.records_exported = 3481;
+        });
+        let line = render_observability_line(Some(&status), render_now());
+        assert!(line.starts_with("Observability: OK"), "{line}");
+        assert!(line.contains("12s ago"), "{line}");
+        assert!(line.contains("host_id=robb-studio"), "{line}");
+        assert!(line.contains("3481 record(s)"), "{line}");
+    }
+
+    #[test]
+    fn observability_line_distinguishes_disabled_from_healthy() {
+        // AC2: a host with observability disabled must not read like a healthy
+        // one (before #5083 both rendered as nothing at all).
+        let disabled = render_observability_line(
+            Some(&loom_daemon::types::ObservabilityExportStatus::disabled()),
+            render_now(),
+        );
+        assert!(disabled.contains("disabled"), "{disabled}");
+        assert!(!disabled.contains("OK"), "{disabled}");
+    }
+
+    #[test]
+    fn observability_line_surfaces_never_exported_as_a_problem() {
+        // AC3: the silent failure mode — configured, running for hours, and
+        // nothing has ever landed.
+        let line = render_observability_line(Some(&export_status(|_| {})), render_now());
+        assert!(line.contains("NEVER EXPORTED"), "{line}");
+        assert!(line.contains("host_id=robb-studio"), "{line}");
+        assert!(line.contains("dashboard.example"), "{line}");
+    }
+
+    #[test]
+    fn observability_line_does_not_alarm_during_the_startup_grace_window() {
+        // A daemon rolled 20 seconds ago must not read as broken.
+        let status = export_status(|e| {
+            e.started_at = Some(render_now() - chrono::Duration::seconds(20));
+        });
+        let line = render_observability_line(Some(&status), render_now());
+        assert!(line.contains("starting"), "{line}");
+        assert!(!line.contains("NEVER EXPORTED"), "{line}");
+    }
+
+    #[test]
+    fn observability_line_reports_a_failing_exporter_with_its_error() {
+        let status = export_status(|e| {
+            e.last_success_at = Some(render_now() - chrono::Duration::hours(2));
+            e.consecutive_failures = 4;
+            e.last_failure_detail = Some("sink rejected batch: HTTP 401 — denied".to_string());
+        });
+        let line = render_observability_line(Some(&status), render_now());
+        assert!(line.contains("FAILING"), "{line}");
+        assert!(line.contains("HTTP 401"), "{line}");
+        assert!(line.contains("2h ago"), "{line}");
+    }
+
+    #[test]
+    fn observability_line_names_both_identities_on_a_mismatch() {
+        let status = export_status(|e| {
+            e.last_success_at = Some(render_now() - chrono::Duration::seconds(12));
+            e.ingest_host_id = Some("robb-pro".to_string());
+            e.records_exported = 77;
+        });
+        let line = render_observability_line(Some(&status), render_now());
+        assert!(line.contains("HOST-ID MISMATCH"), "{line}");
+        assert!(line.contains("robb-pro") && line.contains("robb-studio"), "{line}");
+    }
+
+    #[test]
+    fn observability_line_from_an_older_daemon_is_unknown_not_disabled() {
+        // A `None` field means the daemon could not answer — reporting it as
+        // "disabled" would invent a fact about a daemon that said nothing.
+        let line = render_observability_line(None, render_now());
+        assert!(line.contains("unknown"), "{line}");
+        assert!(line.contains("older daemon binary"), "{line}");
+    }
+
+    #[test]
+    fn observability_export_is_machine_readable_in_json() {
+        // AC5: a watch loop asserts on the state string directly.
+        let mut report = sample_report();
+        report.observability_export = Some(export_status(|e| {
+            e.last_success_at = Some(chrono::Utc::now());
+            e.records_exported = 12;
+            e.state = loom_daemon::types::ObservabilityExportState::Healthy;
+        }));
+        let value = build_status_json_value(&report, None, &no_update(), None, None);
+        let e = &value["observability_export"];
+        assert_eq!(e["state"], "healthy");
+        assert_eq!(e["host_id"], "robb-studio");
+        assert_eq!(e["records_exported"], 12);
+        assert_eq!(e["endpoint"], "https://dashboard.example/ingest");
+        assert!(e["last_success_at"].is_string());
+    }
+
+    #[test]
+    fn observability_export_is_null_for_a_pre_5083_daemon() {
+        let value = build_status_json_value(&sample_report(), None, &no_update(), None, None);
+        assert!(value["observability_export"].is_null());
     }
 
     #[test]

--- a/loom-daemon/src/health.rs
+++ b/loom-daemon/src/health.rs
@@ -26,7 +26,7 @@
 //! | roles | [`crate::role_runner::role_tick_records`] |
 //! | queues | [`crate::pipeline_snapshot`] (`queued`) |
 //! | throughput | [`crate::pipeline_snapshot`] (`merged_24h`, over the requested window) |
-//! | observability *(only when non-green)* | [`crate::types::DaemonStatusReport::observability_host_id_mismatch`], published by [`crate::observability::HostIdStatus`] |
+//! | observability *(only when non-green)* | [`crate::types::DaemonStatusReport::observability_host_id_mismatch`] (published by [`crate::observability::HostIdStatus`]) + [`crate::types::DaemonStatusReport::observability_export`] (published by [`crate::observability::ExportStatus`], #5083) |
 //!
 //! [`assess`] itself is **pure** — it takes an already-collected
 //! [`HealthInputs`] and returns a [`HealthReport`] — so every verdict rule
@@ -69,7 +69,7 @@ use serde::Serialize;
 use crate::daemon_install_state::{InstallState, InstallStateReport};
 use crate::pipeline_snapshot::RepoPipelineSnapshot;
 use crate::script_helpers::log_filter::strip_ansi;
-use crate::types::{DaemonStatusReport, RoleTickRecord};
+use crate::types::{DaemonStatusReport, ObservabilityExportState, RoleTickRecord};
 
 // ============================================================================
 // Exit-code contract
@@ -1522,53 +1522,132 @@ pub fn assess_throughput(inputs: &HealthInputs) -> HealthSection {
 // Observability section (Issue #4830) — conditional
 // ============================================================================
 
-/// Assess the observability exporter's host-identity check: `Some(DEGRADED)`
-/// when the daemon has confirmed that its ingest key is bound to a *different*
-/// `host_id` than the one it reports for itself, else `None`.
+/// Assess the observability exporter: `Some(DEGRADED)` when telemetry is
+/// demonstrably going wrong, else `None`.
 ///
 /// **Deliberately conditional**, unlike every other section. There is nothing
-/// to say when the exporter is disabled, keyless, or reporting under the right
-/// identity — which is all but a handful of daemons — so a permanent
+/// to say when the exporter is disabled, still starting, or exporting under the
+/// right identity — which is all but a handful of daemons — so a permanent
 /// `observability GREEN — ok` line would be pure noise on a surface whose whole
-/// value is that every line printed is worth reading. When the note IS present
-/// the condition is real and confirmed by the backend's own echo, never
-/// inferred, so it is `Degraded`, never `Unknown`.
+/// value is that every line printed is worth reading. That anomaly-only rule
+/// (#4830) is preserved verbatim; the *positive* confirmation an operator needs
+/// lives on `loom-daemon status` instead (`Observability: OK — …`, #5083) and,
+/// machine-readably, in `DaemonStatusReport::observability_export`.
+///
+/// Three conditions qualify as anomalies:
+///
+/// 1. **host-identity mismatch** (#4830) — the daemon has confirmed its ingest
+///    key is bound to a *different* `host_id` than it reports for itself, so
+///    every record it pushes is filed under the wrong host. Kept first and
+///    byte-for-byte as it was, including its `detail` keys.
+/// 2. **never exported** (#5083) — the exporter has been running well past its
+///    flush cadence and has still never had a single batch acked. This is the
+///    silent failure this section previously rendered *identically to healthy*:
+///    as nothing at all.
+/// 3. **export failing** (#5083) — flushes are actively erroring, so the queue
+///    is backing up and telemetry is going stale.
 ///
 /// Read straight off [`DaemonStatusReport`] rather than through a dedicated
-/// [`HealthInputs`] field: the mismatch is *daemon-process* state (only the
-/// daemon holds both halves — its own identity and the backend's echo), and
+/// [`HealthInputs`] field: this is *daemon-process* state (only the daemon
+/// holds both halves — its own identity and the backend's responses), and
 /// `health` runs in a separate CLI process, so the IPC status report is the
 /// only place it can come from. A parallel collector field would just copy it
 /// and add a way for the two to disagree.
 #[must_use]
 pub fn assess_observability(inputs: &HealthInputs) -> Option<HealthSection> {
-    let mismatch = inputs
-        .status
-        .as_ref()?
-        .observability_host_id_mismatch
-        .as_ref()?;
-    let age = inputs
-        .at
-        .signed_duration_since(mismatch.first_seen_at)
-        .num_seconds()
-        .max(0);
-    Some(HealthSection::new(
-        "observability",
-        Verdict::Degraded,
-        format!(
-            "telemetry is being filed under {} — the ingest key on this host is bound to that \
-             id, not to {} (first seen {} ago)",
-            mismatch.ingest_host_id,
-            mismatch.daemon_host_id,
-            format_window(u64::try_from(age).unwrap_or(0))
-        ),
-        serde_json::json!({
-            "daemon_host_id": mismatch.daemon_host_id,
-            "ingest_host_id": mismatch.ingest_host_id,
-            "first_seen_at": mismatch.first_seen_at,
-            "first_seen_age_secs": age,
-        }),
-    ))
+    let status = inputs.status.as_ref()?;
+    // Positive facts, when the daemon is new enough to report them (#5083) —
+    // folded into the mismatch note's `detail` below so a machine consumer
+    // reading a DEGRADED section still learns whether anything is landing at
+    // all, and used on its own for conditions 2 and 3.
+    //
+    // `state` is re-stamped from this report's own `at` before serialization:
+    // the daemon classified it at status-build time, and a section whose
+    // verdict said one thing while its `detail.state` said another would be a
+    // new way for the two halves of the same answer to disagree — precisely
+    // the failure mode this issue is about.
+    let export = status.observability_export.as_ref().map(|e| {
+        let mut classified = e.clone();
+        classified.state = classified.classify(inputs.at);
+        classified
+    });
+    let export = export.as_ref();
+    let export_detail = export.map_or(serde_json::Value::Null, |e| {
+        serde_json::to_value(e).unwrap_or(serde_json::Value::Null)
+    });
+
+    if let Some(mismatch) = status.observability_host_id_mismatch.as_ref() {
+        let age = inputs
+            .at
+            .signed_duration_since(mismatch.first_seen_at)
+            .num_seconds()
+            .max(0);
+        return Some(HealthSection::new(
+            "observability",
+            Verdict::Degraded,
+            format!(
+                "telemetry is being filed under {} — the ingest key on this host is bound to that \
+                 id, not to {} (first seen {} ago)",
+                mismatch.ingest_host_id,
+                mismatch.daemon_host_id,
+                format_window(u64::try_from(age).unwrap_or(0))
+            ),
+            serde_json::json!({
+                "daemon_host_id": mismatch.daemon_host_id,
+                "ingest_host_id": mismatch.ingest_host_id,
+                "first_seen_at": mismatch.first_seen_at,
+                "first_seen_age_secs": age,
+                "export": export_detail,
+            }),
+        ));
+    }
+
+    let export = export?;
+    match export.classify(inputs.at) {
+        // The #5083 headline: configured, running, and has never once
+        // succeeded. Called out only after the grace window
+        // (`never_exported_grace_secs`) so a freshly-restarted daemon is never
+        // reported as broken for its first flush interval.
+        ObservabilityExportState::NeverExported => {
+            Some(HealthSection::new(
+                "observability",
+                Verdict::Degraded,
+                format!(
+                "exporter has been running {} as {} and has NEVER had a batch acked — telemetry \
+                 is not reaching {}{}",
+                format_window(export.uptime_secs(inputs.at).unwrap_or(0)),
+                export.host_id.as_deref().unwrap_or("unknown-host"),
+                export.endpoint.as_deref().unwrap_or("the configured endpoint"),
+                export
+                    .last_failure_detail
+                    .as_deref()
+                    .map_or_else(String::new, |d| format!(" (last error: {d})")),
+            ),
+                export_detail,
+            ))
+        }
+        ObservabilityExportState::Failing => Some(HealthSection::new(
+            "observability",
+            Verdict::Degraded,
+            format!(
+                "{} consecutive failed flush(es) as {}; last successful export {}{}",
+                export.consecutive_failures,
+                export.host_id.as_deref().unwrap_or("unknown-host"),
+                export.last_success_age_secs(inputs.at).map_or_else(
+                    || "never".to_string(),
+                    |age| format!("{} ago", format_window(age))
+                ),
+                export
+                    .last_failure_detail
+                    .as_deref()
+                    .map_or_else(String::new, |d| format!(" (last error: {d})")),
+            ),
+            export_detail,
+        )),
+        // Disabled / Starting / Healthy / HostIdMismatch (handled above) — no
+        // section, exactly as before #5083.
+        _ => None,
+    }
 }
 
 // ============================================================================
@@ -2227,6 +2306,161 @@ mod tests {
         assert_eq!(keys.last(), Some(&"observability"));
         assert_eq!(keys.len(), 7);
         assert_eq!(assess(&healthy_inputs()).sections.len(), 6);
+    }
+
+    // ===================================================================
+    // Observability export liveness (#5083)
+    // ===================================================================
+
+    /// Inputs whose daemon reports a running exporter with the given export
+    /// record. `now()` is the report's `at`, so ages are exact.
+    fn exporting_inputs(
+        mutate: impl FnOnce(&mut crate::types::ObservabilityExportStatus),
+    ) -> HealthInputs {
+        let mut inputs = healthy_inputs();
+        let mut export = crate::types::ObservabilityExportStatus {
+            state: ObservabilityExportState::Starting,
+            host_id: Some("robb-studio".to_string()),
+            ingest_host_id: None,
+            endpoint: Some("https://dashboard.example/ingest".to_string()),
+            exporter: Some("https".to_string()),
+            started_at: Some(now() - chrono::Duration::hours(4)),
+            last_success_at: None,
+            last_failure_at: None,
+            last_failure_detail: None,
+            records_exported: 0,
+            consecutive_failures: 0,
+            flush_interval_secs: Some(30),
+        };
+        mutate(&mut export);
+        inputs.status.as_mut().unwrap().observability_export = Some(export);
+        inputs
+    }
+
+    #[test]
+    fn a_healthy_exporter_still_renders_no_observability_section() {
+        // The #4830 guarantee this issue must NOT reverse: exporting normally
+        // stays silent on the anomaly-only surface. The positive confirmation
+        // lives on `loom-daemon status` instead.
+        let inputs = exporting_inputs(|e| {
+            e.last_success_at = Some(now() - chrono::Duration::seconds(12));
+            e.records_exported = 3481;
+        });
+        let report = assess(&inputs);
+        assert!(report.section("observability").is_none());
+        assert_eq!(report.overall, Verdict::Green);
+        assert_eq!(report.sections.len(), 6);
+    }
+
+    #[test]
+    fn a_disabled_exporter_still_renders_no_observability_section() {
+        let mut inputs = healthy_inputs();
+        inputs.status.as_mut().unwrap().observability_export =
+            Some(crate::types::ObservabilityExportStatus::disabled());
+        assert!(assess_observability(&inputs).is_none());
+    }
+
+    #[test]
+    fn a_starting_exporter_is_not_yet_called_out() {
+        // A daemon restarted 20 seconds ago has not had a fair chance to
+        // flush; reporting it as broken would make every roll look like an
+        // outage.
+        let inputs = exporting_inputs(|e| {
+            e.started_at = Some(now() - chrono::Duration::seconds(20));
+        });
+        assert!(assess_observability(&inputs).is_none());
+    }
+
+    #[test]
+    fn a_never_exporting_host_is_a_degraded_observability_note() {
+        // THE gap this issue exists for: configured, running for four hours,
+        // and has never landed a single batch — which before #5083 rendered
+        // exactly like a healthy host: no section at all.
+        let inputs = exporting_inputs(|_| {});
+        let report = assess(&inputs);
+        let section = report.section("observability").expect("section present");
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(
+            section.summary.contains("NEVER"),
+            "the note must name the condition unambiguously: {}",
+            section.summary
+        );
+        assert!(
+            section.summary.contains("robb-studio")
+                && section.summary.contains("dashboard.example"),
+            "the note must name the host identity AND the endpoint: {}",
+            section.summary
+        );
+        // Machine-readable for a watch loop (AC5).
+        assert_eq!(section.detail["state"], "never_exported");
+        assert_eq!(section.detail["host_id"], "robb-studio");
+        assert!(section.detail["last_success_at"].is_null());
+        assert_eq!(report.overall, Verdict::Degraded);
+        assert_eq!(report.exit_code(), EXIT_DEGRADED);
+    }
+
+    #[test]
+    fn a_failing_exporter_is_a_degraded_observability_note() {
+        let inputs = exporting_inputs(|e| {
+            e.last_success_at = Some(now() - chrono::Duration::hours(2));
+            e.records_exported = 900;
+            e.consecutive_failures = 4;
+            e.last_failure_at = Some(now() - chrono::Duration::seconds(30));
+            e.last_failure_detail = Some("sink rejected batch: HTTP 401 — denied".to_string());
+        });
+        let report = assess(&inputs);
+        let section = report.section("observability").expect("section present");
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(
+            section.summary.contains("HTTP 401"),
+            "the exporter's own error must reach the operator: {}",
+            section.summary
+        );
+        assert!(
+            section.summary.contains("2h"),
+            "a regression must be distinguishable from never-worked: {}",
+            section.summary
+        );
+        assert_eq!(section.detail["state"], "failing");
+        assert_eq!(section.detail["consecutive_failures"], 4);
+    }
+
+    #[test]
+    fn a_mismatch_still_wins_and_now_carries_the_export_facts() {
+        // #4830 regression guard: the mismatch note is unchanged, and the
+        // positive facts ride along in `detail.export` so a machine consumer
+        // reading a DEGRADED section still learns whether anything is landing.
+        let mut inputs = mismatched_inputs(3600);
+        inputs.status.as_mut().unwrap().observability_export =
+            Some(crate::types::ObservabilityExportStatus {
+                state: ObservabilityExportState::HostIdMismatch,
+                host_id: Some("robb-studio".to_string()),
+                ingest_host_id: Some("robb-pro".to_string()),
+                last_success_at: Some(now() - chrono::Duration::seconds(12)),
+                records_exported: 77,
+                started_at: Some(now() - chrono::Duration::hours(4)),
+                ..Default::default()
+            });
+        let section = assess_observability(&inputs).expect("section present");
+        assert_eq!(section.verdict, Verdict::Degraded);
+        // Unchanged #4830 keys.
+        assert_eq!(section.detail["daemon_host_id"], "robb-studio");
+        assert_eq!(section.detail["ingest_host_id"], "robb-pro");
+        assert_eq!(section.detail["first_seen_age_secs"], 3600);
+        // Additive #5083 payload.
+        assert_eq!(section.detail["export"]["records_exported"], 77);
+        assert_eq!(section.detail["export"]["state"], "host_id_mismatch");
+    }
+
+    #[test]
+    fn a_pre_5083_daemon_reporting_no_export_field_renders_nothing() {
+        // An older daemon cannot answer, so the section stays absent — the
+        // pre-#5083 baseline, never a fabricated "never exported".
+        let mut inputs = healthy_inputs();
+        let status = inputs.status.as_mut().unwrap();
+        status.observability_export = None;
+        status.observability_host_id_mismatch = None;
+        assert!(assess_observability(&inputs).is_none());
     }
 
     #[test]

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1711,6 +1711,11 @@ pub fn build_daemon_status(
         // snapshot pattern again, registered only when the exporter actually
         // starts, so a disabled/keyless exporter always reads `None`.
         observability_host_id_mismatch: crate::observability::global_host_id_mismatch(),
+        // Positive export-liveness signal (#5083) — the counterpart to the
+        // anomaly-only field above. Always `Some` from a daemon of this
+        // vintage: an exporter that never started reports `disabled`, which is
+        // a real answer, not the silence #4830 alone could offer.
+        observability_export: Some(crate::observability::global_export_status()),
         // Live safehouse connection state (#4345) — the pool's shared cell is
         // updated by the narration sink / peer-coordination tasks
         // `start_safehouse_narration`/`start_peer_coordination` spawn, and
@@ -5616,6 +5621,17 @@ exit 0
                 ingest_host_id: "robb-pro".to_string(),
                 first_seen_at: chrono::Utc::now(),
             }),
+            observability_export: Some(crate::types::ObservabilityExportStatus {
+                state: crate::types::ObservabilityExportState::HostIdMismatch,
+                host_id: Some("robb-studio".to_string()),
+                ingest_host_id: Some("robb-pro".to_string()),
+                endpoint: Some("https://dashboard.example/ingest".to_string()),
+                exporter: Some("https".to_string()),
+                started_at: Some(chrono::Utc::now()),
+                last_success_at: Some(chrono::Utc::now()),
+                records_exported: 128,
+                ..Default::default()
+            }),
         };
         let resp = Response::DaemonStatus(Box::new(report));
         let json = serde_json::to_string(&resp).expect("serialize response");
@@ -5660,6 +5676,18 @@ exit 0
                     .expect("mismatch round-trips");
                 assert_eq!(mismatch.daemon_host_id, "robb-studio");
                 assert_eq!(mismatch.ingest_host_id, "robb-pro");
+                // #5083: the positive export record survives the wire too —
+                // this is what lets a `status`/`health` client in another
+                // process state that telemetry IS (or is not) landing rather
+                // than infer it from the absence of a warning.
+                let export = r
+                    .observability_export
+                    .as_ref()
+                    .expect("export status round-trips");
+                assert_eq!(export.state, crate::types::ObservabilityExportState::HostIdMismatch);
+                assert_eq!(export.host_id.as_deref(), Some("robb-studio"));
+                assert_eq!(export.ingest_host_id.as_deref(), Some("robb-pro"));
+                assert_eq!(export.records_exported, 128);
                 assert_eq!(r.per_repo[0].health_gate_enabled, Some(true));
                 assert!(r.per_repo[0].health_gate_verdict_at.is_some());
                 assert_eq!(

--- a/loom-daemon/src/observability/mod.rs
+++ b/loom-daemon/src/observability/mod.rs
@@ -332,6 +332,136 @@ pub fn global_host_id_mismatch() -> Option<crate::types::ObservabilityHostIdMism
     GLOBAL_HOST_ID_STATUS.get().and_then(|s| s.snapshot())
 }
 
+// ============================================================================
+// Export liveness status (Issue #5083)
+// ============================================================================
+
+/// Live record of whether telemetry is actually *reaching* the backend, written
+/// by [`sender::try_flush`] on every attempt and read back by
+/// [`global_export_status`] for `loom-daemon status` / `health`.
+///
+/// The complement to [`HostIdStatus`], which is anomaly-only by design (#4830)
+/// and therefore cannot answer "is it working?" — only "is it working *wrong*
+/// in this one specific way?". This cell is always readable and always has an
+/// answer, including the answer #4830 could never give: *configured, running,
+/// and has never successfully exported anything*.
+///
+/// Unlike [`HostIdStatus`] this is **not** write-once: it is a rolling record,
+/// so `last_success_at` genuinely means "the last time data landed" and a watch
+/// loop can alert on its age.
+#[derive(Debug)]
+pub struct ExportStatus {
+    inner: std::sync::Mutex<crate::types::ObservabilityExportStatus>,
+}
+
+// Allow expect_used: a poisoned status mutex means another thread panicked
+// while holding it — unrecoverable, matching the crash-on-poison policy
+// `HostIdStatus` above (and `auto_update`/`ipc`) already use.
+#[allow(clippy::expect_used)]
+impl ExportStatus {
+    /// A status cell for an exporter that is starting *now* under `host_id`,
+    /// pushing to `endpoint` via `exporter` every `flush_interval_secs`.
+    #[must_use]
+    pub fn started(
+        host_id: &str,
+        endpoint: &str,
+        exporter: &str,
+        flush_interval_secs: u64,
+    ) -> Self {
+        ExportStatus {
+            inner: std::sync::Mutex::new(crate::types::ObservabilityExportStatus {
+                state: crate::types::ObservabilityExportState::Starting,
+                host_id: Some(host_id.to_string()),
+                ingest_host_id: None,
+                endpoint: Some(endpoint.to_string()),
+                exporter: Some(exporter.to_string()),
+                started_at: Some(chrono::Utc::now()),
+                last_success_at: None,
+                last_failure_at: None,
+                last_failure_detail: None,
+                records_exported: 0,
+                consecutive_failures: 0,
+                flush_interval_secs: Some(flush_interval_secs),
+            }),
+        }
+    }
+
+    /// Record `count` envelopes acked by the backend. Clears the consecutive-
+    /// failure run: the transport demonstrably works again.
+    pub fn record_success(&self, count: usize) {
+        let mut guard = self
+            .inner
+            .lock()
+            .expect("observability export status mutex poisoned");
+        guard.last_success_at = Some(chrono::Utc::now());
+        guard.records_exported = guard
+            .records_exported
+            .saturating_add(count.try_into().unwrap_or(u64::MAX));
+        guard.consecutive_failures = 0;
+    }
+
+    /// Record a failed flush attempt. `detail` is the exporter's own error
+    /// text; the previous `last_success_at` is deliberately preserved so the
+    /// surfaces can distinguish "used to work, broke 30s ago" from "never
+    /// worked at all".
+    pub fn record_failure(&self, detail: &str) {
+        let mut guard = self
+            .inner
+            .lock()
+            .expect("observability export status mutex poisoned");
+        guard.last_failure_at = Some(chrono::Utc::now());
+        guard.last_failure_detail = Some(detail.to_string());
+        guard.consecutive_failures = guard.consecutive_failures.saturating_add(1);
+    }
+
+    /// The current record, with [`crate::types::ObservabilityExportStatus::state`]
+    /// re-derived as of now. `ingest_host_id` is folded in from
+    /// [`global_host_id_mismatch`] by [`global_export_status`], not here — this
+    /// cell knows nothing about identity.
+    #[must_use]
+    pub fn snapshot(&self) -> crate::types::ObservabilityExportStatus {
+        let mut snapshot = self
+            .inner
+            .lock()
+            .expect("observability export status mutex poisoned")
+            .clone();
+        snapshot.state = snapshot.classify(chrono::Utc::now());
+        snapshot
+    }
+}
+
+/// Process-global export-status handle, registered by [`spawn_task`] when — and
+/// only when — the exporter actually starts. Unset (observability disabled,
+/// keyless, or under-configured) makes [`global_export_status`] report
+/// [`crate::types::ObservabilityExportStatus::disabled`].
+static GLOBAL_EXPORT_STATUS: std::sync::OnceLock<Arc<ExportStatus>> = std::sync::OnceLock::new();
+
+/// Register the exporter's export-status handle as the process-global.
+/// Idempotent: only the first registration wins (one exporter per process).
+pub fn register_global_export_status(status: Arc<ExportStatus>) {
+    let _ = GLOBAL_EXPORT_STATUS.set(status);
+}
+
+/// This process's export status — **always** an answer, never silence.
+///
+/// Unregistered ⇒ `disabled()` (the exporter never started), which is a
+/// materially different report from the `None` an older daemon binary puts on
+/// the wire. Any confirmed #4830 host-identity mismatch is folded in here as
+/// `ingest_host_id`, so a single field carries the whole state machine and
+/// [`crate::types::ObservabilityExportStatus::classify`] needs no second input.
+#[must_use]
+pub fn global_export_status() -> crate::types::ObservabilityExportStatus {
+    let Some(status) = GLOBAL_EXPORT_STATUS.get() else {
+        return crate::types::ObservabilityExportStatus::disabled();
+    };
+    let mut snapshot = status.snapshot();
+    if let Some(mismatch) = global_host_id_mismatch() {
+        snapshot.ingest_host_id = Some(mismatch.ingest_host_id);
+    }
+    snapshot.state = snapshot.classify(chrono::Utc::now());
+    snapshot
+}
+
 /// **env > config > default** ([`ExporterKind::Https`]). An unrecognized
 /// value at either tier (anything but a case-insensitive `"https"` or
 /// `"otlp"`) is logged and degrades to the default, the same "malformed
@@ -438,6 +568,22 @@ pub fn spawn_task(
     );
     let queue = Arc::new(DurableQueue::open(queue_path, capacity));
 
+    // Export-liveness status (Issue #5083). Created here — where the endpoint,
+    // host id, exporter kind and cadence are all resolved — but registered as
+    // the process-global only *after* the exporter has actually been
+    // constructed below, so the degrade-to-disabled paths (HTTPS client
+    // construction failure, `otlp` without the feature) keep reporting
+    // `disabled` rather than a phantom running exporter.
+    let export_status = Arc::new(ExportStatus::started(
+        &host_id,
+        &endpoint,
+        match exporter_kind {
+            ExporterKind::Https => "https",
+            ExporterKind::Otlp => "otlp",
+        },
+        flush_interval.as_secs(),
+    ));
+
     let collector_handle = collector::spawn_task(
         bus,
         queue.clone(),
@@ -479,7 +625,7 @@ pub fn spawn_task(
                     return None;
                 }
             };
-            sender::spawn_task(queue, exporter, batch_size, flush_interval)
+            sender::spawn_task(queue, exporter, batch_size, flush_interval, export_status.clone())
         }
         ExporterKind::Otlp => {
             // No `HostIdStatus` wiring here, deliberately (Issue #4830 vs.
@@ -515,7 +661,13 @@ pub fn spawn_task(
                         return None;
                     }
                 };
-                sender::spawn_task(queue, exporter, batch_size, flush_interval)
+                sender::spawn_task(
+                    queue,
+                    exporter,
+                    batch_size,
+                    flush_interval,
+                    export_status.clone(),
+                )
             }
             #[cfg(not(feature = "otlp"))]
             {
@@ -527,6 +679,10 @@ pub fn spawn_task(
             }
         }
     };
+    // Only reached when an exporter was constructed and its sender spawned —
+    // every degrade-to-disabled path above returns early, so `disabled` on the
+    // status wire stays truthful (Issue #5083).
+    register_global_export_status(export_status);
     Some(vec![collector_handle, sender_handle])
 }
 

--- a/loom-daemon/src/observability/sender.rs
+++ b/loom-daemon/src/observability/sender.rs
@@ -18,6 +18,7 @@ use crate::tokens_pool::rng::Rng;
 
 use super::exporter::Exporter;
 use super::queue::DurableQueue;
+use super::ExportStatus;
 
 /// Starting backoff after a failed export attempt.
 pub const MIN_BACKOFF: Duration = Duration::from_secs(5);
@@ -41,10 +42,19 @@ pub enum FlushOutcome {
 /// front of `queue`) via `exporter`. Only acks (removes) the batch from
 /// `queue` on a confirmed successful export — a failure leaves the queue
 /// untouched so the same envelopes are retried next time.
+///
+/// Every decided attempt (sent or failed) is also recorded on `status` (Issue
+/// #5083) — this is the single point in the daemon that *knows* whether
+/// telemetry is landing, so it is the only honest source for the positive
+/// signal `loom-daemon status`/`health` report. An `Empty` queue records
+/// nothing: nothing was attempted, so it is evidence of neither health nor
+/// failure (this is exactly the ambiguity a 0-byte queue file left an operator
+/// with before #5083).
 pub async fn try_flush<E: Exporter>(
     queue: &DurableQueue,
     exporter: &E,
     batch_size: usize,
+    status: &ExportStatus,
 ) -> FlushOutcome {
     let batch = queue.peek_batch(batch_size);
     if batch.is_empty() {
@@ -54,6 +64,7 @@ pub async fn try_flush<E: Exporter>(
         Ok(()) => {
             let sent = batch.len();
             queue.ack(sent);
+            status.record_success(sent);
             FlushOutcome::Sent(sent)
         }
         Err(error) => {
@@ -63,6 +74,7 @@ pub async fn try_flush<E: Exporter>(
                 queue.len(),
                 queue.dropped_total()
             );
+            status.record_failure(&error.to_string());
             FlushOutcome::Failed
         }
     }
@@ -74,11 +86,12 @@ pub fn spawn_task<E>(
     exporter: E,
     batch_size: usize,
     flush_interval: Duration,
+    status: Arc<ExportStatus>,
 ) -> tokio::task::JoinHandle<()>
 where
     E: Exporter + Send + Sync + 'static,
 {
-    tokio::spawn(run_sender(queue, exporter, batch_size, flush_interval))
+    tokio::spawn(run_sender(queue, exporter, batch_size, flush_interval, status))
 }
 
 async fn run_sender<E: Exporter>(
@@ -86,6 +99,7 @@ async fn run_sender<E: Exporter>(
     exporter: E,
     batch_size: usize,
     flush_interval: Duration,
+    status: Arc<ExportStatus>,
 ) {
     let mut rng = Rng::from_entropy();
     let mut backoff = MIN_BACKOFF;
@@ -95,7 +109,7 @@ async fn run_sender<E: Exporter>(
         // burst that arrived between ticks does not wait a full extra
         // `flush_interval` per batch.
         loop {
-            match try_flush(&queue, &exporter, batch_size).await {
+            match try_flush(&queue, &exporter, batch_size, &status).await {
                 FlushOutcome::Empty => {
                     backoff = MIN_BACKOFF;
                     break;
@@ -195,13 +209,27 @@ mod tests {
         }
     }
 
+    /// A status cell for a just-started exporter, matching what
+    /// [`super::spawn_task`] constructs in production.
+    fn status_cell() -> ExportStatus {
+        ExportStatus::started("host-test", "https://example.invalid/ingest", "https", 30)
+    }
+
     #[tokio::test]
     async fn try_flush_on_empty_queue_is_a_noop() {
         let dir = tempfile::tempdir().unwrap();
         let queue = DurableQueue::open(dir.path().join("q.jsonl"), 10);
         let exporter = FakeExporter::new(true);
-        let outcome = try_flush(&queue, &exporter, 10).await;
+        let status = status_cell();
+        let outcome = try_flush(&queue, &exporter, 10, &status).await;
         assert_eq!(outcome, FlushOutcome::Empty);
+        // #5083: an empty queue is evidence of NEITHER health nor failure —
+        // nothing was attempted. Recording a success here is exactly how a
+        // never-exporting host would masquerade as healthy.
+        let snapshot = status.snapshot();
+        assert!(snapshot.last_success_at.is_none());
+        assert_eq!(snapshot.consecutive_failures, 0);
+        assert_eq!(snapshot.records_exported, 0);
     }
 
     #[tokio::test]
@@ -211,10 +239,17 @@ mod tests {
         queue.push(envelope());
         queue.push(envelope());
         let exporter = FakeExporter::new(true);
-        let outcome = try_flush(&queue, &exporter, 10).await;
+        let status = status_cell();
+        let outcome = try_flush(&queue, &exporter, 10, &status).await;
         assert_eq!(outcome, FlushOutcome::Sent(2));
         assert!(queue.is_empty());
         assert_eq!(exporter.received.lock().unwrap().len(), 2);
+        // #5083: the acked batch is the positive signal `loom-daemon status`
+        // reports as `Observability: OK — last export …`.
+        let snapshot = status.snapshot();
+        assert!(snapshot.last_success_at.is_some());
+        assert_eq!(snapshot.records_exported, 2);
+        assert_eq!(snapshot.state, crate::types::ObservabilityExportState::Healthy);
     }
 
     #[tokio::test]
@@ -223,9 +258,21 @@ mod tests {
         let queue = DurableQueue::open(dir.path().join("q.jsonl"), 10);
         queue.push(envelope());
         let exporter = FakeExporter::new(false);
-        let outcome = try_flush(&queue, &exporter, 10).await;
+        let status = status_cell();
+        let outcome = try_flush(&queue, &exporter, 10, &status).await;
         assert_eq!(outcome, FlushOutcome::Failed);
         assert_eq!(queue.len(), 1, "a failed export must not lose the batch");
+        // #5083: a first-ever flush that errors is `failing`, not `starting` —
+        // there is a real error to report, not merely an absence of evidence.
+        let snapshot = status.snapshot();
+        assert_eq!(snapshot.consecutive_failures, 1);
+        assert!(snapshot.last_success_at.is_none());
+        assert!(snapshot
+            .last_failure_detail
+            .as_deref()
+            .unwrap()
+            .contains("sink down"));
+        assert_eq!(snapshot.state, crate::types::ObservabilityExportState::Failing);
     }
 
     #[tokio::test]
@@ -238,14 +285,25 @@ mod tests {
         queue.push(envelope());
         queue.push(envelope());
         let exporter = FakeExporter::new(false); // sink starts "killed"
+        let status = status_cell();
 
-        assert_eq!(try_flush(&queue, &exporter, 10).await, FlushOutcome::Failed);
+        assert_eq!(try_flush(&queue, &exporter, 10, &status).await, FlushOutcome::Failed);
         assert_eq!(queue.len(), 3, "still queued while the sink is down");
+        assert_eq!(status.snapshot().consecutive_failures, 1);
 
         exporter.set_up(true); // "revive" the sink
-        assert_eq!(try_flush(&queue, &exporter, 10).await, FlushOutcome::Sent(3));
+        assert_eq!(try_flush(&queue, &exporter, 10, &status).await, FlushOutcome::Sent(3));
         assert!(queue.is_empty());
         assert_eq!(exporter.received.lock().unwrap().len(), 3);
+        // #5083: recovery clears the failure run, so the state goes back to
+        // `healthy` rather than latching on the first bad night.
+        let snapshot = status.snapshot();
+        assert_eq!(snapshot.consecutive_failures, 0);
+        assert_eq!(snapshot.records_exported, 3);
+        assert_eq!(snapshot.state, crate::types::ObservabilityExportState::Healthy);
+        // The failure detail is deliberately NOT cleared — "worked, broke,
+        // recovered" stays legible after the fact.
+        assert!(snapshot.last_failure_at.is_some());
     }
 
     #[tokio::test]
@@ -256,12 +314,16 @@ mod tests {
             queue.push(envelope());
         }
         let exporter = FakeExporter::new(true);
-        assert_eq!(try_flush(&queue, &exporter, 2).await, FlushOutcome::Sent(2));
+        let status = status_cell();
+        assert_eq!(try_flush(&queue, &exporter, 2, &status).await, FlushOutcome::Sent(2));
         assert_eq!(queue.len(), 3);
-        assert_eq!(try_flush(&queue, &exporter, 2).await, FlushOutcome::Sent(2));
+        assert_eq!(try_flush(&queue, &exporter, 2, &status).await, FlushOutcome::Sent(2));
         assert_eq!(queue.len(), 1);
-        assert_eq!(try_flush(&queue, &exporter, 2).await, FlushOutcome::Sent(1));
+        assert_eq!(try_flush(&queue, &exporter, 2, &status).await, FlushOutcome::Sent(1));
         assert!(queue.is_empty());
+        // #5083: the record count accumulates across flushes, so the status
+        // line's "N record(s)" is a running total, not a per-batch figure.
+        assert_eq!(status.snapshot().records_exported, 5);
     }
 
     // ------------------------------------------------------------------
@@ -295,5 +357,26 @@ mod tests {
         let mut b = Rng::seeded(99);
         let base = Duration::from_secs(10);
         assert_eq!(jittered(base, &mut a), jittered(base, &mut b));
+    }
+
+    /// The #5083 headline case, at the sender's own granularity: an exporter
+    /// that has been up for hours with a queue that is *never* empty and a sink
+    /// that never acks. Before #5083 this left no trace on any surface — the
+    /// health section renders only on an id mismatch, and the on-disk queue
+    /// looks the same whether it drained or never sent.
+    #[tokio::test]
+    async fn a_never_acking_sink_is_visible_as_a_problem() {
+        let dir = tempfile::tempdir().unwrap();
+        let queue = DurableQueue::open(dir.path().join("q.jsonl"), 10);
+        queue.push(envelope());
+        let exporter = FakeExporter::new(false);
+        let status = status_cell();
+        for _ in 0..5 {
+            assert_eq!(try_flush(&queue, &exporter, 10, &status).await, FlushOutcome::Failed);
+        }
+        let snapshot = status.snapshot();
+        assert_eq!(snapshot.consecutive_failures, 5);
+        assert_eq!(snapshot.records_exported, 0);
+        assert!(snapshot.state.is_problem(), "{:?}", snapshot.state);
     }
 }

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -1239,6 +1239,7 @@ mod tests {
             daemon_build_commit: None,
             work_finder_interval_secs: None,
             observability_host_id_mismatch: None,
+            observability_export: None,
         }
     }
 

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -1382,6 +1382,21 @@ pub struct DaemonStatusReport {
     /// keeps older wire data / older clients compatible.
     #[serde(default)]
     pub observability_host_id_mismatch: Option<ObservabilityHostIdMismatch>,
+    /// **Positive** confirmation of whether telemetry is actually reaching the
+    /// backend, and under which `host_id` (Issue #5083).
+    ///
+    /// [`Self::observability_host_id_mismatch`] above is anomaly-only by
+    /// design (#4830), which left "exporting fine", "observability disabled",
+    /// and "configured but silently never exported" all rendering as the same
+    /// thing: nothing at all. This field is the counterpart that always has an
+    /// answer — see [`ObservabilityExportStatus`].
+    ///
+    /// `None` **only** from a pre-#5083 daemon binary that never computed one
+    /// (never misread as "disabled" — a running daemon that has observability
+    /// off reports `Some(ObservabilityExportStatus::disabled())`).
+    /// `#[serde(default)]` keeps older wire data / older clients compatible.
+    #[serde(default)]
+    pub observability_export: Option<ObservabilityExportStatus>,
 }
 
 /// A confirmed disagreement between the host identity this daemon resolves for
@@ -1410,6 +1425,252 @@ pub struct ObservabilityHostIdMismatch {
     /// once-per-lifetime, so this is the age of the condition, not of the last
     /// flush.
     pub first_seen_at: DateTime<Utc>,
+}
+
+/// The one-word answer to "is this host's telemetry landing?" (Issue #5083),
+/// derived from [`ObservabilityExportStatus`] by
+/// [`ObservabilityExportStatus::classify`].
+///
+/// Serialized in `snake_case` so a watch loop can assert on it directly, e.g.
+/// `loom-daemon status --json | jq -e '.observability_export.state == "healthy"'`.
+/// An unknown variant from a *newer* daemon deserializes as
+/// [`Self::Unrecognized`] rather than failing the whole status parse.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservabilityExportState {
+    /// The exporter is not running: `observability.enabled` is false, or it is
+    /// enabled but under-configured (no endpoint, no/unreadable ingest key, or
+    /// `exporter = "otlp"` on a build without the `otlp` feature). Nothing is
+    /// being collected and nothing is being sent — a legitimate steady state,
+    /// not a fault.
+    #[default]
+    Disabled,
+    /// The exporter is running but has not had a fair chance to flush yet —
+    /// it has been up for less than
+    /// [`ObservabilityExportStatus::never_exported_grace_secs`]. Distinguished
+    /// from [`Self::NeverExported`] precisely so a freshly-restarted daemon
+    /// does not trip a watch loop for the first flush interval.
+    Starting,
+    /// **The silent failure mode this issue exists for.** The exporter has
+    /// been running well past its grace window and has still never had a batch
+    /// acked. Before #5083 this was indistinguishable from healthy: no health
+    /// section, no status line, and a 0-byte queue file that reads the same
+    /// whether it drained or was never written.
+    NeverExported,
+    /// At least one batch has been acked and the most recent attempt did not
+    /// fail. Telemetry is flowing, filed under
+    /// [`ObservabilityExportStatus::host_id`].
+    Healthy,
+    /// Batches are being acked, but the backend echoes a *different* `host_id`
+    /// than this daemon reports for itself (#4830) — the records are landing,
+    /// under the wrong host. Takes precedence over [`Self::Failing`]: it is a
+    /// config-shaped fault that cannot self-recover, whereas a failing flush
+    /// usually can.
+    HostIdMismatch,
+    /// The most recent flush attempt failed (the queue is retrying with
+    /// backoff). `last_failure_detail` carries the exporter's own error text;
+    /// `last_success_at` says whether this is a regression or has never worked.
+    Failing,
+    /// A state name this build does not know — a newer daemon reporting to an
+    /// older client. Never produced by [`ObservabilityExportStatus::classify`].
+    #[serde(other)]
+    Unrecognized,
+}
+
+impl ObservabilityExportState {
+    /// The short, upper-case token the human-readable renderers lead with.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            ObservabilityExportState::Disabled => "disabled",
+            ObservabilityExportState::Starting => "starting",
+            ObservabilityExportState::NeverExported => "NEVER EXPORTED",
+            ObservabilityExportState::Healthy => "OK",
+            ObservabilityExportState::HostIdMismatch => "HOST-ID MISMATCH",
+            ObservabilityExportState::Failing => "FAILING",
+            ObservabilityExportState::Unrecognized => "unrecognized",
+        }
+    }
+
+    /// Whether this state is a *problem* an operator should act on.
+    /// `disabled`, `starting`, and `healthy` are not; the rest are.
+    #[must_use]
+    pub fn is_problem(self) -> bool {
+        matches!(
+            self,
+            ObservabilityExportState::NeverExported
+                | ObservabilityExportState::HostIdMismatch
+                | ObservabilityExportState::Failing
+        )
+    }
+}
+
+/// Positive, always-present state of this daemon's telemetry export (Issue
+/// #5083) — the counterpart to [`ObservabilityHostIdMismatch`]'s anomaly-only
+/// signal.
+///
+/// The 2026-08-03 incident this exists for: two hosts with byte-identical
+/// observability config, one showing an `observability` health section and one
+/// not. The absence was the *only* evidence the second host was fine, which is
+/// inference from absence — and the exact same absence would have been shown
+/// for a host whose exporter had never successfully sent a single batch.
+/// Confirming it took a `daemon.log` grep for the *lack* of a warning.
+///
+/// Published by [`crate::observability::ExportStatus`] (updated by
+/// [`crate::observability::sender::try_flush`] on every attempt) and read back
+/// via [`crate::observability::global_export_status`], mirroring the
+/// process-global pattern [`ObservabilityHostIdMismatch`] already uses.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ObservabilityExportStatus {
+    /// The state as classified by the *daemon* at status-build time. Consumers
+    /// that hold their own `now` (e.g. `loom-daemon health`, which stamps one
+    /// `at` for the whole report) may re-derive it with [`Self::classify`];
+    /// both agree except across the grace boundary.
+    ///
+    /// `#[serde(default)]` (⇒ `disabled`) so a partial payload from any other
+    /// producer still parses rather than failing the whole status read — every
+    /// consumer that cares re-derives with [`Self::classify`] anyway.
+    #[serde(default)]
+    pub state: ObservabilityExportState,
+    /// The host identity this daemon stamps on every outgoing envelope —
+    /// [`crate::sweep_registry::host_identity`]. `None` when the exporter is
+    /// not running. This is the "under which `host_id`" half of the AC.
+    #[serde(default)]
+    pub host_id: Option<String>,
+    /// The `host_id` the ingest backend echoed back, when it *disagrees* with
+    /// [`Self::host_id`] — i.e. `Some` exactly when a #4830 mismatch has been
+    /// confirmed, so [`Self::classify`] needs no second input. `None`
+    /// otherwise, including when the ids agree.
+    #[serde(default)]
+    pub ingest_host_id: Option<String>,
+    /// The configured export endpoint, so an operator can confirm *where* the
+    /// data is going without opening the config. `None` when not running.
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    /// Which exporter implementation is running: `"https"` (Loom's native
+    /// ingest) or `"otlp"`. `None` when not running.
+    #[serde(default)]
+    pub exporter: Option<String>,
+    /// When the exporter task started this daemon process. The denominator for
+    /// "has it had a fair chance to flush yet" — see [`Self::classify`].
+    #[serde(default)]
+    pub started_at: Option<DateTime<Utc>>,
+    /// When a batch was most recently acked by the backend. `None` means *no
+    /// batch has ever been acked this process* — the never-exported signal.
+    #[serde(default)]
+    pub last_success_at: Option<DateTime<Utc>>,
+    /// When a flush attempt most recently failed, if ever.
+    #[serde(default)]
+    pub last_failure_at: Option<DateTime<Utc>>,
+    /// The error text of that most recent failure (the exporter's own
+    /// `Display`, e.g. `sink rejected batch: HTTP 401 — …`). Never contains
+    /// the ingest key: the exporter's errors are built from status codes and
+    /// truncated body snippets only.
+    #[serde(default)]
+    pub last_failure_detail: Option<String>,
+    /// Total envelopes acked this daemon process. `0` alongside a `Some`
+    /// `started_at` is the never-exported signature.
+    #[serde(default)]
+    pub records_exported: u64,
+    /// Consecutive failed flush attempts since the last success (reset to 0 on
+    /// any ack). Non-zero ⇒ [`ObservabilityExportState::Failing`].
+    #[serde(default)]
+    pub consecutive_failures: u32,
+    /// The flush cadence this exporter resolved, in seconds — the unit the
+    /// grace window is scaled by, so a host configured with a long interval
+    /// does not false-alarm as never-exported. `None` when not running.
+    #[serde(default)]
+    pub flush_interval_secs: Option<u64>,
+}
+
+/// Floor on the never-exported grace window — a fresh exporter is never called
+/// out before this much wall-clock has passed, regardless of flush cadence.
+/// Sized above the collector's own 5-minute host-snapshot interval
+/// ([`crate::observability::SNAPSHOT_INTERVAL`]) so a host with no sweep
+/// activity at all still has had at least one record enqueued and one flush
+/// attempted before the window closes.
+pub const NEVER_EXPORTED_GRACE_FLOOR_SECS: u64 = 10 * 60;
+
+impl ObservabilityExportStatus {
+    /// The "exporter is not running" reading — what a daemon with
+    /// observability disabled, keyless, or otherwise under-configured reports.
+    /// Distinct from a `None` field, which means "this daemon binary predates
+    /// #5083 and cannot tell you".
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self {
+            state: ObservabilityExportState::Disabled,
+            ..Self::default()
+        }
+    }
+
+    /// How long a freshly-started exporter is given before a still-empty
+    /// success record is called out: three flush intervals, floored at
+    /// [`NEVER_EXPORTED_GRACE_FLOOR_SECS`].
+    #[must_use]
+    pub fn never_exported_grace_secs(&self) -> u64 {
+        self.flush_interval_secs
+            .unwrap_or(0)
+            .saturating_mul(3)
+            .max(NEVER_EXPORTED_GRACE_FLOOR_SECS)
+    }
+
+    /// Seconds since the last acked batch, as of `now`. `None` when nothing has
+    /// ever been acked. Clamped at zero so a small clock skew never renders a
+    /// negative age.
+    #[must_use]
+    pub fn last_success_age_secs(&self, now: DateTime<Utc>) -> Option<u64> {
+        self.last_success_at.map(|at| {
+            u64::try_from(now.signed_duration_since(at).num_seconds().max(0)).unwrap_or(0)
+        })
+    }
+
+    /// Seconds the exporter has been running, as of `now`. `None` when it is
+    /// not running.
+    #[must_use]
+    pub fn uptime_secs(&self, now: DateTime<Utc>) -> Option<u64> {
+        self.started_at.map(|at| {
+            u64::try_from(now.signed_duration_since(at).num_seconds().max(0)).unwrap_or(0)
+        })
+    }
+
+    /// Derive the state from the recorded facts, as of `now`. Pure, so every
+    /// surface (`status`, `health`, the dashboard) reaches the same verdict
+    /// from the same wire payload rather than each re-inventing the rules.
+    ///
+    /// Precedence, most-specific first:
+    /// 1. not running ⇒ `Disabled`
+    /// 2. confirmed id disagreement ⇒ `HostIdMismatch` (config-shaped, cannot
+    ///    self-recover — outranks a transient flush failure, whose facts stay
+    ///    readable in `last_failure_*` either way)
+    /// 3. the last attempt failed ⇒ `Failing`
+    /// 4. something has been acked ⇒ `Healthy`
+    /// 5. nothing acked, still inside the grace window ⇒ `Starting`
+    /// 6. nothing acked, past the grace window ⇒ `NeverExported`
+    #[must_use]
+    pub fn classify(&self, now: DateTime<Utc>) -> ObservabilityExportState {
+        let Some(uptime) = self.uptime_secs(now) else {
+            return ObservabilityExportState::Disabled;
+        };
+        if self
+            .ingest_host_id
+            .as_ref()
+            .is_some_and(|ingest| Some(ingest) != self.host_id.as_ref())
+        {
+            return ObservabilityExportState::HostIdMismatch;
+        }
+        if self.consecutive_failures > 0 {
+            return ObservabilityExportState::Failing;
+        }
+        if self.last_success_at.is_some() {
+            return ObservabilityExportState::Healthy;
+        }
+        if uptime < self.never_exported_grace_secs() {
+            ObservabilityExportState::Starting
+        } else {
+            ObservabilityExportState::NeverExported
+        }
+    }
 }
 
 /// One work-finder tick's dispatch/skip tally, stamped with the wall-clock
@@ -2721,5 +2982,186 @@ mod tests {
         }"#;
         let status: RepoStatus = serde_json::from_str(json).unwrap();
         assert!(!status.root_missing);
+    }
+
+    // ==================================================================
+    // Observability export status (Issue #5083)
+    // ==================================================================
+
+    fn export_now() -> DateTime<Utc> {
+        "2026-08-03T12:00:00Z".parse().unwrap()
+    }
+
+    /// A running exporter that started `uptime_secs` ago on the default
+    /// 30s cadence and has never been touched by a flush attempt.
+    fn running_exporter(uptime_secs: i64) -> ObservabilityExportStatus {
+        ObservabilityExportStatus {
+            state: ObservabilityExportState::Starting,
+            host_id: Some("robb-studio".to_string()),
+            ingest_host_id: None,
+            endpoint: Some("https://dashboard.example/ingest".to_string()),
+            exporter: Some("https".to_string()),
+            started_at: Some(export_now() - chrono::Duration::seconds(uptime_secs)),
+            last_success_at: None,
+            last_failure_at: None,
+            last_failure_detail: None,
+            records_exported: 0,
+            consecutive_failures: 0,
+            flush_interval_secs: Some(30),
+        }
+    }
+
+    #[test]
+    fn an_unstarted_exporter_classifies_as_disabled() {
+        // The "observability off / keyless / under-configured" reading — a real
+        // answer, materially different from a `None` field on the wire.
+        let status = ObservabilityExportStatus::disabled();
+        assert_eq!(status.classify(export_now()), ObservabilityExportState::Disabled);
+        assert!(!ObservabilityExportState::Disabled.is_problem());
+        assert!(status.uptime_secs(export_now()).is_none());
+    }
+
+    #[test]
+    fn a_fresh_exporter_with_no_export_yet_is_starting_not_never_exported() {
+        // The false-alarm guard: a daemon restarted 12 seconds ago has not yet
+        // had a fair chance to flush, so it must not read as broken.
+        let status = running_exporter(12);
+        assert_eq!(status.classify(export_now()), ObservabilityExportState::Starting);
+        assert!(!ObservabilityExportState::Starting.is_problem());
+    }
+
+    #[test]
+    fn past_the_grace_window_with_no_export_is_never_exported() {
+        // THE state this issue exists for: configured, running for hours, and
+        // silently never landed a single batch. Pre-#5083 this was
+        // indistinguishable from healthy on every surface.
+        let status = running_exporter(4 * 3600);
+        assert_eq!(status.classify(export_now()), ObservabilityExportState::NeverExported);
+        assert!(ObservabilityExportState::NeverExported.is_problem());
+    }
+
+    #[test]
+    fn the_grace_window_scales_with_the_flush_interval_but_never_below_the_floor() {
+        // A host configured with a one-hour flush cadence must not be called
+        // out as never-exported before it has had three chances to flush.
+        let mut slow = running_exporter(30 * 60);
+        slow.flush_interval_secs = Some(3600);
+        assert_eq!(slow.never_exported_grace_secs(), 3 * 3600);
+        assert_eq!(slow.classify(export_now()), ObservabilityExportState::Starting);
+
+        // ...and a very fast cadence still gets the floor, so a quiet host with
+        // nothing to enqueue yet is not misreported either.
+        let mut fast = running_exporter(60);
+        fast.flush_interval_secs = Some(1);
+        assert_eq!(fast.never_exported_grace_secs(), NEVER_EXPORTED_GRACE_FLOOR_SECS);
+        assert_eq!(fast.classify(export_now()), ObservabilityExportState::Starting);
+    }
+
+    #[test]
+    fn an_acked_batch_with_agreeing_ids_is_healthy() {
+        let mut status = running_exporter(4 * 3600);
+        status.last_success_at = Some(export_now() - chrono::Duration::seconds(12));
+        status.records_exported = 3481;
+        assert_eq!(status.classify(export_now()), ObservabilityExportState::Healthy);
+        assert_eq!(status.last_success_age_secs(export_now()), Some(12));
+        assert!(!ObservabilityExportState::Healthy.is_problem());
+    }
+
+    #[test]
+    fn a_disagreeing_ingest_id_is_a_mismatch_even_while_exporting() {
+        // #4830's condition, expressed on the positive surface: data IS
+        // landing, under the wrong identity.
+        let mut status = running_exporter(4 * 3600);
+        status.last_success_at = Some(export_now() - chrono::Duration::seconds(12));
+        status.ingest_host_id = Some("robb-pro".to_string());
+        assert_eq!(status.classify(export_now()), ObservabilityExportState::HostIdMismatch);
+        assert!(ObservabilityExportState::HostIdMismatch.is_problem());
+    }
+
+    #[test]
+    fn an_echoed_id_that_agrees_is_not_a_mismatch() {
+        // Defensive: only a *disagreement* is a mismatch. An echo equal to the
+        // daemon's own id must stay healthy.
+        let mut status = running_exporter(4 * 3600);
+        status.last_success_at = Some(export_now());
+        status.ingest_host_id = Some("robb-studio".to_string());
+        assert_eq!(status.classify(export_now()), ObservabilityExportState::Healthy);
+    }
+
+    #[test]
+    fn consecutive_failures_classify_as_failing() {
+        let mut status = running_exporter(4 * 3600);
+        status.last_success_at = Some(export_now() - chrono::Duration::seconds(7200));
+        status.consecutive_failures = 3;
+        status.last_failure_detail = Some("sink rejected batch: HTTP 401 — denied".to_string());
+        assert_eq!(status.classify(export_now()), ObservabilityExportState::Failing);
+        assert!(ObservabilityExportState::Failing.is_problem());
+        // "Never worked" vs "worked, then broke" stays legible.
+        assert_eq!(status.last_success_age_secs(export_now()), Some(7200));
+    }
+
+    #[test]
+    fn a_mismatch_outranks_a_transient_flush_failure() {
+        // Precedence documented on `classify`: the config-shaped fault that
+        // cannot self-recover wins; the failure facts remain readable in the
+        // `last_failure_*` fields either way.
+        let mut status = running_exporter(4 * 3600);
+        status.last_success_at = Some(export_now() - chrono::Duration::seconds(60));
+        status.ingest_host_id = Some("robb-pro".to_string());
+        status.consecutive_failures = 2;
+        assert_eq!(status.classify(export_now()), ObservabilityExportState::HostIdMismatch);
+        assert_eq!(status.consecutive_failures, 2);
+    }
+
+    #[test]
+    fn never_exported_beats_a_stale_failure_only_after_grace() {
+        // A brand-new exporter whose very first flush errored is `Failing`
+        // (there is a real, current error) — not `Starting`: the error is
+        // evidence, not absence of it.
+        let mut status = running_exporter(12);
+        status.consecutive_failures = 1;
+        assert_eq!(status.classify(export_now()), ObservabilityExportState::Failing);
+    }
+
+    #[test]
+    fn export_state_serializes_snake_case_for_watch_loops() {
+        // The AC's machine-readability requirement: a watch loop asserts on
+        // these exact strings via `status --json | jq`.
+        for (state, wire) in [
+            (ObservabilityExportState::Disabled, "\"disabled\""),
+            (ObservabilityExportState::Starting, "\"starting\""),
+            (ObservabilityExportState::NeverExported, "\"never_exported\""),
+            (ObservabilityExportState::Healthy, "\"healthy\""),
+            (ObservabilityExportState::HostIdMismatch, "\"host_id_mismatch\""),
+            (ObservabilityExportState::Failing, "\"failing\""),
+        ] {
+            assert_eq!(serde_json::to_string(&state).unwrap(), wire);
+            let back: ObservabilityExportState = serde_json::from_str(wire).unwrap();
+            assert_eq!(back, state);
+        }
+    }
+
+    #[test]
+    fn an_unknown_state_from_a_newer_daemon_does_not_break_the_parse() {
+        let back: ObservabilityExportState = serde_json::from_str("\"quantum_entangled\"").unwrap();
+        assert_eq!(back, ObservabilityExportState::Unrecognized);
+    }
+
+    #[test]
+    fn export_status_round_trips_and_tolerates_pre_5083_wire_data() {
+        let mut status = running_exporter(600);
+        status.last_success_at = Some(export_now());
+        status.records_exported = 12;
+        status.state = status.classify(export_now());
+        let json = serde_json::to_string(&status).unwrap();
+        let back: ObservabilityExportStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, status);
+        assert_eq!(back.state, ObservabilityExportState::Healthy);
+
+        // A pre-#5083 daemon omits the whole field; the report must still parse
+        // and the absence must never be misread as "disabled".
+        let minimal: ObservabilityExportStatus = serde_json::from_str("{}").unwrap();
+        assert_eq!(minimal.state, ObservabilityExportState::Disabled);
+        assert!(minimal.host_id.is_none());
     }
 }


### PR DESCRIPTION
## Summary

`loom-daemon health`'s `observability` section is anomaly-only by design (#4830), so
"exporting fine", "observability disabled", and "configured but silently never exported"
all rendered as the same thing: no section at all. Confirming the healthy case meant
grepping `daemon.log` for the *absence* of a warning — which is what the 2026-08-03
robb-studio-vs-loom-worker-1 incident cost.

This adds a positive, always-answerable export-liveness record. #4830's decision is
preserved verbatim: the health section is still anomaly-only. The positive confirmation
lives on `loom-daemon status` (human + `--json`) instead.

```
Observability: OK — last export 12s ago, 3481 record(s) as host_id=robb-studio → https://…/ingest
Observability: disabled (no telemetry export — set observability.enabled=true to opt in)
Observability: NEVER EXPORTED — running 4h as host_id=robb-studio and no batch has EVER been acked; …
Observability: FAILING — 4 consecutive failed flush(es) as host_id=robb-studio, last success 2h ago … (last error: …)
Observability: HOST-ID MISMATCH — telemetry is landing under host_id=robb-pro, not robb-studio …
```

## Changes

- **`loom-daemon/src/types.rs`** — new `ObservabilityExportStatus` +
  `ObservabilityExportState` (`disabled` | `starting` | `never_exported` | `healthy` |
  `host_id_mismatch` | `failing`, `snake_case` on the wire, `#[serde(other)]` fallback for
  forward compat). `classify()` is **pure**, so `status`, `health` and any future consumer
  reach the same verdict from the same payload. A grace window of 3 × flush interval,
  floored at 10 min (above the collector's own 5-min host-snapshot cadence), keeps a
  just-rolled daemon from reading as broken.
- **`loom-daemon/src/observability/mod.rs`** — `ExportStatus` cell + `GLOBAL_EXPORT_STATUS`,
  following the existing `HostIdStatus` / `global_host_id_mismatch()` pattern, but rolling
  rather than write-once. Registered **only after** an exporter is actually constructed, so
  every degrade-to-disabled path (no endpoint, unreadable ingest key, `otlp` without the
  Cargo feature, client construction failure) keeps reporting `disabled` truthfully.
- **`loom-daemon/src/observability/sender.rs`** — `try_flush` records success/failure on
  every *decided* attempt. An `Empty` queue records **nothing**: nothing was attempted, so
  it is evidence of neither health nor failure. (Recording a success there is exactly how a
  never-exporting host would masquerade as healthy — the ambiguity a 0-byte
  `observability-queue.jsonl` left an operator with.)
- **`loom-daemon/src/ipc.rs`** — `build_daemon_status` publishes
  `observability_export: Some(global_export_status())`. Always `Some` from a daemon of this
  vintage; a disabled exporter reports `disabled`, which is a real answer.
- **`loom-daemon/src/cli/status_render.rs`** — new `render_observability_line()` (split out
  and `now`-injected so every state is unit-testable without capturing stdout, mirroring
  `render_admission_brake_line`), printed unconditionally next to the `Safehouse:` block;
  `observability_export` added to the `--json` payload.
- **`loom-daemon/src/health.rs`** — `assess_observability()` keeps the host-id-mismatch note
  byte-for-byte (including its `detail` keys) and additionally flags `never_exported` and
  `failing`. `healthy` / `starting` / `disabled` still render **nothing at all**. When a
  section does render, its `detail` carries the full export record; the mismatch note gets
  it under `detail.export`.
- **`defaults/docs/observability.md`** — new §3b with the state table, the `jq` assertion,
  and an explicit scope note that this is a *transport-level* signal (a host can be
  `healthy` while a specific record kind is never enqueued — #5084; complementary, not
  overlapping).

Only `defaults/docs/` is edited; the installed `.loom/docs/` copy is left to the periodic
`chore: resync installed Loom surfaces` commit.

## Acceptance Criteria Verification

- [x] **An operator can confirm a host's telemetry is flowing, and under which `host_id`,
      without reading logs.** `Observability: OK — last export 12s ago, 3481 record(s) as
      host_id=robb-studio → …` on `loom-daemon status`.
      Test: `observability_line_states_health_positively_with_the_host_id`.
- [x] **A host with observability disabled is distinguishable from one that is healthy.**
      `Observability: disabled (…)` vs `Observability: OK — …`.
      Test: `observability_line_distinguishes_disabled_from_healthy`.
- [x] **A host that is configured but has never successfully exported is surfaced as a
      problem rather than as silence.** `NEVER EXPORTED` on `status` **and** a `Degraded`
      `observability` health section (which drives `health`'s exit code).
      Tests: `observability_line_surfaces_never_exported_as_a_problem`,
      `a_never_exporting_host_is_a_degraded_observability_note`,
      `past_the_grace_window_with_no_export_is_never_exported`,
      `a_never_acking_sink_is_visible_as_a_problem`.
- [x] **The `observability` health section's anomaly-only rendering (#4830) is preserved.**
      A healthy exporter still produces the same 6 sections and `Verdict::Green`; disabled
      and starting produce no section; the mismatch note's summary and `detail` keys are
      unchanged, with the new payload strictly additive under `detail.export`.
      Tests: `a_healthy_exporter_still_renders_no_observability_section`,
      `a_disabled_exporter_still_renders_no_observability_section`,
      `a_starting_exporter_is_not_yet_called_out`,
      `a_mismatch_still_wins_and_now_carries_the_export_facts`,
      `a_pre_5083_daemon_reporting_no_export_field_renders_nothing`.
- [x] **Whatever is added is machine-readable in `--json`, so a watch loop can assert it.**
      `loom-daemon status --json | jq -e '.observability_export.state == "healthy"'`;
      health sections carry the record in `detail`.
      Tests: `observability_export_is_machine_readable_in_json`,
      `export_state_serializes_snake_case_for_watch_loops`,
      `export_status_round_trips_and_tolerates_pre_5083_wire_data`,
      plus the IPC round-trip assertion in `ipc.rs`.

Curator's fifth state, **export failing**, is covered too:
`observability_line_reports_a_failing_exporter_with_its_error`,
`a_failing_exporter_is_a_degraded_observability_note`,
`consecutive_failures_classify_as_failing`.

## Test Plan

- `cargo check --all-targets` — clean.
- `cargo clippy --all-targets` — clean, no new warnings.
- `cargo fmt` — no drift.
- `cargo test --lib 'observability::'` — 85 passed.
- `cargo test --lib 'health::'` — 103 passed.
- `cargo test --lib 'types::'` — 26 passed.
- `cargo test --lib 'ipc::'` — 83 passed.
- `cargo test --bins observability` — 11 passed (all the new `status_render` cases).
- Full `bash .loom/scripts/build-gate.sh` (`cargo test --workspace --lib --bins`): 3271
  passed, 1 failed — `sweep_registry::guards::tests::restore_label_to_ready_does_not_add_loom_issue_when_target_is_pr`,
  which passes in isolation and touches no code in this diff. It is a load-flake: the run
  happened at load average 56 on this host, and the test's `gh` stub timing is what it
  asserts on. Not caused by this change.

### Note on a pre-existing break, and why it is not in this diff

While working this, `loom-daemon/src/observability/collector.rs`'s `HealthInputs` fixture
(#5098) did not compile against `health.rs`'s `gh_unavailable` field (#5097) — the two PRs
landed in parallel and neither saw the other, breaking `cargo test` on `main`. That was
fixed upstream mid-flight (it is on `main` now), so no fix for it ships here.

Closes #5083
