### PR TITLE
feat(daemon): add --prune-stale-entry-points to loom-daemon-update.sh

### DIFF
--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -160,6 +160,7 @@
 #   ./.loom/scripts/cli/loom-daemon-update.sh --auto-resolve-safe-abort  When the ff-only sync would otherwise hard-abort (#4330), auto-perform the fix IF the blocking state classifies as safe (#4951): content-identical diverged commits with an otherwise-CLEAN working tree (`git reset --hard origin/<default-branch>`), or dirty tracked files that are ALL Loom-managed installed copies (`git checkout --` them + re-run resync-installed.sh). Any other cause (genuine content divergence, any unmanaged dirty file, or a dirty tracked file co-existing with the content-identical divergence) still hard-aborts unchanged — this flag never widens what's classified as safe, only whether the safe cases are printed (default) or performed
 #   ./.loom/scripts/cli/loom-daemon-update.sh --fetch        Artifact-fetch mode (Epic #4990 Phase 3, #5020): REQUIRE a verified GitHub Release artifact for this host's platform (resolve latest Release >= installed version, download, verify checksum unconditionally + signature when present, provision) instead of `cargo build --release`; hard-fails (exit 1) rather than silently falling back to a source build when no matching artifact resolves. Same as LOOM_DAEMON_UPDATE_FETCH=1.
 #   ./.loom/scripts/cli/loom-daemon-update.sh --no-fetch      Disable artifact-fetch mode entirely; always use the local source-build path (pre-#5020 behavior). Same as LOOM_DAEMON_UPDATE_FETCH=0.
+#   ./.loom/scripts/cli/loom-daemon-update.sh --prune-stale-entry-points  Remove exactly the PATH entries the stale-entry-point advisory below (#4079/#4557) classifies as a "Python console script (stale pip/pipx editable install)" — a frozen console script left behind by the retired pip/pipx package (epic #4081 Phase 4 / #4557) that never resolves to the current loom-daemon binary and so is never touched by an update again. Conservative by construction: it reuses the SAME classification the advisory already computes, so `loom-daemon` itself and the auto-generated bash-wrapper shims (`loom-clean`/`loom-recover-orphans`/`loom-claim`, #4272/#4275 — including a STALE shim whose target moved) are never candidates, only ever reported. Standalone: performs the prune, reports what it removed, and exits — no build/provision/restart. Idempotent (a second run finds nothing to remove) and reports "nothing to prune" when the PATH is already clean. Honors LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1 (a no-op, matching the check it would otherwise act on) (#5139).
 #   ./.loom/scripts/cli/loom-daemon-update.sh --help
 #
 # Environment:
@@ -282,7 +283,10 @@
 #      untouched), a signature-verification failure on a PRESENT signature
 #      (distinct from "unsigned", which is not an error), and --fetch given
 #      with no matching release artifact resolvable (refuses to silently
-#      fall back to a source build).
+#      fall back to a source build). Also used by --prune-stale-entry-points
+#      (#5139) if any candidate path failed to `rm` (permissions, a race) —
+#      the paths that DID remove successfully are still reported individually
+#      above the error.
 #   3  (--check only) update available
 #   4  build verification FAILED: the freshly-built binary's embedded commit
 #      does not match the source HEAD it was built from. This is a BUILD-SYSTEM
@@ -856,10 +860,26 @@ fetch_and_verify_artifact() {
 # which makes every surviving `loom-*` pip console script pure hazard: nothing
 # regenerates or updates them ever again.
 #
-# This check is a WARNING ONLY. It never deletes anything, never mutates PATH,
-# and never changes this script's exit code — an operator's ~/.local/bin is
-# theirs, and a false positive must not block an update. Opt out entirely with
-# LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1.
+# This check itself is a WARNING ONLY, on every ordinary run. It never deletes
+# anything, never mutates PATH, and never changes this script's exit code — an
+# operator's ~/.local/bin is theirs, and a false positive must not block an
+# update. Opt out entirely with LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1.
+#
+# The warning used to be the end of the story: it fired on every single run,
+# forever, and nothing ever removed what it found (#5139) — an operator had to
+# `rm` each path by hand, and a fresh host doing so once would still get warned
+# again next run if it missed one (observed on loom-worker-1: removing the
+# first batch surfaced two more). `--prune-stale-entry-points` (below) closes
+# that gap: an explicit, opt-in, standalone action that removes EXACTLY the
+# entries this check classifies as a "Python console script (stale pip/pipx
+# editable install)" — reusing the same classification helpers the warning
+# uses (_lde_shim_target / _lde_describe), never reimplementing it. A stale
+# SHIM (an auto-generated loom-clean/loom-recover-orphans/loom-claim wrapper
+# whose sibling loom-daemon moved) is reported by the warning too but is
+# deliberately NOT a prune candidate — it is a legitimate wrapper that needs
+# re-provisioning, not deletion, and this script has no way to tell "moved" from
+# "an operator is mid-migration". `loom-daemon` itself and any allowlisted
+# entry are excluded up front, the same as the warning.
 #
 # A `loom-*` PATH entry is considered LEGITIMATE when it is either:
 #   1. `loom-daemon` itself (the native binary), or
@@ -1014,6 +1034,7 @@ warn_stale_entry_points() {
         warn "was retired (epic #4081 Phase 4, #4557), so nothing regenerates them — they are"
         warn "frozen and will shadow the real binary's entry points (incident #4079)."
         warn "Remove them, e.g.:  rm <path>    (or 'pipx uninstall loom-tools')"
+        warn "Or run:  $(basename "$0") --prune-stale-entry-points   (removes exactly the stale Python console scripts above, #5139)."
         warn "Suppress this check with LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1."
     fi
 
@@ -1029,6 +1050,111 @@ warn_stale_entry_points() {
         warn "Callers resolving 'loom-daemon' by name get ${daemon_hits[0]}. Remove the others"
         warn "or pin LOOM_DAEMON_BIN explicitly."
     fi
+}
+
+# prune_stale_entry_points <resolved_daemon_bin> — remove EXACTLY the PATH
+# entries warn_stale_entry_points() above would classify as "Python console
+# script (stale pip/pipx editable install)" (#5139). Deliberately narrower
+# than the full warning:
+#   - `loom-daemon` itself and any STALE_ENTRY_POINT_ALLOWLIST entry are
+#     excluded up front, same as the warning.
+#   - ANY auto-generated PATH shim (`_lde_shim_target` returns non-empty) is
+#     skipped, whether it currently resolves to the resolved binary or not.
+#     A stale shim (its sibling loom-daemon moved) IS reported by the warning,
+#     but it is a legitimate bash wrapper that needs re-provisioning, not a
+#     frozen Python console script — pruning it would violate the "never
+#     touch the legitimate bash wrappers" guardrail.
+#   - only entries whose classification (`_lde_describe`) is EXACTLY the
+#     Python-console-script string are removed.
+# Idempotent: a second run finds nothing left to remove and reports that.
+# Reports every path removed (and any removal failure, without aborting the
+# rest — a permissions problem on one path should not hide a successful
+# removal of the others). Returns 1 if any `rm` failed, 0 otherwise (including
+# the "nothing to prune" case).
+prune_stale_entry_points() {
+    local resolved="$1"
+    if [[ "${LOOM_SKIP_STALE_ENTRY_POINT_CHECK:-0}" =~ ^(1|true|yes)$ ]]; then
+        echo "LOOM_SKIP_STALE_ENTRY_POINT_CHECK is set — leaving all 'loom-*' PATH entries untouched."
+        return 0
+    fi
+
+    # Not consulted for classification (a shim is skipped outright, whatever
+    # it points at), but kept for parity with warn_stale_entry_points and in
+    # case a future classification wants it.
+    local resolved_real=""
+    [[ -n "$resolved" ]] && resolved_real="$(_lde_realpath "$resolved")"
+
+    # Counter tracked alongside the array — see warn_stale_entry_points'
+    # comment above on why `${#arr[@]}` is unsafe under `set -u` on bash 3.2.
+    local -a to_remove=()
+    local remove_count=0
+    local -a seen_dirs=()
+
+    local oldifs="$IFS"
+    IFS=':'
+    # shellcheck disable=SC2206 # deliberate word-splitting of $PATH on ':'
+    local -a path_dirs=($PATH)
+    IFS="$oldifs"
+
+    local dir
+    for dir in "${path_dirs[@]}"; do
+        [[ -z "$dir" ]] && dir="."
+        [[ -d "$dir" ]] || continue
+        local dir_real seen skip
+        dir_real="$(_lde_realpath "$dir")"
+        skip=false
+        for seen in ${seen_dirs[@]+"${seen_dirs[@]}"}; do
+            [[ "$seen" == "$dir_real" ]] && { skip=true; break; }
+        done
+        [[ "$skip" == "true" ]] && continue
+        seen_dirs+=("$dir_real")
+
+        local entry
+        for entry in "$dir"/loom-*; do
+            [[ -f "$entry" && -x "$entry" ]] || continue
+            local name
+            name="$(basename "$entry")"
+            [[ "$name" == "loom-daemon" ]] && continue
+
+            case " $STALE_ENTRY_POINT_ALLOWLIST " in
+                *" $name "*) continue ;;
+            esac
+
+            # Any shim — current OR stale — is never a prune candidate; only
+            # warn_stale_entry_points reports a stale one, and it is a
+            # legitimate wrapper, not a frozen Python console script.
+            local shim_target
+            shim_target="$(_lde_shim_target "$entry")"
+            [[ -n "$shim_target" ]] && continue
+
+            if [[ "$(_lde_describe "$entry")" == "Python console script (stale pip/pipx editable install)" ]]; then
+                to_remove+=("$entry")
+                remove_count=$((remove_count + 1))
+            fi
+        done
+    done
+
+    if (( remove_count == 0 )); then
+        ok "No stale Python console-script entry points found on PATH — nothing to prune."
+        return 0
+    fi
+
+    echo "Pruning $remove_count stale Python console-script entry point(s):"
+    local path failures=0
+    for path in ${to_remove[@]+"${to_remove[@]}"}; do
+        if rm -f -- "$path" 2>/dev/null; then
+            ok "  removed: $path"
+        else
+            err "  FAILED to remove: $path"
+            failures=$((failures + 1))
+        fi
+    done
+    if (( failures > 0 )); then
+        err "Pruning finished with $failures failure(s) above — check permissions on those paths."
+        return 1
+    fi
+    ok "Pruned $remove_count stale entry point(s). Re-run with --check (or the check on the next update) to confirm the advisory is now silent."
+    return 0
 }
 
 # verify_destination_binary <dest_path> — assert the provisioned binary at
@@ -1116,6 +1242,7 @@ NO_RESTART=false
 RELAUNCH=false
 ALLOW_STALE=false
 AUTO_RESOLVE_SAFE_ABORT=false
+PRUNE_STALE=false
 # FETCH_MODE: auto (default -- prefer a verified release artifact when one
 # resolves, else soft-fall-back to the source build), force (--fetch --
 # require an artifact, hard-fail rather than silently building from source),
@@ -1136,6 +1263,7 @@ while [[ $# -gt 0 ]]; do
         --auto-resolve-safe-abort) AUTO_RESOLVE_SAFE_ABORT=true; shift ;;
         --fetch) FETCH_MODE="force"; shift ;;
         --no-fetch) FETCH_MODE="off"; shift ;;
+        --prune-stale-entry-points) PRUNE_STALE=true; shift ;;
         *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
     esac
 done
@@ -1582,6 +1710,21 @@ if [[ "$FETCH_MODE" != "off" ]]; then
     else
         ARTIFACT_FALLBACK_REASON="$FETCH_RESOLVE_REASON"
         warn "Artifact-fetch: ${ARTIFACT_FALLBACK_REASON} — falling back to the local source-build path."
+    fi
+fi
+
+# ---------- --prune-stale-entry-points: standalone action, then exit (#5139) ----------
+# Deliberately checked BEFORE the advisory below (skipping it, not running it
+# first) — this flag exists precisely so an operator does not have to read the
+# warning and act on it by hand; it performs the prune and reports the result
+# directly. Never builds/provisions/restarts; combining it with other flags on
+# the same invocation is not supported (--check et al. are simply ignored once
+# this fires).
+if [[ "$PRUNE_STALE" == "true" ]]; then
+    if prune_stale_entry_points "$DAEMON_BIN"; then
+        exit 0
+    else
+        exit 1
     fi
 fi
 

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -4527,6 +4527,205 @@ else
 fi
 
 # ============================================================
+# P1-P8. --prune-stale-entry-points (#5139): the stale-entry-point advisory
+#     (tests 45-48 above) detects but never removes anything. This flag
+#     removes EXACTLY what the check classifies as a "Python console script
+#     (stale pip/pipx editable install)" — never `loom-daemon` itself, never
+#     a legitimate bash-wrapper shim (whether current or itself stale).
+#
+#     Fixture PATH holds, across two directories:
+#       PSTALE_BIN_DIR (the resolved binary's own directory):
+#         - loom-daemon      : the resolved binary (must survive)
+#         - loom-clean       : a CURRENT auto-generated shim, sibling
+#                               loom-daemon == resolved (must survive)
+#         - loom-claim       : same shape, a second legitimate wrapper
+#                               (must survive) — the AC's named example
+#         - loom-tokens      : a stale pip console script (must be pruned)
+#         - loom-agent-spawn : a second stale pip console script (pruned)
+#         - loom-search      : a third stale console script (pruned)
+#       POLD_SHIM_DIR (a second PATH entry, simulating a moved install):
+#         - loom-recover-orphans : an auto-generated shim whose sibling
+#                                   loom-daemon does NOT match the resolved
+#                                   binary (a STALE shim) — reported by the
+#                                   warning, but must NEVER be pruned (it is
+#                                   a legitimate wrapper, not a frozen Python
+#                                   script).
+# ============================================================
+WP="$BASE_WORKDIR/w-prune"
+new_fixture "$WP"
+HEADP="$(cd "$WP" && git rev-parse --short HEAD)"
+PSTALE_BIN_DIR="$WP/stale-bin"
+mkdir -p "$PSTALE_BIN_DIR"
+
+# The resolved daemon binary, on PATH.
+write_fake_daemon "$PSTALE_BIN_DIR/loom-daemon" "$HEADP" "$WP/markerP"
+
+# Two legitimate, CURRENT auto-generated PATH shims.
+for _shim in loom-clean loom-claim; do
+    cat > "$PSTALE_BIN_DIR/$_shim" <<SHIM
+#!/usr/bin/env bash
+# Auto-generated PATH shim (issue #4272) — do not edit by hand.
+exec "\$(dirname "\$0")/loom-daemon" ${_shim#loom-} "\$@"
+SHIM
+    chmod +x "$PSTALE_BIN_DIR/$_shim"
+done
+
+# Three stale pip/PATH console scripts of the #4079 shape.
+for _stale in loom-tokens loom-agent-spawn loom-search; do
+    cat > "$PSTALE_BIN_DIR/$_stale" <<STALEPY
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+import sys
+sys.exit(0)
+STALEPY
+    chmod +x "$PSTALE_BIN_DIR/$_stale"
+done
+
+# A second PATH directory holding a STALE (moved-target) legitimate shim: its
+# sibling loom-daemon exists but is NOT the resolved binary.
+POLD_SHIM_DIR="$WP/old-install"
+mkdir -p "$POLD_SHIM_DIR"
+write_fake_daemon "$POLD_SHIM_DIR/loom-daemon" "oldc0mm" "$WP/markerP-old"
+cat > "$POLD_SHIM_DIR/loom-recover-orphans" <<'SHIM'
+#!/usr/bin/env bash
+# Auto-generated PATH shim (issue #4272) — do not edit by hand.
+exec "$(dirname "$0")/loom-daemon" recover-orphans "$@"
+SHIM
+chmod +x "$POLD_SHIM_DIR/loom-recover-orphans"
+
+PRUNE_PATH="$PSTALE_BIN_DIR:$POLD_SHIM_DIR:$TEST_PATH"
+
+# P1. First run: the 3 stale Python scripts are reported as removed.
+outP1=$( cd "$WP" && PATH="$PRUNE_PATH" \
+    LOOM_DAEMON_BIN="$PSTALE_BIN_DIR/loom-daemon" \
+    bash "$UPDATE_SCRIPT" --prune-stale-entry-points 2>&1; echo "EXIT=$?" )
+rcP1=$(echo "$outP1" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcP1" "prune: successful prune exits 0"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outP1" | grep -q "removed: $PSTALE_BIN_DIR/loom-tokens" \
+   && echo "$outP1" | grep -q "removed: $PSTALE_BIN_DIR/loom-agent-spawn" \
+   && echo "$outP1" | grep -q "removed: $PSTALE_BIN_DIR/loom-search"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} prune: all 3 stale Python console scripts are reported removed (#5139)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} prune: all 3 stale Python console scripts are reported removed (#5139)"
+    echo "  output: $outP1"
+fi
+
+# P2. The 3 stale scripts are actually gone from disk.
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -e "$PSTALE_BIN_DIR/loom-tokens" && ! -e "$PSTALE_BIN_DIR/loom-agent-spawn" \
+      && ! -e "$PSTALE_BIN_DIR/loom-search" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} prune: the stale Python console scripts are actually deleted from disk"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} prune: the stale Python console scripts are actually deleted from disk"
+fi
+
+# P3. loom-daemon itself is never touched.
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -x "$PSTALE_BIN_DIR/loom-daemon" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} prune: loom-daemon itself is never removed"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} prune: loom-daemon itself is never removed"
+fi
+
+# P4. The two CURRENT legitimate bash-wrapper shims (loom-clean, loom-claim)
+#     are never touched — the exact "never touch the legitimate bash wrapper"
+#     guardrail named in the issue.
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -x "$PSTALE_BIN_DIR/loom-clean" && -x "$PSTALE_BIN_DIR/loom-claim" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} prune: current legitimate bash-wrapper shims (loom-clean, loom-claim) survive"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} prune: current legitimate bash-wrapper shims (loom-clean, loom-claim) survive"
+fi
+
+# P5. The STALE bash-wrapper shim (loom-recover-orphans, target moved) is
+#     reported by the warning but survives the prune untouched — the whole
+#     point of excluding ANY shim (current or stale) from pruning.
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -x "$POLD_SHIM_DIR/loom-recover-orphans" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} prune: a STALE bash-wrapper shim (moved target) is reported but never deleted"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} prune: a STALE bash-wrapper shim (moved target) is reported but never deleted"
+fi
+
+# P6. Idempotent: running it again finds nothing left to prune.
+outP6=$( cd "$WP" && PATH="$PRUNE_PATH" \
+    LOOM_DAEMON_BIN="$PSTALE_BIN_DIR/loom-daemon" \
+    bash "$UPDATE_SCRIPT" --prune-stale-entry-points 2>&1; echo "EXIT=$?" )
+rcP6=$(echo "$outP6" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcP6" "prune: second run (idempotent) exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$outP6" | grep -q 'nothing to prune'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} prune: second run is a no-op (idempotent, #5139)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} prune: second run is a no-op (idempotent, #5139)"
+    echo "  output: $outP6"
+fi
+
+# P7. After pruning, re-running the ordinary update (--check) emits NO stale
+#     Python-console-script warning any more — the stale shim (a DIFFERENT
+#     hazard class, deliberately left in place by design) may still surface
+#     its own warning, so this asserts on the Python-script paths specifically
+#     rather than "no warning at all".
+outP7=$( cd "$WP" && PATH="$PRUNE_PATH" \
+    LOOM_DAEMON_BIN="$PSTALE_BIN_DIR/loom-daemon" \
+    bash "$UPDATE_SCRIPT" --check 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! echo "$outP7" | grep -q "$PSTALE_BIN_DIR/loom-tokens" \
+   && ! echo "$outP7" | grep -q "$PSTALE_BIN_DIR/loom-agent-spawn" \
+   && ! echo "$outP7" | grep -q "$PSTALE_BIN_DIR/loom-search"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} prune: converges — a later --check no longer warns about the pruned paths (#5139)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} prune: converges — a later --check no longer warns about the pruned paths (#5139)"
+    echo "  output: $outP7"
+fi
+
+# P8. LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1 keeps --prune-stale-entry-points a
+#     no-op too (mirrors test 48's guarantee for the warning itself).
+WP8="$BASE_WORKDIR/w-prune-skip"
+new_fixture "$WP8"
+HEADP8="$(cd "$WP8" && git rev-parse --short HEAD)"
+PSTALE_BIN_DIR8="$WP8/stale-bin"
+mkdir -p "$PSTALE_BIN_DIR8"
+write_fake_daemon "$PSTALE_BIN_DIR8/loom-daemon" "$HEADP8" "$WP8/markerP8"
+cat > "$PSTALE_BIN_DIR8/loom-tokens" <<'STALEPY'
+#!/usr/bin/python3
+import sys
+sys.exit(0)
+STALEPY
+chmod +x "$PSTALE_BIN_DIR8/loom-tokens"
+
+outP8=$( cd "$WP8" && PATH="$PSTALE_BIN_DIR8:$TEST_PATH" \
+    LOOM_DAEMON_BIN="$PSTALE_BIN_DIR8/loom-daemon" \
+    LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1 \
+    bash "$UPDATE_SCRIPT" --prune-stale-entry-points 2>&1; echo "EXIT=$?" )
+rcP8=$(echo "$outP8" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rcP8" "prune: LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1 still exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -e "$PSTALE_BIN_DIR8/loom-tokens" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} prune: LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1 leaves stale entries untouched"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} prune: LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1 leaves stale entries untouched"
+fi
+
+# ============================================================
 # 25. Launchd-sandbox guards (#4078): the whole suite exercises the REAL
 #     start/stop scripts, so prove it never reached the operator's live daemon.
 #     (a) The suite-level decoy loom-daemon is still alive — no by-name kill


### PR DESCRIPTION
## Summary

`loom-daemon-update.sh` has warned about stale `loom-*` PATH entry points
(frozen Python console scripts from the retired pip/pipx package, epic
#4081 Phase 4 / #4557) on every run, forever, but never removed them —
observed as 8 leftover entries on robb-studio and 18+ on loom-worker-1
(#5139).

This adds an opt-in `--prune-stale-entry-points` flag that removes exactly
what the existing advisory already classifies as a stale Python console
script, and nothing else.

- Reuses the existing classification helpers (`_lde_shim_target`,
  `_lde_describe`) verbatim rather than reimplementing the detection logic —
  the same PATH scan, the same "Python console script (stale pip/pipx
  editable install)" string comparison the warning already prints.
- Conservative by construction: `loom-daemon` itself, any
  `STALE_ENTRY_POINT_ALLOWLIST` entry, and **any** auto-generated bash-wrapper
  shim (`loom-clean`/`loom-recover-orphans`/`loom-claim`) — whether it
  currently resolves to the resolved binary or is itself stale (its sibling
  `loom-daemon` moved) — are never prune candidates, only ever reported by
  the existing warning.
- Idempotent: a second run reports "nothing to prune"; a subsequent
  `--check` no longer warns about the removed paths.
- Reports every path removed (and any removal failure individually, exit 1
  on any `rm` failure without hiding the successes).
- Honors `LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1` as a no-op, matching the
  advisory it would otherwise act on.

## Test plan

- [x] `bash defaults/scripts/tests/test-loom-daemon-update.sh` — 231/231
      passing, including 10 new scenarios (P1-P8) covering: stale Python
      scripts removed + reported, `loom-daemon` untouched, current AND
      stale legitimate bash-wrapper shims untouched, idempotency, warning
      convergence after pruning, and `LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1`.
- [x] `shellcheck -x` clean on both modified files (no new findings).
- [x] `bash -n` syntax check on both modified files.

Closes #5139

🤖 Generated with [Claude Code](https://claude.com/claude-code)
