### PR TITLE
fix(daemon): serialize env-seam-leaking tests against #[serial] siblings

### DIFF
--- a/loom-daemon/src/observability/backfill.rs
+++ b/loom-daemon/src/observability/backfill.rs
@@ -380,7 +380,13 @@ mod tests {
         assert_eq!(load_state(&path), BackfillState::default());
     }
 
+    // Serialized against the other tests in this module: they mutate the
+    // process-wide `BACKFILL_STATE_PATH_ENV` var (leaked for the duration of
+    // their body), and `#[serial]` only serializes against other `#[serial]`
+    // tests — a non-serial reader can otherwise observe a sibling's leaked
+    // override and flake nondeterministically (#5133).
     #[test]
+    #[serial]
     fn default_backfill_state_path_is_under_loom_logs() {
         let workspace = Path::new("/workspace/repo");
         let path = default_backfill_state_path(workspace);

--- a/loom-daemon/src/sweep_outcomes.rs
+++ b/loom-daemon/src/sweep_outcomes.rs
@@ -488,6 +488,7 @@ fn median_i64(sorted: &[i64]) -> i64 {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::tempdir;
 
     fn record(issue: u32, outcome: &str) -> OutcomeRecord {
@@ -721,7 +722,15 @@ mod tests {
         assert_eq!(records[0].issue, 2);
     }
 
+    // Serialized against `observability::backfill`'s tests: they mutate the
+    // process-wide `OUTCOME_TELEMETRY_JOURNAL_PATH_ENV` var (leaked for the
+    // duration of their body) via this same constant, and `#[serial]` only
+    // serializes against other `#[serial]` tests — a non-serial reader can
+    // otherwise observe that leaked override and flake nondeterministically
+    // (#5133, same class as `observability::backfill`'s
+    // `default_backfill_state_path_is_under_loom_logs`).
     #[test]
+    #[serial]
     fn default_outcome_telemetry_path_is_under_loom_logs() {
         let workspace = Path::new("/workspace/repo");
         let path = default_outcome_telemetry_path(workspace);

--- a/loom-daemon/src/tokens_pool/monitor.rs
+++ b/loom-daemon/src/tokens_pool/monitor.rs
@@ -435,6 +435,7 @@ pub fn run_monitor_check(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::fs;
 
     fn fresh_now() -> DateTime<Utc> {
@@ -758,7 +759,13 @@ mod tests {
         assert_eq!(format_ranking_lines(&available), "c|available|0.12|2026-08-01T06:50:00Z\n");
     }
 
+    // Serialized against its sibling below: both mutate the process-wide
+    // `CLAUDE_MONITOR_DIR_VAR` env var without restoring a prior value, so
+    // two non-serial instances can race and one can observe the other's
+    // `monitor_dir` override (#5133, same class as
+    // `observability::backfill`'s env-seam leak).
     #[test]
+    #[serial]
     fn run_monitor_check_writes_available_for_unmentioned_manifest_account() {
         // Regression test for issue #4645: a manifest account the monitor DB
         // never mentions (e.g. freshly bootstrapped/never-used) must serialize
@@ -872,7 +879,9 @@ mod tests {
         assert_eq!(b.reset_5h, None);
     }
 
+    // Serialized against its sibling above for the same reason.
     #[test]
+    #[serial]
     fn run_monitor_check_reports_and_writes_the_binding_reset() {
         // End-to-end for the monitor backend (issue #4874): the CLI table
         // (`ProbeReport`) and the written `.ranking` must BOTH carry the reset,


### PR DESCRIPTION
## Summary

`cargo test -p loom-daemon --lib` was flaky under the default parallel test threads: `observability::backfill::tests::default_backfill_state_path_is_under_loom_logs` was not `#[serial]` while its module siblings mutate the process-wide `LOOM_OBSERVABILITY_BACKFILL_STATE_PATH` env var under `#[serial]`. Since `#[serial]` only serializes against other `#[serial]` tests, the non-serial reader could run concurrently with a serial sibling and observe its leaked override.

## Fix

Applied the minimal fix (option 1 from the issue): mark the affected test `#[serial]`, matching the module's existing convention.

Per the issue's AC, I also did a repo-wide scan for the same bug class (a non-`#[serial]` test reading a `LOOM_*` env seam some `#[serial]` sibling sets) and found two more **live** instances, fixed the same way:

- `loom-daemon/src/sweep_outcomes.rs`: `default_outcome_telemetry_path_is_under_loom_logs` races **cross-file** against `observability::backfill`'s `#[serial]` tests, which mutate the same `OUTCOME_TELEMETRY_JOURNAL_PATH_ENV` constant (imported via `sweep_outcomes::OUTCOME_TELEMETRY_JOURNAL_PATH_ENV`). `#[serial]`'s default lock is crate-wide, so this cross-file pairing is real.
- `loom-daemon/src/tokens_pool/monitor.rs`: `run_monitor_check_writes_available_for_unmentioned_manifest_account` and `run_monitor_check_reports_and_writes_the_binding_reset` both mutate `CLAUDE_MONITOR_DIR_VAR` with **neither** marked `#[serial]` — a mutual race between two non-serial tests, not just "non-serial vs serial sibling," but the same underlying hazard.

I audited a broader set of `_ENV` constants shared across many test files (e.g. `workspace_registry::REGISTRY_PATH_ENV`, used unguarded by dozens of tests in `ipc.rs`/`auto_update.rs`/`role_runner.rs`/`safehouse.rs`/`cli/tokens.rs`) and confirmed those are a **pre-existing, much larger** structural pattern — not new, not the shape reported in this issue (a "default path" test racing a sibling that overrides it), and out of scope for this routine fix per the issue's own "scan-and-verify pass, not a rewrite" framing. That pattern deserves its own tracked issue rather than a blind mechanical `#[serial]` sweep here (which would also seriously slow the test suite by serializing a large fraction of it).

## Verification

- `cargo test -p loom-daemon --lib` full suite: 3299 passed, 0 failed.
- Targeted loop (15x) on `observability::backfill`, `sweep_outcomes`, `tokens_pool::monitor` under default parallel threads: all green.
- `cargo fmt -p loom-daemon -- --check`: clean.

Closes #5133