### PR TITLE
fix(daemon): honest + self-healing supervised restart on systemd (#5119)

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -4166,12 +4166,24 @@ systemd Linux host it detects the `systemd --user` ownership
 unit (`systemctl --user disable --now`), so a subsequent reboot does not
 resurrect it (#4268 — see "systemd user unit (Linux)" below).
 
-**Shutdown decision — sweeps survive, they are not drained.** A clean daemon stop
-removes the Unix socket and exits, but **does not cancel in-flight `/loom:sweep`
-children**. Those are independent detached processes that survive a daemon
-restart by design — killing the dispatcher must not kill dispatched work — and
-the registry reconciles their state on the next start (`SweepRegistry::reconstruct`
-re-admits live-lock owners). To actively cancel a sweep, use
+**Shutdown decision — sweeps survive *on launchd*, they are not drained.** A clean
+daemon stop removes the Unix socket and exits, but **does not cancel in-flight
+`/loom:sweep` children**. On **launchd** those are independent detached processes
+that reparent to `pid 1` and survive a daemon restart by design — killing the
+dispatcher must not kill dispatched work — and the registry reconciles their state
+on the next start (`SweepRegistry::reconstruct` re-admits live-lock owners).
+
+> **Supervisor difference — on systemd, a plain stop/restart KILLS sweeps (#5119).**
+> Under a `systemd --user` service the sweep/role children run **inside the service's
+> cgroup**, so systemd's stop job signals them by construction when the daemon
+> exits (`KillMode=mixed` SIGKILLs the remaining cgroup processes). The "sweeps
+> survive by design" guarantee is therefore **launchd-only**; a plain
+> `loom-daemon restart` on systemd terminates in-flight sweeps and role runs. Use
+> `loom-daemon restart --drain` (below) — which empties the sweep registry before
+> exiting so the cgroup is empty when the stop job runs — to preserve them. The
+> restart primitive's ack message is supervisor-aware and states this plainly.
+
+To actively cancel a sweep, use
 `mcp__loom__cancel_sweep` against a running daemon *before* stopping it.
 
 > **Amended by #4090 (scheduled drain-and-restart).** The above describes the
@@ -4961,10 +4973,12 @@ Both make launchd re-read the plist file, which a plain `restart` never does.
 
 #### Scheduled drain-and-restart (`--drain`, #4090)
 
-A plain `loom-daemon restart` exits immediately: in-flight sweeps survive the
-process boundary but become **orphans** (absent from the relaunched daemon's
-in-memory registry — see the "sweeps survive, they are not drained" amendment
-above). `--drain` closes that gap by finishing in-flight work *before* rolling:
+A plain `loom-daemon restart` exits immediately: on launchd, in-flight sweeps
+survive the process boundary but become **orphans** (absent from the relaunched
+daemon's in-memory registry — see the "sweeps survive, they are not drained"
+amendment above); **on systemd they do not survive at all** — the stop job reaps
+the service cgroup (#5119). `--drain` closes both gaps by finishing in-flight work
+*before* rolling (and, on systemd, leaving the cgroup empty so nothing is killed):
 
 ```bash
 loom-daemon restart --drain                       # finish in-flight sweeps, then restart

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -123,10 +123,18 @@
 # exit 0 lets systemd's `Restart=on-success` relaunch onto the fresh binary.
 # That ack is verified, not trusted (#4950, mirroring #4232's launchd
 # verification): the script polls for a NEW, live MainPID within a bounded
-# window before reporting success, and — if the unit instead lands in `failed`
-# (e.g. a stop-timeout escalation, which `Restart=on-success` never matches) —
-# self-heals via `systemctl --user reset-failed <unit> && systemctl --user
-# start <unit>` before giving up (exit 7). On a
+# window before reporting success, and — if the unit does not come back on its
+# own — self-heals via `systemctl --user reset-failed <unit> && systemctl --user
+# start <unit>` before giving up (exit 7). #5119 widened that self-heal: on a
+# busy host the daemon's clean exit can leave the unit sitting in
+# `deactivating (stop-sigterm)` for the full TimeoutStopSec while systemd reaps
+# the sweep/role children still in the service cgroup — far past the pid poll on
+# a STALE unit (default 90s). The verifier now WAITS for a transitional stop to
+# settle (LOOM_DAEMON_STOP_SETTLE_SECS), then self-heals ANY non-`active` settled
+# state (`failed` — the #4950 stop-timeout shape — as well as `inactive`),
+# instead of the pre-#5119 behavior of only acting on an already-`failed`
+# snapshot and otherwise "refusing to guess" (which left the 2026-08-03
+# loom-worker-1 daemon down until a hand `reset-failed && start`). On a
 # refused restart (a pre-#4267 binary with no RestartDaemon handler, or a dead
 # socket), the script refuses loudly (exit 6) exactly like launchd, and
 # --relaunch (or LOOM_DAEMON_UPDATE_RELAUNCH=1) re-renders the unit and forces
@@ -246,6 +254,14 @@
 #                          Linux/systemd (#4950): seconds to re-poll for a new,
 #                          live pid after the self-heal fallback before giving
 #                          up (default 15).
+#   LOOM_DAEMON_STOP_SETTLE_SECS  Linux/systemd (#5119): after the pid poll
+#                          expires, seconds to wait for a still-transitioning
+#                          unit (ActiveState=deactivating/activating) to SETTLE
+#                          into a terminal state before running the reset-failed+
+#                          start self-heal. Sized to exceed systemd's default 90s
+#                          TimeoutStopSec so a stale unit's slow SIGTERM→SIGKILL
+#                          cgroup teardown is waited out rather than mistaken for
+#                          "refusing to guess" (default 100).
 #
 # Exit codes:
 #   0  up to date (no-op) OR rebuild+provision+restart succeeded
@@ -291,12 +307,17 @@
 #      the job/unit onto a NEW, live pid within the poll window, AND the
 #      self-heal fallback also failed to bring it up within its own poll
 #      window. On launchd (#4232) the fallback is a plain `launchctl
-#      kickstart` (never -k). On systemd (#4950) the fallback is `systemctl
-#      --user reset-failed <unit> && systemctl --user start <unit>`, tried ONLY
-#      when the unit's ActiveState is confirmed `failed` (systemd never
-#      auto-relaunches a `failed` unit even under `Restart=on-success` — a
-#      `Result=timeout` stop escalation is the exact incident shape #4950
-#      closes). The fresh binary IS provisioned, but the daemon's live status
+#      kickstart` (never -k). On systemd (#4950/#5119) the fallback is
+#      `systemctl --user reset-failed <unit> && systemctl --user start <unit>`,
+#      tried whenever the unit is NOT `active` — the confirmed-`failed`
+#      `Result=timeout` stop escalation #4950 closes, AND (#5119) a unit still
+#      stuck `deactivating`/`inactive` when the poll expired: after the poll the
+#      script now WAITS up to LOOM_DAEMON_STOP_SETTLE_SECS for a transitional
+#      unit's stop to complete, then self-heals the settled non-`active` state
+#      rather than "refusing to guess" and leaving the daemon down (systemd never
+#      auto-relaunches a failed/stopped unit even under `Restart=on-success`).
+#      Only a genuinely `active` unit on an unobserved pid is left untouched. The
+#      fresh binary IS provisioned, but the daemon's live status
 #      is NOT confirmed — this is the "restart scheduled but the supervisor
 #      silently never relaunched" outage class these issues close; the script
 #      refuses to report success on the ack alone.
@@ -1833,6 +1854,46 @@ wait_for_new_systemd_pid() {
     done
 }
 
+# wait_for_systemd_stop_settle <timeout_secs> <interval_secs> — poll the unit's
+# ActiveState until it SETTLES out of a transitional state (deactivating /
+# activating / reloading) into a terminal one (failed / inactive / active), for
+# up to <timeout_secs>. Echoes the settled ActiveState and returns 0; on timeout
+# echoes the last-observed (still-transitional) state and returns 1.
+#
+# WHY (#5119). On a busy host a `loom-daemon restart` exits the daemon 0, but the
+# unit's stop job can sit in `deactivating (stop-sigterm)` for the full
+# TimeoutStopSec while it SIGTERMs — then SIGKILLs — the sweep/role children still
+# in the service cgroup. A STALE unit (one rendered before #4862's KillMode=mixed
+# fix — the exact 2026-08-03 incident) drags that out to systemd's 90s default,
+# far past the #4950 pid poll's default 30s. The pre-#5119 code read ActiveState
+# ONCE right after that poll expired, saw `deactivating` (not yet `failed`), and
+# fell through to "refusing to guess" — leaving the daemon down until an operator
+# ran reset-failed+start by hand. This helper lets the recovery WAIT for the stop
+# transition to complete so it can act on the settled state instead of a
+# mid-teardown snapshot.
+wait_for_systemd_stop_settle() {
+    local timeout_secs="$1" interval_secs="$2"
+    local deadline state
+    deadline=$(( $(date +%s) + timeout_secs ))
+    while true; do
+        state="$(systemd_unit_active_state)"
+        case "$state" in
+            deactivating|activating|reloading|deactivating-sigterm|deactivating-sigkill)
+                # still mid-transition — keep waiting
+                ;;
+            *)
+                echo "$state"
+                return 0
+                ;;
+        esac
+        if (( $(date +%s) >= deadline )); then
+            echo "$state"
+            return 1
+        fi
+        sleep "$interval_secs"
+    done
+}
+
 # log_systemd_diagnostics — dump `systemctl --user status`'s current state
 # (including the `Active:`/`Result:` line the incident's journal excerpt was
 # read off of) as a diagnostic breadcrumb when a relaunch cannot be verified,
@@ -2452,24 +2513,50 @@ if [[ "$DAEMON_MANAGER" == "systemd" ]]; then
         UNIT_ACTIVE_STATE="$(systemd_unit_active_state)"
         UNIT_RESULT="$(systemd_unit_result)"
 
-        if [[ "$UNIT_ACTIVE_STATE" == "failed" ]]; then
-            # The exact incident shape (#4950): a stop-timeout escalation left
-            # the unit `failed`, so `Restart=on-success` will NEVER fire on its
-            # own — systemd refuses to auto-restart a unit already in `failed`.
-            # Self-heal via the documented recovery.
-            warn "Unit is in a 'failed' state (Result=${UNIT_RESULT:-unknown}) — systemd will NOT auto-relaunch a failed unit even under Restart=on-success. Self-healing via 'systemctl --user reset-failed $SYSTEMD_UNIT && systemctl --user start $SYSTEMD_UNIT'."
+        # #5119: the unit may still be mid-teardown when the #4950 pid poll
+        # expires — the exact 2026-08-03 loom-worker-1 incident, where a busy
+        # host's stale unit (default TimeoutStopSec=90s + KillMode=control-group)
+        # sat in `deactivating (stop-sigterm)` while systemd SIGTERMed then
+        # SIGKILLed the sweep/role children still in the cgroup, long past the
+        # default 30s pid poll. The pre-#5119 code only self-healed a unit
+        # ALREADY `failed`, so a `deactivating` snapshot fell through to "refusing
+        # to guess" and left the daemon DOWN until an operator ran reset-failed+
+        # start by hand. WAIT for the stop transition to settle so the recovery
+        # can act on the terminal state (`failed`/`inactive`) it lands in.
+        case "$UNIT_ACTIVE_STATE" in
+            deactivating|activating|reloading|deactivating-sigterm|deactivating-sigkill)
+                STOP_SETTLE_SECS="${LOOM_DAEMON_STOP_SETTLE_SECS:-100}"
+                warn "Unit is still transitioning (ActiveState=${UNIT_ACTIVE_STATE}) — its stop job has not finished (a stale unit predating #4862's KillMode=mixed drags the SIGTERM→SIGKILL teardown of in-cgroup sweep/role children out to the default 90s TimeoutStopSec). Waiting up to ${STOP_SETTLE_SECS}s for it to settle before recovering (#5119)."
+                SETTLED_STATE="$(wait_for_systemd_stop_settle "$STOP_SETTLE_SECS" "$RESTART_POLL_INTERVAL")"
+                UNIT_ACTIVE_STATE="$SETTLED_STATE"
+                UNIT_RESULT="$(systemd_unit_result)"
+                warn "Unit settled to ActiveState=${UNIT_ACTIVE_STATE} (Result=${UNIT_RESULT:-unknown}) after its stop transition."
+                ;;
+        esac
+
+        # A unit that is NOT `active` after that settle will NOT come back on its
+        # own: `Restart=on-success` fires only for a clean-exit relaunch, never
+        # for a stop-timeout escalation (`failed`, Result=timeout — the classic
+        # #4950 shape) nor a completed stop (`inactive`). Only a genuinely
+        # `active` unit on a pid the poll simply failed to observe is left alone —
+        # touching that would risk bouncing a healthy daemon. Self-heal
+        # everything else via the documented reset-failed+start recovery (#4950),
+        # now reached for the #5119 `deactivating`/`inactive` cases too, not just
+        # a confirmed `failed`.
+        if [[ "$UNIT_ACTIVE_STATE" != "active" ]]; then
+            warn "Unit is in a non-running state (ActiveState=${UNIT_ACTIVE_STATE:-unknown}, Result=${UNIT_RESULT:-unknown}) — systemd will NOT auto-relaunch it (Restart=on-success does not fire for a failed/stopped unit). Self-healing via 'systemctl --user reset-failed $SYSTEMD_UNIT && systemctl --user start $SYSTEMD_UNIT'."
             systemctl --user reset-failed "$SYSTEMD_UNIT" >/dev/null 2>&1
             systemctl --user start "$SYSTEMD_UNIT" >/dev/null 2>&1
 
             if NEW_PID="$(wait_for_new_systemd_pid "$PRE_RESTART_PID" "$KICKSTART_POLL_SECS" "$RESTART_POLL_INTERVAL")"; then
-                ok "loom-daemon restart scheduled — systemd's own relaunch did not occur within ${RESTART_POLL_SECS}s (unit landed in 'failed', Result=${UNIT_RESULT:-unknown}), but 'systemctl --user reset-failed && start' recovered it (new pid ${NEW_PID}, verified within ${KICKSTART_POLL_SECS}s). Remediation note: the reset-failed+start fallback was required (#4950) — investigate why the unit's stop sequence exceeded TimeoutStopSec (a live unit that predates #4862's KillMode=mixed fix — never re-rendered by a plain restart — is the most likely cause; re-render it with 'loom-daemon-update.sh --relaunch')."
+                ok "loom-daemon restart scheduled — systemd's own relaunch did not occur within ${RESTART_POLL_SECS}s (unit settled to '${UNIT_ACTIVE_STATE}', Result=${UNIT_RESULT:-unknown}), but 'systemctl --user reset-failed && start' recovered it (new pid ${NEW_PID}, verified within ${KICKSTART_POLL_SECS}s). Remediation note: the reset-failed+start fallback was required (#4950/#5119) — investigate why the unit's stop sequence exceeded TimeoutStopSec (a live unit that predates #4862's KillMode=mixed fix — never re-rendered by a plain restart — is the most likely cause; re-render it with 'loom-daemon-update.sh --relaunch')."
                 print_final_installed_line "$BUILT_COMMIT"
                 exit 0
             fi
 
             err "loom-daemon restart FAILED: no new, live MainPID was observed even after 'systemctl --user reset-failed && start'."
         else
-            err "loom-daemon restart FAILED: the unit is not confirmed relaunched, and its ActiveState (${UNIT_ACTIVE_STATE:-unknown}) is not 'failed' — refusing to guess at a recovery action."
+            err "loom-daemon restart FAILED: the unit is not confirmed relaunched, yet its ActiveState is 'active' on an unchanged/unobserved pid — refusing to bounce a possibly-healthy daemon."
         fi
         log_systemd_diagnostics
         err "The freshly-built binary IS provisioned, but the daemon's live status is NOT confirmed (pre-restart pid was ${PRE_RESTART_PID:-<none>})."

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -511,12 +511,27 @@ EOF
 #                           that ALSO fails to bring the unit up (the state
 #                           stays whatever `reset-failed` left it at:
 #                           "<pid>:inactive:success").
+#   <settle_state>          (optional, #5119) the state a TRANSITIONAL
+#                           ActiveState (deactivating/activating/reloading)
+#                           SETTLES into after being observed twice — simulating
+#                           systemd finishing a slow stop transition. On the 1st
+#                           `show ActiveState` read the transitional value is
+#                           returned unchanged (so the update script sees the
+#                           mid-teardown snapshot the #4950 poll saw); on the 2nd
+#                           the state file is rewritten to <settle_state> and it
+#                           is returned. Lets a test drive the exact 2026-08-03
+#                           incident: post_state="0:deactivating:timeout" ->
+#                           settle_state="0:failed:timeout" -> reset-failed+start
+#                           recovery. A settle counter lives in
+#                           "<state_file>.actcount".
 write_fake_systemd_pid_bin() {
     local bin_dir="$1" log="$2" state_file="$3" pre_state="$4"
     local post_restart_marker="${5:-}" post_state="${6:-}" recovery_state="${7:-}"
+    local settle_state="${8:-}"
     mkdir -p "$bin_dir"
     : > "$log"
     echo "${pre_state}" > "${state_file}"
+    rm -f "${state_file}.actcount"
     cat > "$bin_dir/systemctl" <<EOF
 #!/usr/bin/env bash
 echo "\$*" >> "${log}"
@@ -546,7 +561,30 @@ case "\${1:-}" in
     done
     case "\$prop" in
       MainPID)     echo "\$cur_pid" ;;
-      ActiveState) echo "\$cur_active" ;;
+      ActiveState)
+        # #5119 settle simulation: a transitional state advances to
+        # <settle_state> on its SECOND ActiveState observation, so the update
+        # script first sees the mid-teardown snapshot (deactivating) and then
+        # the settled terminal state (failed/inactive) once it waits.
+        if [[ -n "${settle_state}" ]]; then
+          case "\$cur_active" in
+            deactivating|activating|reloading|deactivating-sigterm|deactivating-sigkill)
+              actcount=\$(( \$(cat "\${state_file}.actcount" 2>/dev/null || echo 0) + 1 ))
+              echo "\$actcount" > "\${state_file}.actcount"
+              if (( actcount >= 2 )); then
+                echo "${settle_state}" > "\$state_file"
+                IFS=: read -r _sp _sa _sr <<< "${settle_state}"
+                echo "\$_sa"
+              else
+                echo "\$cur_active"
+              fi
+              ;;
+            *) echo "\$cur_active" ;;
+          esac
+        else
+          echo "\$cur_active"
+        fi
+        ;;
       Result)      echo "\$cur_result" ;;
       *)           echo "" ;;
     esac
@@ -3107,11 +3145,14 @@ else
 fi
 
 # ============================================================
-# 56. Systemd restart ack'd but never relaunches, and the unit is NOT in a
-#     'failed' state (some other stall, e.g. still 'activating') -> the
-#     updater refuses to guess at a recovery action (no reset-failed/start
-#     invoked) and exits non-zero (7) with diagnostics (#4950 AC2 scope: the
-#     self-heal is gated on a CONFIRMED 'failed' ActiveState).
+# 56. Systemd restart ack'd but never relaunches, and the unit is STUCK in a
+#     transitional state that never settles (e.g. `activating` forever) -> under
+#     #5119 the updater WAITS the bounded settle window and then STILL attempts
+#     the documented reset-failed+start recovery (rather than the pre-#5119
+#     "refusing to guess" — which left the daemon down). The recovery here does
+#     not bring it up, so it exits 7 loudly, but reset-failed WAS invoked. This
+#     supersedes the old #4950 "self-heal gated on a confirmed failed state"
+#     behavior: a transitional stall is exactly the 2026-08-03 incident shape.
 # ============================================================
 W56="$BASE_WORKDIR/w56"
 new_fixture "$W56"
@@ -3126,8 +3167,9 @@ write_fake_daemon_restart "$NEW_FAKE56" "$HEAD56" "$RESTART_MARKER56" 0
 SD_BIN56="$W56/systemd-bin"
 SD_LOG56="$W56/systemctl.log"
 SD_STATE56="$W56/systemd-pid-state"
-# post_state is 'activating', not 'failed' -- the pid never moves, but the
-# self-heal gate must NOT fire since the unit was never confirmed failed.
+# post_state is 'activating' and NO settle_state is given -> the stub stays
+# transitional forever, so the settle wait times out and the recovery is still
+# attempted against the (never-recovering) unit.
 write_fake_systemd_pid_bin "$SD_BIN56" "$SD_LOG56" "$SD_STATE56" "9999:active:success" \
     "$RESTART_MARKER56" "0:activating:success"
 
@@ -3135,18 +3177,18 @@ out56=$( cd "$W56" && PATH="$SD_BIN56:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEM
     LOOM_SYSTEMD_UNIT="loom-daemon-test-sd56.service" \
     LOOM_DAEMON_BIN="$INSTALLED56" NEW_FAKE_BIN_SRC="$NEW_FAKE56" \
     LOOM_DAEMON_RESTART_POLL_SECS=1 LOOM_DAEMON_RESTART_POLL_INTERVAL=0.2 \
+    LOOM_DAEMON_STOP_SETTLE_SECS=1 LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS=1 \
     bash "$UPDATE_SCRIPT" 2>&1 )
 rc56=$?
-assert_eq "7" "$rc56" "unit stalled but never confirmed failed -> exit 7, no guessed recovery"
+assert_eq "7" "$rc56" "transitional stall never recovers -> exit 7 after attempted self-heal (#5119)"
 TESTS_RUN=$((TESTS_RUN + 1))
-if grep -q -- 'reset-failed' "$SD_LOG56" 2>/dev/null \
-    || grep -qE -- '(^|[[:space:]])start([[:space:]]|$)' "$SD_LOG56" 2>/dev/null; then
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "${RED}✗${NC} self-heal is NEVER invoked when ActiveState is not confirmed 'failed'"
-    echo "  systemctl.log: $(cat "$SD_LOG56" 2>/dev/null)"
-else
+if grep -q -- 'reset-failed' "$SD_LOG56" 2>/dev/null; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "${GREEN}✓${NC} self-heal is NEVER invoked when ActiveState is not confirmed 'failed'"
+    echo -e "${GREEN}✓${NC} a transitional stall now ATTEMPTS reset-failed+start recovery, not 'refusing to guess' (#5119)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} a transitional stall now ATTEMPTS reset-failed+start recovery, not 'refusing to guess' (#5119)"
+    echo "  systemctl.log: $(cat "$SD_LOG56" 2>/dev/null)"
 fi
 TESTS_RUN=$((TESTS_RUN + 1))
 if echo "$out56" | grep -qi 'FAILED'; then
@@ -3156,6 +3198,79 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} failure output loudly reports the unconfirmed relaunch"
     echo "  output: $out56"
+fi
+
+# ============================================================
+# 56b. THE #5119 INCIDENT (2026-08-03 loom-worker-1): systemd restart ack'd, the
+#      daemon exited 0, but on a busy host the unit sat in
+#      `deactivating (stop-sigterm)` while systemd reaped the sweep/role children
+#      still in the cgroup — long past the #4950 pid poll on a stale unit's 90s
+#      TimeoutStopSec. The pre-#5119 code read ActiveState once, saw
+#      `deactivating` (not yet `failed`), and "refused to guess" -> exit 7, daemon
+#      left DOWN. Under #5119 the updater WAITS for the stop to settle (here it
+#      lands in `failed`, Result=timeout — the classic escalation) and then
+#      reset-failed+start RECOVERS it -> exit 0, no manual intervention. This is
+#      the acceptance-criteria scenario for the issue.
+# ============================================================
+W56B="$BASE_WORKDIR/w56b"
+new_fixture "$W56B"
+INSTALLED56B="$W56B/installed/loom-daemon"
+mkdir -p "$W56B/installed"
+RESTART_MARKER56B="$W56B/restart-invoked"
+write_fake_daemon_restart "$INSTALLED56B" "deadbee" "$RESTART_MARKER56B" 0
+NEW_FAKE56B="$W56B/new-fake-daemon"
+HEAD56B="$(cd "$W56B" && git rev-parse --short HEAD)"
+write_fake_daemon_restart "$NEW_FAKE56B" "$HEAD56B" "$RESTART_MARKER56B" 0
+
+sleep 60 >/dev/null 2>&1 &
+RECOVERED_PID56B=$!
+bg_proc_track "$RECOVERED_PID56B"
+SD_BIN56B="$W56B/systemd-bin"
+SD_LOG56B="$W56B/systemctl.log"
+SD_STATE56B="$W56B/systemd-pid-state"
+# post_state: the mid-teardown snapshot the pid poll observes (deactivating,
+# Result=timeout). settle_state: what it lands in after the stop completes
+# (failed). recovery_state: only reset-failed+start reaches a NEW, live pid.
+write_fake_systemd_pid_bin "$SD_BIN56B" "$SD_LOG56B" "$SD_STATE56B" "9999:active:success" \
+    "$RESTART_MARKER56B" "0:deactivating:timeout" "${RECOVERED_PID56B}:active:success" \
+    "0:failed:timeout"
+
+out56b=$( cd "$W56B" && PATH="$SD_BIN56B:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+    LOOM_SYSTEMD_UNIT="loom-daemon-test-sd56b.service" \
+    LOOM_DAEMON_BIN="$INSTALLED56B" NEW_FAKE_BIN_SRC="$NEW_FAKE56B" \
+    LOOM_DAEMON_RESTART_POLL_SECS=1 LOOM_DAEMON_RESTART_POLL_INTERVAL=0.2 \
+    LOOM_DAEMON_STOP_SETTLE_SECS=3 LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS=3 \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc56b=$?
+kill "$RECOVERED_PID56B" 2>/dev/null || true
+assert_eq "0" "$rc56b" "deactivating stall settles to failed -> settle-wait + reset-failed+start recovers -> exit 0 (#5119)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out56b" | grep -qi 'settle' || echo "$out56b" | grep -qi 'transitioning'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} output names the settle-wait for the still-transitioning stop (#5119)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} output names the settle-wait for the still-transitioning stop (#5119)"
+    echo "  output: $out56b"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- 'reset-failed' "$SD_LOG56B" 2>/dev/null \
+    && grep -qE -- '(^|[[:space:]])start([[:space:]]|$)' "$SD_LOG56B" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} the incident recovery invokes the documented reset-failed then start"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} the incident recovery invokes the documented reset-failed then start"
+    echo "  systemctl.log: $(cat "$SD_LOG56B" 2>/dev/null)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q "new pid ${RECOVERED_PID56B}" <<< "$out56b"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} success message reports the pid recovered after the settle-wait (#5119)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} success message reports the pid recovered after the settle-wait (#5119)"
+    echo "  output: $out56b"
 fi
 
 # ============================================================

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -101,6 +101,54 @@ pub fn detect_supervisor() -> Option<String> {
     }
 }
 
+/// Compose the "restart scheduled" ack message for a supervised relaunch, worded
+/// PER-SUPERVISOR because the two recognized supervisors treat in-flight sweep /
+/// role children FUNDAMENTALLY DIFFERENTLY when the daemon exits (#5119):
+///
+/// * **launchd** — the daemon's children reparent to `pid 1` on its exit and keep
+///   running, so in-flight sweeps GENUINELY survive the process boundary (verified
+///   repeatedly on macOS — #5081). The relaunched daemon re-adopts them from the
+///   forge/checkpoints.
+/// * **systemd** — the daemon's children run INSIDE the service's cgroup, so
+///   systemd's stop job signals them by construction the moment the main process
+///   exits. Under the unit's `KillMode=mixed` the remaining cgroup processes get a
+///   `SIGKILL`, so in-flight sweeps and role runs are TERMINATED, not preserved.
+///   The pre-#5119 message printed "In-flight sweeps survive by design" on every
+///   platform — a macOS-only truth that was actively false on systemd, where a
+///   `restart` landing on a busy host destroyed the very work it claimed to
+///   protect. The systemd wording now states plainly that in-flight work is lost
+///   and points at `--drain` (which empties the sweep registry BEFORE exiting, so
+///   the cgroup is empty when the stop job runs) as the preserving alternative.
+///
+/// Pure (no env / no I/O beyond the caller-supplied supervisor string) so both
+/// wordings are unit-testable without a live supervisor.
+pub fn restart_scheduled_message(supervisor: &str) -> String {
+    if supervisor == "launchd" {
+        // Preserved semantics: sweeps DO survive on launchd (children reparent
+        // to pid 1). Wording kept close to the historical message so operators
+        // and existing playbooks still recognize it.
+        "restart scheduled: exiting 0 for a launchd-supervised relaunch. \
+         In-flight sweeps survive by design (their child processes reparent to \
+         launchd and keep running); the relaunched daemon re-reads the same launchd \
+         plist, so it comes back with exactly its start flags."
+            .to_string()
+    } else {
+        // systemd (and any other cgroup-scoped supervisor): be HONEST that the
+        // stop job reaps the cgroup. Do NOT claim sweeps survive.
+        format!(
+            "restart scheduled: exiting 0 for a {supervisor}-supervised relaunch. \
+             WARNING: in-flight sweeps and role runs do NOT survive on {supervisor} — \
+             they run inside this service's cgroup, so the stop job terminates them \
+             (KillMode=mixed sends SIGKILL to the remaining cgroup processes) as this \
+             process exits. The relaunched daemon re-reads its {supervisor} unit's \
+             configuration, so it comes back with exactly its start flags, but any \
+             work that was mid-flight is lost. To preserve it, use \
+             `loom-daemon restart --drain`, which waits for in-flight sweeps to finish \
+             before exiting so the cgroup is empty when the stop job runs."
+        )
+    }
+}
+
 /// Decide how to answer a `RestartDaemon` request (Issue #4054): the `Response`
 /// to send back, plus whether the daemon should then end its own process (exit
 /// [`EXIT_RESTART`]) for a supervised relaunch.
@@ -112,30 +160,14 @@ pub fn detect_supervisor() -> Option<String> {
 /// supervisor to relaunch it would be strictly worse than the status quo.
 pub fn build_restart_decision() -> (Response, bool) {
     match detect_supervisor() {
-        Some(sup) => {
-            // launchd wording is preserved byte-for-byte (its start-flag source is
-            // a plist); other recognized supervisors (e.g. systemd) get a
-            // supervisor-neutral phrasing referencing their own config.
-            let relaunch_note = if sup == "launchd" {
-                "the same launchd plist, so it comes back with exactly its start flags".to_string()
-            } else {
-                format!(
-                    "its {sup} unit's configuration, so it comes back with exactly its start flags"
-                )
-            };
-            (
-                Response::DaemonRestart {
-                    scheduled: true,
-                    supervisor: Some(sup.clone()),
-                    message: format!(
-                        "restart scheduled: exiting 0 for a {sup}-supervised relaunch. \
-                         In-flight sweeps survive by design; the relaunched daemon re-reads \
-                         {relaunch_note}."
-                    ),
-                },
-                true,
-            )
-        }
+        Some(sup) => (
+            Response::DaemonRestart {
+                scheduled: true,
+                supervisor: Some(sup.clone()),
+                message: restart_scheduled_message(&sup),
+            },
+            true,
+        ),
         None => (
             Response::DaemonRestart {
                 scheduled: false,
@@ -1241,11 +1273,20 @@ async fn handle_client(
                     } => s.clone(),
                     _ => "supervisor".to_string(),
                 };
+                // #5119: log the SAME supervisor-aware sweep-survival semantics
+                // the ack message carries — sweeps survive on launchd (children
+                // reparent to pid 1) but are SIGKILLed with the cgroup on systemd.
+                let sweep_fate = if sup == "launchd" {
+                    "In-flight sweeps survive by design (children reparent to launchd)"
+                } else {
+                    "In-flight sweeps do NOT survive — the stop job reaps this service's \
+                     cgroup (use --drain to preserve them)"
+                };
                 log::warn!(
                     "RestartDaemon: supervised — exiting {EXIT_RESTART} for a {sup}-supervised \
-                     relaunch. In-flight sweeps survive by design; the relaunched daemon \
-                     re-reads the same start-up configuration (exactly its start flags). \
-                     The stale socket is reclaimed by the relaunched daemon's singleton guard."
+                     relaunch. {sweep_fate}; the relaunched daemon re-reads the same start-up \
+                     configuration (exactly its start flags). The stale socket is reclaimed by \
+                     the relaunched daemon's singleton guard."
                 );
                 std::process::exit(EXIT_RESTART);
             }
@@ -5762,10 +5803,20 @@ exit 0
             Response::DaemonRestart {
                 scheduled,
                 supervisor,
-                ..
+                message,
             } => {
                 assert!(scheduled);
                 assert_eq!(supervisor.as_deref(), Some("launchd"));
+                // #5119: on launchd, sweeps GENUINELY survive (children reparent
+                // to pid 1) — the message must still say so.
+                assert!(
+                    message.contains("survive"),
+                    "launchd restart message must state sweeps survive: {message}"
+                );
+                assert!(
+                    !message.contains("do NOT survive"),
+                    "launchd restart message must NOT claim sweeps are terminated: {message}"
+                );
             }
             other => panic!("Expected DaemonRestart, got: {other:?}"),
         }
@@ -5820,6 +5871,26 @@ exit 0
                 assert!(
                     !message.contains("launchd"),
                     "systemd restart message must not hardcode launchd wording: {message}"
+                );
+                // #5119: the systemd message must be HONEST — sweeps are reaped
+                // with the cgroup, NOT preserved. It must not print the old
+                // macOS-only "In-flight sweeps survive by design" claim, and it
+                // must point at --drain as the preserving alternative.
+                assert!(
+                    message.contains("do NOT survive"),
+                    "systemd restart message must state in-flight sweeps do NOT survive: {message}"
+                );
+                assert!(
+                    !message.contains("survive by design"),
+                    "systemd restart message must not repeat the false 'survive by design' claim: {message}"
+                );
+                assert!(
+                    message.contains("cgroup"),
+                    "systemd restart message must name the cgroup as the reason: {message}"
+                );
+                assert!(
+                    message.contains("--drain"),
+                    "systemd restart message must point at --drain to preserve sweeps: {message}"
                 );
             }
             other => panic!("Expected DaemonRestart, got: {other:?}"),


### PR DESCRIPTION
## Summary

`loom-daemon restart` on a busy **systemd** host broke both halves of its own printed promise (2026-08-03, loom-worker-1):

1. It **SIGKILLed in-flight sweeps** — on systemd the sweep/role children run *inside the service's cgroup*, so systemd's stop job signals them by construction when the daemon exits (under `KillMode=mixed`, SIGKILL to the remaining processes). The primitive nonetheless printed the launchd-only line *"In-flight sweeps survive by design"* on every platform.
2. It **left the daemon down** — on a busy host the clean exit left the unit stuck in `deactivating (stop-sigterm)` past the #4950 pid-poll (a stale unit's 90s `TimeoutStopSec`), landing in `failed`, where `Restart=on-success` never fires. The #4950 verification *detected* this ("live status is NOT confirmed") but its self-heal only fired for an already-`failed` snapshot, so a `deactivating` reading fell through to "refusing to guess" and required a manual `reset-failed && start`.

## What this changes

**1. Supervisor-aware restart message** (`ipc::restart_scheduled_message`, new pure fn)
- **launchd**: keeps the "sweeps survive" wording (children reparent to `pid 1`, verified — #5081).
- **systemd**: states plainly that in-flight sweeps/role runs do **NOT** survive (cgroup SIGKILL), names the cgroup as the reason, and points at `loom-daemon restart --drain` (empties the sweep registry before exit so the cgroup is empty when the stop job runs). The `RestartDaemon` exit log mirrors this per-supervisor.

**2. Widened update-script self-heal** (`loom-daemon-update.sh`, #4950 → #5119)
- After the pid poll expires, a new `wait_for_systemd_stop_settle` **waits for a still-transitioning unit** (`deactivating`/`activating`) to settle into a terminal state (`LOOM_DAEMON_STOP_SETTLE_SECS`, default `100` > systemd's 90s `TimeoutStopSec`), then runs `reset-failed && start` for **any non-`active` settled state** — not just a confirmed `failed`. Only a genuinely `active` unit on an unobserved pid is left untouched (never bounce a healthy daemon).

**3. Doc correction** — `daemon-reference.md`'s "sweeps survive a stop" claims are now supervisor-specific.

## Acceptance criteria

- [x] `restart` on a systemd host with active sweeps/role runs results in a **running daemon without manual intervention** (settle-wait + reset-failed+start recovery; new shell test `56b`).
- [x] In-flight sweeps are **stated plainly to be terminated** on systemd (the AC-permitted alternative to genuine preservation), with `--drain` offered as the preserving path.
- [x] A stop-timeout landing in `failed`/stuck `deactivating` is **detected and recovered automatically**.
- [x] Behaviour **covered on both supervisors** — Rust asserts launchd (survive) vs systemd (do NOT survive / cgroup / `--drain`) wording; shell covers systemd recovery, launchd recovery already covered (#4232).

## Testing

- `test-loom-daemon-update.sh`: **220/220 pass**, incl. new `56` (transitional stall now *attempts* recovery instead of refusing) and `56b` (the `deactivating` → `failed` → recover → exit 0 incident path). The stub `systemctl` gained a settle-transition simulation.
- `cargo test --lib ipc::tests::` (83 pass), `cargo clippy --lib` clean, `cargo fmt --check` clean.

## Known limitations (honest scope)

- **Genuinely preserving sweeps on systemd** via a per-agent transient `systemd-run --scope` (which would also give #5111 its CPU bounding) is **out of scope** — this PR takes the "state plainly + `--drain` to preserve" path the issue's AC explicitly allows, since moving children out of the cgroup is a cross-cutting change to the spawn path.
- The systemd recovery is validated against a **stub `systemctl`** on the Darwin CI runner (`LOOM_SYSTEMD_FORCE=1`); end-to-end behaviour on a live `systemd --user` manager could not be exercised in this environment.

Closes #5119

🤖 Generated with [Claude Code](https://claude.com/claude-code)