### PR TITLE
fix(loom): suppress duplicate stand-down comments; port TTL reclaim to loom:curating

### DIFF
--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -30,6 +30,11 @@ If a number is provided (e.g., `/curator 42`):
 
 **CRITICAL**: You MUST run the `gh issue edit` command above BEFORE doing any other work. The `loom:curating` label signals that you have claimed the issue and prevents duplicate work.
 
+**If the named issue already carries `loom:curating`** (someone else's — or a
+dead — claim), do not add the label blindly on top of it: run the "Stale
+`loom:curating` Claim Check" (under "Claiming Work" below) first to decide
+stand-down vs. reclaim.
+
 If no argument is provided, use the normal "Finding Work" workflow below.
 
 ## Label Workflow
@@ -230,6 +235,135 @@ gh issue edit <number> --add-label "loom:curating"
 ```
 
 This signals to other Curators that you're working on this issue. The search command above already filters out claimed issues, so you won't see issues other Curators are enhancing.
+
+**If the issue you selected already carries `loom:curating`** (a point-in-time
+race with the Finding Work query above, or a claim surfaced some other way —
+e.g. an explicit user instruction naming an already-claimed issue), do **not**
+add the label a second time and do **not** silently skip it forever — run the
+"Stale `loom:curating` Claim Check" below first. A dead Curator's claim (parent
+sweep crashed mid-enhancement) is otherwise invisible to every later pass, the
+same livelock shape already fixed for `loom:reviewing` (Judge) and
+`loom:treating` (Doctor) — see #5123.
+
+### Stale `loom:curating` Claim Check
+
+Run this whenever the issue you are about to claim **already carries**
+`loom:curating` — from Priority 1/2 discovery, an explicit `/curator <number>`
+invocation, or the re-curation playbook above. Without this check a dead claim
+(the claiming Curator's parent sweep died mid-enhancement) blocks the issue
+from ever being curated again, exactly the `loom:reviewing`/`loom:treating`
+failure mode `judge.md`/`doctor.md` already guard against — this section
+mirrors "Stale `loom:reviewing` Claim Check" in `judge.md` structurally, with
+`gh issue` in place of `gh pr` (issues and PRs share the same underlying
+`/issues/{n}` REST resource, so the same timeline/comments endpoints apply).
+
+**If the issue does NOT carry `loom:curating`:** proceed to claim as today —
+no behavior change: `gh issue edit <number> --add-label "loom:curating"`.
+
+**If the issue DOES carry `loom:curating`:** determine the claim's age and
+whether anyone has *genuinely* commented since the claim was made — see
+"Stand-down marker convention" below for why the comment count excludes
+stand-down comments:
+
+```bash
+N=<issue-number>
+# All reads in this block must be live `gh`/`gh api` calls — this is claim
+# arbitration, and a stale cache read would reintroduce the double-claim this
+# check exists to prevent. `--paginate` re-invokes `--jq` once per response
+# page and concatenates the per-page results rather than applying the filter
+# across the combined timeline (#4637) — `sort | tail -n 1` collapses the
+# resulting per-page timestamps to the single latest one; RFC3339 UTC
+# timestamps sort correctly as plain strings.
+CLAIMED_AT=$(gh api "repos/{owner}/{repo}/issues/$N/timeline" --paginate \
+  --jq '[.[] | select(.event=="labeled" and .label.name=="loom:curating")] | last | .created_at // empty' \
+  | sort | tail -n 1)
+MARKER="<!-- loom:standdown claim=$CLAIMED_AT -->"
+COMMENTS_JSON=$(gh api "repos/{owner}/{repo}/issues/$N/comments" \
+  | jq --arg t "$CLAIMED_AT" '[.[] | select(.created_at > $t)]')
+# printf, not echo: zsh's echo interprets \n escapes inside the JSON, corrupting it
+COMMENTS_AFTER=$(printf '%s\n' "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m) | not)] | length')
+STANDDOWN_COUNT=$(printf '%s\n' "$COMMENTS_JSON" | jq --arg m "$MARKER" '[.[] | select(.body | contains($m))] | length')
+```
+
+Then decide:
+
+| Condition | Verdict | Action |
+|-----------|---------|--------|
+| `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default **3**) AND claim age ≥ `LOOM_STALE_CURATING_MINUTES` (default **30**) | **Stale — bounded fallback** (see below) | Force-reclaim regardless of `COMMENTS_AFTER`. Breaks the livelock even if the marker/exclusion logic above is somehow bypassed — mirrors the age-floor join `judge.md`/`doctor.md` already apply (#4790): the streak alone is never enough, it also requires the claim to have aged past the normal staleness threshold. |
+| Claim age < `LOOM_STALE_CURATING_MINUTES` (default **30**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Curator is actively enhancing this issue | **Do not stomp the claim.** Post a marked stand-down comment **unless the latest comment already carries an identical marker for this exact `$CLAIMED_AT`** (see "Duplicate stand-down suppression" below — then skip silently instead), then skip this issue and continue to the next candidate. |
+| Claim age ≥ `LOOM_STALE_CURATING_MINUTES` AND `COMMENTS_AFTER == 0` | **Stale** — the claiming Curator's process almost certainly died mid-enhancement | Reclaim (see below), then proceed with normal curation. |
+| Timeline API call fails or returns empty (`CLAIMED_AT` unset) | **Unknown — fail safe** | Treat as **fresh**. Never stomp a claim on API failure or missing data. |
+
+**Stand-down marker convention (mirrors #4618)**: a "standing down, not
+stomping" comment is evidence of **no activity**, not activity — it means a
+*later* Curator pass declined to touch the claim, not that the *original*
+claimant is still working. Every stand-down comment you post in the "Fresh"
+row above MUST end with the `<!-- loom:standdown claim=$CLAIMED_AT -->` marker
+so it is excluded from `COMMENTS_AFTER` on every subsequent pass, and counted
+in `STANDDOWN_COUNT` instead. **Duplicate stand-down suppression (#5123)**:
+re-verification of staleness still runs on every pass — only the redundant
+*comment* is skipped, by checking whether the *latest* comment already carries
+the identical marker (`COMMENTS_JSON` was already fetched above — no extra API
+call needed):
+
+```bash
+LATEST_COMMENT_BODY=$(printf '%s\n' "$COMMENTS_JSON" | jq -r 'sort_by(.created_at) | last | .body // empty')
+if printf '%s' "$LATEST_COMMENT_BODY" | grep -qF -- "$MARKER"; then
+  echo "Latest comment already carries the stand-down marker for claim $CLAIMED_AT — skipping duplicate comment (still standing down, not reclaiming)."
+else
+  gh issue comment $N --body "Curator pass: issue still carries a fresh \`loom:curating\` claim (claimed $CLAIMED_AT) — standing down without reclaiming. Not stomping.
+<!-- loom:standdown claim=$CLAIMED_AT -->"
+fi
+```
+
+**Bounded fallback** (mirrors AC3, #4618; age-floor join added by #4798):
+`STANDDOWN_COUNT` is a hard cap independent of the marker-exclusion logic
+working correctly — it counts how many stand-down comments have accumulated
+against *this exact* `$CLAIMED_AT` (the marker embeds it, so a genuine
+reclaim — which changes `CLAIMED_AT` — resets the count to zero
+automatically). The fallback fires only once **both** hold:
+`LOOM_MAX_STANDDOWN_STREAK` marked comments have piled up against the same
+claim with no reclaim, **and** the claim's own age is ≥
+`LOOM_STALE_CURATING_MINUTES` — reusing the same age floor the ordinary
+staleness row above already applies. Use this reclaim comment:
+
+```bash
+gh issue edit $N --remove-label "loom:curating"
+gh issue comment $N --body "Reclaiming loom:curating claim: $STANDDOWN_COUNT consecutive stand-down comments have accumulated against claim $CLAIMED_AT (age ≥ ${LOOM_STALE_CURATING_MINUTES:-30}m) with no actual curation progress (bounded fallback, LOOM_MAX_STANDDOWN_STREAK=${LOOM_MAX_STANDDOWN_STREAK:-3}) — breaking the livelock."
+gh issue edit $N --add-label "loom:curating"
+# Continue with normal curation
+```
+
+**Reclaiming a stale claim** (the ordinary claim-age path):
+
+```bash
+gh issue edit $N --remove-label "loom:curating"
+gh issue comment $N --body "Reclaiming stale loom:curating claim (age > ${LOOM_STALE_CURATING_MINUTES:-30}m, no follow-up comment) — a prior Curator's parent sweep likely died mid-enhancement."
+gh issue edit $N --add-label "loom:curating"
+# Continue with normal curation
+```
+
+**Env vars**: `LOOM_STALE_CURATING_MINUTES` (default **30**) — named to mirror
+`LOOM_STALE_REVIEWING_MINUTES`/`LOOM_STALE_TREATING_MINUTES` (`judge.md` /
+`doctor.md`), on the same minutes-scale grace period: a typical Curator pass
+(read issue + comments, research the codebase, write an enhancement) runs
+closer in duration to a Judge's review pass than to a Doctor's fix-build-test
+cycle, so it reuses the Judge's 30-minute default rather than the Doctor's 60
+— a repo whose Curator passes routinely run longer (e.g. heavy use of the
+"Running Measurement / Board-Pipeline Reproductions" playbook above) should
+raise this. `LOOM_MAX_STANDDOWN_STREAK` (default **3**) — the same
+bounded-fallback cap shared with `judge.md`/`doctor.md`.
+
+**No daemon-side backstop today**: unlike `loom:reviewing`/`loom:treating`,
+`loom-daemon`'s `claim_reconciliation` pass does **not** reconcile
+`loom:curating` — this check is agent-side-only (it fires when another
+Curator pass happens to revisit the same issue). See
+`defaults/docs/daemon-reference.md` § "Stale-claim reconciliation & the sweep
+journal" for the current daemon-side coverage matrix.
+
+**Applies everywhere a Curator claims an issue** — Priority 1/2 discovery
+above, the re-curation playbook, and an explicit `/curator <number>`
+invocation naming an issue that turns out to already carry `loom:curating`.
 
 ## Before Starting Curation
 

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -574,7 +574,7 @@ Then decide:
 | Condition | Verdict | Action |
 |-----------|---------|--------|
 | `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default **3**) AND claim age ≥ `LOOM_STALE_TREATING_MINUTES` (default **60**) | **Stale — bounded fallback** (see below) | Force-reclaim regardless of `COMMENTS_AFTER`. Breaks the livelock even if the marker/exclusion logic above is somehow bypassed — but the streak alone is never enough (#4790): it also requires the claim to have aged past the normal staleness threshold, so a high *peer arrival rate* (several concurrent Doctors each standing down within minutes) cannot force-reclaim a claim that is still genuinely fresh. |
-| Claim age < `LOOM_STALE_TREATING_MINUTES` (default **60**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Doctor is actively fixing this PR | **Do not stomp the claim.** Post a marked stand-down comment (see below), then skip this PR and move to the next candidate in the queue. |
+| Claim age < `LOOM_STALE_TREATING_MINUTES` (default **60**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Doctor is actively fixing this PR | **Do not stomp the claim.** Post a marked stand-down comment **unless the latest comment on the PR already carries an identical marker for this exact `$CLAIMED_AT`** (see "Duplicate stand-down suppression" below — then skip silently instead), then skip this PR and move to the next candidate in the queue. |
 | Claim age ≥ `LOOM_STALE_TREATING_MINUTES` AND `COMMENTS_AFTER == 0` | **Stale** — the claiming Doctor's process almost certainly died mid-fix | Reclaim (see below), then proceed with the normal fix from step 3. |
 | Timeline API call fails or returns empty (`CLAIMED_AT` unset) | **Unknown — fail safe** | Treat as **fresh**. Never stomp a claim on API failure or missing data. |
 
@@ -595,6 +595,28 @@ excluded from `COMMENTS_AFTER` on every subsequent pass, and counted in
 ```bash
 gh pr comment $N --body "Doctor pass: PR still carries a fresh \`loom:treating\` claim (claimed $CLAIMED_AT) — standing down without reclaiming. Not stomping.
 <!-- loom:standdown claim=$CLAIMED_AT -->"
+```
+
+**Duplicate stand-down suppression (#5123)**: the marker convention above stops
+a stand-down from ever looking like live activity, but it does not by itself
+stop a *pile of identical stand-downs* from accumulating — every "Fresh" pass
+still posted a new marked comment unconditionally, so a claim sitting just
+inside the TTL produced one near-identical comment per Doctor pass (the same
+defect shape observed live on the Judge lane on PR #5115: 3 stand-downs in 85
+seconds). Re-verification of staleness still runs on **every** pass — only the
+redundant comment is skipped. Before posting the stand-down comment above,
+check whether the *latest* comment on the PR already carries the identical
+marker for this exact `$CLAIMED_AT` (`COMMENTS_JSON` was already fetched above
+— no extra API call needed):
+
+```bash
+LATEST_COMMENT_BODY=$(printf '%s\n' "$COMMENTS_JSON" | jq -r 'sort_by(.created_at) | last | .body // empty')
+if printf '%s' "$LATEST_COMMENT_BODY" | grep -qF -- "$MARKER"; then
+  echo "Latest comment already carries the stand-down marker for claim $CLAIMED_AT — skipping duplicate comment (still standing down, not reclaiming)."
+else
+  gh pr comment $N --body "Doctor pass: PR still carries a fresh \`loom:treating\` claim (claimed $CLAIMED_AT) — standing down without reclaiming. Not stomping.
+<!-- loom:standdown claim=$CLAIMED_AT -->"
+fi
 ```
 
 **Bounded fallback (AC3, #4618; age-floor join added by #4798)**:

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -517,7 +517,7 @@ Then decide:
 | Condition | Verdict | Action |
 |-----------|---------|--------|
 | `STANDDOWN_COUNT >= LOOM_MAX_STANDDOWN_STREAK` (default **3**) AND claim age ≥ `LOOM_STALE_REVIEWING_MINUTES` (default **30**) | **Stale — bounded fallback** (see below) | Force-reclaim regardless of `COMMENTS_AFTER`. Breaks the livelock even if the marker/exclusion logic above is somehow bypassed — but the streak alone is never enough (#4790): it also requires the claim to have aged past the normal staleness threshold, so a high *peer arrival rate* (several concurrent Judges each standing down within minutes) cannot force-reclaim a claim that is still genuinely fresh. |
-| Claim age < `LOOM_STALE_REVIEWING_MINUTES` (default **30**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Judge is actively working this PR | **Do not stomp the claim.** Post a marked stand-down comment (see below), then skip this PR and continue the batch to the next candidate PR. |
+| Claim age < `LOOM_STALE_REVIEWING_MINUTES` (default **30**), OR `COMMENTS_AFTER > 0` | **Fresh** — a Judge is actively working this PR | **Do not stomp the claim.** Post a marked stand-down comment **unless the latest comment on the PR already carries an identical marker for this exact `$CLAIMED_AT`** (see "Duplicate stand-down suppression" below — then skip silently instead), then skip this PR and continue the batch to the next candidate PR. |
 | Claim age ≥ `LOOM_STALE_REVIEWING_MINUTES` AND `COMMENTS_AFTER == 0` | **Stale** — the claiming Judge's process almost certainly died mid-review | Reclaim (see below), then proceed with the normal review from step 3. |
 | Timeline API call fails or returns empty (`CLAIMED_AT` unset) | **Unknown — fail safe** | Treat as **fresh**. Never stomp a claim on API failure or missing data. |
 
@@ -537,6 +537,27 @@ instead:
 ```bash
 gh pr comment $N --body "Judge pass: PR still carries a fresh \`loom:reviewing\` claim (claimed $CLAIMED_AT) — standing down without reclaiming. Not stomping.
 <!-- loom:standdown claim=$CLAIMED_AT -->"
+```
+
+**Duplicate stand-down suppression (#5123)**: the marker convention above stops
+a stand-down from ever looking like live activity, but it does not by itself
+stop a *pile of identical stand-downs* from accumulating — every "Fresh" pass
+still posted a new marked comment unconditionally, so a claim sitting just
+inside the TTL produced one near-identical comment per Judge pass (observed
+live on PR #5115: 3 stand-downs in 85 seconds). Re-verification of staleness
+still runs on **every** pass — only the redundant comment is skipped. Before
+posting the stand-down comment above, check whether the *latest* comment on
+the PR already carries the identical marker for this exact `$CLAIMED_AT`
+(`COMMENTS_JSON` was already fetched above — no extra API call needed):
+
+```bash
+LATEST_COMMENT_BODY=$(printf '%s\n' "$COMMENTS_JSON" | jq -r 'sort_by(.created_at) | last | .body // empty')
+if printf '%s' "$LATEST_COMMENT_BODY" | grep -qF -- "$MARKER"; then
+  echo "Latest comment already carries the stand-down marker for claim $CLAIMED_AT — skipping duplicate comment (still standing down, not reclaiming)."
+else
+  gh pr comment $N --body "Judge pass: PR still carries a fresh \`loom:reviewing\` claim (claimed $CLAIMED_AT) — standing down without reclaiming. Not stomping.
+<!-- loom:standdown claim=$CLAIMED_AT -->"
+fi
 ```
 
 **Bounded fallback (AC3, #4618; age-floor join added by #4798)**:

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1739,6 +1739,29 @@ is shared by both role prompts, mirroring how
 `LOOM_STALE_REVIEWING_MINUTES`/`LOOM_STALE_TREATING_MINUTES` are already
 shared.
 
+### `loom:curating` (Curator): agent-side only, no daemon backstop (#5123)
+
+`loom:curating` gained the same TTL + standdown-marker + bounded-fallback
+mechanism as `loom:reviewing`/`loom:treating` — `.claude/commands/loom/curator.md`'s
+"Stale `loom:curating` Claim Check" — but **only** on the agent-side fast
+path. Unlike the PR-side claims above, `reconcile_pr_claims` (and
+`reconcile_workspace`) do **not** reconcile `loom:curating` at all: there is
+no always-on daemon backstop for a dead Curator claim today. A stranded
+`loom:curating` claim is only reclaimed when another Curator pass happens to
+revisit the same issue (Priority 1/2 discovery, a re-curation pass, or an
+explicit `/curator <number>` naming it) and runs the stale-claim check —
+there is no periodic sweep that reclaims it in the background the way
+`reconcile_pr_claims` does for `loom:reviewing`/`loom:treating` or
+`reconcile_workspace` does for `loom:building`. `LOOM_STALE_CURATING_MINUTES`
+(default 30, matching `LOOM_STALE_REVIEWING_MINUTES`) and
+`LOOM_MAX_STANDDOWN_STREAK` are shared with the Judge/Doctor convention
+above. Extending `claim_reconciliation` to cover `loom:curating` as a fourth
+surface (mirroring `reconcile_pr_claims`'s `decide_pr`, keyed off the same
+`labeled` timeline event) is a natural follow-up but was not required to
+close #5123 — the agent-side check is a complete fix on its own, just with a
+longer worst-case tail (bounded by how often issues in the Curator's queues
+get revisited) than a PR-side claim has.
+
 ## Stacked-PR dependency — #3729 (v1), #3747 (v2 item 1)
 
 Stacked-PR mode pipelines a genuine dependency: when issue B consumes issue

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -96,6 +96,7 @@ test-resync-installed.sh
 test-safehoused-service.sh
 test-spawn-generic.sh
 test-spawn-worker.sh
+test-stale-claim-standdown-suppression.sh
 test-sweep-auto-stack.sh
 test-sweep-checkpoint.sh
 test-sweep-experiment.sh

--- a/defaults/scripts/tests/test-stale-claim-standdown-suppression.sh
+++ b/defaults/scripts/tests/test-stale-claim-standdown-suppression.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# test-stale-claim-standdown-suppression.sh - Regression guard for #5123.
+#
+# #5123 closed two gaps in the loom:reviewing / loom:treating / loom:curating
+# stale-claim livelock protection:
+#
+#   1. judge.md's and doctor.md's "Fresh" stand-down path posted a new marked
+#      `<!-- loom:standdown claim=$CLAIMED_AT -->` comment on EVERY pass, even
+#      when the immediately preceding comment already carried the identical
+#      marker for the same claim — pure noise (observed live on PR #5115: 3
+#      near-identical stand-downs in 85 seconds).
+#   2. loom:curating (Curator) had no TTL/marker/bounded-fallback mechanism at
+#      all — a dead Curator claim was permanently stranded, the exact failure
+#      shape already fixed for loom:reviewing/loom:treating.
+#
+# This suite has two parts:
+#
+#   A. Extracts the ACTUAL "Duplicate stand-down suppression" bash block from
+#      judge.md, doctor.md, and curator.md (not a reimplementation) and runs
+#      it against mocked `gh`/`jq` input, asserting: (a) an unchanged latest
+#      marker suppresses the comment, (b) a stale/absent marker still posts
+#      one. This means an edit that breaks the extracted block's syntax or
+#      behavior fails this suite directly — no docs/test drift possible for
+#      this specific code path.
+#
+#   B. A decision-table conformance check mirroring the Fresh/Stale/bounded-
+#      fallback table shared by all three role prompts (the table itself is
+#      prose, not executable, so this reimplements it once and asserts
+#      boundary behavior: never stomp a fresh claim, TTL-reclaim once stale,
+#      and the streak+age-floor join for the bounded fallback) — covering the
+#      loom:curating port specifically, since that lane is new in this PR.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-stale-claim-standdown-suppression.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+JUDGE_MD="$REPO_ROOT/defaults/.claude/commands/loom/judge.md"
+DOCTOR_MD="$REPO_ROOT/defaults/.claude/commands/loom/doctor.md"
+CURATOR_MD="$REPO_ROOT/defaults/.claude/commands/loom/curator.md"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+}
+
+for f in "$JUDGE_MD" "$DOCTOR_MD" "$CURATOR_MD"; do
+    [[ -f "$f" ]] || { echo "FATAL: missing $f"; exit 1; }
+done
+
+# Extract a fenced ```bash ... ``` block: starts at the line containing
+# $2 (must be inside the fence, right after the opening ```bash) and reads
+# through (but excludes) the next line that is exactly ```.
+extract_block() { # <file> <start-substring>
+    local file="$1" start="$2"
+    awk -v start="$start" '
+        index($0, start) { capture=1 }
+        capture {
+            if ($0 == "```") exit
+            print
+        }
+    ' "$file"
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ============================================================================
+# Part A: extracted duplicate-suppression blocks (real code under test)
+# ============================================================================
+
+echo "Part A: duplicate stand-down comment suppression (extracted from role prompts)"
+
+# <lane-name> <file> <gh-subcommand-that-must-fire e.g. "gh pr comment"/"gh issue comment">
+run_suppression_case() {
+    local lane="$1" file="$2" gh_kind="$3" comments_json="$4" expect_comment="$5"
+    local case_label="$6"
+
+    local block
+    block="$(extract_block "$file" 'LATEST_COMMENT_BODY=')"
+    if [[ -z "$block" ]]; then
+        fail "$lane ($case_label): could not extract the duplicate-suppression block from $file"
+        return
+    fi
+
+    local gh_calls="$WORK/${lane}-gh-calls-$RANDOM"
+    : > "$gh_calls"
+
+    # Mock `gh` — records every invocation so we can assert whether a
+    # comment was (or wasn't) posted, without touching the network.
+    gh() {
+        printf '%s\n' "gh $*" >> "$gh_calls"
+    }
+    export -f gh >/dev/null 2>&1 || true
+
+    N=12345
+    CLAIMED_AT="2026-08-03T21:11:41Z"
+    MARKER="<!-- loom:standdown claim=$CLAIMED_AT -->"
+    COMMENTS_JSON="$comments_json"
+
+    local out
+    out="$(eval "$block" 2>&1)"
+    local rc=$?
+
+    if [[ "$rc" -ne 0 ]]; then
+        fail "$lane ($case_label): extracted block exited non-zero (rc=$rc): $out"
+        return
+    fi
+
+    local comment_posted=0
+    grep -q "$gh_kind" "$gh_calls" 2>/dev/null && comment_posted=1
+
+    if [[ "$expect_comment" == "yes" ]]; then
+        if [[ "$comment_posted" -eq 1 ]]; then
+            pass "$lane ($case_label): posted a stand-down comment as expected"
+        else
+            fail "$lane ($case_label): expected a stand-down comment, none was posted. gh calls: $(cat "$gh_calls" 2>/dev/null)"
+        fi
+    else
+        if [[ "$comment_posted" -eq 0 ]]; then
+            pass "$lane ($case_label): suppressed the duplicate comment as expected"
+        else
+            fail "$lane ($case_label): expected NO comment (duplicate suppression), but one was posted: $(cat "$gh_calls" 2>/dev/null)"
+        fi
+        if [[ "$out" == *"skipping duplicate comment"* ]]; then
+            pass "$lane ($case_label): logged the skip reason"
+        else
+            fail "$lane ($case_label): did not log a skip reason. Got: $out"
+        fi
+    fi
+
+    unset -f gh 2>/dev/null || true
+}
+
+MARKER_TXT='<!-- loom:standdown claim=2026-08-03T21:11:41Z -->'
+
+# Case 1: latest (and only) comment already carries the identical marker ->
+# suppress.
+DUP_JSON=$(cat <<EOF
+[{"created_at":"2026-08-03T21:12:31Z","body":"Judge pass: PR still carries a fresh claim. $MARKER_TXT"}]
+EOF
+)
+
+# Case 2: no comments since the claim at all -> must still post (first
+# stand-down for this claim, nothing to suppress).
+EMPTY_JSON='[]'
+
+# Case 3: a real (non-marker) comment is the latest -> must still post (this
+# is genuine activity, not a repeat stand-down).
+FRESH_JSON=$(cat <<EOF
+[{"created_at":"2026-08-03T21:12:00Z","body":"Actually reviewing now, one moment."}]
+EOF
+)
+
+run_suppression_case "judge"   "$JUDGE_MD"   "gh pr comment"    "$DUP_JSON"   "no"  "identical marker already latest"
+run_suppression_case "judge"   "$JUDGE_MD"   "gh pr comment"    "$EMPTY_JSON" "yes" "no comments yet"
+run_suppression_case "judge"   "$JUDGE_MD"   "gh pr comment"    "$FRESH_JSON" "yes" "latest comment is real activity"
+
+run_suppression_case "doctor"  "$DOCTOR_MD"  "gh pr comment"    "$DUP_JSON"   "no"  "identical marker already latest"
+run_suppression_case "doctor"  "$DOCTOR_MD"  "gh pr comment"    "$EMPTY_JSON" "yes" "no comments yet"
+run_suppression_case "doctor"  "$DOCTOR_MD"  "gh pr comment"    "$FRESH_JSON" "yes" "latest comment is real activity"
+
+run_suppression_case "curator" "$CURATOR_MD" "gh issue comment" "$DUP_JSON"   "no"  "identical marker already latest"
+run_suppression_case "curator" "$CURATOR_MD" "gh issue comment" "$EMPTY_JSON" "yes" "no comments yet"
+run_suppression_case "curator" "$CURATOR_MD" "gh issue comment" "$FRESH_JSON" "yes" "latest comment is real activity"
+
+# ============================================================================
+# Part B: loom:curating decision-table conformance (mirrors the doc's table)
+# ============================================================================
+
+echo ""
+echo "Part B: loom:curating Fresh/Stale/bounded-fallback decision table"
+
+# Mirrors the exact table added to curator.md's "Stale loom:curating Claim
+# Check" (structurally identical to judge.md/doctor.md's). Kept in sync by
+# hand with that table — if the table's conditions change, update this
+# function to match.
+decide_curating() { # <claim_age_min> <comments_after> <standdown_count> [ttl] [streak_cap]
+    local age="$1" comments_after="$2" standdown_count="$3"
+    local ttl="${4:-30}" streak_cap="${5:-3}"
+
+    if [[ "$standdown_count" -ge "$streak_cap" && "$age" -ge "$ttl" ]]; then
+        echo "stale-bounded-fallback"
+    elif [[ "$age" -lt "$ttl" || "$comments_after" -gt 0 ]]; then
+        echo "fresh"
+    else
+        echo "stale"
+    fi
+}
+
+assert_decision() { # <label> <expected> <actual...>
+    local label="$1" expected="$2"; shift 2
+    local actual
+    actual="$(decide_curating "$@")"
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$label -> $expected"
+    else
+        fail "$label -> expected $expected, got $actual (inputs: $*)"
+    fi
+}
+
+# Never stomp a genuinely fresh claim (age well under TTL, no other activity).
+assert_decision "fresh: age=5m, no activity"                 "fresh"                 5 0 0
+# Real (non-standdown) activity keeps it fresh even once past the TTL.
+assert_decision "fresh: age=45m but real comment after claim" "fresh"                45 1 0
+# Ordinary staleness: past TTL, zero non-standdown activity.
+assert_decision "stale: age=31m, no activity"                 "stale"                 31 0 0
+# Exact TTL boundary (age == ttl) must already be reclaimable, not fresh.
+assert_decision "boundary: age==ttl exactly"                  "stale"                 30 0 0
+assert_decision "boundary: age==ttl-1 is still fresh"         "fresh"                 29 0 0
+# Bounded fallback: streak alone (claim still young) must NOT force-reclaim —
+# this is the #4790 regression the age-floor join exists to prevent.
+assert_decision "peer-arrival-rate alone (age=10m, streak=3) stays fresh" "fresh" 10 0 3
+# Bounded fallback fires only once BOTH the streak cap and the age floor hold.
+assert_decision "bounded fallback: age=30m AND streak=3"      "stale-bounded-fallback" 30 0 3
+# One short of the streak cap, past TTL -> ordinary stale (not "fallback"),
+# same outcome either way but exercises the boundary distinctly.
+assert_decision "streak=2 (below cap), past TTL"              "stale"                 40 0 2
+
+# Custom TTL / streak cap (repo override) still honored.
+assert_decision "custom TTL=60: age=45m stays fresh"          "fresh"                 45 0 0 60 3
+assert_decision "custom TTL=60: age=61m goes stale"           "stale"                 61 0 0 60 3
+
+# ============================================================================
+# Summary
+# ============================================================================
+
+echo ""
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "${RED}FAILED${NC}: $TESTS_FAILED test(s) failed"
+    exit 1
+fi
+echo -e "${GREEN}OK${NC}: all tests passed"
+exit 0

--- a/defaults/scripts/tests/test-stale-claim-standdown-suppression.sh
+++ b/defaults/scripts/tests/test-stale-claim-standdown-suppression.sh
@@ -111,9 +111,14 @@ run_suppression_case() {
     }
     export -f gh >/dev/null 2>&1 || true
 
+    # These four are consumed by the extracted block below via `eval`, not
+    # referenced directly in this function — shellcheck can't see that use.
+    # shellcheck disable=SC2034
     N=12345
     CLAIMED_AT="2026-08-03T21:11:41Z"
+    # shellcheck disable=SC2034
     MARKER="<!-- loom:standdown claim=$CLAIMED_AT -->"
+    # shellcheck disable=SC2034
     COMMENTS_JSON="$comments_json"
 
     local out


### PR DESCRIPTION
## Summary

Closes two remaining gaps identified in #5123's Curator Enhancement (the TTL-based stale-claim reclaim mechanism for `loom:reviewing`/`loom:treating` already shipped in `judge.md`/`doctor.md`; this PR does not re-implement that):

1. **Duplicate stand-down comment suppression** in both `judge.md` and `doctor.md` — a "Fresh" stand-down pass previously posted a new marked `<!-- loom:standdown claim=$CLAIMED_AT -->` comment on every single pass, producing pure noise (observed live on PR #5115: 3 near-identical stand-downs in 85 seconds). Re-verification of staleness still runs every pass; only the redundant *comment* is now skipped when the latest comment already carries an identical marker for the current claim.
2. **`loom:curating` gains the same TTL + standdown-marker + bounded-fallback mechanism** `loom:reviewing`/`loom:treating` already have, via a new "Stale `loom:curating` Claim Check" section in `curator.md` (new `LOOM_STALE_CURATING_MINUTES` env var, default 30, matching Judge's threshold — a Curator pass runs closer in duration to a review pass than to a Doctor fix-build-test cycle).

Per the issue's own scoping, the reaper-side release (`loom-daemon/src/sweep_registry/reaper.rs`) is explicitly optional/stretch and is **not** included here — the TTL-based approach is a complete fix on its own.

## Changes

- `defaults/.claude/commands/loom/judge.md` — "Stale `loom:reviewing` Claim Check": add duplicate-standdown-comment suppression before posting the marked comment (reuses the already-fetched `COMMENTS_JSON`, no extra API call).
- `defaults/.claude/commands/loom/doctor.md` — "Stale `loom:treating` Claim Check": identical suppression.
- `defaults/.claude/commands/loom/curator.md` — new "Stale `loom:curating` Claim Check" section mirroring `judge.md`'s structure (`gh issue` in place of `gh pr`), wired into "Claiming Work" and "Argument Handling". Documents `LOOM_STALE_CURATING_MINUTES` alongside the existing `LOOM_STALE_REVIEWING_MINUTES`/`LOOM_STALE_TREATING_MINUTES` convention.
- `defaults/docs/daemon-reference.md` — "Stale-claim reconciliation & the sweep journal": new subsection noting `loom:curating` has **no** daemon-side reconciliation backstop today (agent-side fast path only), unlike `loom:reviewing`/`loom:treating`.
- `defaults/scripts/tests/test-stale-claim-standdown-suppression.sh` (new) — regression suite, wired into `ci-wired.txt`:
  - **Part A** extracts the *actual* duplicate-suppression bash block from all three role prompts (not a reimplementation) and runs it against mocked `gh`/comment fixtures, asserting suppression fires only when the latest comment already carries the identical marker, and never suppresses genuine new activity.
  - **Part B** conformance-checks the Fresh/Stale/bounded-fallback decision table for `loom:curating`: never stomps a genuinely fresh claim, TTL boundary reclaim, and the streak+age-floor join for the bounded fallback (guards against the #4790 peer-arrival-rate false positive).

## Acceptance Criteria Verification

- [x] A `loom:reviewing`/`loom:treating` stand-down pass does not post a duplicate comment when an identical marker for the same claim timestamp is already the latest comment — staleness is still re-verified every pass. Verified by the extracted-block test (Part A) against both files.
- [x] `loom:curating` gains the same TTL + standdown-marker + bounded-fallback mechanism, reclaimable by a later Curator pass without operator intervention (`LOOM_STALE_CURATING_MINUTES`, default 30).
- [x] A genuinely live claim is never stomped in any of the three lanes — verified for `loom:curating` by Part B (fresh-with-real-activity, fresh-below-TTL, streak-alone-does-not-force-reclaim cases) and for `judge`/`doctor` suppression by Part A's "latest comment is real activity" case.
- [x] Reclaiming states the evidence used (claim age vs. TTL, or standdown-streak count) explicitly in the reclaim comment — same pattern as the existing Judge/Doctor reclaim comments.
- [x] `LOOM_STALE_CURATING_MINUTES` documented in `curator.md` alongside `LOOM_STALE_REVIEWING_MINUTES`/`LOOM_STALE_TREATING_MINUTES`.

## Test Plan

- `bash defaults/scripts/tests/test-stale-claim-standdown-suppression.sh` — 22/22 assertions pass.
- `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — confirms the new suite is wired (no unlisted-suite violation).
- `shellcheck --severity=warning defaults/scripts/tests/test-stale-claim-standdown-suppression.sh` — clean (SC2034 false positives on `eval`-consumed vars silenced with the established `# shellcheck disable=SC2034` convention used elsewhere in this directory).
- Manually verified test-suite regression coverage: temporarily broke the extracted `judge.md` suppression conditional (`if false; then`) and confirmed the suite fails with the expected assertion messages before reverting.
- No Rust files touched; `cargo test`/build-gate unaffected.

Closes #5123