### PR TITLE
feat(daemon): thread --drain through loom-daemon-update.sh, drain-by-default on systemd

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -5150,15 +5150,42 @@ manually rebuilt the Rust binary, reprovisioned it, and restarted the process.
 `loom-daemon-update.sh` is the single operator command that closes that gap:
 
 ```bash
-./.loom/scripts/cli/loom-daemon-update.sh              # detect, rebuild if stale, provision, restart (preserving flags)
+./.loom/scripts/cli/loom-daemon-update.sh              # detect, rebuild if stale, provision, restart (preserving flags) -- DRAINS FIRST on systemd (see below)
 ./.loom/scripts/cli/loom-daemon-update.sh --check       # detect only; exit 0 (up to date) / 3 (update available); no writes
 ./.loom/scripts/cli/loom-daemon-update.sh --dry-run     # print the plan without building/provisioning/restarting
 ./.loom/scripts/cli/loom-daemon-update.sh --force       # rebuild + provision + restart even if already up to date
 ./.loom/scripts/cli/loom-daemon-update.sh --no-restart  # rebuild + provision only; leave the running daemon untouched
-./.loom/scripts/cli/loom-daemon-update.sh --relaunch    # launchd only: after a refused restart, re-render the plist + relaunch under supervision (preserves the live plist's LOOM_* env)
+./.loom/scripts/cli/loom-daemon-update.sh --relaunch    # launchd/systemd only: after a refused restart, re-render the plist/unit + relaunch under supervision (preserves the live LOOM_* env)
+./.loom/scripts/cli/loom-daemon-update.sh --drain       # launchd/systemd, Issue #5138: build+provision+restart via `restart --drain` in ONE invocation, no manual second step -- see below
+./.loom/scripts/cli/loom-daemon-update.sh --timeout SECS --force-after-timeout  # passthrough to `restart --drain` (only meaningful with an active drain)
+./.loom/scripts/cli/loom-daemon-update.sh --restart-now # systemd only, Issue #5138: opt OUT of the drain-by-default below, restart immediately
 ./.loom/scripts/cli/loom-daemon-update.sh --fetch        # REQUIRE a verified release artifact (never silently fall back to a source build); exit 1 if none resolves
 ./.loom/scripts/cli/loom-daemon-update.sh --no-fetch     # never consider release artifacts; always build from local source (pre-#5020 behavior)
 ```
+
+**One-shot drain roll (Issue #5138).** Before this, a drained roll needed the
+documented two-step dance — `loom-daemon-update.sh --no-restart` followed by a
+separate hand-run `loom-daemon restart --drain` — because the update script only
+ever invoked a plain, immediate `restart`. `--drain` (with `--timeout SECS` /
+`--force-after-timeout` passthrough) collapses that into the single invocation
+above: build, provision, and restart via the exact `restart --drain` primitive
+described in "Scheduled drain-and-restart" above, all from one command. **On
+systemd, drain is now the DEFAULT** (no flag needed) — an immediate restart there
+is destructive, not merely lossy: sweep/role children live in the unit's cgroup,
+so a plain restart's stop job can SIGKILL them past `TimeoutStopSec`, landing the
+unit in `failed` with `Restart=on-success` never firing (#5119) — a real outage.
+`--restart-now` opts back into the immediate/non-drained restart for an operator
+who has confirmed nothing is in flight. Launchd's own default is unchanged
+(immediate restart, `--drain` opts in) since the launchd failure mode is "only"
+lossy telemetry (#5084: an adopted-across-restart sweep never exports
+`sweep.completed`/`sweep.outcome`), not a stop-job outage. The fail-safe is
+preserved exactly as `restart --drain` implements it: a drain that cannot finish
+within its timeout (default/`--timeout`) leaves the **pre-update binary running**
+rather than cancelling in-flight sweeps — the script reports this as exit `8`
+(distinct from exit `7`'s "restart never took effect" failure), not a silent
+success. The `--no-restart` + manual `restart --drain` two-step from before still
+works unchanged, for a caller that wants the build/provision and restart steps
+kept apart.
 
 #### Artifact-based self-update (epic #4990 Phase 3, #5020)
 

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -156,6 +156,10 @@
 #   ./.loom/scripts/cli/loom-daemon-update.sh --force       Rebuild + provision + restart even if already up to date
 #   ./.loom/scripts/cli/loom-daemon-update.sh --no-restart  Rebuild + provision only; leave the running daemon untouched
 #   ./.loom/scripts/cli/loom-daemon-update.sh --relaunch    Launchd/systemd only: after a refused restart, re-render the plist/unit and relaunch under supervision (SIGTERMs the daemon so sweep children reparent; preserves the live LOOM_* env)
+#   ./.loom/scripts/cli/loom-daemon-update.sh --drain        Launchd/systemd only (Issue #5138): restart via the existing `loom-daemon restart --drain` primitive (#4090) instead of an immediate restart — pauses dispatch, waits for every in-flight sweep to finish (so sweep.completed/sweep.outcome telemetry is never lost, #5084), THEN relaunches. On systemd this is now the DEFAULT (see below) because an immediate restart there is actively destructive (#5119), not merely lossy — this flag is for opting IN on launchd, or for being explicit on systemd. A drain that cannot finish within its timeout leaves the CURRENT (pre-update) binary running rather than cancelling sweeps (fail-safe, unchanged from #4090) and this script says so clearly (exit 8). Same as LOOM_DAEMON_UPDATE_DRAIN=1. Combine with the single-invocation roll this issue closes: build + provision + drain-restart in one command, no more manual `--no-restart` then `loom-daemon restart --drain` two-step (that workaround still works unchanged, see --no-restart above).
+#   ./.loom/scripts/cli/loom-daemon-update.sh --timeout SECS Passthrough to `loom-daemon restart --drain --timeout SECS` (only meaningful with an active drain, explicit or systemd-default): max seconds to wait for in-flight sweeps before the fail-safe refuses the restart (daemon default: tens of minutes, currently 1800s). Ignored (with no error) when no drain is active.
+#   ./.loom/scripts/cli/loom-daemon-update.sh --force-after-timeout  Passthrough to `loom-daemon restart --drain --force-after-timeout` (only meaningful with an active drain): on a drain timeout, cancel the remaining in-flight sweep(s) and restart anyway instead of refusing. Without this, a drain timeout keeps the daemon running its PRE-update binary (the fail-safe) and this script exits 8. Ignored (with no error) when no drain is active.
+#   ./.loom/scripts/cli/loom-daemon-update.sh --restart-now   Systemd only (Issue #5138): opt OUT of the systemd drain-by-default behavior above and restart IMMEDIATELY (the pre-#5138 behavior on every supervisor) — for an operator who has confirmed nothing is in flight and wants the roll to finish as fast as possible. Mutually exclusive with --drain (exit 1 if both are given). No effect on launchd (already the default there) or the bare pid-file/nohup path (which never speaks the drain primitive at all).
 #   ./.loom/scripts/cli/loom-daemon-update.sh --allow-stale Skip the default ff-first sync with origin/<default-branch> and build the current (possibly stale) checkout as-is (#4330) — for deliberate use: bisecting, testing a local patch
 #   ./.loom/scripts/cli/loom-daemon-update.sh --auto-resolve-safe-abort  When the ff-only sync would otherwise hard-abort (#4330), auto-perform the fix IF the blocking state classifies as safe (#4951): content-identical diverged commits with an otherwise-CLEAN working tree (`git reset --hard origin/<default-branch>`), or dirty tracked files that are ALL Loom-managed installed copies (`git checkout --` them + re-run resync-installed.sh). Any other cause (genuine content divergence, any unmanaged dirty file, or a dirty tracked file co-existing with the content-identical divergence) still hard-aborts unchanged — this flag never widens what's classified as safe, only whether the safe cases are printed (default) or performed
 #   ./.loom/scripts/cli/loom-daemon-update.sh --fetch        Artifact-fetch mode (Epic #4990 Phase 3, #5020): REQUIRE a verified GitHub Release artifact for this host's platform (resolve latest Release >= installed version, download, verify checksum unconditionally + signature when present, provision) instead of `cargo build --release`; hard-fails (exit 1) rather than silently falling back to a source build when no matching artifact resolves. Same as LOOM_DAEMON_UPDATE_FETCH=1.
@@ -231,6 +235,29 @@
 #   LOOM_DAEMON_UPDATE_RELAUNCH  Launchd/systemd only: 1/true/yes is equivalent to
 #                          passing --relaunch (opt in to the re-render + relaunch
 #                          on a refused restart).
+#   LOOM_DAEMON_UPDATE_DRAIN  Launchd/systemd only (Issue #5138): 1/true/yes is
+#                          equivalent to passing --drain. Has no effect on
+#                          systemd's own default (already drained unless
+#                          --restart-now/LOOM_DAEMON_UPDATE_RESTART_NOW is given) —
+#                          it exists mainly to opt IN on launchd, or in a script
+#                          that wants to be explicit.
+#   LOOM_DAEMON_UPDATE_RESTART_NOW  Systemd only (Issue #5138): 1/true/yes is
+#                          equivalent to passing --restart-now (opt OUT of the
+#                          systemd drain-by-default and restart immediately).
+#   LOOM_DAEMON_DRAIN_POLL_SECS  Seconds this script polls for the supervisor to
+#                          relaunch a NEW, live pid after a drain-mode restart is
+#                          accepted (#5138), before treating it as either the
+#                          fail-safe (no --force-after-timeout: leaves the
+#                          pre-update binary running, exit 8) or an unconfirmed
+#                          failure (--force-after-timeout: falls through to the
+#                          same self-heal fallback a plain restart uses).
+#                          Default: the drain's own --timeout (or the daemon's
+#                          built-in default, 1800s) plus a 60s grace buffer —
+#                          long enough that a real drain is never mistaken for a
+#                          hang. If LOOM_DAEMON_RESTART_POLL_SECS (below) is ALSO
+#                          set, it wins over this default (drain or not) — an
+#                          explicit poll-window override always takes
+#                          precedence over either default.
 #   LOOM_MACHINE_CHECKOUT  Machine mode (Epic #3835 Phase 3b, #4229): set by the
 #                          `scripts/loom` dispatcher to the resolved
 #                          ~/.local/share/loom checkout before it execs this
@@ -324,7 +351,22 @@
 #      fresh binary IS provisioned, but the daemon's live status
 #      is NOT confirmed — this is the "restart scheduled but the supervisor
 #      silently never relaunched" outage class these issues close; the script
-#      refuses to report success on the ack alone.
+#      refuses to report success on the ack alone. A drain-mode restart
+#      (--drain, or the systemd default, #5138) reaches this code ONLY when
+#      --force-after-timeout was also given and the forced restart still never
+#      took effect — see exit 8 for the (expected, not a failure) case where a
+#      drain timed out WITHOUT --force-after-timeout.
+#   8  drain fail-safe preserved (Issue #5138, launchd/systemd only): a
+#      drain-mode restart (--drain, or the systemd default) timed out WITHOUT
+#      --force-after-timeout, and the daemon's own fail-safe (#4090) held:
+#      dispatch resumed, no in-flight sweep was cancelled or killed, and
+#      loom-daemon is STILL RUNNING its PRE-update binary (pid unchanged from
+#      before the restart request). This is NOT a failure — it is the drain
+#      primitive refusing to choose between "cancel work" and "restart" on the
+#      operator's behalf, exactly as designed. The freshly-built/provisioned
+#      binary IS staged at the resolved destination; it just was not activated
+#      this run. Re-run once the in-flight sweep(s) finish, or re-run with
+#      --force-after-timeout to force the roll through immediately.
 #
 # See also: loom-daemon-start.sh (writes .loom/.daemon.flags), loom-daemon-stop.sh
 # (SIGTERM -> grace -> SIGKILL; in-flight sweeps survive by design — this
@@ -1243,12 +1285,20 @@ RELAUNCH=false
 ALLOW_STALE=false
 AUTO_RESOLVE_SAFE_ABORT=false
 PRUNE_STALE=false
+# Drain-mode restart passthrough (Issue #5138) -- see build_restart_invoke_args
+# below for how these thread into `loom-daemon restart --drain ...`.
+DRAIN=false
+DRAIN_TIMEOUT=""
+FORCE_AFTER_TIMEOUT=false
+RESTART_NOW=false
 # FETCH_MODE: auto (default -- prefer a verified release artifact when one
 # resolves, else soft-fall-back to the source build), force (--fetch --
 # require an artifact, hard-fail rather than silently building from source),
 # or off (--no-fetch -- always build from source, the pre-#5020 behavior).
 FETCH_MODE="auto"
 [[ "${LOOM_DAEMON_UPDATE_RELAUNCH:-}" =~ ^(1|true|yes)$ ]] && RELAUNCH=true
+[[ "${LOOM_DAEMON_UPDATE_DRAIN:-}" =~ ^(1|true|yes)$ ]] && DRAIN=true
+[[ "${LOOM_DAEMON_UPDATE_RESTART_NOW:-}" =~ ^(1|true|yes)$ ]] && RESTART_NOW=true
 [[ "${LOOM_DAEMON_UPDATE_FETCH:-}" =~ ^(0|false|no)$ ]] && FETCH_MODE="off"
 [[ "${LOOM_DAEMON_UPDATE_FETCH:-}" =~ ^(1|true|yes)$ ]] && FETCH_MODE="force"
 while [[ $# -gt 0 ]]; do
@@ -1259,6 +1309,12 @@ while [[ $# -gt 0 ]]; do
         --check) CHECK_ONLY=true; shift ;;
         --no-restart) NO_RESTART=true; shift ;;
         --relaunch) RELAUNCH=true; shift ;;
+        --drain) DRAIN=true; shift ;;
+        --timeout)
+            [[ $# -ge 2 && "$2" =~ ^[0-9]+$ ]] || { err "--timeout requires a numeric SECS argument"; exit 1; }
+            DRAIN_TIMEOUT="$2"; shift 2 ;;
+        --force-after-timeout) FORCE_AFTER_TIMEOUT=true; shift ;;
+        --restart-now) RESTART_NOW=true; shift ;;
         --allow-stale) ALLOW_STALE=true; shift ;;
         --auto-resolve-safe-abort) AUTO_RESOLVE_SAFE_ABORT=true; shift ;;
         --fetch) FETCH_MODE="force"; shift ;;
@@ -1267,6 +1323,11 @@ while [[ $# -gt 0 ]]; do
         *) err "Unknown option '$1'"; echo "Use --help for usage" >&2; exit 1 ;;
     esac
 done
+
+if [[ "$DRAIN" == "true" && "$RESTART_NOW" == "true" ]]; then
+    err "--drain and --restart-now are mutually exclusive (drain vs. immediate restart)."
+    exit 1
+fi
 
 REPO_ROOT=$(find_repo_root)
 
@@ -2049,6 +2110,25 @@ log_systemd_diagnostics() {
     done < <(systemctl --user status "$SYSTEMD_UNIT" --no-pager --full 2>&1)
 }
 
+# ---------- drain-restart flag passthrough (Issue #5138) ----------
+# build_restart_invoke_args -- populate the global RESTART_INVOKE_ARGS array
+# with the `restart` subcommand plus the drain passthrough flags (--drain,
+# --timeout, --force-after-timeout), shared by the launchd and systemd
+# supervised-restart branches below. All drain SEMANTICS (pause dispatch,
+# wait for in-flight sweeps, fail-safe refusal on timeout) already live in
+# `loom-daemon restart --drain` (#4090) -- this script only decides WHETHER to
+# pass --drain (see the DRAIN default-selection block near DAEMON_MANAGER
+# resolution below) and threads the operator's own --timeout/
+# --force-after-timeout straight through, unchanged.
+build_restart_invoke_args() {
+    RESTART_INVOKE_ARGS=(restart)
+    if [[ "$DRAIN" == "true" ]]; then
+        RESTART_INVOKE_ARGS+=(--drain)
+        [[ -n "$DRAIN_TIMEOUT" ]] && RESTART_INVOKE_ARGS+=(--timeout "$DRAIN_TIMEOUT")
+        [[ "$FORCE_AFTER_TIMEOUT" == "true" ]] && RESTART_INVOKE_ARGS+=(--force-after-timeout)
+    fi
+}
+
 # ---------- re-render + relaunch on a refused restart (#4118) ----------
 # The exit-6 fallback USED to tell the operator to `launchctl bootstrap` the
 # EXISTING plist. That plist is stale by construction (it is the pre-#4077 file
@@ -2221,6 +2301,42 @@ describe_manager() {
     esac
 }
 
+# ---------- drain-restart default selection (Issue #5138) ----------
+# On systemd an IMMEDIATE (non-drained) restart is actively destructive
+# (#5119): the daemon exits 0, but its role-run/sweep children remain in the
+# unit's cgroup, so the stop job can sit in `deactivating` past
+# TimeoutStopSec while systemd SIGKILLs them, landing the unit in `failed`
+# with `Restart=on-success` never firing — a real outage, not merely lossy
+# telemetry. So DRAIN now defaults to true on systemd unless the operator
+# opts out with --restart-now. On launchd/pidfile an immediate restart is
+# "only" lossy (#5084: sweeps adopted across the restart never export
+# sweep.completed/sweep.outcome telemetry), so the pre-#5138 default
+# (immediate restart) is unchanged there — --drain opts IN explicitly.
+DRAIN_DEFAULTED=false
+if [[ "$RESTART_NOW" != "true" && "$DRAIN" != "true" && "$DAEMON_MANAGER" == "systemd" ]]; then
+    DRAIN=true
+    DRAIN_DEFAULTED=true
+fi
+
+# --drain (explicit or the systemd default above) only has an effect through
+# the launchd/systemd supervised `restart` IPC path below — the bare
+# pid-file/nohup branch stops+starts directly and never speaks it. Warn
+# (never fail) so an operator who passed --drain on an unsupervised host
+# isn't left wondering why nothing drained.
+if [[ "$DRAIN" == "true" && "$DAEMON_MANAGER" != "launchd" && "$DAEMON_MANAGER" != "systemd" ]]; then
+    warn "--drain (or LOOM_DAEMON_UPDATE_DRAIN=1) was given, but loom-daemon is not launchd- or systemd-managed — there is no supervisor to relaunch it, so drain mode has no effect here. Proceeding with the ordinary stop+start restart."
+fi
+
+# Poll window for a drain-mode restart to actually relaunch (#5138): a drain
+# can legitimately take up to its own --timeout (daemon default 1800s) before
+# it either relaunches or hits the fail-safe, so the fast ~30s
+# LOOM_DAEMON_RESTART_POLL_SECS default used for an immediate restart would
+# false-negative on every real drain. Mirrors fleet/drain.rs's own
+# WAIT_EXIT_GRACE_SECS=60 pattern for the same class of wait.
+if [[ "$DRAIN" == "true" ]]; then
+    DRAIN_POLL_SECS="${LOOM_DAEMON_DRAIN_POLL_SECS:-$(( ${DRAIN_TIMEOUT:-1800} + 60 ))}"
+fi
+
 # ---------- --check: report only, no writes ----------
 if [[ "$CHECK_ONLY" == "true" ]]; then
     describe_manager
@@ -2300,12 +2416,25 @@ if [[ "$DRY_RUN" == "true" ]]; then
         echo "[dry-run] Would run: (cd $DAEMON_DIR && cargo build --release)"
     fi
     echo "[dry-run] Would provision the fresh binary to: $PROVISION_TARGET"
+    build_restart_invoke_args
     if [[ "$NO_RESTART" == "true" ]]; then
         echo "[dry-run] --no-restart given: would leave the running daemon (if any) untouched."
     elif [[ "$DAEMON_MANAGER" == "launchd" ]]; then
-        echo "[dry-run] loom-daemon is launchd-managed (label ${LAUNCHD_LABEL}) — would restart via '$PROVISION_TARGET restart' (the #4077 supervised primitive); .daemon.flags is NOT consulted (the plist's EnvironmentVariables carries the equivalent config)."
+        if [[ "$DRAIN" == "true" ]]; then
+            echo "[dry-run] loom-daemon is launchd-managed (label ${LAUNCHD_LABEL}) — would restart via '$PROVISION_TARGET ${RESTART_INVOKE_ARGS[*]}' (Issue #5138, the #4090 drain primitive): pauses dispatch, waits for in-flight sweeps to finish (preserving sweep.completed/sweep.outcome telemetry, #5084), THEN relaunches. A drain timeout without --force-after-timeout leaves the pre-update binary running (fail-safe, exit 8) instead of cancelling sweeps."
+        else
+            echo "[dry-run] loom-daemon is launchd-managed (label ${LAUNCHD_LABEL}) — would restart via '$PROVISION_TARGET restart' (the #4077 supervised primitive); .daemon.flags is NOT consulted (the plist's EnvironmentVariables carries the equivalent config)."
+        fi
     elif [[ "$DAEMON_MANAGER" == "systemd" ]]; then
-        echo "[dry-run] loom-daemon is systemd-managed (unit ${SYSTEMD_UNIT}) — would restart via '$PROVISION_TARGET restart' (the #4267 supervised primitive); .daemon.flags is NOT consulted (the unit's Environment= lines carry the equivalent config)."
+        if [[ "$DRAIN" == "true" ]]; then
+            if [[ "$DRAIN_DEFAULTED" == "true" ]]; then
+                echo "[dry-run] loom-daemon is systemd-managed (unit ${SYSTEMD_UNIT}) — would restart via '$PROVISION_TARGET ${RESTART_INVOKE_ARGS[*]}', the systemd DEFAULT since Issue #5138 (an immediate restart there can kill in-flight sweeps and land the unit in 'failed', #5119): pauses dispatch, waits for in-flight sweeps to finish, THEN relaunches. Pass --restart-now to opt back into an immediate (non-drained) restart."
+            else
+                echo "[dry-run] loom-daemon is systemd-managed (unit ${SYSTEMD_UNIT}) — would restart via '$PROVISION_TARGET ${RESTART_INVOKE_ARGS[*]}' (Issue #5138, the #4090 drain primitive): pauses dispatch, waits for in-flight sweeps to finish, THEN relaunches. A drain timeout without --force-after-timeout leaves the pre-update binary running (fail-safe, exit 8) instead of cancelling sweeps."
+            fi
+        else
+            echo "[dry-run] loom-daemon is systemd-managed (unit ${SYSTEMD_UNIT}) — --restart-now given: would restart IMMEDIATELY (non-drained) via '$PROVISION_TARGET restart', which can kill in-flight sweeps and land the unit in 'failed' if any are running (#5119)."
+        fi
     elif [[ "$WAS_RUNNING" == "true" ]]; then
         echo "[dry-run] Would stop + restart loom-daemon with flags from ${FLAGS_SOURCE}: ${RESTART_ARGS[*]:-<none>}"
     else
@@ -2504,12 +2633,16 @@ if [[ "$NO_RESTART" == "true" ]]; then
         if [[ "$DAEMON_MANAGER" == "launchd" ]]; then
             echo "The running (launchd-managed) daemon is still the PRE-update binary. Restart it with:"
             echo "  $PROVISION_TARGET restart      (graceful: supervised in-place relaunch, in-flight sweeps preserved)"
+            echo "  $PROVISION_TARGET restart --drain   (Issue #5138: pauses dispatch, waits for in-flight sweeps to finish first — no sweep.completed/sweep.outcome telemetry gap, #5084)"
+            echo "(this two-step --no-restart + manual restart is equivalent to a single 'loom-daemon-update.sh --drain' invocation, which builds + provisions + drain-restarts in one command)"
             echo "If that binary predates #4077 and refuses the restart, re-render + relaunch under supervision:"
             echo "  loom-daemon-update.sh --relaunch   (preserves the live plist's LOOM_* env; SIGTERMs the daemon so sweep children reparent)"
             echo "'launchctl bootout $LAUNCHD_SERVICE' no longer kills in-flight sweeps on a current build (#5081 — each sweep runs in its own process group and reparents to pid 1), but a hand-run bootout+bootstrap can still race and leave the daemon down (bootout is asynchronous); prefer --relaunch above, which settles/retries/verifies the relaunch safely."
         elif [[ "$DAEMON_MANAGER" == "systemd" ]]; then
             echo "The running (systemd-managed) daemon is still the PRE-update binary. Restart it with:"
-            echo "  $PROVISION_TARGET restart      (graceful: supervised in-place relaunch, in-flight sweeps preserved)"
+            echo "  $PROVISION_TARGET restart --drain   (RECOMMENDED, Issue #5138: pauses dispatch, waits for in-flight sweeps to finish, THEN relaunches — an immediate restart here can kill sweeps and land the unit in 'failed', #5119)"
+            echo "  $PROVISION_TARGET restart      (immediate/non-drained — only if you have confirmed nothing is in flight)"
+            echo "(this two-step --no-restart + manual restart is equivalent to a single 'loom-daemon-update.sh --drain' invocation, which builds + provisions + drain-restarts in one command — drain is also the DEFAULT on systemd for a plain 'loom-daemon-update.sh' run, no flag needed)"
             echo "If that binary predates #4267 and refuses the restart, re-render + relaunch under supervision:"
             echo "  loom-daemon-update.sh --relaunch   (preserves the live unit's LOOM_* env; SIGTERMs the daemon so sweep children reparent)"
             echo "Do NOT 'systemctl --user stop $SYSTEMD_UNIT' by hand — stop tears down the whole cgroup and KILLS in-flight sweeps (they are direct children of the unit)."
@@ -2537,29 +2670,67 @@ fi
 # relaunches it onto the freshly-provisioned binary with the plist's config.
 if [[ "$DAEMON_MANAGER" == "launchd" ]]; then
     echo "loom-daemon is launchd-managed (label ${LAUNCHD_LABEL})."
-    echo "Restarting via the supervised restart primitive: $PROVISION_TARGET restart"
+    build_restart_invoke_args
+    if [[ "$DRAIN" == "true" ]]; then
+        echo "Restarting via the supervised DRAIN restart primitive: $PROVISION_TARGET ${RESTART_INVOKE_ARGS[*]} (Issue #5138 / #4090) — pausing dispatch, waiting for in-flight sweeps to finish (preserving sweep.completed/sweep.outcome telemetry, #5084), then relaunching."
+    else
+        echo "Restarting via the supervised restart primitive: $PROVISION_TARGET restart"
+    fi
     echo "(.daemon.flags is NOT consulted — the plist's EnvironmentVariables carries the equivalent config.)"
 
     # Capture the pre-restart pid BEFORE the request so the poll below can tell
     # "launchd relaunched onto a new pid" apart from "the same job never moved".
     PRE_RESTART_PID="$(launchd_job_pid)"
 
-    if "$PROVISION_TARGET" restart; then
+    if "$PROVISION_TARGET" "${RESTART_INVOKE_ARGS[@]}"; then
         # The RUNNING (old) binary accepted the request — but that ack is the
         # daemon's promise, not proof launchd actually honored it (#4232: the
         # daemon can exit 0 and launchd can still fail to relaunch it). Verify
         # a NEW, live pid before reporting success; the success message below
         # is intentionally the ONLY "restart scheduled"-style success line in
         # this branch, and it is unreachable until verification passes.
-        RESTART_POLL_SECS="${LOOM_DAEMON_RESTART_POLL_SECS:-30}"
         RESTART_POLL_INTERVAL="${LOOM_DAEMON_RESTART_POLL_INTERVAL:-1}"
         KICKSTART_POLL_SECS="${LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS:-15}"
-        echo "Restart request accepted (pre-restart pid: ${PRE_RESTART_PID:-<none>}). Verifying launchd relaunches onto a NEW, live pid within ${RESTART_POLL_SECS}s before reporting success (#4232)..."
+        RESTART_KIND_NOTE="(#4232)"
+        if [[ -n "${LOOM_DAEMON_RESTART_POLL_SECS:-}" ]]; then
+            # An explicit override always wins, drain or not — an operator (or
+            # test) who asked for a specific poll window gets exactly that.
+            RESTART_POLL_SECS="$LOOM_DAEMON_RESTART_POLL_SECS"
+        elif [[ "$DRAIN" == "true" ]]; then
+            # A drain can legitimately take up to its own --timeout before it
+            # relaunches — the fast #4232 default would false-negative on
+            # every real drain (see the DRAIN_POLL_SECS computation above).
+            RESTART_POLL_SECS="$DRAIN_POLL_SECS"
+            RESTART_KIND_NOTE="(Issue #5138 drain window)"
+        else
+            RESTART_POLL_SECS=30
+        fi
+        echo "Restart request accepted (pre-restart pid: ${PRE_RESTART_PID:-<none>}). Verifying launchd relaunches onto a NEW, live pid within ${RESTART_POLL_SECS}s before reporting success ${RESTART_KIND_NOTE}..."
 
         if NEW_PID="$(wait_for_new_launchd_pid "$PRE_RESTART_PID" "$RESTART_POLL_SECS" "$RESTART_POLL_INTERVAL")"; then
             ok "loom-daemon restart scheduled — launchd relaunched it onto the freshly-provisioned binary (new pid ${NEW_PID}, verified within ${RESTART_POLL_SECS}s)."
             print_final_installed_line "$BUILT_COMMIT"
             exit 0
+        fi
+
+        # #5138: a drain that timed out WITHOUT --force-after-timeout is the
+        # fail-safe working exactly as designed — the daemon refused the
+        # restart and resumed dispatch on its CURRENT (pre-update) binary
+        # rather than cancelling in-flight sweeps. NEVER kickstart in that
+        # case: doing so would force exactly the sweep-cancelling restart the
+        # fail-safe exists to prevent. Detect it by the pid being unchanged
+        # (still alive, still the pre-restart pid) — anything else (pid gone,
+        # or some other unrecognized shape) falls through to the ordinary
+        # self-heal/investigation path below.
+        if [[ "$DRAIN" == "true" && "$FORCE_AFTER_TIMEOUT" != "true" ]]; then
+            CUR_PID_AFTER_DRAIN="$(launchd_job_pid)"
+            if [[ -n "$CUR_PID_AFTER_DRAIN" && "$CUR_PID_AFTER_DRAIN" == "$PRE_RESTART_PID" ]] \
+                && kill -0 "$CUR_PID_AFTER_DRAIN" 2>/dev/null; then
+                warn "Drain timed out after ${RESTART_POLL_SECS}s without --force-after-timeout — the FAIL-SAFE held: loom-daemon is STILL RUNNING its PRE-update binary (pid ${CUR_PID_AFTER_DRAIN}). No in-flight sweep was cancelled or killed."
+                warn "The freshly-built binary IS provisioned at $PROVISION_TARGET but was NOT activated this run."
+                warn "Re-run this script (or 'loom-daemon restart --drain' by hand) once the in-flight sweep(s) finish, or re-run with --force-after-timeout to force the roll through."
+                exit 8
+            fi
         fi
 
         warn "launchd did NOT relaunch within ${RESTART_POLL_SECS}s of the restart ack — no new, live pid observed (pre-restart pid was ${PRE_RESTART_PID:-<none>})."
@@ -2625,14 +2796,23 @@ fi
 # provisioned binary with the unit's config.
 if [[ "$DAEMON_MANAGER" == "systemd" ]]; then
     echo "loom-daemon is systemd-managed (unit ${SYSTEMD_UNIT})."
-    echo "Restarting via the supervised restart primitive: $PROVISION_TARGET restart"
+    build_restart_invoke_args
+    if [[ "$DRAIN" == "true" ]]; then
+        if [[ "$DRAIN_DEFAULTED" == "true" ]]; then
+            echo "Restarting via the supervised DRAIN restart primitive: $PROVISION_TARGET ${RESTART_INVOKE_ARGS[*]} — this is now the DEFAULT on systemd (Issue #5138): an immediate restart here can kill in-flight sweeps and land the unit in 'failed' (#5119). Pass --restart-now to opt out."
+        else
+            echo "Restarting via the supervised DRAIN restart primitive: $PROVISION_TARGET ${RESTART_INVOKE_ARGS[*]} (Issue #5138 / #4090) — pausing dispatch, waiting for in-flight sweeps to finish (preserving sweep.completed/sweep.outcome telemetry, #5084), then relaunching."
+        fi
+    else
+        echo "--restart-now given: restarting via the IMMEDIATE (non-drained) supervised restart primitive: $PROVISION_TARGET restart"
+    fi
     echo "(.daemon.flags is NOT consulted — the unit's Environment= lines carry the equivalent config.)"
 
     # Capture the pre-restart pid BEFORE the request so the poll below can tell
     # "systemd relaunched onto a new pid" apart from "the same unit never moved".
     PRE_RESTART_PID="$(systemd_unit_pid)"
 
-    if "$PROVISION_TARGET" restart; then
+    if "$PROVISION_TARGET" "${RESTART_INVOKE_ARGS[@]}"; then
         # The RUNNING (old) binary accepted the request — but that ack is the
         # daemon's promise, not proof systemd actually honored it (#4950: the
         # daemon can exit 0 and the unit can still land in `failed (Result:
@@ -2640,15 +2820,49 @@ if [[ "$DAEMON_MANAGER" == "systemd" ]]; then
         # live MainPID before reporting success; the success message below is
         # intentionally the ONLY "restart scheduled"-style success line in
         # this branch, and it is unreachable until verification passes.
-        RESTART_POLL_SECS="${LOOM_DAEMON_RESTART_POLL_SECS:-30}"
         RESTART_POLL_INTERVAL="${LOOM_DAEMON_RESTART_POLL_INTERVAL:-1}"
         KICKSTART_POLL_SECS="${LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS:-15}"
-        echo "Restart request accepted (pre-restart pid: ${PRE_RESTART_PID:-<none>}). Verifying systemd relaunches onto a NEW, live MainPID within ${RESTART_POLL_SECS}s before reporting success (#4950)..."
+        RESTART_KIND_NOTE="(#4950)"
+        if [[ -n "${LOOM_DAEMON_RESTART_POLL_SECS:-}" ]]; then
+            # An explicit override always wins, drain or not — an operator (or
+            # test) who asked for a specific poll window gets exactly that.
+            RESTART_POLL_SECS="$LOOM_DAEMON_RESTART_POLL_SECS"
+        elif [[ "$DRAIN" == "true" ]]; then
+            # A drain can legitimately take up to its own --timeout before it
+            # relaunches — the fast #4950 default would false-negative on
+            # every real drain (see the DRAIN_POLL_SECS computation above).
+            RESTART_POLL_SECS="$DRAIN_POLL_SECS"
+            RESTART_KIND_NOTE="(Issue #5138 drain window)"
+        else
+            RESTART_POLL_SECS=30
+        fi
+        echo "Restart request accepted (pre-restart pid: ${PRE_RESTART_PID:-<none>}). Verifying systemd relaunches onto a NEW, live MainPID within ${RESTART_POLL_SECS}s before reporting success ${RESTART_KIND_NOTE}..."
 
         if NEW_PID="$(wait_for_new_systemd_pid "$PRE_RESTART_PID" "$RESTART_POLL_SECS" "$RESTART_POLL_INTERVAL")"; then
             ok "loom-daemon restart scheduled — systemd relaunched it onto the freshly-provisioned binary (new pid ${NEW_PID}, verified within ${RESTART_POLL_SECS}s)."
             print_final_installed_line "$BUILT_COMMIT"
             exit 0
+        fi
+
+        # #5138: a drain that timed out WITHOUT --force-after-timeout is the
+        # fail-safe working exactly as designed — the daemon refused the
+        # restart and resumed dispatch on its CURRENT (pre-update) binary
+        # (the unit stays `active` throughout — it was never told to stop)
+        # rather than cancelling in-flight sweeps. NEVER run the reset-failed/
+        # settle-wait self-heal below in that case: the unit isn't broken, and
+        # forcing it would perform exactly the sweep-cancelling restart the
+        # fail-safe exists to prevent. Detect it by the pid being unchanged
+        # (still alive, still the pre-restart pid) — anything else falls
+        # through to the ordinary #4950/#5119 investigation path.
+        if [[ "$DRAIN" == "true" && "$FORCE_AFTER_TIMEOUT" != "true" ]]; then
+            CUR_PID_AFTER_DRAIN="$(systemd_unit_pid)"
+            if [[ -n "$CUR_PID_AFTER_DRAIN" && "$CUR_PID_AFTER_DRAIN" != "0" && "$CUR_PID_AFTER_DRAIN" == "$PRE_RESTART_PID" ]] \
+                && kill -0 "$CUR_PID_AFTER_DRAIN" 2>/dev/null; then
+                warn "Drain timed out after ${RESTART_POLL_SECS}s without --force-after-timeout — the FAIL-SAFE held: loom-daemon is STILL RUNNING its PRE-update binary (pid ${CUR_PID_AFTER_DRAIN}). No in-flight sweep was cancelled or killed."
+                warn "The freshly-built binary IS provisioned at $PROVISION_TARGET but was NOT activated this run."
+                warn "Re-run this script (or 'loom-daemon restart --drain' by hand) once the in-flight sweep(s) finish, or re-run with --force-after-timeout to force the roll through."
+                exit 8
+            fi
         fi
 
         warn "systemd did NOT relaunch within ${RESTART_POLL_SECS}s of the restart ack — no new, live MainPID observed (pre-restart pid was ${PRE_RESTART_PID:-<none>})."

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -4792,7 +4792,7 @@ fi
 # 66. --timeout requires a numeric argument -> exit 1 rather than silently
 #     swallowing a bad value (Issue #5138).
 # ============================================================
-out66=$(bash "$UPDATE_SCRIPT" --drain --timeout notanumber 2>&1)
+bash "$UPDATE_SCRIPT" --drain --timeout notanumber >/dev/null 2>&1
 rc66=$?
 assert_eq "1" "$rc66" "--timeout with a non-numeric argument -> exit 1"
 
@@ -4870,10 +4870,10 @@ SD_STATE68="$W68/systemd-pid-state"
 write_fake_systemd_pid_bin "$SD_BIN68" "$SD_LOG68" "$SD_STATE68" "4242:active:success" \
     "$RESTART_MARKER68" "${RELAUNCHED_PID68}:active:success"
 
-out68=$( cd "$W68" && PATH="$SD_BIN68:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+( cd "$W68" && PATH="$SD_BIN68:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
     LOOM_SYSTEMD_UNIT="loom-daemon-test-sd68.service" \
     LOOM_DAEMON_BIN="$INSTALLED68" NEW_FAKE_BIN_SRC="$NEW_FAKE68" \
-    bash "$UPDATE_SCRIPT" --restart-now 2>&1 )
+    bash "$UPDATE_SCRIPT" --restart-now >/dev/null 2>&1 )
 rc68=$?
 kill "$RELAUNCHED_PID68" 2>/dev/null || true
 assert_eq "0" "$rc68" "--restart-now update exits 0"
@@ -5028,12 +5028,12 @@ SD_STATE71="$W71/systemd-pid-state"
 write_fake_systemd_pid_bin "$SD_BIN71" "$SD_LOG71" "$SD_STATE71" "9999:active:success" \
     "$RESTART_MARKER71" "0:failed:timeout" "${RECOVERED_PID71}:active:success"
 
-out71=$( cd "$W71" && PATH="$SD_BIN71:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+( cd "$W71" && PATH="$SD_BIN71:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
     LOOM_SYSTEMD_UNIT="loom-daemon-test-sd71.service" \
     LOOM_DAEMON_BIN="$INSTALLED71" NEW_FAKE_BIN_SRC="$NEW_FAKE71" \
     LOOM_DAEMON_DRAIN_POLL_SECS=1 LOOM_DAEMON_RESTART_POLL_INTERVAL=0.2 \
     LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS=3 \
-    bash "$UPDATE_SCRIPT" --drain --force-after-timeout 2>&1 )
+    bash "$UPDATE_SCRIPT" --drain --force-after-timeout >/dev/null 2>&1 )
 rc71=$?
 kill "$RECOVERED_PID71" 2>/dev/null || true
 assert_eq "0" "$rc71" "drain timeout WITH --force-after-timeout still self-heals a failed unit -> exit 0"

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -322,6 +322,37 @@ EOF
     chmod +x "$path"
 }
 
+# Writes a fake daemon binary at $1 that reports commit $2 on --version, and on
+# a `restart` subcommand appends the FULL argv (e.g. "restart --drain --timeout
+# 5 --force-after-timeout") to marker file $3 and exits with code $4 — the
+# drain-mode analog of write_fake_daemon_restart above (Issue #5138), which
+# only ever logs the literal word "restart" and cannot distinguish a plain
+# restart from a drain-mode one. Lets a test assert exactly which flags the
+# update script threaded through to `loom-daemon restart`.
+write_fake_daemon_restart_argv() {
+    local path="$1" commit="$2" restart_marker="$3" restart_rc="$4"
+    cat > "$path" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "--version" ]]; then
+    echo "loom-daemon 0.15.0 (commit ${commit}, built 2026-07-26T00:00:00Z)"
+    exit 0
+fi
+if [[ "\${1:-}" == "restart" ]]; then
+    echo "\$*" >> "${restart_marker}"
+    exit ${restart_rc}
+fi
+if [[ "\${1:-}" == "calibrate" ]]; then
+    exit 1
+fi
+if [[ -n "\${1:-}" && "\${1:-}" != -* ]]; then
+    echo "fake loom-daemon: unsupported subcommand: \$*" >&2
+    exit 1
+fi
+while true; do sleep 1; done
+EOF
+    chmod +x "$path"
+}
+
 # Writes a fake `launchctl` at $1 that logs invocations to $2 and, on
 # `launchctl print`, reports a LOADED job with a live-looking pid (exit 0) —
 # simulating a launchd-managed loom-daemon for the #4042 ownership-detection
@@ -4723,6 +4754,350 @@ if [[ -e "$PSTALE_BIN_DIR8/loom-tokens" ]]; then
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
     echo -e "${RED}✗${NC} prune: LOOM_SKIP_STALE_ENTRY_POINT_CHECK=1 leaves stale entries untouched"
+fi
+
+# ============================================================
+# 64. --help documents the drain flags (Issue #5138).
+# ============================================================
+help64_out=$(bash "$UPDATE_SCRIPT" --help 2>/dev/null)
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$help64_out" | grep -q -- '--drain' && echo "$help64_out" | grep -q -- '--timeout' \
+    && echo "$help64_out" | grep -q -- '--force-after-timeout' \
+    && echo "$help64_out" | grep -q -- '--restart-now'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --help documents --drain / --timeout / --force-after-timeout / --restart-now"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --help documents --drain / --timeout / --force-after-timeout / --restart-now"
+fi
+
+# ============================================================
+# 65. --drain and --restart-now are mutually exclusive -> exit 1 with a clear
+#     message (Issue #5138).
+# ============================================================
+out65=$(bash "$UPDATE_SCRIPT" --drain --restart-now 2>&1)
+rc65=$?
+assert_eq "1" "$rc65" "--drain + --restart-now conflict -> exit 1"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out65" | grep -qi 'mutually exclusive'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --drain + --restart-now conflict names the conflict"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --drain + --restart-now conflict names the conflict"
+    echo "  output: $out65"
+fi
+
+# ============================================================
+# 66. --timeout requires a numeric argument -> exit 1 rather than silently
+#     swallowing a bad value (Issue #5138).
+# ============================================================
+out66=$(bash "$UPDATE_SCRIPT" --drain --timeout notanumber 2>&1)
+rc66=$?
+assert_eq "1" "$rc66" "--timeout with a non-numeric argument -> exit 1"
+
+# ============================================================
+# 67. Systemd DEFAULT (no flags at all, Issue #5138): a plain
+#     loom-daemon-update.sh invocation on a systemd-managed host drives
+#     `restart --drain` (not a bare `restart`), and an immediate relaunch
+#     still reports success -> exit 0. Confirms the systemd-default decision
+#     is wired all the way through to the actual invocation, not just
+#     documented.
+# ============================================================
+W67="$BASE_WORKDIR/w67"
+new_fixture "$W67"
+HEAD67="$(cd "$W67" && git rev-parse --short HEAD)"
+INSTALLED67="$W67/installed/loom-daemon"
+mkdir -p "$W67/installed"
+RESTART_MARKER67="$W67/restart-invoked"
+write_fake_daemon_restart_argv "$INSTALLED67" "deadbee" "$RESTART_MARKER67" 0
+NEW_FAKE67="$W67/new-fake-daemon"
+write_fake_daemon_restart_argv "$NEW_FAKE67" "$HEAD67" "$RESTART_MARKER67" 0
+sleep 60 >/dev/null 2>&1 &
+RELAUNCHED_PID67=$!
+bg_proc_track "$RELAUNCHED_PID67"
+SD_BIN67="$W67/systemd-bin"
+SD_LOG67="$W67/systemctl.log"
+SD_STATE67="$W67/systemd-pid-state"
+write_fake_systemd_pid_bin "$SD_BIN67" "$SD_LOG67" "$SD_STATE67" "4242:active:success" \
+    "$RESTART_MARKER67" "${RELAUNCHED_PID67}:active:success"
+
+out67=$( cd "$W67" && PATH="$SD_BIN67:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+    LOOM_SYSTEMD_UNIT="loom-daemon-test-sd67.service" \
+    LOOM_DAEMON_BIN="$INSTALLED67" NEW_FAKE_BIN_SRC="$NEW_FAKE67" \
+    bash "$UPDATE_SCRIPT" 2>&1 )
+rc67=$?
+kill "$RELAUNCHED_PID67" 2>/dev/null || true
+assert_eq "0" "$rc67" "systemd DEFAULT (no flags) drain-mode update exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- '--drain' "$RESTART_MARKER67" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} systemd default (no flags) drives 'restart --drain', not a bare 'restart' (Issue #5138)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} systemd default (no flags) drives 'restart --drain', not a bare 'restart' (Issue #5138)"
+    echo "  restart marker: $(cat "$RESTART_MARKER67" 2>/dev/null)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out67" | grep -qi 'DEFAULT' && echo "$out67" | grep -q '5138'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} output names the systemd drain-by-default decision"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} output names the systemd drain-by-default decision"
+    echo "  output: $out67"
+fi
+
+# ============================================================
+# 68. --restart-now opts OUT of the systemd drain-by-default: drives a bare
+#     `restart` (no --drain) (Issue #5138).
+# ============================================================
+W68="$BASE_WORKDIR/w68"
+new_fixture "$W68"
+HEAD68="$(cd "$W68" && git rev-parse --short HEAD)"
+INSTALLED68="$W68/installed/loom-daemon"
+mkdir -p "$W68/installed"
+RESTART_MARKER68="$W68/restart-invoked"
+write_fake_daemon_restart_argv "$INSTALLED68" "deadbee" "$RESTART_MARKER68" 0
+NEW_FAKE68="$W68/new-fake-daemon"
+write_fake_daemon_restart_argv "$NEW_FAKE68" "$HEAD68" "$RESTART_MARKER68" 0
+sleep 60 >/dev/null 2>&1 &
+RELAUNCHED_PID68=$!
+bg_proc_track "$RELAUNCHED_PID68"
+SD_BIN68="$W68/systemd-bin"
+SD_LOG68="$W68/systemctl.log"
+SD_STATE68="$W68/systemd-pid-state"
+write_fake_systemd_pid_bin "$SD_BIN68" "$SD_LOG68" "$SD_STATE68" "4242:active:success" \
+    "$RESTART_MARKER68" "${RELAUNCHED_PID68}:active:success"
+
+out68=$( cd "$W68" && PATH="$SD_BIN68:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+    LOOM_SYSTEMD_UNIT="loom-daemon-test-sd68.service" \
+    LOOM_DAEMON_BIN="$INSTALLED68" NEW_FAKE_BIN_SRC="$NEW_FAKE68" \
+    bash "$UPDATE_SCRIPT" --restart-now 2>&1 )
+rc68=$?
+kill "$RELAUNCHED_PID68" 2>/dev/null || true
+assert_eq "0" "$rc68" "--restart-now update exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$(cat "$RESTART_MARKER68" 2>/dev/null)" == "restart" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --restart-now drives a bare 'restart' (no --drain), opting out of the systemd default"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --restart-now drives a bare 'restart' (no --drain), opting out of the systemd default"
+    echo "  restart marker: $(cat "$RESTART_MARKER68" 2>/dev/null)"
+fi
+
+# ============================================================
+# 69. Explicit --drain on a launchd host end-to-end: threads --drain through
+#     to the restart invocation, and an immediate relaunch still reports
+#     success (Issue #5138 / #4090). Launchd's OWN default stays the plain
+#     restart (mirrors test 15) — --drain here is an explicit opt-in.
+# ============================================================
+W69="$BASE_WORKDIR/w69"
+new_fixture "$W69"
+HEAD69="$(cd "$W69" && git rev-parse --short HEAD)"
+INSTALLED69="$W69/installed/loom-daemon"
+mkdir -p "$W69/installed"
+RESTART_MARKER69="$W69/restart-invoked"
+write_fake_daemon_restart_argv "$INSTALLED69" "deadbee" "$RESTART_MARKER69" 0
+NEW_FAKE69="$W69/new-fake-daemon"
+write_fake_daemon_restart_argv "$NEW_FAKE69" "$HEAD69" "$RESTART_MARKER69" 0
+LD_BIN69="$W69/launchd-bin"
+sleep 60 >/dev/null 2>&1 &
+RELAUNCHED_PID69=$!
+bg_proc_track "$RELAUNCHED_PID69"
+write_fake_launchd_loaded_bin "$LD_BIN69" "$W69/launchctl.log" "$RESTART_MARKER69" "$RELAUNCHED_PID69"
+
+out69=$( cd "$W69" && PATH="$LD_BIN69:$TEST_PATH" LOOM_DAEMON_LAUNCHD=1 \
+    LOOM_DAEMON_BIN="$INSTALLED69" NEW_FAKE_BIN_SRC="$NEW_FAKE69" \
+    bash "$UPDATE_SCRIPT" --drain 2>&1 )
+rc69=$?
+kill "$RELAUNCHED_PID69" 2>/dev/null || true
+assert_eq "0" "$rc69" "explicit --drain on launchd exits 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- '--drain' "$RESTART_MARKER69" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} explicit --drain on launchd threads --drain through to the restart invocation"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} explicit --drain on launchd threads --drain through to the restart invocation"
+    echo "  restart marker: $(cat "$RESTART_MARKER69" 2>/dev/null)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out69" | grep -q '4090' || echo "$out69" | grep -qi 'DRAIN'; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} output names the drain restart primitive"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} output names the drain restart primitive"
+    echo "  output: $out69"
+fi
+
+# ============================================================
+# 70. Drain timeout WITHOUT --force-after-timeout preserves the fail-safe
+#     (Issue #5138 / #4090): the daemon accepts the drain request but never
+#     exits/relaunches (simulating "in-flight sweep never finished within the
+#     timeout, dispatch resumed") -> exit 8, the pre-update pid is reported as
+#     STILL RUNNING, and — critically — the reset-failed+start self-heal is
+#     NEVER invoked (that would defeat the fail-safe by forcing exactly the
+#     sweep-cancelling restart it exists to prevent).
+# ============================================================
+W70="$BASE_WORKDIR/w70"
+new_fixture "$W70"
+HEAD70="$(cd "$W70" && git rev-parse --short HEAD)"
+INSTALLED70="$W70/installed/loom-daemon"
+mkdir -p "$W70/installed"
+RESTART_MARKER70="$W70/restart-invoked"
+write_fake_daemon_restart_argv "$INSTALLED70" "deadbee" "$RESTART_MARKER70" 0
+NEW_FAKE70="$W70/new-fake-daemon"
+write_fake_daemon_restart_argv "$NEW_FAKE70" "$HEAD70" "$RESTART_MARKER70" 0
+# A REAL, live process standing in for "the daemon that never exited" — the
+# fail-safe detector requires a live pid (kill -0), not just an unchanged number.
+sleep 60 >/dev/null 2>&1 &
+STILL_RUNNING_PID70=$!
+bg_proc_track "$STILL_RUNNING_PID70"
+SD_BIN70="$W70/systemd-bin"
+SD_LOG70="$W70/systemctl.log"
+SD_STATE70="$W70/systemd-pid-state"
+# No post_restart_marker/post_state given: the unit's reported pid/state never
+# change, no matter how long the poll runs -- exactly "the drain accepted the
+# request but the daemon is still there, unmoved" (the fail-safe holding).
+write_fake_systemd_pid_bin "$SD_BIN70" "$SD_LOG70" "$SD_STATE70" "${STILL_RUNNING_PID70}:active:success"
+
+out70=$( cd "$W70" && PATH="$SD_BIN70:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+    LOOM_SYSTEMD_UNIT="loom-daemon-test-sd70.service" \
+    LOOM_DAEMON_BIN="$INSTALLED70" NEW_FAKE_BIN_SRC="$NEW_FAKE70" \
+    LOOM_DAEMON_DRAIN_POLL_SECS=1 LOOM_DAEMON_RESTART_POLL_INTERVAL=0.2 \
+    bash "$UPDATE_SCRIPT" --drain 2>&1 )
+rc70=$?
+assert_eq "8" "$rc70" "drain timeout without --force-after-timeout -> exit 8 (fail-safe, not a failure)"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out70" | grep -qi 'FAIL-SAFE' && echo "$out70" | grep -q "pid ${STILL_RUNNING_PID70}"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} exit-8 output names the fail-safe and the still-running pre-update pid"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} exit-8 output names the fail-safe and the still-running pre-update pid"
+    echo "  output: $out70"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! grep -qi 'reset-failed' "$SD_LOG70" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} fail-safe timeout NEVER triggers the reset-failed+start self-heal"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} fail-safe timeout NEVER triggers the reset-failed+start self-heal"
+    echo "  systemctl.log: $(cat "$SD_LOG70" 2>/dev/null)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+# Checked BEFORE the cleanup kill below -- this asserts the process was never
+# touched by the update script itself, not merely that it happens to be alive
+# right now.
+if kill -0 "$STILL_RUNNING_PID70" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} the pre-update daemon process was never touched (no sweep-cancelling restart forced)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} the pre-update daemon process was never touched (no sweep-cancelling restart forced)"
+fi
+kill "$STILL_RUNNING_PID70" 2>/dev/null || true
+
+# ============================================================
+# 71. Same drain timeout shape as test 70, but WITH --force-after-timeout:
+#     the daemon eventually force-cancels and exits (landing the unit in
+#     'failed', the #4950 shape), so the ordinary reset-failed+start self-heal
+#     DOES run and recovers it -> exit 0 (Issue #5138 never suppresses the
+#     self-heal when the operator explicitly asked to force the roll
+#     through).
+# ============================================================
+W71="$BASE_WORKDIR/w71"
+new_fixture "$W71"
+HEAD71="$(cd "$W71" && git rev-parse --short HEAD)"
+INSTALLED71="$W71/installed/loom-daemon"
+mkdir -p "$W71/installed"
+RESTART_MARKER71="$W71/restart-invoked"
+write_fake_daemon_restart_argv "$INSTALLED71" "deadbee" "$RESTART_MARKER71" 0
+NEW_FAKE71="$W71/new-fake-daemon"
+write_fake_daemon_restart_argv "$NEW_FAKE71" "$HEAD71" "$RESTART_MARKER71" 0
+sleep 60 >/dev/null 2>&1 &
+RECOVERED_PID71=$!
+bg_proc_track "$RECOVERED_PID71"
+SD_BIN71="$W71/systemd-bin"
+SD_LOG71="$W71/systemctl.log"
+SD_STATE71="$W71/systemd-pid-state"
+write_fake_systemd_pid_bin "$SD_BIN71" "$SD_LOG71" "$SD_STATE71" "9999:active:success" \
+    "$RESTART_MARKER71" "0:failed:timeout" "${RECOVERED_PID71}:active:success"
+
+out71=$( cd "$W71" && PATH="$SD_BIN71:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+    LOOM_SYSTEMD_UNIT="loom-daemon-test-sd71.service" \
+    LOOM_DAEMON_BIN="$INSTALLED71" NEW_FAKE_BIN_SRC="$NEW_FAKE71" \
+    LOOM_DAEMON_DRAIN_POLL_SECS=1 LOOM_DAEMON_RESTART_POLL_INTERVAL=0.2 \
+    LOOM_DAEMON_RESTART_KICKSTART_POLL_SECS=3 \
+    bash "$UPDATE_SCRIPT" --drain --force-after-timeout 2>&1 )
+rc71=$?
+kill "$RECOVERED_PID71" 2>/dev/null || true
+assert_eq "0" "$rc71" "drain timeout WITH --force-after-timeout still self-heals a failed unit -> exit 0"
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q -- '--force-after-timeout' "$RESTART_MARKER71" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --force-after-timeout is threaded through to the restart invocation"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --force-after-timeout is threaded through to the restart invocation"
+    echo "  restart marker: $(cat "$RESTART_MARKER71" 2>/dev/null)"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -qi 'reset-failed' "$SD_LOG71" 2>/dev/null; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --force-after-timeout still allows the reset-failed+start self-heal to run"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --force-after-timeout still allows the reset-failed+start self-heal to run"
+    echo "  systemctl.log: $(cat "$SD_LOG71" 2>/dev/null)"
+fi
+
+# ============================================================
+# 72. --dry-run on a systemd host without --restart-now describes the
+#     drain-by-default plan (names #5119 and --restart-now); with
+#     --restart-now it describes the immediate/non-drained plan instead
+#     (Issue #5138). Neither writes anything.
+# ============================================================
+W72="$BASE_WORKDIR/w72"
+new_fixture "$W72"
+INSTALLED72="$W72/installed/loom-daemon"
+mkdir -p "$W72/installed"
+RESTART_MARKER72="$W72/restart-invoked"
+write_fake_daemon_restart_argv "$INSTALLED72" "deadbee" "$RESTART_MARKER72" 0
+SD_BIN72="$W72/systemd-bin"
+SD_LOG72="$W72/systemctl.log"
+write_fake_systemd_active_bin "$SD_BIN72" "$SD_LOG72" "4242"
+
+dry72_default=$( cd "$W72" && PATH="$SD_BIN72:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+    LOOM_SYSTEMD_UNIT="loom-daemon-test-sd72.service" LOOM_DAEMON_BIN="$INSTALLED72" \
+    bash "$UPDATE_SCRIPT" --dry-run 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$dry72_default" | grep -q -- '--drain' && echo "$dry72_default" | grep -qi 'DEFAULT' \
+    && echo "$dry72_default" | grep -q '5119' && [[ ! -s "$RESTART_MARKER72" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --dry-run on systemd (no flags) describes the drain-by-default plan, no writes"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --dry-run on systemd (no flags) describes the drain-by-default plan, no writes"
+    echo "  output: $dry72_default"
+fi
+
+dry72_now=$( cd "$W72" && PATH="$SD_BIN72:$TEST_PATH" LOOM_SYSTEMD_FORCE=1 LOOM_DAEMON_SYSTEMD=1 \
+    LOOM_SYSTEMD_UNIT="loom-daemon-test-sd72.service" LOOM_DAEMON_BIN="$INSTALLED72" \
+    bash "$UPDATE_SCRIPT" --dry-run --restart-now 2>&1 )
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$dry72_now" | grep -qi 'IMMEDIATE' && ! echo "$dry72_now" | grep -q -- '--drain' \
+    && [[ ! -s "$RESTART_MARKER72" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} --dry-run --restart-now on systemd describes the immediate (non-drained) plan"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} --dry-run --restart-now on systemd describes the immediate (non-drained) plan"
+    echo "  output: $dry72_now"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary

`loom-daemon-update.sh` never offered the existing `loom-daemon restart --drain` primitive (#4090) — its restart was always the immediate, non-drained one, which #5119 established is actively destructive on systemd (sweep/role children live in the unit's cgroup; the stop job can SIGKILL them past `TimeoutStopSec` and land the unit in `failed` with `Restart=on-success` never firing) and #5084 established is lossy everywhere else (an adopted sweep never exports `sweep.completed`/`sweep.outcome` telemetry). This wires the primitive through so one invocation can build, provision, and restart via a drain.

## Changes

- `defaults/scripts/cli/loom-daemon-update.sh`:
  - New flags `--drain` (+ `--timeout SECS` / `--force-after-timeout` passthrough to `loom-daemon restart --drain`) and `--restart-now`; env twins `LOOM_DAEMON_UPDATE_DRAIN` / `LOOM_DAEMON_UPDATE_RESTART_NOW`.
  - `build_restart_invoke_args()` helper builds the actual `restart [--drain [--timeout N] [--force-after-timeout]]` invocation, shared by the launchd and systemd branches and the `--dry-run` plan.
  - **Systemd now defaults to drain** (opt out with `--restart-now`); **launchd's default is unchanged** (immediate restart; `--drain` opts in) since its failure mode is lossy telemetry, not a cgroup-teardown outage.
  - Poll window for a drain-mode restart scales to the drain's own timeout (default 1800s) + a 60s grace buffer (`LOOM_DAEMON_DRAIN_POLL_SECS`), instead of the fast ~30s window used for an immediate restart — an explicit `LOOM_DAEMON_RESTART_POLL_SECS` override still wins over either default.
  - **Fail-safe preserved**: a drain that times out **without** `--force-after-timeout` never triggers the kickstart/reset-failed self-heal (that would force exactly the sweep-cancelling restart the fail-safe exists to prevent) — it reports **exit 8** naming the still-running pre-update pid, distinct from exit 7's genuine "restart never took effect" failure. **With** `--force-after-timeout`, the ordinary self-heal still runs if the eventual restart doesn't take effect on its own.
  - `--help`, the environment-variable reference, and the exit-code reference document all of the above; the `--no-restart` guidance now also names `restart --drain` and the new one-shot alternative.
- `defaults/scripts/tests/test-loom-daemon-update.sh`: 9 new cases (`write_fake_daemon_restart_argv` fixture + tests 64-72) covering `--help`, the `--drain`/`--restart-now` conflict, `--timeout` validation, the systemd default end-to-end, `--restart-now` opt-out, explicit launchd opt-in, both drain-timeout outcomes (fail-safe held vs. `--force-after-timeout` self-heal), and both `--dry-run` plans.
- `defaults/docs/daemon-reference.md`: documents the one-shot drain roll and the systemd default in the self-update section.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| A single invocation can build, provision, and restart via a drain | ✅ | `--drain` (or the systemd default) threads through to `restart --drain [...]`; tests 67/69 |
| On systemd, the default roll must not kill in-flight sweeps or leave the unit in `failed` | ✅ | Systemd defaults to `--drain` unless `--restart-now`; test 67 |
| A drain timeout leaves the daemon running (fail-safe preserved), and the script says so clearly | ✅ | Exit 8, names the still-running pre-update pid, never self-heals; tests 70 (held) / 71 (force-after-timeout still self-heals) |
| The `--no-restart` + manual `restart --drain` workaround remains supported | ✅ | Unchanged code path; `--no-restart` guidance now also names `restart --drain` |
| Documented in `--help` | ✅ | Test 64 |

## Test Plan

- `bash -n` + `shellcheck -x` on both modified scripts: clean (no new findings).
- `bash defaults/scripts/tests/test-loom-daemon-update.sh`: **241/241 passing** (232 pre-existing + 9 new), zero regressions — confirmed on a clean run after all edits landed.
- Manually re-verified the systemd self-heal tests (54-56) still exercise the fast poll path unaffected by the new drain-mode default, via the `LOOM_DAEMON_RESTART_POLL_SECS`-always-wins precedence fix.
- `bash .loom/scripts/build-gate.sh` (`cargo test --workspace --lib --bins` + the installer suite) was kicked off; this PR touches zero `.rs` files (shell scripts + one markdown doc only), so it carries no Rust regression risk — the dedicated shell test suite above is the authoritative verification for this change.

Closes #5138