### PR TITLE
fix(watchdog): socket-first liveness, honor LOOM_PID_FILE, distinct UNDETERMINED state (#5118)

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -4265,6 +4265,7 @@ loop is not reusable as the reporter). It has three cooperating parts:
 | IPC probe argv (#4398) | `LOOM_WATCHDOG_IPC_PROBE_ARGS` | — | `quarantine list` |
 | confirmed-hang threshold (#4398) | `LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD` | — | `3` consecutive ticks |
 | IPC probe startup grace (#4398) | `LOOM_WATCHDOG_IPC_PROBE_GRACE_SECS` | — | `LOOM_DAEMON_STARTUP_GRACE_SECS`, else `90` |
+| pid file path (#5118) | `LOOM_PID_FILE` | — | the start script's `<state home>/.daemon.pid`, exported into the daemon **and** watchdog job/unit |
 
 **Why an interval timer, not a resident process or `KeepAlive`/`Restart=`.** The
 reporter must itself be supervised, but a long-lived resident watchdog just moves
@@ -4275,20 +4276,24 @@ systemd's `.timer` re-fires its paired `Type=oneshot` service the same way — s
 neither can crash-and-stay-dead. `KeepAlive`/`Restart=` are deliberately **not**
 set on the watchdog job/service — that would busy-loop a short-lived job/oneshot
 service instead of driving it off a fixed interval clock. The watchdog exit code
-(`0` healthy / no daemon expected, `1` divergence) is for testability + a human
-running it by hand; neither a `StartInterval` job's nor a timer-fired oneshot
-service's exit code affects the next scheduled run.
+(`0` healthy / no daemon expected, `1` divergence, `3` liveness undetermined —
+#5118) is for testability + a human running it by hand; neither a
+`StartInterval` job's nor a timer-fired oneshot service's exit code affects the
+next scheduled run.
 
 **Decision matrix** (marker present ⇒ a daemon is expected):
 
 | Marker | Reality | Watchdog |
 |--------|---------|----------|
 | present | daemon alive, heartbeat fresh, IPC round-trip OK | silent (OK) |
+| present | no live pid/job found out-of-band, but the **socket answers** (#5118) | silent (OK) — the round-trip is authoritative; an absent/stale pid file is a hint, not an outage |
+| present | supervisor says its job is **down** while the socket **answers** (#5118) | **report (WARN)** — an UNSUPERVISED but serving daemon; auto-remediation is suppressed (relaunching into a served socket can only be refused) |
+| present | no live pid/job **and** the socket probe could not run at all (#5118) | **report (UNKNOWN, exit 3)** — liveness undetermined, explicitly *not* "the daemon is down" |
 | present | daemon alive, heartbeat fresh, **IPC round-trip fails** (#4398) | **report** — 1 tick: "not yet confirmed"; N consecutive: **IPC UNRESPONSIVE (CONFIRMED)** |
 | present | daemon alive, heartbeat **stale**, written this boot (younger than the process) | **report** — daemon may be wedged |
 | present | daemon alive, heartbeat **older than the process itself** (#4368: a previous-boot/enablement leftover) | silent (liveness-only; not evidence about the current process) |
 | present | daemon alive, no heartbeat file | silent (liveness-only; heartbeat disabled or not yet written) |
-| present | daemon **not loaded/alive** | **report** — the #4011 outage |
+| present | daemon **not loaded/alive**, and the socket confirms it is unreachable | **report** — the #4011 outage |
 | **absent** | **nothing running** | silent — deliberate stop, no false page |
 | **absent** | **daemon IS running** | **report (WARN)** — state mismatch, crash protection disarmed (#4331) |
 
@@ -4348,6 +4353,33 @@ the non-launchd path) and, only when a daemon **is** demonstrably alive, WARNs +
 exits `1`. The load-bearing quiet case — marker absent *and* nothing alive, i.e. a
 deliberate `loom-daemon-stop.sh` (which also boots the daemon job out, so nothing
 is found) — stays exactly as silent as before.
+
+**Socket-first liveness, pid file demoted to a hint (#5118).** Until #5118 the
+out-of-band probe was the *only* thing that could establish liveness, and on a
+host with no launchd job and no systemd-managed unit to ask, that reduced to one
+artifact: the pid file. Three defects stacked on it. (a) **Path disagreement** —
+the watchdog derived the path from the *socket's* directory while the daemon
+derives it from `LOOM_PID_FILE` / the workspace (`daemon_pidfile.rs`); on a
+workspace-rooted install those are never the same directory. (b) **`LOOM_PID_FILE`
+was ignored by the watchdog** even though `loom-daemon-start.sh` exports it and
+the daemon honors it as tier 1. (c) **A stale pid file read as a confirmed
+death.** Observed 2026-08-03: *both* fleet hosts ran healthy daemons while the
+watchdog reported `[DIVERGENCE] … no live pid file at ~/.loom/.daemon.pid` every
+five minutes for two days — and two genuine outages in that window were
+indistinguishable from the steady-state false alarm.
+
+The precedence is now the same one `loom-daemon health` already uses: **the IPC
+round-trip is authoritative, the pid file corroborates**. When the out-of-band
+probe finds no live daemon the watchdog *asks the socket* before reporting
+anything (see the three new decision-matrix rows above), and the pid file's path
+is resolved by the identical precedence the daemon uses — `LOOM_PID_FILE` > the
+marker's `pid_file=` > `LOOM_MACHINE_CHECKOUT` (machine-level loom dir) >
+`LOOM_WORKSPACE`/`repo_root` (`<repo>/.loom`) > `<loom_dir>`. `LOOM_PID_FILE` is
+now also baked into the **watchdog** job/unit (previously only the daemon's), so
+both ends read the file the start script chose. The `UNKNOWN`/exit-3 state is the
+other half of the fix: an alerting component that cannot determine liveness must
+say so, because defaulting to "the daemon is gone" is precisely what turned this
+detector into a permanent false positive.
 
 **Marker lifetime across a self-update.** `loom-daemon-update.sh` performs an
 internal stop→start, which is a **restart**, not operator intent to stop — so it

--- a/defaults/scripts/cli/loom-daemon-start.sh
+++ b/defaults/scripts/cli/loom-daemon-start.sh
@@ -964,6 +964,13 @@ render_watchdog_plist() {
     printf '        <key>HOME</key>\n        <string>%s</string>\n' "$(xml_escape "$HOME")"
     printf '        <key>LOOM_AUTONOMY_MARKER</key>\n        <string>%s</string>\n' "$(xml_escape "$INTENT_MARKER")"
     printf '        <key>LOOM_SOCKET_PATH</key>\n        <string>%s</string>\n' "$(xml_escape "$SOCKET_PATH")"
+    # #5118: the watchdog honors LOOM_PID_FILE with the SAME precedence the
+    # daemon does (daemon_pidfile.rs tier 1), so passing the path this script
+    # chose makes the two ends single-source it. Before this the watchdog
+    # derived its own path from the socket's directory and, on a
+    # workspace-rooted install, looked at a file nothing ever writes -- a
+    # permanent false "[DIVERGENCE] no live pid file" on every fleet host.
+    printf '        <key>LOOM_PID_FILE</key>\n        <string>%s</string>\n' "$(xml_escape "$PID_FILE")"
     printf '        <key>LOOM_LAUNCHD_LABEL</key>\n        <string>%s</string>\n' "$(xml_escape "$(resolve_launchd_label)")"
     printf '    </dict>\n'
     printf '    <key>RunAtLoad</key>\n    <true/>\n'
@@ -1055,6 +1062,11 @@ render_systemd_watchdog_service() {
     printf 'Environment=HOME=%s\n' "$HOME"
     printf 'Environment=LOOM_AUTONOMY_MARKER=%s\n' "$INTENT_MARKER"
     printf 'Environment=LOOM_SOCKET_PATH=%s\n' "$SOCKET_PATH"
+    # #5118: same single-sourcing as the launchd watchdog plist above -- the
+    # watchdog resolves the pid file exactly as the daemon does, and this is
+    # the tier-1 value. (Observed on loom-worker-1: the watchdog read
+    # ~/.loom/.daemon.pid while the daemon wrote <workspace>/.loom/.daemon.pid.)
+    printf 'Environment=LOOM_PID_FILE=%s\n' "$PID_FILE"
     printf 'Environment=LOOM_DAEMON_LAUNCHD=0\n'
     printf 'StandardOutput=append:%s\n' "$log_path"
     printf 'StandardError=append:%s\n' "$log_path"

--- a/defaults/scripts/cli/loom-daemon-watchdog.sh
+++ b/defaults/scripts/cli/loom-daemon-watchdog.sh
@@ -90,6 +90,52 @@
 #       escalates to a maximally actionable DIVERGENCE report (exit 1) with the
 #       explicit recovery commands — never an automatic kill/restart.
 #
+# SOCKET-FIRST LIVENESS, PID FILE DEMOTED TO A HINT (#5118)
+#   Until #5118 the OUT-OF-BAND probe above was the ONLY thing that could
+#   establish liveness, and on a host with neither a launchd job nor a
+#   systemd-managed unit to ask, that reduced to a single artifact: the pid
+#   file. Three stacked defects made that unusable fleet-wide:
+#     1. PATH DISAGREEMENT. This script derived the pid file from the SOCKET's
+#        directory (`<dirname $LOOM_SOCKET_PATH>/.daemon.pid`) in the
+#        marker-absent path, while the daemon derives it from the START
+#        SCRIPT's `LOOM_PID_FILE` / the workspace (`daemon_pidfile.rs`). On a
+#        workspace-rooted install those are never the same directory.
+#     2. `LOOM_PID_FILE` WAS IGNORED HERE. It is exported by
+#        loom-daemon-start.sh and baked into every plist/unit it renders — and
+#        honored by the daemon as precedence tier 1 — but this script had no
+#        support for it at all, so the one variable that is supposed to
+#        single-source the path could not align the two ends.
+#     3. A STALE pid file reads as a CONFIRMED death. A pid file naming a
+#        long-dead pid (#4774, before the daemon self-wrote it at bind) is
+#        indistinguishable here from "no daemon".
+#   Observed 2026-08-03: BOTH fleet hosts ran healthy daemons while this
+#   watchdog reported `[DIVERGENCE] ... no live pid file at ~/.loom/.daemon.pid`
+#   every five minutes since 2026-08-01. An alarm that is always on carries no
+#   information — and two genuine outages that same session were
+#   indistinguishable from it.
+#
+#   The fix inverts the precedence to match what `loom-daemon health` already
+#   does: the IPC ROUND-TRIP IS AUTHORITATIVE, the pid file is a corroborating
+#   hint. Concretely, when the out-of-band probe does NOT find a live daemon
+#   this script now ASKS THE SOCKET before reporting anything:
+#     * socket ANSWERS + no supervisor was consulted (pid-file path) ⇒ HEALTHY.
+#       The pid file's absence/staleness is a note, never a page.
+#     * socket ANSWERS + the supervisor (launchd/systemd) says its job is down
+#       ⇒ a WARN state mismatch: a daemon is serving work but nothing is
+#       supervising it. Auto-remediation is SUPPRESSED — kickstarting a second
+#       daemon at a socket a live one already owns only produces a refusal.
+#     * socket is UNREACHABLE ⇒ the daemon really is down: the existing
+#       DIVERGENCE + bounded auto-remediation path, unchanged.
+#     * liveness CANNOT BE DETERMINED (no probe available — no resolvable
+#       binary, probe disabled, CLI wedged — AND no usable pid file) ⇒ a
+#       DISTINCT `UNKNOWN` report and exit 3. Defaulting to "the daemon is
+#       gone" is what manufactured the permanent false positive; an alerting
+#       component must say "I cannot tell" in its own words.
+#   The pid file's PATH is also now derived by the same precedence the daemon
+#   uses (`LOOM_PID_FILE` > the marker's `pid_file=` > machine/workspace >
+#   `<loom dir>`), so the two ends can no longer disagree about which file
+#   they mean.
+#
 # BOUNDED AUTO-REMEDIATION (#4232)
 #   The watchdog was deliberately report-only until #4232: on 2026-07-28 a
 #   `loom-daemon restart` was ack'd (the running daemon exited 0, honoring its
@@ -127,8 +173,15 @@
 #      heartbeat is stale (possibly wedged), OR (#4398) it is running with a
 #      fresh heartbeat but its bounded IPC round-trip failed, OR (#4331) a daemon
 #      IS running while the marker is ABSENT (crash protection disarmed — a WARN
-#      state mismatch)
+#      state mismatch), OR (#5118) the socket answers while the supervisor says
+#      its job is down (an UNSUPERVISED daemon — serving work, but not crash
+#      protected)
 #   2  usage error
+#   3  (#5118) LIVENESS UNDETERMINED — deliberately NOT exit 1: no out-of-band
+#      signal found a live daemon AND the in-band socket probe could not run (no
+#      resolvable loom-daemon binary, the probe is disabled, or the CLI itself
+#      never returned), so this tick has NO EVIDENCE either way. Reported as
+#      UNKNOWN, never as "the daemon is down".
 #
 # Usage:
 #   ./.loom/scripts/cli/loom-daemon-watchdog.sh            Check once, report on divergence
@@ -142,6 +195,14 @@
 #   LOOM_DAEMON_HEARTBEAT_STALE_SECS  Staleness threshold in seconds (default:
 #                                  max(5 × heartbeat cadence, 300))
 #   LOOM_SOCKET_PATH              Override the daemon socket (its dir is the loom dir)
+#   LOOM_PID_FILE                 #5118: the pid file path, honored END-TO-END —
+#                                 the same precedence tier 1 the daemon itself
+#                                 uses (daemon_pidfile.rs) and the value
+#                                 loom-daemon-start.sh exports into every plist
+#                                 / systemd unit it renders. Wins over the
+#                                 marker's `pid_file=` field. The pid file is
+#                                 only ever a CORROBORATING hint here: the
+#                                 socket round-trip is authoritative.
 #   LOOM_LAUNCHD_LABEL            macOS: the DAEMON label to probe (default com.rjwalters.loom-daemon)
 #   LOOM_LAUNCHD_DOMAIN          macOS: pin the launchd domain (gui/<uid> or user/<uid>);
 #                                else auto-resolved gui→user (#4130), matching the start
@@ -274,6 +335,54 @@ report() {
     esac
 }
 
+# ---------- marker reader ----------
+# Defined UP HERE (moved by #5118) rather than beside the marker-present path
+# below: locate_daemon_bin() consults `marker_get repo_root`, and #5118's
+# socket probe now runs on the marker-ABSENT path too, which executes before
+# that path's own code. A function must exist at CALL time, so this has to be
+# defined before section 1 runs.
+marker_get() {
+    local key="$1"
+    # First matching `key=value` line; strip the key= prefix. Comments start '#'.
+    [[ -f "$MARKER" ]] || return 0
+    grep -E "^${key}=" "$MARKER" 2>/dev/null | head -n1 | cut -d= -f2-
+}
+
+# ---------- pid-file path resolution (#5118) ----------
+# Mirrors the daemon's own `daemon_pidfile::resolve_pid_file_path_from`
+# precedence EXACTLY so the two ends can never mean different files — the #5118
+# path disagreement (this script read `<socket dir>/.daemon.pid`; the daemon
+# wrote `<workspace>/.loom/.daemon.pid`) was possible only because each side
+# derived its own path:
+#   1. LOOM_PID_FILE            — explicit, exported by loom-daemon-start.sh and
+#                                 baked into the rendered plist / systemd unit,
+#                                 so every supervisor relaunch resolves it too.
+#   2. the marker's `pid_file=` — the path the start script chose on THIS host
+#                                 (i.e. what it exported as LOOM_PID_FILE).
+#   3. LOOM_MACHINE_CHECKOUT    — machine mode keeps runtime state in the
+#                                 machine-level loom dir.
+#   4. LOOM_WORKSPACE / the marker's repo_root — repo mode: `<repo>/.loom`.
+#   5. `<loom dir>/.daemon.pid` — the daemon's own final fallback.
+# Whatever this returns is only ever a CORROBORATING hint; an absent or stale
+# file must not by itself produce a divergence (that is the whole bug).
+resolve_pid_file() { # [marker pid_file value]
+    local from_marker="${1:-}"
+    if [[ -n "${LOOM_PID_FILE:-}" ]]; then
+        echo "$LOOM_PID_FILE"; return 0
+    fi
+    if [[ -n "$from_marker" ]]; then
+        echo "$from_marker"; return 0
+    fi
+    if [[ -n "${LOOM_MACHINE_CHECKOUT:-}" ]]; then
+        echo "$LOOM_DIR/.daemon.pid"; return 0
+    fi
+    local workspace="${LOOM_WORKSPACE:-$(marker_get repo_root)}"
+    if [[ -n "$workspace" ]]; then
+        echo "$workspace/.loom/.daemon.pid"; return 0
+    fi
+    echo "$LOOM_DIR/.daemon.pid"
+}
+
 # ---------- reality probe (shared) ----------
 # Determine whether the expected daemon is actually alive. Reads the resolved
 # USE_LAUNCHD / USE_SYSTEMD / LABEL / SYSTEMD_UNIT / PID_FILE and sets globals
@@ -285,6 +394,13 @@ report() {
 #                    gates)
 #   launchd_service  <domain>/<label> for the launchd path (else empty)
 #   systemd_service  <unit> for the systemd path (else empty)
+#   liveness_source  launchd|systemd|pidfile — WHICH out-of-band signal was
+#                    consulted (#5118: a supervisor's "job is down" is real
+#                    evidence; a missing pid file is not, so the two must be
+#                    told apart by the callers)
+#   pidfile_evidence alive|dead|absent — only meaningful on the pidfile path
+#                    (#5118: `dead` — a file naming a non-live pid — is positive
+#                    evidence; `absent` is no evidence at all)
 # Factored out (#4331) so the no-marker state-mismatch check below and the
 # marker-present path below run the IDENTICAL liveness logic — they can never
 # diverge on what "alive" means.
@@ -295,9 +411,12 @@ detect_daemon_liveness() {
     launchd_service=""
     systemd_service=""
     live_pid=""
+    liveness_source=pidfile
+    pidfile_evidence=absent
     if [[ "$USE_LAUNCHD" == "true" ]] && command -v launchctl >/dev/null 2>&1; then
         # Resolve the domain (gui/<uid> ↦ user/<uid>, #4130) the same way the
         # start did, so a headless daemon in user/<uid> is probed correctly.
+        liveness_source=launchd
         launchd_service="$(resolve_launchd_domain)/${LABEL}"
         launchd_print_output="$(launchctl print "$launchd_service" 2>/dev/null)"
         launchd_print_rc=$?
@@ -318,6 +437,7 @@ detect_daemon_liveness() {
         # Linux. `show -p X --value` against an unknown unit answers cleanly
         # (LoadState=not-found) rather than erroring, so no separate rc check
         # is needed the way launchd's print exit code is used above.
+        liveness_source=systemd
         systemd_service="$SYSTEMD_UNIT"
         systemd_main_pid="$(systemctl --user show -p MainPID --value "$systemd_service" 2>/dev/null)"
         if [[ -n "$systemd_main_pid" && "$systemd_main_pid" != "0" ]] && kill -0 "$systemd_main_pid" 2>/dev/null; then
@@ -334,17 +454,25 @@ detect_daemon_liveness() {
             fi
         fi
     else
-        # Non-launchd, non-systemd (nohup) path: the pid file is the only signal.
+        # Non-launchd, non-systemd (nohup) path: the pid file is the only
+        # OUT-OF-BAND signal — and, since #5118, explicitly the WEAKEST one.
+        # A live pid here is still accepted as liveness (cheap, and correct
+        # whenever the file is fresh), but neither of the negative outcomes
+        # below may end the check: the caller asks the socket before reporting.
+        liveness_source=pidfile
         if [[ -n "$PID_FILE" && -f "$PID_FILE" ]]; then
             pid="$(cat "$PID_FILE" 2>/dev/null || true)"
             if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
                 daemon_alive=true
+                pidfile_evidence=alive
                 liveness_detail="pid $pid (from $PID_FILE) alive"
                 live_pid="$pid"
             else
+                pidfile_evidence=dead
                 liveness_detail="pid file $PID_FILE present but pid not alive"
             fi
         else
+            pidfile_evidence=absent
             liveness_detail="no live pid file at ${PID_FILE:-<none>}"
         fi
     fi
@@ -440,6 +568,130 @@ probe_fail_count_clear() {
     rm -f "$PROBE_STATE_FILE" 2>/dev/null || true
 }
 
+# Run the bounded probe command ONCE. Extracted from run_ipc_probe() by #5118 so
+# the post-liveness hang probe and the new pre-report socket-liveness probe
+# invoke the daemon CLI through the IDENTICAL code path (same binary
+# resolution, same argv, same hard budget) and can never disagree about what
+# "the daemon answered" means.
+#
+# Sets PROBE_RUN_RC / PROBE_RUN_OUTPUT / PROBE_RUN_BIN and returns 0 when the
+# command actually ran; returns 1 with PROBE_RUN_SKIP_REASON set when it could
+# NOT be run at all (disabled, no bounded_run, no binary, empty argv). The
+# distinction matters: "ran and failed" is evidence, "could not run" is not.
+invoke_probe_command() {
+    PROBE_RUN_RC=0
+    PROBE_RUN_OUTPUT=""
+    PROBE_RUN_BIN=""
+    PROBE_RUN_SKIP_REASON=""
+
+    if [[ "${LOOM_WATCHDOG_IPC_PROBE:-}" =~ ^(0|false|no)$ ]]; then
+        PROBE_RUN_SKIP_REASON="IPC probe disabled via LOOM_WATCHDOG_IPC_PROBE"
+        return 1
+    fi
+
+    # #4832: bounded_run is defined by sourcing lib/bounded-run.sh above. A
+    # missing/unreadable lib file leaves it undefined -- without this explicit
+    # check, the invocation below would fail as a raw shell "command not
+    # found" (rc 127) on every scheduled tick instead of a diagnosed skip.
+    if ! command -v bounded_run >/dev/null 2>&1; then
+        PROBE_RUN_SKIP_REASON="bounded_run is undefined -- lib/bounded-run.sh failed to source (missing or unreadable)"
+        return 1
+    fi
+
+    local bin
+    bin="$(locate_daemon_bin)" || bin=""
+    if [[ -z "$bin" ]]; then
+        PROBE_RUN_SKIP_REASON="no loom-daemon binary resolvable (LOOM_DAEMON_BIN unset, not on PATH, no in-repo build)"
+        return 1
+    fi
+    PROBE_RUN_BIN="$bin"
+
+    local -a probe_argv
+    # shellcheck disable=SC2206  # deliberate word-splitting of the argv override
+    read -r -a probe_argv <<< "$PROBE_ARGS"
+    if (( ${#probe_argv[@]} == 0 )); then
+        PROBE_RUN_SKIP_REASON="LOOM_WATCHDOG_IPC_PROBE_ARGS is empty — nothing to probe with"
+        return 1
+    fi
+
+    local out rc=0
+    out="$(mktemp "${TMPDIR:-/tmp}/loom-watchdog-probe.XXXXXX" 2>/dev/null)" || out=""
+    if [[ -n "$out" ]]; then
+        LOOM_SOCKET_PATH="$SOCKET_PATH" bounded_run "$PROBE_TIMEOUT_SECS" \
+            "$bin" "${probe_argv[@]}" > "$out" 2>&1
+        rc=$?
+        PROBE_RUN_OUTPUT="$(cat "$out" 2>/dev/null)"
+        rm -f "$out" 2>/dev/null
+    else
+        LOOM_SOCKET_PATH="$SOCKET_PATH" bounded_run "$PROBE_TIMEOUT_SECS" \
+            "$bin" "${probe_argv[@]}" >/dev/null 2>&1
+        rc=$?
+    fi
+    PROBE_RUN_RC=$rc
+    return 0
+}
+
+# ---------- authoritative socket-liveness probe (#5118) ----------
+# Ask the daemon's own socket whether ANYTHING is serving there, and classify
+# the answer for the liveness decision (NOT the hang decision — that is
+# run_ipc_probe's job, and it only runs once liveness is established).
+#
+# Sets:
+#   socket_verdict  answered | unreachable | indeterminate
+#   socket_detail   human-readable reason, mirrored into every report
+#
+# The three verdicts are deliberately asymmetric about what counts as evidence:
+#   answered      a round-trip completed, OR the daemon replied with an
+#                 application-level error (which PROVES the socket is served),
+#                 OR the CLI itself says the daemon is alive-but-starting.
+#   unreachable   positive evidence of absence: the CLI could not reach the
+#                 socket (no listener / connect refused / connect timed out).
+#   indeterminate everything else — the probe could not be run, the CLI itself
+#                 never returned, or the daemon looks alive-but-wedged. The
+#                 caller must report UNKNOWN, never "the daemon is down".
+probe_socket_liveness() {
+    socket_verdict=indeterminate
+    socket_detail=""
+
+    if ! invoke_probe_command; then
+        socket_detail="could not ask the socket: ${PROBE_RUN_SKIP_REASON}"
+        return 0
+    fi
+
+    local label
+    label="$(basename "$PROBE_RUN_BIN") ${PROBE_ARGS}"
+    case "$PROBE_RUN_RC" in
+        0)
+            socket_verdict=answered
+            socket_detail="'${label}' round-tripped over ${SOCKET_PATH} within ${PROBE_TIMEOUT_SECS}s"
+            return 0
+            ;;
+        124)
+            socket_detail="'${label}' did NOT return within the ${PROBE_TIMEOUT_SECS}s probe budget — the CLI itself is wedged, so this tick proves nothing about the daemon either way"
+            return 0
+            ;;
+        2|126|127)
+            socket_detail="probe command '${label}' is unsupported by this binary (exit ${PROBE_RUN_RC}) — no in-band liveness signal available"
+            return 0
+            ;;
+    esac
+
+    if printf '%s' "$PROBE_RUN_OUTPUT" | grep -qiE 'alive-starting|socket has not bound'; then
+        socket_verdict=answered
+        socket_detail="the daemon is alive and STARTING (its socket is not bound yet) — alive, not gone"
+    elif printf '%s' "$PROBE_RUN_OUTPUT" | grep -qiE 'alive-but-unresponsive'; then
+        socket_detail="the CLI reports the daemon process as alive-but-unresponsive — alive-vs-gone is UNDETERMINED from this tick"
+    elif printf '%s' "$PROBE_RUN_OUTPUT" | grep -qiE 'could not reach loom-daemon|connect timed out|connect failed|connection refused|no such file'; then
+        socket_verdict=unreachable
+        socket_detail="'${label}' could not reach anything at ${SOCKET_PATH} (exit ${PROBE_RUN_RC}): $(printf '%s' "$PROBE_RUN_OUTPUT" | head -n1)"
+    elif printf '%s' "$PROBE_RUN_OUTPUT" | grep -qiE 'round-trip timed out|closed the connection without responding'; then
+        socket_detail="'${label}' connected but the round-trip did not complete (exit ${PROBE_RUN_RC}) — a wedge, not a proven absence: $(printf '%s' "$PROBE_RUN_OUTPUT" | head -n1)"
+    else
+        socket_verdict=answered
+        socket_detail="'${label}' exited ${PROBE_RUN_RC} with an application-level error (the daemon ANSWERED, so the socket is served): $(printf '%s' "$PROBE_RUN_OUTPUT" | head -n1)"
+    fi
+}
+
 # Perform the bounded IPC round-trip and classify the outcome. Sets:
 #   probe_verdict  healthy | unresponsive | skipped
 #   probe_detail   human-readable reason (mirrored into the report)
@@ -450,62 +702,29 @@ run_ipc_probe() { # <live_pid> <proc_age_or_empty>
     probe_detail=""
     local pid="$1" age="$2"
 
-    if [[ "${LOOM_WATCHDOG_IPC_PROBE:-}" =~ ^(0|false|no)$ ]]; then
-        probe_detail="IPC probe disabled via LOOM_WATCHDOG_IPC_PROBE"
-        return 0
-    fi
-
-    # #4832: bounded_run is defined by sourcing lib/bounded-run.sh above. A
-    # missing/unreadable lib file leaves it undefined -- without this explicit
-    # check, the invocation below would fail as a raw shell "command not
-    # found" (rc 127) on every scheduled tick instead of a diagnosed skip.
-    if ! command -v bounded_run >/dev/null 2>&1; then
-        probe_detail="bounded_run is undefined -- lib/bounded-run.sh failed to source (missing or unreadable)"
-        return 0
-    fi
-
     # Post-relaunch socket-bind window (#4213/#4331): a live pid whose socket is
     # not bound yet is STARTING, not wedged. Skip outright so it cannot count
     # toward a confirmed hang. An UNPARSEABLE age does not skip — `ps` failing
     # for a live pid is not a real deployment state, and silently disabling the
     # probe on it would reintroduce the blind spot; the N-consecutive debounce
-    # still spans far more than any bind window.
+    # still spans far more than any bind window. Checked BEFORE the invocation
+    # so a young daemon is never even asked.
     if [[ "$age" =~ ^[0-9]+$ ]] && (( age < PROBE_GRACE_SECS )); then
         probe_detail="process is only ${age}s old (< ${PROBE_GRACE_SECS}s startup grace) — socket may not be bound yet"
         return 0
     fi
 
-    local bin
-    bin="$(locate_daemon_bin)" || bin=""
-    if [[ -z "$bin" ]]; then
-        probe_detail="no loom-daemon binary resolvable (LOOM_DAEMON_BIN unset, not on PATH, no in-repo build)"
+    # #5118: the invocation itself (probe-disabled / missing bounded_run /
+    # unresolvable binary / empty argv checks included) now lives in the shared
+    # invoke_probe_command(). Its skip reasons are the SAME "could not run at
+    # all" set this function has always degraded on, so they still map to
+    # `skipped`, never to a divergence.
+    if ! invoke_probe_command; then
+        probe_detail="$PROBE_RUN_SKIP_REASON"
         return 0
     fi
 
-    local -a probe_argv
-    # shellcheck disable=SC2206  # deliberate word-splitting of the argv override
-    read -r -a probe_argv <<< "$PROBE_ARGS"
-    if (( ${#probe_argv[@]} == 0 )); then
-        probe_detail="LOOM_WATCHDOG_IPC_PROBE_ARGS is empty — nothing to probe with"
-        return 0
-    fi
-
-    local out rc=0
-    out="$(mktemp "${TMPDIR:-/tmp}/loom-watchdog-probe.XXXXXX" 2>/dev/null)" || out=""
-    if [[ -n "$out" ]]; then
-        LOOM_SOCKET_PATH="$SOCKET_PATH" bounded_run "$PROBE_TIMEOUT_SECS" \
-            "$bin" "${probe_argv[@]}" > "$out" 2>&1
-        rc=$?
-    else
-        LOOM_SOCKET_PATH="$SOCKET_PATH" bounded_run "$PROBE_TIMEOUT_SECS" \
-            "$bin" "${probe_argv[@]}" >/dev/null 2>&1
-        rc=$?
-    fi
-    local probe_output=""
-    if [[ -n "$out" ]]; then
-        probe_output="$(cat "$out" 2>/dev/null)"
-        rm -f "$out" 2>/dev/null
-    fi
+    local bin="$PROBE_RUN_BIN" rc="$PROBE_RUN_RC" probe_output="$PROBE_RUN_OUTPUT"
 
     case "$rc" in
         0)
@@ -575,8 +794,23 @@ if [[ ! -f "$MARKER" ]]; then
         USE_SYSTEMD=true
     fi
     SYSTEMD_UNIT="${LOOM_SYSTEMD_UNIT:-loom-daemon.service}"
-    PID_FILE="$LOOM_DIR/.daemon.pid"
+    # #5118: derived by the SAME precedence the daemon uses, not blindly from
+    # the socket's directory (which is what made this file unfindable on a
+    # workspace-rooted install).
+    PID_FILE="$(resolve_pid_file "")"
     detect_daemon_liveness
+    if [[ "$daemon_alive" != "true" ]]; then
+        # #5118: the out-of-band signals found nothing — which, before this fix,
+        # was accepted as "nothing is running" on the strength of a pid file
+        # alone. Ask the socket before concluding: an unmarked-but-LIVE daemon
+        # is exactly the #4331 state this section exists to surface, and it must
+        # not be missed just because its pid file is absent or stale.
+        probe_socket_liveness
+        if [[ "$socket_verdict" == "answered" ]]; then
+            daemon_alive=true
+            liveness_detail="a daemon ANSWERS on ${SOCKET_PATH} (${socket_detail}); the out-of-band signal disagreed: ${liveness_detail}"
+        fi
+    fi
     if [[ "$daemon_alive" == "true" ]]; then
         report WARN \
             "STATE MISMATCH: no autonomy-desired marker at $MARKER, but a daemon IS running (${liveness_detail}). Crash protection is DISARMED — if this daemon dies the watchdog will NOT revive it. Heal it by restarting the daemon (it self-heals the marker at startup, #4331) or re-running ./.loom/scripts/cli/loom-daemon-start.sh; if the daemon should NOT be running, stop it with ./.loom/scripts/cli/loom-daemon-stop.sh."
@@ -590,24 +824,24 @@ if [[ ! -f "$MARKER" ]]; then
 fi
 
 # ---------- parse the marker (key=value; ignore comments/blanks) ----------
-marker_get() {
-    local key="$1"
-    # First matching `key=value` line; strip the key= prefix. Comments start '#'.
-    grep -E "^${key}=" "$MARKER" 2>/dev/null | head -n1 | cut -d= -f2-
-}
-
+# marker_get() itself is defined near the top (#5118) so the marker-ABSENT path
+# above can use the same reader.
 HEARTBEAT_FILE="$(marker_get heartbeat_file)"
 HEARTBEAT_INTERVAL_SECS="$(marker_get heartbeat_interval_secs)"
 MARKER_USE_LAUNCHD="$(marker_get use_launchd)"
 MARKER_LABEL="$(marker_get launchd_label)"
 MARKER_USE_SYSTEMD="$(marker_get use_systemd)"
 MARKER_SYSTEMD_UNIT="$(marker_get systemd_unit)"
-PID_FILE="$(marker_get pid_file)"
+# #5118: LOOM_PID_FILE (the value loom-daemon-start.sh exports and the daemon
+# honors as its own tier 1) now wins over the marker's recorded path, and an
+# absent field falls through the daemon's remaining tiers instead of resolving
+# to the empty string. Before this the two ends could — and on both fleet hosts
+# did — mean different files.
+PID_FILE="$(resolve_pid_file "$(marker_get pid_file)")"
 
 # Fallbacks when the marker predates a field or the value is empty.
 [[ -z "$HEARTBEAT_FILE" ]] && HEARTBEAT_FILE="$LOOM_DIR/daemon.heartbeat"
 [[ "$HEARTBEAT_INTERVAL_SECS" =~ ^[0-9]+$ ]] || HEARTBEAT_INTERVAL_SECS=60
-[[ -z "$PID_FILE" ]] && PID_FILE=""
 
 # Env overrides win over the marker (a stop/start under a different label should
 # be probed with the current env, not a stale marker value).
@@ -655,6 +889,66 @@ SYSTEMD_UNIT="${LOOM_SYSTEMD_UNIT:-${MARKER_SYSTEMD_UNIT:-loom-daemon.service}}"
 # (a booted-out job, or a non-launchd host), which stays report-only no matter
 # what.
 detect_daemon_liveness
+
+# ---------- 2b. authoritative in-band cross-check (#5118) ----------
+# The probe above is entirely OUT-OF-BAND. When it does not find a live daemon,
+# that is NOT yet a finding: on both fleet hosts the pid-file branch reported
+# "no live pid file" every five minutes for two days while a healthy daemon was
+# serving work on the socket the whole time. So before ANY report, ask the
+# socket — the same signal `loom-daemon health` already treats as authoritative,
+# with the pid file demoted to a corroborating hint.
+#
+# SOCKET_ONLY_LIVENESS records that liveness came from the socket alone (no live
+# pid to age-check or key a hang streak to), which the sections below honor.
+SOCKET_ONLY_LIVENESS=false
+socket_verdict=""
+socket_detail=""
+if [[ "$daemon_alive" != "true" ]]; then
+    probe_socket_liveness
+    case "$socket_verdict" in
+        answered)
+            if [[ "$liveness_source" == "pidfile" ]]; then
+                # No supervisor was consulted, so nothing contradicts the
+                # socket: the daemon is HEALTHY and the pid file was simply not
+                # a usable signal. This is the false-alarm case #5118 fixes —
+                # it must be an OK, never a page.
+                daemon_alive=true
+                SOCKET_ONLY_LIVENESS=true
+                liveness_detail="daemon ANSWERS on ${SOCKET_PATH} (${socket_detail}) — authoritative; the pid-file hint was unusable (${liveness_detail}), which is NOT evidence of an outage (#5118)"
+                report OK "daemon healthy via the in-band socket round-trip: ${liveness_detail}."
+            else
+                # A supervisor DOES claim its job is down while something is
+                # serving the socket. That is a real anomaly (an unsupervised
+                # daemon: still dispatching, but with no crash protection) — but
+                # it is NOT "autonomous dispatch has stopped", and auto-
+                # remediation must NOT fire: kickstarting a second daemon at a
+                # socket a live one already owns can only produce a refusal.
+                report WARN \
+                    "STATE MISMATCH: ${liveness_detail}, yet a daemon ANSWERS on ${SOCKET_PATH} (${socket_detail}). Dispatch is still running, so this is NOT an autonomy outage — but the daemon is UNSUPERVISED: nothing will relaunch it if it dies, and no auto-remediation is attempted here (relaunching into a served socket would only be refused by the singleton guard). Heal it by rolling the daemon through ./.loom/scripts/cli/loom-daemon-stop.sh && ./.loom/scripts/cli/loom-daemon-start.sh [flags] so the supervisor owns it again."
+                exit 1
+            fi
+            ;;
+        unreachable)
+            # Positive evidence of absence — fall through to the existing
+            # divergence + bounded auto-remediation path, now carrying BOTH
+            # signals in its message.
+            liveness_detail="${liveness_detail}; and the in-band probe confirms it: ${socket_detail}"
+            ;;
+        *)
+            # Indeterminate. Report "the daemon is down" ONLY when some signal
+            # actually says so: a supervisor that reports its job down, or a pid
+            # file naming a pid that is not alive. With neither — the exact
+            # shape that produced the permanent false positive — say UNKNOWN in
+            # its own words and exit 3, distinct from a real outage (#5118).
+            if [[ "$liveness_source" == "pidfile" && "$pidfile_evidence" == "absent" ]]; then
+                report UNKNOWN \
+                    "LIVENESS UNDETERMINED: a daemon is EXPECTED (autonomy-desired marker present, started $(marker_get started_at)) but this tick found NO evidence either way — ${liveness_detail}, and the in-band socket probe could not answer: ${socket_detail}. This is deliberately NOT reported as an outage (#5118): the pid file alone is too weak a signal to declare one. Restore the in-band probe (make a loom-daemon binary resolvable — LOOM_DAEMON_BIN / PATH / ~/.local/bin — and leave LOOM_WATCHDOG_IPC_PROBE enabled), then re-check with 'loom-daemon health'."
+                exit 3
+            fi
+            liveness_detail="${liveness_detail}; the in-band probe could not corroborate: ${socket_detail}"
+            ;;
+    esac
+fi
 
 if [[ "$daemon_alive" != "true" ]]; then
     # ---------- bounded auto-remediation (#4232) ----------
@@ -765,7 +1059,16 @@ fi
 # heartbeat check below, so both consumers see the same number.
 proc_age="$(process_age_secs "$live_pid" 2>/dev/null)" || proc_age=""
 
-run_ipc_probe "$live_pid" "$proc_age"
+if [[ "$SOCKET_ONLY_LIVENESS" == "true" ]]; then
+    # #5118: liveness was ESTABLISHED by a socket round-trip a moment ago, so
+    # re-running the same probe would only spend a second budget to learn the
+    # same thing. Adopt that result directly (and clear any stale streak: a
+    # successful round-trip is exactly what ends one).
+    probe_verdict=healthy
+    probe_detail="$socket_detail"
+else
+    run_ipc_probe "$live_pid" "$proc_age"
+fi
 
 case "$probe_verdict" in
     healthy)

--- a/defaults/scripts/tests/test-loom-daemon-watchdog.sh
+++ b/defaults/scripts/tests/test-loom-daemon-watchdog.sh
@@ -16,8 +16,13 @@
 #
 # Exit-code contract under test:
 #   0  no divergence (healthy, or no daemon expected)
-#   1  DIVERGENCE reported (expected-but-not-running, wedged/stale heartbeat, or
-#      #4398: alive + heartbeat-fresh but the bounded IPC round-trip failed)
+#   1  DIVERGENCE reported (expected-but-not-running, wedged/stale heartbeat,
+#      #4398: alive + heartbeat-fresh but the bounded IPC round-trip failed, or
+#      #5118: the socket answers while the supervisor says its job is down)
+#   3  #5118: liveness UNDETERMINED — no out-of-band signal AND no usable
+#      in-band probe. Deliberately distinct from 1: "I cannot tell" is not
+#      "the daemon is down", and defaulting to the latter is what made this
+#      watchdog fire every 5 minutes fleet-wide against healthy daemons.
 
 set -uo pipefail
 
@@ -99,9 +104,19 @@ back_date_file() { # <file> <seconds_ago>
 # is listed BEFORE "$@" so a caller can re-enable the probe by passing
 # LOOM_WATCHDOG_IPC_PROBE=1 (later `env` assignments win). The dedicated probe
 # cases in section 12+ do exactly that.
+#
+# #5118: LOOM_PID_FILE / LOOM_WORKSPACE / LOOM_MACHINE_CHECKOUT are pinned EMPTY
+# (empty ⇒ "unset" in both the watchdog's resolve_pid_file and the daemon's
+# daemon_pidfile.rs) so the pid-file path resolves from the MARKER, the tier
+# these cases mean to exercise. Without this the suite is non-hermetic on any
+# host whose daemon exports those into its agents' environment — a real
+# observed failure: an inherited LOOM_PID_FILE pointed every case at the
+# operator's live ~/GitHub/loom/.loom/.daemon.pid. Listed BEFORE "$@" so the
+# dedicated LOOM_PID_FILE case can still set it.
 run_watchdog() {
     : > "$OUT"
-    env LOOM_WATCHDOG_IPC_PROBE=0 "$@" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+    env LOOM_WATCHDOG_IPC_PROBE=0 LOOM_PID_FILE= LOOM_WORKSPACE= LOOM_MACHINE_CHECKOUT= \
+        "$@" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
         LOOM_SOCKET_PATH="$WORKDIR/loom-daemon.sock" \
         LOOM_DAEMON_LAUNCHD=0 bash "$WATCHDOG" > "$OUT" 2>&1
     RC=$?
@@ -112,11 +127,22 @@ run_watchdog() {
 # log) are asserted from the same log the operator would read.
 run_watchdog_verbose() {
     : > "$OUT"
-    env LOOM_WATCHDOG_IPC_PROBE=0 "$@" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+    env LOOM_WATCHDOG_IPC_PROBE=0 LOOM_PID_FILE= LOOM_WORKSPACE= LOOM_MACHINE_CHECKOUT= \
+        "$@" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
         LOOM_SOCKET_PATH="$WORKDIR/loom-daemon.sock" \
         LOOM_DAEMON_LAUNCHD=0 bash "$WATCHDOG" --verbose > "$OUT" 2>&1
     RC=$?
 }
+
+# #5118: the supervisor-gate cases (8/9/10/10a/10b) drive a STUBBED
+# launchctl/systemctl and assert on the OUT-OF-BAND branch alone, so they pin
+# the in-band socket probe OFF and the socket into the tempdir. Without this
+# they reach the operator's real ~/.loom/loom-daemon.sock, and a live host
+# daemon answering there would (correctly, per #5118) reclassify "the
+# supervisor says its job is down" as the unsupervised-daemon WARN — skipping
+# the very remediation gate these cases exist to pin down.
+SUPERVISOR_CASE_ENV=(LOOM_WATCHDOG_IPC_PROBE=0 LOOM_PID_FILE= LOOM_WORKSPACE=
+                     LOOM_MACHINE_CHECKOUT= LOOM_SOCKET_PATH="$WORKDIR/loom-daemon.sock")
 
 log_has()  { grep -q "$1" "$WDLOG" 2>/dev/null; }
 log_hasi() { grep -qi "$1" "$WDLOG" 2>/dev/null; }
@@ -398,14 +424,20 @@ socket_path=$WORKDIR/loom-daemon.sock
 EOF
 : > "$WDLOG" "$OUT"
 if [[ "$(uname -s)" == "Darwin" ]]; then
-    env PATH="$STUB_BIN:$PATH" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+    env PATH="$STUB_BIN:$PATH" "${SUPERVISOR_CASE_ENV[@]}" \
+        LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
         bash "$WATCHDOG" > "$OUT" 2>&1
     assert_rc 1 "$?" "launchd path: booted-out job (stub print exit 1) ⇒ divergence"
 else
-    # On non-Darwin the watchdog forces the pid-file path; with no pid_file in the
-    # marker that resolves to "no live pid" ⇒ divergence, which is still correct.
-    env LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" bash "$WATCHDOG" > "$OUT" 2>&1
-    assert_rc 1 "$?" "non-Darwin: expected daemon with no live pid ⇒ divergence"
+    # On non-Darwin the watchdog forces the pid-file path. With no pid_file in
+    # the marker AND the in-band probe pinned off, NOTHING can establish
+    # liveness either way — since #5118 that is reported as UNDETERMINED
+    # (exit 3), deliberately NOT as the "daemon is down" divergence a missing
+    # pid file used to manufacture. Section 23 below asserts the same contract
+    # platform-independently.
+    env "${SUPERVISOR_CASE_ENV[@]}" LOOM_AUTONOMY_MARKER="$MARKER" \
+        LOOM_WATCHDOG_LOG="$WDLOG" bash "$WATCHDOG" > "$OUT" 2>&1
+    assert_rc 3 "$?" "non-Darwin: no pid file + no in-band probe ⇒ UNDETERMINED, not a false 'down'"
 fi
 
 # ===================================================================
@@ -457,7 +489,8 @@ launchd_label=com.example.loom-sandbox-remediate-$$
 socket_path=$WORKDIR/loom-daemon.sock
 EOF
     : > "$WDLOG" "$OUT"
-    env PATH="$STUB9:$PATH" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+    env PATH="$STUB9:$PATH" "${SUPERVISOR_CASE_ENV[@]}" \
+        LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
         LOOM_WATCHDOG_KICKSTART_RECHECK_ATTEMPTS=5 LOOM_WATCHDOG_KICKSTART_RECHECK_INTERVAL=0.2 \
         bash "$WATCHDOG" > "$OUT" 2>&1
     rc9=$?
@@ -529,7 +562,8 @@ launchd_label=com.example.loom-sandbox-noremediate-$$
 socket_path=$WORKDIR/loom-daemon.sock
 EOF
     : > "$WDLOG" "$OUT"
-    env PATH="$STUB10:$PATH" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+    env PATH="$STUB10:$PATH" "${SUPERVISOR_CASE_ENV[@]}" \
+        LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
         bash "$WATCHDOG" > "$OUT" 2>&1
     rc10=$?
     assert_rc 1 "$rc10" "exit-143-and-down: stays report-only (no auto-kickstart) -> exits 1"
@@ -592,7 +626,8 @@ systemd_unit=$UNIT10A
 socket_path=$WORKDIR/loom-daemon.sock
 EOF
 : > "$WDLOG" "$OUT"
-env PATH="$STUB10A:$PATH" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+env PATH="$STUB10A:$PATH" "${SUPERVISOR_CASE_ENV[@]}" \
+    LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
     LOOM_WATCHDOG_KICKSTART_RECHECK_ATTEMPTS=5 LOOM_WATCHDOG_KICKSTART_RECHECK_INTERVAL=0.2 \
     bash "$WATCHDOG" > "$OUT" 2>&1
 rc10a=$?
@@ -654,7 +689,8 @@ systemd_unit=$UNIT10B
 socket_path=$WORKDIR/loom-daemon.sock
 EOF
 : > "$WDLOG" "$OUT"
-env PATH="$STUB10B:$PATH" LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+env PATH="$STUB10B:$PATH" "${SUPERVISOR_CASE_ENV[@]}" \
+    LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
     bash "$WATCHDOG" > "$OUT" 2>&1
 rc10b=$?
 assert_rc 1 "$rc10b" "systemd exit-1-and-down: stays report-only (no auto-remediation) -> exits 1 (#4054 no-crash-loop preserved)"
@@ -1008,6 +1044,179 @@ else
     pass "missing lib/bounded-run.sh: no raw 'command not found' surfaced"
 fi
 rm -rf "$PS_STUB_DIR" "$STUB22"
+
+# ===================================================================
+# #5118 — SOCKET-FIRST LIVENESS. Everything below drives the state the fleet
+# was ACTUALLY in on 2026-08-03: a healthy daemon serving its socket while the
+# pid file the watchdog consulted was absent or named a long-dead pid. Before
+# #5118 every one of these ticks reported `[DIVERGENCE] ... no live pid file`.
+#
+# The daemon stub answers `quarantine list` (mode `ok`) with no socket
+# involved, so these cases are platform-independent: a launchd host and a
+# systemd host run the identical code path here, which is how the "verified on
+# both" acceptance criterion is met without two live hosts.
+# ===================================================================
+
+# ---- 23. pid file ABSENT + socket ANSWERS ⇒ healthy, NOT a divergence ----
+# The exact worker-1 / robb-studio false alarm.
+STUB23="$(make_daemon_stub ok)"
+rm -f "$WORKDIR/pid23"
+write_marker "$WORKDIR/pid23" 60            # marker names a pid file that does not exist
+printf '%s pid=x ts=now\n' "$(date +%s)" > "$HEARTBEAT"
+: > "$WDLOG"
+run_watchdog_verbose LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB23/loom-daemon"
+assert_rc 0 "$RC" "#5118 pid file ABSENT but socket answers: exits 0 (healthy via the IPC round-trip)"
+if log_has DIVERGENCE; then
+    fail "#5118 pid file absent + socket answers: reported a DIVERGENCE ($(cat "$WDLOG"))"
+else
+    pass "#5118 pid file absent + socket answers: no false DIVERGENCE"
+fi
+if log_hasi 'ANSWERS on'; then
+    pass "#5118 pid file absent + socket answers: the report names the authoritative in-band signal"
+else
+    fail "#5118 pid file absent + socket answers: report should cite the socket round-trip ($(cat "$WDLOG"))"
+fi
+rm -rf "$STUB23"
+
+# ---- 24. pid file STALE (names a dead pid) + socket ANSWERS ⇒ healthy ----
+# #4774's leftover-pid shape: worse than absent, because a pid file naming a
+# dead process used to read as CONFIRMED death.
+STUB24="$(make_daemon_stub ok)"
+dead24=$(sleeper); bg_proc_track "$dead24"; kill "$dead24" 2>/dev/null; wait "$dead24" 2>/dev/null
+echo "$dead24" > "$WORKDIR/pid24"
+write_marker "$WORKDIR/pid24" 60
+printf '%s pid=x ts=now\n' "$(date +%s)" > "$HEARTBEAT"
+: > "$WDLOG"
+run_watchdog_verbose LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB24/loom-daemon"
+assert_rc 0 "$RC" "#5118 STALE pid file (dead pid) but socket answers: exits 0 (healthy)"
+if log_has DIVERGENCE; then
+    fail "#5118 stale pid file + socket answers: reported a DIVERGENCE ($(cat "$WDLOG"))"
+else
+    pass "#5118 stale pid file + socket answers: no false DIVERGENCE"
+fi
+rm -rf "$STUB24"
+
+# ---- 25. socket UNREACHABLE ⇒ the outage is still detected in ONE tick ----
+# The load-bearing inverse: socket-first liveness must not blunt real detection.
+STUB25="$(make_daemon_stub unreachable)"
+rm -f "$WORKDIR/pid25"
+write_marker "$WORKDIR/pid25" 60
+: > "$WDLOG"
+run_watchdog LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB25/loom-daemon"
+assert_rc 1 "$RC" "#5118 daemon genuinely down (socket unreachable): exits 1 on the FIRST tick"
+if log_has DIVERGENCE && log_hasi 'in-band probe confirms it'; then
+    pass "#5118 daemon down: DIVERGENCE cites BOTH the out-of-band and in-band signals"
+else
+    fail "#5118 daemon down: expected a DIVERGENCE citing the in-band confirmation ($(cat "$WDLOG"))"
+fi
+rm -rf "$STUB25"
+
+# ---- 26. NEITHER signal available ⇒ UNDETERMINED (exit 3), never "down" ----
+# No usable pid file AND no way to ask the socket (no resolvable binary). The
+# old code called this an outage; that default is what made the alarm useless.
+rm -f "$WORKDIR/pid26"
+write_marker "$WORKDIR/pid26" 60
+: > "$WDLOG"
+NO_HOME_26="$WORKDIR/no-home-26"
+mkdir -p "$NO_HOME_26"
+run_watchdog PATH="/usr/bin:/bin" HOME="$NO_HOME_26" LOOM_WATCHDOG_IPC_PROBE=1 \
+    LOOM_DAEMON_BIN="$WORKDIR/definitely-not-a-binary"
+assert_rc 3 "$RC" "#5118 no pid file + no probe available: exits 3 (liveness UNDETERMINED)"
+if log_hasi 'LIVENESS UNDETERMINED'; then
+    pass "#5118 undetermined liveness: reported in its own words"
+else
+    fail "#5118 undetermined liveness: expected an UNDETERMINED report ($(cat "$WDLOG"))"
+fi
+if log_has DIVERGENCE; then
+    fail "#5118 undetermined liveness: must NOT be reported as a DIVERGENCE/outage"
+else
+    pass "#5118 undetermined liveness: distinct from 'the daemon is down'"
+fi
+
+# ---- 27. LOOM_PID_FILE is honored END-TO-END (AC4) ----
+# The daemon's own resolver (daemon_pidfile.rs) puts LOOM_PID_FILE first; the
+# watchdog now agrees, so an explicit override outranks the marker's recorded
+# path. Proven by pointing the marker at a bogus file and LOOM_PID_FILE at a
+# live one — no in-band probe involved, so ONLY the env tier can explain a pass.
+live27=$(sleeper); bg_proc_track "$live27"
+echo "$live27" > "$WORKDIR/pid27-env"
+write_marker "$WORKDIR/pid27-marker-bogus" 60    # marker path deliberately absent
+printf '%s pid=%s ts=now\n' "$(date +%s)" "$live27" > "$HEARTBEAT"
+: > "$WDLOG"
+run_watchdog LOOM_PID_FILE="$WORKDIR/pid27-env"
+kill "$live27" 2>/dev/null || true
+assert_rc 0 "$RC" "#5118 LOOM_PID_FILE overrides the marker's pid_file: exits 0 (daemon found)"
+if log_hasi "pid $live27 (from $WORKDIR/pid27-env) alive"; then
+    pass "#5118 LOOM_PID_FILE: liveness was read from the env-named file"
+else
+    fail "#5118 LOOM_PID_FILE: expected liveness from the env-named file ($(cat "$WDLOG"))"
+fi
+
+# ---- 28. supervisor says DOWN while the socket ANSWERS ⇒ WARN, no kickstart ----
+# An unsupervised-but-serving daemon. Auto-remediation must NOT fire: launching
+# a second daemon at a socket a live one already owns can only be refused.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    STUB28="$WORKDIR/stub28"
+    mkdir -p "$STUB28"
+    LOG28="$WORKDIR/launchctl28.log"
+    : > "$LOG28"
+    cat > "$STUB28/launchctl" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> "$LOG28"
+case "\${1:-}" in
+  print)
+    echo "	state = not running"
+    echo "	last exit status = 0"     # the ONE signature that would auto-kickstart
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+EOF
+    chmod +x "$STUB28/launchctl"
+    STUB28D="$(make_daemon_stub ok)"
+    cat > "$MARKER" <<EOF
+started_at=2026-07-27T00:00:00Z
+heartbeat_file=$HEARTBEAT
+heartbeat_interval_secs=60
+use_launchd=true
+launchd_label=com.example.loom-sandbox-unsupervised-$$
+socket_path=$WORKDIR/loom-daemon.sock
+EOF
+    : > "$WDLOG" "$OUT"
+    env PATH="$STUB28:$PATH" LOOM_PID_FILE= LOOM_WORKSPACE= LOOM_MACHINE_CHECKOUT= \
+        LOOM_SOCKET_PATH="$WORKDIR/loom-daemon.sock" \
+        LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
+        LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB28D/loom-daemon" \
+        bash "$WATCHDOG" > "$OUT" 2>&1
+    rc28=$?
+    assert_rc 1 "$rc28" "#5118 supervisor down + socket answers: exits 1 (state mismatch)"
+    if log_hasi 'UNSUPERVISED'; then
+        pass "#5118 unsupervised daemon: WARNs that dispatch still runs but nothing supervises it"
+    else
+        fail "#5118 unsupervised daemon: expected the UNSUPERVISED warning ($(cat "$WDLOG"))"
+    fi
+    if grep -qE '^kickstart ' "$LOG28"; then
+        fail "#5118 unsupervised daemon: must NOT kickstart into a socket a live daemon owns"
+    else
+        pass "#5118 unsupervised daemon: no auto-kickstart attempted"
+    fi
+    if log_hasi 'Autonomous dispatch has stopped'; then
+        fail "#5118 unsupervised daemon: must not claim dispatch has stopped — it demonstrably has not"
+    else
+        pass "#5118 unsupervised daemon: does not falsely claim dispatch has stopped"
+    fi
+    rm -rf "$STUB28D"
+else
+    pass "#5118 unsupervised-daemon (launchd) case skipped (non-Darwin host)"
+fi
+
+# ---- 29. --help documents the new contract ----
+help_out_5118=$(bash "$WATCHDOG" --help 2>/dev/null)
+if grep -q 'LOOM_PID_FILE' <<< "$help_out_5118" && grep -qi 'UNDETERMINED' <<< "$help_out_5118"; then
+    pass "--help documents LOOM_PID_FILE and the UNDETERMINED (exit 3) contract"
+else
+    fail "--help should document LOOM_PID_FILE and the exit-3 UNDETERMINED contract"
+fi
 
 echo
 echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"


### PR DESCRIPTION
Closes #5118

## The bug

`loom-daemon-watchdog.sh` decided liveness from a pid file whose path it derived
**itself** (`<dirname $LOOM_SOCKET_PATH>/.daemon.pid`), while the daemon derives it
from `LOOM_PID_FILE` / the workspace (`daemon_pidfile.rs`). On a workspace-rooted
install those are never the same directory, `LOOM_PID_FILE` had no support in the
watchdog at all, and a stale pid file read as a confirmed death. Result: both fleet
hosts reported `[DIVERGENCE] ... no live pid file` every five minutes for two days
while healthy daemons served work — and two genuine outages in that window were
indistinguishable from the steady-state false alarm.

## What changed

**`defaults/scripts/cli/loom-daemon-watchdog.sh`**

- **Socket-first liveness.** When the out-of-band probe (launchd / systemd / pid
  file) finds no live daemon, the watchdog now *asks the socket* — the same bounded
  `loom-daemon quarantine list` round-trip the #4398 hang probe already uses, and the
  same precedence `loom-daemon health` applies (IPC authoritative, pid file a
  corroborating hint). Answers ⇒ healthy; unreachable ⇒ the existing DIVERGENCE +
  bounded auto-remediation path, unchanged.
- **New `UNKNOWN` verdict, exit 3.** No out-of-band signal **and** no usable in-band
  probe now reports `LIVENESS UNDETERMINED` rather than defaulting to "the daemon is
  gone". That default is what made the alarm permanent and information-free.
- **New WARN for an unsupervised daemon.** Supervisor says its job is down while the
  socket answers: dispatch has *not* stopped, so it is not a DIVERGENCE — and
  auto-remediation is **suppressed**, because kickstarting a second daemon at a
  socket a live one already owns can only be refused by the singleton guard.
- **`LOOM_PID_FILE` honored end-to-end.** `resolve_pid_file()` mirrors
  `daemon_pidfile::resolve_pid_file_path_from` tier for tier (`LOOM_PID_FILE`, then
  the marker's `pid_file=`, then `LOOM_MACHINE_CHECKOUT`, then
  `LOOM_WORKSPACE`/`repo_root`, then `<loom dir>`), so the two ends can no longer
  mean different files.
- The probe invocation is factored into `invoke_probe_command()` so the liveness
  probe and the hang probe share one binary-resolution / argv / budget code path.

**`defaults/scripts/cli/loom-daemon-start.sh`** — the rendered **watchdog** launchd
plist and systemd unit now carry `LOOM_PID_FILE` (previously only the daemon's job
did). AC3's other half was already in place: the daemon rewrites the pid file on
every start right after its socket bind (#4786), including supervisor relaunches.

**`defaults/docs/daemon-reference.md`** — decision matrix rows for the three new
states, the exit-3 contract, the env table, and a "socket-first liveness" subsection.

## Tests

17 new cases in `defaults/scripts/tests/test-loom-daemon-watchdog.sh` (**85/85 pass**):
pid-file-absent + socket answers ⇒ healthy; stale (dead-pid) file + socket answers ⇒
healthy; socket unreachable ⇒ still detected on the **first** tick; neither signal ⇒
exit 3 UNDETERMINED and never "down"; `LOOM_PID_FILE` overrides the marker; supervisor
down + socket answers ⇒ WARN with **no** kickstart. The suite was also made hermetic
against an inherited `LOOM_PID_FILE`/`LOOM_WORKSPACE` (a real observed failure on this
host) and the supervisor-gate cases can no longer reach the operator's real socket.

Also run clean: `test-loom-daemon-start.sh` (80/80), `test-loom-daemon-stop.sh`
(37/37), shellcheck, docs/defaults parity, CI suite manifest. (`test-loom-status.sh`
fails 5 identically on `main` — pre-existing, untouched here.)

## Live verification (this host, launchd, real daemon + real socket)

Reproducing the worker-1 shape — marker present, pid file missing, healthy daemon:

- `main`'s watchdog: `rc=1` — `[DIVERGENCE] ... but is NOT running: no live pid file`
- this branch: `rc=0` — `[OK] daemon healthy via the in-band socket round-trip ...`

And the inverse (socket pointed at a nonexistent path): `rc=1` with a DIVERGENCE that
now cites **both** signals (`...; and the in-band probe confirms it: ... connect
failed: No such file or directory`).

## Follow-up (not blocking)

AC6 asks for verification on **both** a launchd and a systemd host. The launchd half is
done live above; the logic is platform-agnostic (the socket round-trip is identical on
both) and the systemd half is covered by automated cases, but a live confirmation on
**loom-worker-1** after this merges + the hosts roll is an operator step. Concretely,
after the roll: `systemctl --user status loom-daemon-watchdog` should stop showing
`failed (Result: exit-code)` on every tick, and `~/.loom/logs/daemon-watchdog.log`
should stop accumulating the `no live pid file` DIVERGENCE line. Note that the
plist/unit `LOOM_PID_FILE` addition only takes effect after a `loom-daemon-start.sh`
re-provision on each host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
