### PR TITLE
fix(daemon): require .git beside .loom when resolving the repo root; never report a false all-clear

### DIFF
--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -392,6 +392,18 @@ fails with `No module named loom_tools.orphan_recovery` or a "stale build"
 error, see [`loom-clean` / `loom-cleanup` / `loom-recover-orphans` fail on a
 stale binary](#loom-clean--loom-cleanup--loom-recover-orphans-fail-on-a-stale-binary-4384).
 
+**Run it from inside the checkout** (or pass `--workspace <path>`): repo-root
+resolution requires an ancestor holding **both** `.git` and `.loom/`, so a
+machine-level `~/.loom` (the token pool) is never mistaken for a repository. Run
+from anywhere else it exits `1` naming the directory it searched — it does not
+guess (#5140).
+
+**Exit codes**: `0` = assessed, nothing orphaned · `2` = orphans found in
+dry-run mode · `3` = **could not assess** (e.g. the `gh issue list --label
+loom:building` query failed). A `3` is never reported as "No orphaned tasks
+found" — a failed query is not evidence that nothing is stranded, and `--json`
+carries `assessment_failed` / `assessment_errors` for automation.
+
 **What it does**:
 - Finds issues with `loom:building` label that have been stuck
 - Checks if there's an associated PR (by branch name or body reference)

--- a/defaults/scripts/cli/loom-daemon-update.sh
+++ b/defaults/scripts/cli/loom-daemon-update.sh
@@ -362,10 +362,23 @@ else
 fi
 
 # ---------- repo root ----------
+# Walk up from $1 (default $PWD) to the nearest ancestor that is a Loom
+# repository root: a directory holding BOTH a `.git` entry and a `.loom/`
+# directory.
+#
+# Requiring `.git` alongside `.loom/` is load-bearing (#5140). This walk used
+# to accept any ancestor with a `.loom/` directory, and every fleet host that
+# has run `loom-daemon tokens bootstrap` keeps machine-level daemon state in
+# `~/.loom` — so invoking this script from $HOME matched $HOME on the very
+# first iteration, set REPO_ROOT=$HOME and then refused with the misleading
+# "No loom-daemon/Cargo.toml found at $HOME/loom-daemon". `.git` alone is any
+# git checkout; `.loom/` alone is machine state; only the pair is a Loom repo.
+# Mirrors loom-daemon's own `crate::repo_root::find_repo_root`.
 find_repo_root() {
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -d "$dir/.loom" ]]; then echo "$dir"; return 0; fi
+    local dir="${1:-$PWD}"
+    dir="$(cd "$dir" 2>/dev/null && pwd)" || { echo ""; return 0; }
+    while [[ -n "$dir" && "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" && -d "$dir/.loom" ]]; then echo "$dir"; return 0; fi
         if [[ -f "$dir/.git" ]]; then
             local gitdir main_repo
             gitdir=$(sed 's/^gitdir: //' "$dir/.git")
@@ -375,6 +388,11 @@ find_repo_root() {
         dir="$(dirname "$dir")"
     done
     echo ""
+}
+
+# Whether $1 is a Loom SOURCE checkout (has the crate this script rebuilds).
+is_loom_source_checkout() {
+    [[ -n "${1:-}" && -f "$1/loom-daemon/Cargo.toml" ]]
 }
 
 # ---------- locate the daemon binary ----------
@@ -1142,6 +1160,25 @@ done
 
 REPO_ROOT=$(find_repo_root)
 
+# ---------- self-location fallback (#5140) ----------------------------------
+# This script rebuilds FROM SOURCE, and its own location is unambiguous when it
+# is invoked by absolute path (`bash ~/GitHub/loom/.loom/scripts/cli/loom-daemon-update.sh`
+# from $HOME — the reported case). When $PWD is not inside ANY Loom checkout but
+# the checkout this very script lives in is a source checkout, use that instead
+# of refusing on a path the operator never named. Announced on stderr, never
+# silent: choosing a different checkout than $PWD implies is exactly the kind of
+# thing an operator must be able to see in the log.
+#
+# Deliberately scoped to the "no checkout at all" case. When $PWD DOES resolve
+# to a Loom checkout that simply has no loom-daemon/ crate (a consumer repo),
+# the pre-existing refusal stands — retargeting the machine checkout from
+# inside another repo is opt-in via LOOM_MACHINE_CHECKOUT (#4229), not a guess.
+SELF_REPO_ROOT=$(find_repo_root "$SCRIPT_DIR")
+if [[ -z "$REPO_ROOT" ]] && is_loom_source_checkout "$SELF_REPO_ROOT"; then
+    warn "\$PWD ($PWD) is not inside a Loom source checkout; using this script's own checkout: $SELF_REPO_ROOT"
+    REPO_ROOT="$SELF_REPO_ROOT"
+fi
+
 # ---------- machine-mode source-tree override (Epic #3835 Phase 3b, #4229) --
 # Gap 1: this script rebuilds FROM SOURCE and used to resolve that source tree
 # by walking up from $PWD -- so from a consumer repo (find_repo_root() finds
@@ -1164,14 +1201,20 @@ if [[ -n "$MACHINE_CHECKOUT" ]]; then
 elif [[ -n "$REPO_ROOT" ]]; then
     DAEMON_STATE_HOME="$REPO_ROOT/.loom"
 else
-    err "Not in a Loom workspace (.loom directory not found)"
+    # #5140: name what was searched and what is required, so this never reads
+    # as "your checkout is broken" when the real answer is "you are standing in
+    # the wrong directory".
+    err "Not in a Loom workspace: neither \$PWD ($PWD) nor this script's own location ($SCRIPT_DIR) is inside a Loom checkout."
+    echo "A Loom checkout is a directory containing BOTH .git and .loom/ (a bare ~/.loom, e.g. the token pool, is not one)." >&2
+    echo "cd into a Loom source checkout, or set LOOM_MACHINE_CHECKOUT=<path-to-checkout>." >&2
     exit 1
 fi
 
 DAEMON_DIR="$REPO_ROOT/loom-daemon"
 if [[ ! -f "$DAEMON_DIR/Cargo.toml" ]]; then
-    err "No loom-daemon/Cargo.toml found at $DAEMON_DIR."
+    err "No loom-daemon/Cargo.toml found at $DAEMON_DIR (repo root resolved as $REPO_ROOT)."
     echo "loom-daemon-update.sh rebuilds FROM SOURCE and only works inside a Loom source checkout." >&2
+    echo "cd into a Loom source checkout, or set LOOM_MACHINE_CHECKOUT=<path-to-checkout>." >&2
     exit 1
 fi
 

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -202,6 +202,21 @@ EOF
     ( cd "$root" && git init -q && git -c user.email=test@test -c user.name=test commit -q --allow-empty -m init )
 }
 
+# install_update_script_into <root> (#5140) — drops a real copy of
+# loom-daemon-update.sh (plus every lib/ it sources, resolved relative to its
+# own $SCRIPT_DIR) into a fixture's .loom/scripts/, so the self-location
+# fallback can be exercised on a THROWAWAY checkout. Every other scenario
+# invokes $UPDATE_SCRIPT from the real repo, which is fine while $PWD decides
+# the repo root — but the whole point of the #5140 scenarios is that the
+# script's OWN location decides it, so they must not run the real repo's copy.
+install_update_script_into() {
+    local root="$1"
+    mkdir -p "$root/.loom/scripts/cli" "$root/.loom/scripts/lib"
+    cp "$UPDATE_SCRIPT" "$root/.loom/scripts/cli/loom-daemon-update.sh"
+    chmod +x "$root/.loom/scripts/cli/loom-daemon-update.sh"
+    cp "$CLI_DIR/../lib/"*.sh "$root/.loom/scripts/lib/"
+}
+
 # new_fixture_with_origin <root> <bare_dir> (#4330) — builds on new_fixture(),
 # adding a local BARE repo as `origin` so the ff-first sync path (which
 # resolves the default branch via refs/remotes/origin/HEAD, then fetches and
@@ -2028,19 +2043,78 @@ else
     echo "  output: $out"
 fi
 
-# Dev-mode fallback (scope guard, filed AC5): the SAME non-Loom directory,
-# invoked directly (no LOOM_MACHINE_CHECKOUT -- no dispatcher), still refuses
-# exactly as before #4229. Machine mode is additive, never a replacement.
-out_dev=$( cd "$NON_LOOM_DIR" && PATH="$TEST_PATH" HOME="$HOME_WM1" bash "$UPDATE_SCRIPT" --check 2>&1 )
-rc_dev=$?
-assert_eq "1" "$rc_dev" "dev-mode fallback unchanged: --check from a non-Loom \$PWD (no dispatcher) still exits 1"
+# ============================================================
+# M2 (#5140). CWD-independent source-tree resolution, direct invocation (no
+#     dispatcher, no LOOM_MACHINE_CHECKOUT). The reported failure: the script
+#     was invoked BY ABSOLUTE PATH from $HOME on a fleet host where
+#     `~/.loom/tokens` exists (the token pool `loom-daemon tokens bootstrap`
+#     provisions), so the old `.loom`-only upward walk matched $HOME on its
+#     first iteration and refused with "No loom-daemon/Cargo.toml found at
+#     $HOME/loom-daemon" -- a path the operator never named. Two fixes are
+#     asserted here: the walk now requires .git ALONGSIDE .loom/ (so a bare
+#     ~/.loom is never mistaken for a checkout), and the script falls back to
+#     the checkout it physically lives in, which is unambiguous when it is
+#     invoked by absolute path.
+# ============================================================
+WM2="$BASE_WORKDIR/wm2-checkout"
+new_fixture "$WM2"
+install_update_script_into "$WM2"
+HEADM2="$(cd "$WM2" && git rev-parse --short HEAD)"
+write_fake_daemon "$WM2/installed-loom-daemon" "$HEADM2" "$WM2/marker"
+HOME_LIKE_M2="$BASE_WORKDIR/wm2-home"
+mkdir -p "$HOME_LIKE_M2/.loom/tokens"   # machine-level daemon state, NOT a repo
+out_m2=$( cd "$HOME_LIKE_M2" && PATH="$TEST_PATH" HOME="$HOME_LIKE_M2" \
+    LOOM_DAEMON_BIN="$WM2/installed-loom-daemon" \
+    bash "$WM2/.loom/scripts/cli/loom-daemon-update.sh" --check 2>&1; echo "EXIT=$?" )
+rc_m2=$(echo "$out_m2" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "0" "$rc_m2" "#5140: --check from a \$HOME-like dir holding a bare .loom/ resolves the script's own checkout"
 TESTS_RUN=$((TESTS_RUN + 1))
-if echo "$out_dev" | grep -qi "Not in a Loom workspace"; then
+if echo "$out_m2" | grep -qF "$HOME_LIKE_M2/loom-daemon"; then
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} #5140: never resolves a bare ~/.loom directory as the repo root"
+    echo "  output: $out_m2"
+else
     TESTS_PASSED=$((TESTS_PASSED + 1))
-    echo -e "${GREEN}✓${NC} dev-mode fallback unchanged: reports 'Not in a Loom workspace'"
+    echo -e "${GREEN}✓${NC} #5140: never resolves a bare ~/.loom directory as the repo root"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out_m2" | grep -qF "using this script's own checkout: $WM2"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} #5140: announces the self-location fallback (never a silent switch)"
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "${RED}✗${NC} dev-mode fallback unchanged: reports 'Not in a Loom workspace'"
+    echo -e "${RED}✗${NC} #5140: announces the self-location fallback (never a silent switch)"
+    echo "  output: $out_m2"
+fi
+
+# ============================================================
+# M3 (#5140, scope guard -- supersedes the pre-#5140 "dev-mode fallback"
+#     assertion that used the REAL repo's script copy). When NEITHER $PWD NOR
+#     the script's own location is inside a Loom checkout, the refusal is
+#     preserved: exit 1, naming the CWD it searched and what a checkout
+#     requires. A bare `.loom/` in the CWD must not change that. Machine mode
+#     (M1) remains the additive escape hatch.
+# ============================================================
+WM3_TOOLS="$BASE_WORKDIR/wm3-tools"   # a script tree that is NOT a Loom checkout
+mkdir -p "$WM3_TOOLS/cli" "$WM3_TOOLS/lib"
+cp "$UPDATE_SCRIPT" "$WM3_TOOLS/cli/loom-daemon-update.sh"
+cp "$CLI_DIR/../lib/"*.sh "$WM3_TOOLS/lib/"
+NON_REPO_M3="$BASE_WORKDIR/wm3-cwd"
+mkdir -p "$NON_REPO_M3/.loom"
+HOME_M3="$BASE_WORKDIR/wm3-home"
+mkdir -p "$HOME_M3"
+out_m3=$( cd "$NON_REPO_M3" && PATH="$TEST_PATH" HOME="$HOME_M3" \
+    bash "$WM3_TOOLS/cli/loom-daemon-update.sh" --check 2>&1; echo "EXIT=$?" )
+rc_m3=$(echo "$out_m3" | grep -o 'EXIT=[0-9]*' | cut -d= -f2)
+assert_eq "1" "$rc_m3" "#5140: refuses (exit 1) when neither \$PWD nor the script's own tree is a Loom checkout"
+TESTS_RUN=$((TESTS_RUN + 1))
+if echo "$out_m3" | grep -qi "Not in a Loom workspace" && echo "$out_m3" | grep -qF "$NON_REPO_M3"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} #5140: the refusal names the CWD it searched"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} #5140: the refusal names the CWD it searched"
+    echo "  output: $out_m3"
 fi
 
 # ============================================================

--- a/loom-daemon/src/agent_session/mod.rs
+++ b/loom-daemon/src/agent_session/mod.rs
@@ -300,56 +300,14 @@ pub fn sh_escape(s: &str) -> String {
 }
 
 /// Walk up from `start` to the repository root, requiring a `.loom/`
-/// directory alongside the git root.
+/// directory alongside the git root — re-exported from the single-source
+/// [`crate::repo_root`] helper (issue #5140).
 ///
 /// Mirrors `loom_tools.common.repo.find_repo_root`, including the worktree
 /// case where `.git` is a *file* holding a `gitdir:` pointer back into the
 /// main repository's `.git/worktrees/<name>` (the resolved root is the main
 /// checkout, not the worktree).
-pub fn find_repo_root(start: &Path) -> Option<PathBuf> {
-    let current = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
-    for candidate in current.ancestors() {
-        let git_path = candidate.join(".git");
-        if !git_path.exists() {
-            continue;
-        }
-        let root = resolve_git_root(candidate, &git_path);
-        if root.join(".loom").is_dir() {
-            return Some(root);
-        }
-    }
-    None
-}
-
-fn resolve_git_root(candidate: &Path, git_path: &Path) -> PathBuf {
-    if git_path.is_dir() {
-        return candidate.to_path_buf();
-    }
-    let Ok(text) = std::fs::read_to_string(git_path) else {
-        return candidate.to_path_buf();
-    };
-    let text = text.trim();
-    let Some(gitdir) = text.strip_prefix("gitdir:") else {
-        return candidate.to_path_buf();
-    };
-    let gitdir = gitdir.trim();
-    let joined = candidate.join(gitdir);
-    let resolved = joined.canonicalize().unwrap_or(joined);
-    // /repo/.git/worktrees/issue-42 -> /repo/.git -> /repo
-    let mut p = resolved.as_path();
-    while p.file_name().is_some_and(|n| n != ".git") {
-        match p.parent() {
-            Some(parent) if parent != p => p = parent,
-            _ => break,
-        }
-    }
-    if p.file_name().is_some_and(|n| n == ".git") {
-        if let Some(parent) = p.parent() {
-            return parent.to_path_buf();
-        }
-    }
-    candidate.to_path_buf()
-}
+pub use crate::repo_root::find_repo_root;
 
 // ---------------------------------------------------------------------------
 // Production environment

--- a/loom-daemon/src/cli/cleanup_ops.rs
+++ b/loom-daemon/src/cli/cleanup_ops.rs
@@ -139,8 +139,26 @@ pub(crate) fn handle_recover_orphans_command(
         println!("{}", orphans::format_result_human(&result));
     }
 
+    // A failed dependency (e.g. the `gh issue list --label loom:building`
+    // query) means the claims could not be enumerated at all. That is not a
+    // clean bill of health, so it must never exit 0 — an operator or watch
+    // loop checking for stranded claims would read success as "none stranded"
+    // (issue #5140). Distinct exit code from the "orphans found" 2 below.
+    if result.assessment_failed() {
+        eprintln!(
+            "recover-orphans could not assess orphaned tasks (see errors above); \
+             exiting {EXIT_ASSESSMENT_FAILED} rather than reporting a false all-clear"
+        );
+        std::process::exit(EXIT_ASSESSMENT_FAILED);
+    }
+
     if !result.orphaned.is_empty() && !recover {
         std::process::exit(2);
     }
     Ok(())
 }
+
+/// `recover-orphans` exit code for "the assessment itself failed" — distinct
+/// from `2` ("orphans found in dry-run mode") and from `0` ("assessed, nothing
+/// orphaned"). Issue #5140.
+const EXIT_ASSESSMENT_FAILED: i32 = 3;

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -172,6 +172,7 @@ pub mod phase_join;
 pub mod pipeline_snapshot;
 pub mod quarantine_reconciliation;
 pub mod rate_limit_breaker;
+pub mod repo_root;
 pub mod role_collision;
 pub mod role_runner;
 pub mod role_validation;

--- a/loom-daemon/src/repo_root.rs
+++ b/loom-daemon/src/repo_root.rs
@@ -1,0 +1,212 @@
+//! Single-source repository-root resolution for every `loom-daemon` entry
+//! point (issue #5140).
+//!
+//! Three copies of "walk up looking for the repo root" used to live in this
+//! crate ([`crate::script_helpers`], [`crate::agent_session`], and
+//! `worktree_ops::repo`), and they did not agree: the `worktree_ops` copy
+//! accepted **any** ancestor containing a `.loom/` directory, with no `.git`
+//! check. That is not a hypothetical mismatch — every fleet host that runs
+//! `loom-daemon tokens bootstrap` has a machine-level `~/.loom/` (the token
+//! pool), so `loom-daemon recover-orphans` invoked from `$HOME` resolved
+//! `$HOME` as the "repo root" on the very first iteration and then ran
+//! `gh issue list` there, which failed with `fatal: not a git repository`.
+//!
+//! The canonical rule implemented here (the one the other two copies already
+//! used, and the one `loom_tools.common.repo.find_repo_root` used before the
+//! Rust port):
+//!
+//! - A candidate ancestor qualifies only when it contains a `.git` entry.
+//! - When `.git` is a **file** (a linked worktree's `gitdir:` pointer) the
+//!   pointer is followed back to the *main* checkout, so a builder inside
+//!   `.loom/worktrees/issue-N` resolves to the shared root.
+//! - The resolved root must also contain a `.loom/` directory.
+//!
+//! Both `.git` and `.loom` are required: `.git` alone is any git checkout,
+//! `.loom` alone is machine-level daemon state such as `~/.loom/tokens`.
+
+use std::path::{Path, PathBuf};
+
+/// Walk up from `start` looking for the enclosing Loom repository root.
+///
+/// Returns `None` outside any Loom repository. Callers degrade to an empty
+/// config or an explicit exit code rather than panicking — that degradation is
+/// what keeps `resolve-model.sh` working outside a Loom repo (issue #4060
+/// contract).
+#[must_use]
+pub fn find_repo_root(start: &Path) -> Option<PathBuf> {
+    let mut current: PathBuf = if start.is_absolute() {
+        start.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(start)
+    };
+    // Best-effort canonicalization; a non-existent start path still walks up.
+    if let Ok(c) = current.canonicalize() {
+        current = c;
+    }
+    loop {
+        let git_path = current.join(".git");
+        if git_path.exists() {
+            let root = resolve_git_root(&current, &git_path);
+            if root.join(".loom").is_dir() {
+                return Some(root);
+            }
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
+/// [`find_repo_root`] rooted at the process working directory.
+#[must_use]
+pub fn find_repo_root_from_cwd() -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    find_repo_root(&cwd)
+}
+
+/// Resolve a `--workspace` CLI argument (default `.`) to the enclosing Loom
+/// repository root.
+///
+/// Unlike [`find_repo_root`] this is the *entry-point* form: it fails with an
+/// operator-facing message naming both the directory it searched from and what
+/// it required, so a run from the wrong directory is never mistaken for a
+/// forge or git outage (issue #5140).
+pub fn resolve_repo_root(workspace: &str) -> anyhow::Result<PathBuf> {
+    let p = Path::new(workspace);
+    let start = if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(p)
+    };
+    let start = start.canonicalize().unwrap_or(start);
+    find_repo_root(&start).ok_or_else(|| {
+        anyhow::anyhow!(
+            "not inside a Loom repository: no ancestor of {} contains both a .git entry and a \
+             .loom/ directory. Run this command from inside a Loom checkout, or pass \
+             --workspace <path-to-checkout>. (A machine-level ~/.loom/ — e.g. the token pool — \
+             is not a repository.)",
+            start.display()
+        )
+    })
+}
+
+/// Resolve the main repo root for a candidate directory, following a linked
+/// worktree's `.git` `gitdir:` pointer file when present. Mirrors
+/// `loom_tools.common.repo._resolve_git_root`.
+fn resolve_git_root(candidate: &Path, git_path: &Path) -> PathBuf {
+    if git_path.is_dir() {
+        return candidate.to_path_buf();
+    }
+    let Ok(text) = std::fs::read_to_string(git_path) else {
+        return candidate.to_path_buf();
+    };
+    let Some(rest) = text.trim().strip_prefix("gitdir:") else {
+        return candidate.to_path_buf();
+    };
+    let gitdir = Path::new(rest.trim());
+    let joined = if gitdir.is_absolute() {
+        gitdir.to_path_buf()
+    } else {
+        candidate.join(gitdir)
+    };
+    let mut p = joined.canonicalize().unwrap_or(joined);
+    // Walk up from e.g. /repo/.git/worktrees/issue-42 to /repo/.git.
+    while p.file_name().is_some_and(|n| n != ".git") {
+        if !p.pop() {
+            return candidate.to_path_buf();
+        }
+    }
+    if p.file_name().is_some_and(|n| n == ".git") {
+        if let Some(parent) = p.parent() {
+            return parent.to_path_buf();
+        }
+    }
+    candidate.to_path_buf()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn make_repo(root: &Path) {
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(root.join(".loom")).unwrap();
+    }
+
+    #[test]
+    fn finds_repo_root_at_start() {
+        let dir = tempdir().unwrap();
+        make_repo(dir.path());
+        assert_eq!(find_repo_root(dir.path()), Some(dir.path().canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn finds_repo_root_in_ancestor() {
+        let dir = tempdir().unwrap();
+        make_repo(dir.path());
+        let nested = dir.path().join("a").join("b").join("c");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert_eq!(find_repo_root(&nested), Some(dir.path().canonicalize().unwrap()));
+    }
+
+    /// The #5140 regression: a directory holding machine-level daemon state
+    /// (`~/.loom/tokens`) but no `.git` is NOT a repository root.
+    #[test]
+    fn loom_dir_without_git_is_not_a_repo_root() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".loom").join("tokens")).unwrap();
+        assert_eq!(find_repo_root(dir.path()), None);
+    }
+
+    /// ...and the walk must not stop there either — a real checkout above a
+    /// `~/.loom`-shaped directory still wins.
+    #[test]
+    fn walk_continues_past_a_bare_loom_dir() {
+        let dir = tempdir().unwrap();
+        make_repo(dir.path());
+        let home_like = dir.path().join("home").join("worker");
+        std::fs::create_dir_all(home_like.join(".loom").join("tokens")).unwrap();
+        assert_eq!(find_repo_root(&home_like), Some(dir.path().canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn git_without_loom_is_not_a_repo_root() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+        assert_eq!(find_repo_root(dir.path()), None);
+    }
+
+    #[test]
+    fn resolves_worktree_gitlink_to_main_checkout() {
+        let dir = tempdir().unwrap();
+        let main = dir.path().join("repo");
+        make_repo(&main);
+        std::fs::create_dir_all(main.join(".git").join("worktrees").join("issue-42")).unwrap();
+        let worktree = dir.path().join("wt");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            format!(
+                "gitdir: {}\n",
+                main.join(".git")
+                    .join("worktrees")
+                    .join("issue-42")
+                    .display()
+            ),
+        )
+        .unwrap();
+        assert_eq!(find_repo_root(&worktree), Some(main.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn resolve_repo_root_error_names_the_searched_directory() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".loom")).unwrap();
+        let err = resolve_repo_root(dir.path().to_str().unwrap()).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not inside a Loom repository"), "{msg}");
+        assert!(msg.contains("--workspace"), "{msg}");
+    }
+}

--- a/loom-daemon/src/script_helpers/mod.rs
+++ b/loom-daemon/src/script_helpers/mod.rs
@@ -41,88 +41,16 @@ pub mod validate_phase;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-/// Walk up from `start` looking for the enclosing Loom repository root.
+/// Repo-root discovery, re-exported from the single-source
+/// [`crate::repo_root`] helper (issue #5140 — this module used to carry its own
+/// copy of the walk, one of three that had drifted apart).
 ///
-/// Native port of `loom_tools.common.repo.find_repo_root` (and the identical
-/// walk in `validate_phase._find_repo_root`). Semantics preserved exactly:
-///
-/// - A candidate directory qualifies when it contains a `.git` entry.
-/// - When `.git` is a **file** (a linked worktree's `gitdir:` pointer) the
-///   pointer is followed and walked back up to the *main* repo root, so a
-///   builder running inside `.loom/worktrees/issue-N` resolves to the shared
-///   root — which is what keeps `.loom/claims/`, `.loom/config.json` and
-///   `.loom/usage-cache.json` single-instance across worktrees.
-/// - The resolved root must also contain a `.loom/` directory.
-///
-/// Returns `None` outside any Loom repository (where the Python raised
-/// `FileNotFoundError`). Callers degrade to an empty config or an explicit exit
-/// code rather than panicking — that degradation is what keeps
-/// `resolve-model.sh` working outside a Loom repo (issue #4060 contract).
-#[must_use]
-pub fn find_repo_root(start: &Path) -> Option<PathBuf> {
-    let mut current: PathBuf = if start.is_absolute() {
-        start.to_path_buf()
-    } else {
-        std::env::current_dir().ok()?.join(start)
-    };
-    // Best-effort canonicalization; a non-existent start path still walks up.
-    if let Ok(c) = current.canonicalize() {
-        current = c;
-    }
-    loop {
-        let git_path = current.join(".git");
-        if git_path.exists() {
-            let root = resolve_git_root(&current, &git_path);
-            if root.join(".loom").is_dir() {
-                return Some(root);
-            }
-        }
-        if !current.pop() {
-            return None;
-        }
-    }
-}
-
-/// [`find_repo_root`] rooted at the process working directory.
-#[must_use]
-pub fn find_repo_root_from_cwd() -> Option<PathBuf> {
-    let cwd = std::env::current_dir().ok()?;
-    find_repo_root(&cwd)
-}
-
-/// Resolve the main repo root for a candidate directory, following a linked
-/// worktree's `.git` `gitdir:` pointer file when present. Mirrors
-/// `loom_tools.common.repo._resolve_git_root`.
-fn resolve_git_root(candidate: &Path, git_path: &Path) -> PathBuf {
-    if git_path.is_dir() {
-        return candidate.to_path_buf();
-    }
-    let Ok(text) = std::fs::read_to_string(git_path) else {
-        return candidate.to_path_buf();
-    };
-    let Some(rest) = text.trim().strip_prefix("gitdir:") else {
-        return candidate.to_path_buf();
-    };
-    let gitdir = Path::new(rest.trim());
-    let joined = if gitdir.is_absolute() {
-        gitdir.to_path_buf()
-    } else {
-        candidate.join(gitdir)
-    };
-    let mut p = joined.canonicalize().unwrap_or(joined);
-    // Walk up from e.g. /repo/.git/worktrees/issue-42 to /repo/.git.
-    while p.file_name().is_some_and(|n| n != ".git") {
-        if !p.pop() {
-            return candidate.to_path_buf();
-        }
-    }
-    if p.file_name().is_some_and(|n| n == ".git") {
-        if let Some(parent) = p.parent() {
-            return parent.to_path_buf();
-        }
-    }
-    candidate.to_path_buf()
-}
+/// Semantics are unchanged from the `loom_tools.common.repo.find_repo_root`
+/// port that lived here: `.git` + `.loom/` required, worktree gitlinks resolved
+/// to the main checkout, `None` (not a panic) outside any Loom repository —
+/// which is what keeps `resolve-model.sh` working outside a Loom repo (issue
+/// #4060 contract).
+pub use crate::repo_root::{find_repo_root, find_repo_root_from_cwd};
 
 /// The current UTC instant in the `%Y-%m-%dT%H:%M:%SZ` shape every Loom
 /// on-disk record uses (claims, checkpoints, experiment records, recovery

--- a/loom-daemon/src/worktree_ops/orphan_recovery.rs
+++ b/loom-daemon/src/worktree_ops/orphan_recovery.rs
@@ -90,6 +90,20 @@ pub struct OrphanRecoveryResult {
     pub recovered: Vec<RecoveryEntry>,
     pub watched: Vec<WatchedEntry>,
     pub recover_mode: bool,
+    /// Dependency failures that made the assessment incomplete (e.g. the
+    /// `gh issue list --label loom:building` query failed). Non-empty means
+    /// "could not assess", which is NOT the same claim as "found nothing" —
+    /// the report must say so and the CLI must exit non-zero (issue #5140).
+    pub assessment_errors: Vec<String>,
+}
+
+impl OrphanRecoveryResult {
+    /// Whether a dependency needed to enumerate claims failed, making the
+    /// result inconclusive rather than empty.
+    #[must_use]
+    pub fn assessment_failed(&self) -> bool {
+        !self.assessment_errors.is_empty()
+    }
 }
 
 /// Authoritative evidence of which sweeps are alive right now.
@@ -207,7 +221,15 @@ pub fn check_untracked_building(
     let building_issues = match gh::list_building_issues(repo_root) {
         Ok(v) => v,
         Err(e) => {
+            // A failed query is NOT evidence that nothing is claimed. Record
+            // it so the report says "could not assess" instead of the
+            // reassuring "No orphaned tasks found", and so the CLI exits
+            // non-zero (issue #5140).
             eprintln!("Failed to list loom:building issues: {e}");
+            result.assessment_errors.push(format!(
+                "could not enumerate loom:building claims in {}: {e}",
+                repo_root.display()
+            ));
             return;
         }
     };
@@ -534,7 +556,30 @@ fn format_duration(seconds: i64) -> String {
 #[must_use]
 pub fn format_result_human(result: &OrphanRecoveryResult) -> String {
     let mut lines: Vec<String> = Vec::new();
-    if result.orphaned.is_empty() {
+    if result.assessment_failed() {
+        // Never print a success-shaped summary after a dependency failed
+        // (issue #5140): an operator or watch loop reading "No orphaned tasks
+        // found" would conclude nothing is stranded.
+        lines.push("Could not assess orphaned tasks -- results are INCOMPLETE".to_string());
+        for e in &result.assessment_errors {
+            lines.push(format!("  [error] {e}"));
+        }
+        if !result.orphaned.is_empty() {
+            lines.push(String::new());
+            lines.push(format!(
+                "{} orphaned task(s) detected before the failure (partial):",
+                result.orphaned.len()
+            ));
+            for orphan in &result.orphaned {
+                lines.push(format!(
+                    "  [{}] #{}: {}",
+                    orphan.kind,
+                    orphan.issue.unwrap_or(0),
+                    orphan.reason
+                ));
+            }
+        }
+    } else if result.orphaned.is_empty() {
         lines.push("No orphaned tasks found".to_string());
     } else {
         lines.push(format!("Found {} orphaned task(s)", result.orphaned.len()));
@@ -654,6 +699,10 @@ pub fn format_result_json(result: &OrphanRecoveryResult) -> String {
         "total_recovered": result.recovered.len(),
         "total_watched": result.watched.len(),
         "recover_mode": result.recover_mode,
+        // #5140: a consumer must be able to tell "assessed, found nothing"
+        // from "could not assess" — `total_orphaned: 0` alone cannot.
+        "assessment_failed": result.assessment_failed(),
+        "assessment_errors": result.assessment_errors,
     });
     serde_json::to_string_pretty(&obj).unwrap_or_default()
 }
@@ -778,6 +827,77 @@ mod tests {
     fn format_result_human_reports_zero_orphans() {
         let result = OrphanRecoveryResult::default();
         assert_eq!(format_result_human(&result), "No orphaned tasks found");
+    }
+
+    /// #5140: a failed `gh issue list` must never be summarized as a clean
+    /// bill of health.
+    #[test]
+    fn format_result_human_never_reports_all_clear_after_query_failure() {
+        let mut result = OrphanRecoveryResult::default();
+        result
+            .assessment_errors
+            .push("could not enumerate loom:building claims in /home/x: boom".to_string());
+        let out = format_result_human(&result);
+        assert!(
+            !out.contains("No orphaned tasks found"),
+            "false all-clear after a failed query: {out}"
+        );
+        assert!(out.contains("Could not assess orphaned tasks"), "{out}");
+        assert!(out.contains("boom"), "{out}");
+        assert!(result.assessment_failed());
+    }
+
+    #[test]
+    fn format_result_json_flags_assessment_failure() {
+        let mut result = OrphanRecoveryResult::default();
+        result.assessment_errors.push("boom".to_string());
+        let parsed: serde_json::Value = serde_json::from_str(&format_result_json(&result)).unwrap();
+        assert_eq!(parsed["assessment_failed"], true);
+        assert_eq!(parsed["total_orphaned"], 0);
+        assert_eq!(parsed["assessment_errors"][0], "boom");
+    }
+
+    #[test]
+    fn format_result_json_reports_success_when_assessment_completed() {
+        let result = OrphanRecoveryResult::default();
+        let parsed: serde_json::Value = serde_json::from_str(&format_result_json(&result)).unwrap();
+        assert_eq!(parsed["assessment_failed"], false);
+    }
+
+    /// #5140: the failing `gh issue list` path records an assessment error
+    /// instead of returning silently (which read as "nothing is orphaned").
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn check_untracked_building_records_error_when_gh_query_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let bin = dir.path().join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let fake_gh = bin.join("gh");
+        std::fs::write(&fake_gh, "#!/bin/sh\necho 'boom' >&2\nexit 1\n").unwrap();
+        std::fs::set_permissions(&fake_gh, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let saved_path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{saved_path}", bin.display()));
+
+        let mut result = OrphanRecoveryResult::default();
+        let evidence = LivenessEvidence {
+            available: true,
+            sources: vec!["spawn-loop-state.json"],
+            ..Default::default()
+        };
+        check_untracked_building(&evidence, &mut result, dir.path(), 600, false);
+
+        std::env::set_var("PATH", saved_path);
+
+        assert!(result.assessment_failed(), "query failure must be recorded");
+        assert!(result.orphaned.is_empty());
+        assert!(
+            !format_result_human(&result).contains("No orphaned tasks found"),
+            "must not report a false all-clear"
+        );
     }
 
     #[test]

--- a/loom-daemon/src/worktree_ops/repo.rs
+++ b/loom-daemon/src/worktree_ops/repo.rs
@@ -1,77 +1,13 @@
-//! Resolve the Loom repository root from a starting directory.
+//! Resolve the Loom repository root for the `worktree_ops` CLIs (`clean`,
+//! `cleanup`, `recover-orphans`).
 //!
-//! Rust port of `loom_tools.common.repo.find_repo_root` (the piece the
-//! `worktree_ops` family needs): walk up from a starting directory until a
-//! `.loom/` directory is found. Unlike the Python original this does not
-//! special-case the `.git` gitlink-file worktree case — every caller in this
-//! module runs from the main workspace checkout (the `clean` / `cleanup` /
-//! `recover-orphans` CLIs operate on `.loom/worktrees/issue-*`, not from
-//! inside one), so a plain "nearest ancestor with a `.loom/` dir" walk is
-//! sufficient and matches practical behavior.
+//! This module used to carry its own walk that accepted **any** ancestor
+//! containing a `.loom/` directory, with no `.git` check — so on any host with
+//! machine-level daemon state at `~/.loom` (the token pool provisioned by
+//! `loom-daemon tokens bootstrap`), running these CLIs from `$HOME` resolved
+//! `$HOME` as the "repo root" and then ran `gh` there, which failed with
+//! `fatal: not a git repository`. Repo-root resolution now comes from the
+//! single-source [`crate::repo_root`] helper shared by every entry point
+//! (issue #5140).
 
-use std::path::{Path, PathBuf};
-
-/// Walk up from `start` looking for the nearest ancestor containing a
-/// `.loom/` directory. Returns `None` if none is found before the filesystem
-/// root.
-#[must_use]
-pub fn find_repo_root(start: &Path) -> Option<PathBuf> {
-    let mut current = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
-    loop {
-        if current.join(".loom").is_dir() {
-            return Some(current);
-        }
-        match current.parent() {
-            Some(parent) => current = parent.to_path_buf(),
-            None => return None,
-        }
-    }
-}
-
-/// Resolve a `--workspace` CLI argument (default `.`) to an absolute path,
-/// then confirm/locate the Loom repo root from there. Mirrors the
-/// `find_repo_root()` call every Python entry point in this family makes
-/// immediately after `argparse`.
-pub fn resolve_repo_root(workspace: &str) -> anyhow::Result<PathBuf> {
-    let p = Path::new(workspace);
-    let start = if p.is_absolute() {
-        p.to_path_buf()
-    } else {
-        std::env::current_dir()?.join(p)
-    };
-    find_repo_root(&start)
-        .ok_or_else(|| anyhow::anyhow!("Not in a git repository with .loom directory"))
-}
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    #[test]
-    fn finds_loom_dir_at_start() {
-        let dir = tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join(".loom")).unwrap();
-        assert_eq!(find_repo_root(dir.path()), Some(dir.path().canonicalize().unwrap()));
-    }
-
-    #[test]
-    fn finds_loom_dir_in_ancestor() {
-        let dir = tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join(".loom")).unwrap();
-        let nested = dir.path().join("a").join("b").join("c");
-        std::fs::create_dir_all(&nested).unwrap();
-        assert_eq!(find_repo_root(&nested), Some(dir.path().canonicalize().unwrap()));
-    }
-
-    #[test]
-    fn does_not_match_a_directory_lacking_loom() {
-        let dir = tempdir().unwrap();
-        let nested = dir.path().join("x");
-        std::fs::create_dir_all(&nested).unwrap();
-        // `nested` itself has no `.loom/`, so it must never be returned
-        // as-is (the walk must go at least one level up looking for it).
-        assert_ne!(find_repo_root(&nested), Some(nested));
-    }
-}
+pub use crate::repo_root::{find_repo_root, resolve_repo_root};

--- a/loom-daemon/tests/recover_orphans_cwd.rs
+++ b/loom-daemon/tests/recover_orphans_cwd.rs
@@ -1,0 +1,87 @@
+//! Regression tests for `loom-daemon recover-orphans` run from a non-repo CWD
+//! (issue #5140).
+//!
+//! The reported failure was run from `$HOME` on a fleet host: `~/.loom` exists
+//! there (the token pool `loom-daemon tokens bootstrap` provisions), the
+//! repo-root walk accepted any ancestor with a `.loom/` directory, so `$HOME`
+//! was resolved as the "repo root" and `gh issue list` was run there — failing
+//! with `fatal: not a git repository`. The command then printed the reassuring
+//! **"No orphaned tasks found"** and exited 0: a false all-clear for exactly
+//! the check (are any claims stranded?) an operator runs after a killed sweep.
+
+use std::process::Command;
+
+/// A directory holding machine-level daemon state (`.loom/tokens`) but no
+/// `.git` must not be mistaken for a repository root. The command must fail
+/// loudly, name what it required, and never emit the all-clear line.
+#[test]
+fn recover_orphans_from_a_bare_loom_dir_fails_loudly() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join(".loom").join("tokens")).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_loom-daemon"))
+        .arg("recover-orphans")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "must exit non-zero when it cannot assess claims; stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("No orphaned tasks found"),
+        "false all-clear after a failed assessment: {stdout}"
+    );
+    assert!(
+        stderr.contains("not inside a Loom repository"),
+        "the error must name what it required; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("--workspace"),
+        "the error must name the escape hatch; stderr: {stderr}"
+    );
+}
+
+/// The already-working "not in a repo at all" case must keep working — no
+/// `.loom/` anywhere upward.
+#[test]
+fn recover_orphans_from_a_plain_non_repo_dir_fails_loudly() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_loom-daemon"))
+        .arg("recover-orphans")
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!output.status.success(), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("No orphaned tasks found"),
+        "false all-clear outside any repository: {stdout}"
+    );
+}
+
+/// `--json` consumers get the same honesty: no success-shaped payload, and the
+/// process still exits non-zero.
+#[test]
+fn recover_orphans_json_from_a_bare_loom_dir_fails_loudly() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join(".loom").join("tokens")).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_loom-daemon"))
+        .args(["recover-orphans", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!output.status.success(), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("\"total_orphaned\": 0"),
+        "a zero-orphan payload after a failed resolution is a false all-clear: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

`loom-daemon recover-orphans` run from `$HOME` on a fleet host printed **"No orphaned tasks found"** after its `gh issue list` had failed — a false all-clear for the exact check an operator runs after a killed sweep. Root cause: `worktree_ops::repo::find_repo_root` accepted **any** ancestor containing a `.loom/` directory with no `.git` check, and every host that has run `loom-daemon tokens bootstrap` has a machine-level `~/.loom` (the token pool). So `$HOME` was resolved as the "repo root" on the first iteration, `gh` ran there (`fatal: not a git repository`), and the failure was folded into "no evidence of orphans".

The same `.loom`-only walk had been hand-ported into `loom-daemon-update.sh`, with the same result (`No loom-daemon/Cargo.toml found at $HOME/loom-daemon`).

## Changes

**Single-sourced repo-root resolution** — new `loom-daemon/src/repo_root.rs` is now the only implementation of the walk (there were three, and they disagreed). A candidate qualifies only when it holds **both** `.git` and `.loom/`; a linked worktree's `.git` gitlink resolves to the main checkout. `script_helpers::find_repo_root`, `agent_session::find_repo_root` and `worktree_ops::repo::{find_repo_root, resolve_repo_root}` are now re-exports, so a future subcommand inherits the behaviour instead of re-deriving it.

**Honest failure reporting for `recover-orphans`**
- `resolve_repo_root` errors with the directory it searched, what a checkout requires, and the `--workspace` escape hatch — never a bare "Not in a git repository".
- A failed `gh issue list --label loom:building` is recorded on `OrphanRecoveryResult::assessment_errors` instead of being swallowed.
- Human output leads with `Could not assess orphaned tasks -- results are INCOMPLETE` and **never** emits `No orphaned tasks found`; `--json` gains `assessment_failed` / `assessment_errors`.
- New exit code `3` = "could not assess" (distinct from `0` assessed-clean and `2` orphans-found-in-dry-run).

**`loom-daemon-update.sh`**
- Its bash walk gains the same `.git`-beside-`.loom` rule and takes an optional start dir.
- When `$PWD` is inside **no** Loom checkout, it falls back to the checkout the script itself lives in (unambiguous when invoked by absolute path — the reported invocation), announced on stderr, never silent.
- Deliberately scoped: when `$PWD` *does* resolve to a Loom checkout that merely lacks `loom-daemon/` (a consumer repo), the pre-existing refusal stands — retargeting another checkout from inside a repo remains opt-in via `LOOM_MACHINE_CHECKOUT` (#4229). The refusal message now names `$PWD`, the script's own location, and what a checkout requires.

**Docs** — `defaults/docs/troubleshooting.md` documents the CWD requirement and the exit-code table.

### Behaviour change worth noting for review

`loom-daemon clean` / `cleanup` / `recover-orphans` run from *inside* an issue worktree now resolve the **main checkout** (via the gitlink) rather than the worktree itself, matching every other entry point. That is the intended semantics — `.loom/locks`, `.loom/spawn-loop-state.json` and `.loom/worktrees/` all live in the main checkout.

## Acceptance Criteria Verification

- [x] **`recover-orphans` from an arbitrary CWD resolves the repo or fails naming the required CWD, and never prints "No orphaned tasks found" when the query failed** — verified manually from a scratch dir with `.loom/tokens`: `Error: not inside a Loom repository: no ancestor of /tmp/… contains both a .git entry and a .loom/ directory. Run this command from inside a Loom checkout, or pass --workspace <path-to-checkout>.` exit `1`, no all-clear line. Covered by `loom-daemon/tests/recover_orphans_cwd.rs` (3 tests) and `format_result_human_never_reports_all_clear_after_query_failure`.
- [x] **Exits non-zero when it cannot enumerate claims** — `1` when repo-root resolution fails, `3` when the `gh` query itself fails (`EXIT_ASSESSMENT_FAILED` in `cli/cleanup_ops.rs`).
- [x] **`loom-daemon-update.sh` resolves its checkout from its own path, or errors naming the required CWD** — both paths asserted (scenarios M2 and M3 in `test-loom-daemon-update.sh`).
- [x] **Repo-root resolution is shared, not per-subcommand** — one implementation in `crate::repo_root`; the other three sites are re-exports.
- [x] **Regression test invoking both from a non-repo CWD** — Rust integration test for the daemon CLI, bash scenarios M2/M3 for the script.
- [x] **`LOOM_MACHINE_CHECKOUT` override unaffected** — scenario M1 passes unchanged.

## Test Plan

- `cargo test --workspace --locked --no-fail-fast` — all green (3336 lib tests + integration suites; new `recover_orphans_cwd` 3/3, new `repo_root` 7/7, new orphan-report tests 4/4).
- `cargo clippy --workspace --all-targets --locked` — clean; `cargo fmt --all` applied.
- `bash defaults/scripts/tests/test-loom-daemon-update.sh` — **221 passed, 0 failed** (includes the 5 new #5140 assertions).
- `shellcheck -S warning` on both changed shell files — clean.
- Manual: `recover-orphans` from a `.loom/tokens`-only dir → exit 1 with the naming error; from a plain non-repo dir → same; from this checkout → normal report (exit 0) with the watched-claims list.

Note: `pre-existing` untracked `loom-tools/` in the main checkout trips `check-main-clean.sh`; it predates this branch and was left untouched.

Closes #5140
