### PR TITLE
fix(guard): thread a cd-prefix into force-op cwd/branch-identity resolution

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -1630,10 +1630,29 @@ function mask_heredoc_bodies(s,   out, lines, nl, i, j, line, trimmed, body, del
 #       * `HEAD`, or no ref => the literal "@HEAD@" (resolve checked-out branch)
 #   - reset --hard: always emitted with <target> = "@HEAD@".
 # The caller resolves "@HEAD@" to the checked-out branch and applies the mode.
+#
+# $2 seeds the starting cwd (the hook's own session cwd — callers pass $CWD,
+# mirroring extract_write_targets's `startcwd` parameter). A `cd <dir>`
+# segment updates that cwd for LATER segments of the SAME command — global awk
+# variable `curcwd`, threaded across the per-segment loop exactly like
+# extract_write_targets threads it via its own `cd` case (#4933/#4881). This
+# closes the false-ask where a command first `cd`s into a worktree (e.g. `cd
+# .loom/worktrees/issue-N && git reset --hard origin/feature/issue-N`) while
+# the hook's reported session cwd is still the main repo root: without cd
+# tracking the "@HEAD@" target resolved against the WRONG checkout (#5156).
+#
+# The cd-tracked cwd is used ONLY for "@HEAD@"-target lines (reset --hard, and
+# a push with no/HEAD refspec) — i.e. only where branch identity actually
+# needs resolving against a checkout. A push naming an explicit branch refspec
+# keeps deriving its <cpath> from an explicit `-C <path>` ONLY, exactly as
+# before: its target is the literal refspec text, not cwd/HEAD-derived, so cd
+# tracking must not change its behavior (a still-empty <cpath> there continues
+# to fall back to the caller's raw $CWD, unchanged).
 parse_force_ops() {
-    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
-    BEGIN { SEP = sprintf("%c", 31) }  # US (unit separator) — non-whitespace so
-                                       # bash read does not trim an empty cpath.
+    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK"'
+    BEGIN { SEP = sprintf("%c", 31); curcwd = startcwd }
+                                       # SEP is non-whitespace so bash read
+                                       # does not trim an empty cpath.
     {
         $0 = qsplit($0)   # quote-aware segmentation (#3755)
         n = split($0, segs, "\n")
@@ -1644,6 +1663,20 @@ parse_force_ops() {
             sub(/^[ \t]+/, "", seg)
             m = split(seg, toks, /[ \t]+/)
             if (m == 0) continue
+            # Thread a `cd <dir>` prefix through LATER segments of this same
+            # compound command (mirrors extract_write_targets, #4933/#4881).
+            # `cd -` and a bare `cd` are left unresolved (matches the same
+            # known limitation there) rather than guessed.
+            if (toks[1] == "cd") {
+                if (m >= 2 && toks[2] != "" && toks[2] != "-") {
+                    if (toks[2] ~ /^\//) {
+                        curcwd = toks[2]
+                    } else if (curcwd != "") {
+                        curcwd = curcwd "/" toks[2]
+                    }
+                }
+                continue
+            }
             if (toks[1] != "git") continue
             # Walk global options between `git` and the subcommand.
             cpath = ""
@@ -1657,6 +1690,12 @@ parse_force_ops() {
             }
             if (k > m) continue
             subcmd = toks[k]
+            # headcpath is used ONLY for "@HEAD@"-target lines: an explicit
+            # -C always wins; otherwise fall back to the cd-tracked curcwd
+            # (which starts at startcwd, so a command with no cd prefix
+            # resolves identically to the pre-#5156 behaviour).
+            headcpath = cpath
+            if (headcpath == "") headcpath = curcwd
             if (subcmd == "push") {
                 force = 0
                 np = 0
@@ -1678,22 +1717,24 @@ parse_force_ops() {
                 # (not just the first) reaches the per-line check in the caller. A
                 # bare push with no refspec (np < 2) resolves the checked-out branch.
                 if (np < 2) {
-                    print cpath SEP "@HEAD@"
+                    print headcpath SEP "@HEAD@"
                 } else {
                     for (p = 2; p <= np; p++) {
                         rs = pos[p]
                         sub(/^\+/, "", rs)
                         ci = index(rs, ":")
                         if (ci > 0) rs = substr(rs, ci + 1)
-                        target = "@HEAD@"
-                        if (rs != "HEAD" && rs != "") target = rs
-                        print cpath SEP target
+                        if (rs != "HEAD" && rs != "") {
+                            print cpath SEP rs
+                        } else {
+                            print headcpath SEP "@HEAD@"
+                        }
                     }
                 }
             } else if (subcmd == "reset") {
                 hard = 0
                 for (j = k+1; j <= m; j++) if (toks[j] == "--hard") hard = 1
-                if (hard) print cpath SEP "@HEAD@"
+                if (hard) print headcpath SEP "@HEAD@"
             }
         }
     }'
@@ -3056,7 +3097,7 @@ if [[ "$COMMAND_NO_COMMENT" == *git* ]] && \
    echo "$COMMAND_NO_COMMENT" | grep -qE '(--force|--force-with-lease|(^|[[:space:]])-f([[:space:]]|$)|--hard)'; then
     _FORCE_MODE=$(force_scope_mode)
     if [[ "$_FORCE_MODE" != "off" ]]; then
-        _FORCE_OPS=$(parse_force_ops "$COMMAND_NO_COMMENT")
+        _FORCE_OPS=$(parse_force_ops "$COMMAND_NO_COMMENT" "$CWD")
         if [[ -n "$_FORCE_OPS" ]]; then
             if [[ "$_FORCE_MODE" == "all" ]]; then
                 # Preserve pre-#3674 behaviour byte-for-byte: any force op asks.

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1630,10 +1630,29 @@ function mask_heredoc_bodies(s,   out, lines, nl, i, j, line, trimmed, body, del
 #       * `HEAD`, or no ref => the literal "@HEAD@" (resolve checked-out branch)
 #   - reset --hard: always emitted with <target> = "@HEAD@".
 # The caller resolves "@HEAD@" to the checked-out branch and applies the mode.
+#
+# $2 seeds the starting cwd (the hook's own session cwd — callers pass $CWD,
+# mirroring extract_write_targets's `startcwd` parameter). A `cd <dir>`
+# segment updates that cwd for LATER segments of the SAME command — global awk
+# variable `curcwd`, threaded across the per-segment loop exactly like
+# extract_write_targets threads it via its own `cd` case (#4933/#4881). This
+# closes the false-ask where a command first `cd`s into a worktree (e.g. `cd
+# .loom/worktrees/issue-N && git reset --hard origin/feature/issue-N`) while
+# the hook's reported session cwd is still the main repo root: without cd
+# tracking the "@HEAD@" target resolved against the WRONG checkout (#5156).
+#
+# The cd-tracked cwd is used ONLY for "@HEAD@"-target lines (reset --hard, and
+# a push with no/HEAD refspec) — i.e. only where branch identity actually
+# needs resolving against a checkout. A push naming an explicit branch refspec
+# keeps deriving its <cpath> from an explicit `-C <path>` ONLY, exactly as
+# before: its target is the literal refspec text, not cwd/HEAD-derived, so cd
+# tracking must not change its behavior (a still-empty <cpath> there continues
+# to fall back to the caller's raw $CWD, unchanged).
 parse_force_ops() {
-    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
-    BEGIN { SEP = sprintf("%c", 31) }  # US (unit separator) — non-whitespace so
-                                       # bash read does not trim an empty cpath.
+    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK"'
+    BEGIN { SEP = sprintf("%c", 31); curcwd = startcwd }
+                                       # SEP is non-whitespace so bash read
+                                       # does not trim an empty cpath.
     {
         $0 = qsplit($0)   # quote-aware segmentation (#3755)
         n = split($0, segs, "\n")
@@ -1644,6 +1663,20 @@ parse_force_ops() {
             sub(/^[ \t]+/, "", seg)
             m = split(seg, toks, /[ \t]+/)
             if (m == 0) continue
+            # Thread a `cd <dir>` prefix through LATER segments of this same
+            # compound command (mirrors extract_write_targets, #4933/#4881).
+            # `cd -` and a bare `cd` are left unresolved (matches the same
+            # known limitation there) rather than guessed.
+            if (toks[1] == "cd") {
+                if (m >= 2 && toks[2] != "" && toks[2] != "-") {
+                    if (toks[2] ~ /^\//) {
+                        curcwd = toks[2]
+                    } else if (curcwd != "") {
+                        curcwd = curcwd "/" toks[2]
+                    }
+                }
+                continue
+            }
             if (toks[1] != "git") continue
             # Walk global options between `git` and the subcommand.
             cpath = ""
@@ -1657,6 +1690,12 @@ parse_force_ops() {
             }
             if (k > m) continue
             subcmd = toks[k]
+            # headcpath is used ONLY for "@HEAD@"-target lines: an explicit
+            # -C always wins; otherwise fall back to the cd-tracked curcwd
+            # (which starts at startcwd, so a command with no cd prefix
+            # resolves identically to the pre-#5156 behaviour).
+            headcpath = cpath
+            if (headcpath == "") headcpath = curcwd
             if (subcmd == "push") {
                 force = 0
                 np = 0
@@ -1678,22 +1717,24 @@ parse_force_ops() {
                 # (not just the first) reaches the per-line check in the caller. A
                 # bare push with no refspec (np < 2) resolves the checked-out branch.
                 if (np < 2) {
-                    print cpath SEP "@HEAD@"
+                    print headcpath SEP "@HEAD@"
                 } else {
                     for (p = 2; p <= np; p++) {
                         rs = pos[p]
                         sub(/^\+/, "", rs)
                         ci = index(rs, ":")
                         if (ci > 0) rs = substr(rs, ci + 1)
-                        target = "@HEAD@"
-                        if (rs != "HEAD" && rs != "") target = rs
-                        print cpath SEP target
+                        if (rs != "HEAD" && rs != "") {
+                            print cpath SEP rs
+                        } else {
+                            print headcpath SEP "@HEAD@"
+                        }
                     }
                 }
             } else if (subcmd == "reset") {
                 hard = 0
                 for (j = k+1; j <= m; j++) if (toks[j] == "--hard") hard = 1
-                if (hard) print cpath SEP "@HEAD@"
+                if (hard) print headcpath SEP "@HEAD@"
             }
         }
     }'
@@ -3056,7 +3097,7 @@ if [[ "$COMMAND_NO_COMMENT" == *git* ]] && \
    echo "$COMMAND_NO_COMMENT" | grep -qE '(--force|--force-with-lease|(^|[[:space:]])-f([[:space:]]|$)|--hard)'; then
     _FORCE_MODE=$(force_scope_mode)
     if [[ "$_FORCE_MODE" != "off" ]]; then
-        _FORCE_OPS=$(parse_force_ops "$COMMAND_NO_COMMENT")
+        _FORCE_OPS=$(parse_force_ops "$COMMAND_NO_COMMENT" "$CWD")
         if [[ -n "$_FORCE_OPS" ]]; then
             if [[ "$_FORCE_MODE" == "all" ]]; then
                 # Preserve pre-#3674 behaviour byte-for-byte: any force op asks.

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -1626,6 +1626,69 @@ assert_allow "forceScope protected: multi-refspec force-push +feature/x and HEAD
 assert_ask "forceScope default(all): multi-refspec force-push asks" \
     "git push --force origin feature/x feature/y" "$FORCE_ALL_REPO"
 
+# ---- protected mode: `cd <worktree> &&` prefix before an "@HEAD@"-target force
+# op (#5156). ----
+# Regression: the hook's reported session cwd can still be the MAIN repo root
+# while the COMMAND itself first `cd`s into a linked worktree and
+# force-operates on that worktree's own already-checked-out branch — a
+# routine, safe operation (e.g. fast-forwarding a worktree to its own
+# just-pushed/rebased branch). Before the #5156 fix, "@HEAD@" branch-identity
+# resolution for a hard reset / refspec-less force-push fell back to the raw
+# session cwd whenever no explicit `-C` flag was present, so it queried the
+# checked-out branch of the MAIN root (protected) instead of the worktree's own
+# feature branch, and incorrectly asked citing the protected branch. A REAL
+# linked `git worktree add` fixture is used (not a plain subdirectory) so the
+# worktree genuinely has its own independent HEAD, mirroring make_wt_repo_linked
+# above.
+FORCE_CD_REPO=$(mktemp -d 2>/dev/null)
+FORCE_CD_REPO=$(cd "$FORCE_CD_REPO" && pwd -P)
+git -C "$FORCE_CD_REPO" init -q >/dev/null 2>&1
+mkdir -p "$FORCE_CD_REPO/.loom"
+printf '%s' '{"guards":{"forceScope":"protected"}}' > "$FORCE_CD_REPO/.loom/config.json"
+# .loom/config.json must be COMMITTED (not left untracked) so it is present in
+# the linked worktree's own checkout too -- force_scope_mode() resolves
+# REPO_ROOT from `git rev-parse --show-toplevel` on the hook's OWN reported
+# cwd, which for a cwd inside the worktree is the WORKTREE root, not this main
+# root; an untracked file here would be invisible from there.
+git -C "$FORCE_CD_REPO" add .loom/config.json >/dev/null 2>&1
+git -C "$FORCE_CD_REPO" -c user.email=loom@test -c user.name=loom \
+    commit -q -m init >/dev/null 2>&1
+mkdir -p "$FORCE_CD_REPO/.loom/worktrees"
+git -C "$FORCE_CD_REPO" worktree add -q "$FORCE_CD_REPO/.loom/worktrees/issue-1" \
+    -b feature/issue-1 >/dev/null 2>&1
+FORCE_CD_WT="$FORCE_CD_REPO/.loom/worktrees/issue-1"
+
+# Hook cwd = MAIN repo root; command cd's into the worktree, then hard-resets
+# the worktree's own already-checked-out branch -> must ALLOW (the false-ask
+# this issue fixes).
+assert_allow "forceScope protected (#5156): cd into worktree then reset --hard own branch allows (hook cwd=main root)" \
+    "cd $FORCE_CD_WT && git reset --hard origin/feature/issue-1" "$FORCE_CD_REPO"
+# Same effective operation with the hook cwd already AT the worktree -> must
+# also ALLOW (this was already correct pre-fix; kept as a matching control).
+assert_allow "forceScope protected (#5156): reset --hard own branch allows (hook cwd=worktree already)" \
+    "git reset --hard origin/feature/issue-1" "$FORCE_CD_WT"
+# A refspec-less force-push after a cd-prefix resolves "@HEAD@" the same way ->
+# ALLOW.
+assert_allow "forceScope protected (#5156): cd into worktree then bare force-push allows (hook cwd=main root)" \
+    "cd $FORCE_CD_WT && git push --force" "$FORCE_CD_REPO"
+
+# Control: cd-ing BACK into the main (protected-branch) root and hard-resetting
+# there must still ASK -- the fix must never widen an allow past a genuine
+# protected-branch target.
+assert_ask "forceScope protected (#5156): cd into main root then reset --hard still asks (hook cwd=worktree)" \
+    "cd $FORCE_CD_REPO && git reset --hard HEAD~1" "$FORCE_CD_WT"
+# Control: cd into a directory with no real git checkout must stay ambiguous ->
+# ASK, never silently allow ("never widen a deny into an allow").
+assert_ask "forceScope protected (#5156): cd into an unresolvable directory still asks (ambiguous)" \
+    "cd /nonexistent-dir-5156-does-not-exist && git reset --hard HEAD~1" "$FORCE_CD_REPO"
+# Control: an explicit branch refspec is untouched by cd-tracking -- a
+# cd-prefixed push naming a protected branch by refspec still asks (it was
+# already correctly resolved from the refspec text, not cwd/HEAD).
+assert_ask_env "forceScope protected (#5156): cd-prefixed push naming a protected refspec branch still asks (explicit-refspec path untouched)" \
+    "LOOM_DEFAULT_BRANCH=develop" "cd $FORCE_CD_WT && git push --force origin develop" "$FORCE_CD_REPO"
+
+rm -rf "$FORCE_CD_REPO"
+
 # Clean up force-scope temp repos.
 for _force_dir in "$FORCE_ALL_REPO" "$FORCE_PROT_DEFAULT" "$FORCE_PROT_FEATURE" \
     "$FORCE_PROT_DETACHED" "$FORCE_OFF_REPO" "$FORCE_BAD_REPO" "$FORCE_BOGUS_REPO"; do


### PR DESCRIPTION
## Summary

`parse_force_ops()`'s "@HEAD@"-target branch-identity resolution (used by a hard
git reset and a refspec-less force-push) only ever resolved the effective cwd
from an explicit `-C <dir>` flag, falling back to the hook's raw session cwd
otherwise. It never accounted for a `cd <dir> &&` prefix earlier in the same
compound command. When a builder's session cwd was still the main repo root
but the actual command first `cd`s into a `.loom/worktrees/issue-N` worktree
and then force-operates on that worktree's own already-checked-out branch (a
routine, safe operation), the guard resolved branch identity against the main
checkout's branch instead and falsely asked, citing "protected branch 'main'".

## Changes

- `defaults/hooks/guard-destructive-generic.sh`: `parse_force_ops()` now
  accepts a `startcwd` second argument (callers pass `$CWD`) and threads a `cd
  <dir>` prefix through later segments of the same compound command — mirrors
  `extract_write_targets()`'s existing cd-tracking (#4933/#4881). The
  cd-tracked cwd is used **only** for `"@HEAD@"`-target lines (hard reset, and
  a push with no/HEAD refspec); a push naming an explicit branch refspec keeps
  deriving its cwd from `-C` alone, unchanged.
- `.loom/hooks/guard-destructive-generic.sh`: same change, kept in sync with
  the canonical `defaults/` copy.
- `tests/hooks/test-guard-destructive.sh`: new regression fixtures using a
  real linked worktree repo — cd-into-worktree-then-hard-reset/force-push own
  branch (hook cwd = main root) allows; the same operation with hook cwd
  already at the worktree allows; cd-ing back into the main (protected) root
  still asks; an unresolvable cd target still asks (ambiguous, never silently
  allowed); a cd-prefixed push naming an explicit protected branch refspec
  still asks (confirms the explicit-refspec path is untouched).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Resolves cwd for `@HEAD@`-target checks by accounting for a cd-prefix, not just `-C` | Done | New `curcwd` threading in `parse_force_ops()`, seeded from `$CWD`, updated on `cd` segments |
| Explicit-refspec force-push unaffected | Done | The cd-tracked cwd is used only for `@HEAD@` lines; named-refspec lines keep the original `-C`-only cwd — a regression fixture confirms an ask still fires for a cd-prefixed explicit-refspec push to a protected branch |
| "Never widen a deny into an allow" invariant holds | Done | Fixture: cd into a directory with no real git checkout still resolves to an ambiguous/detached identity and asks |
| New test fixture covers cd-into-worktree-then-force-op (hook cwd = repo root) allow, matching hook-cwd-already-at-worktree allow | Done | Both fixtures added and pass |
| Existing protected-branch fixtures (real reset/force-push to main/master, ambiguous/detached HEAD) still ask | Done | Full existing suite passes unchanged, plus a new cd-back-to-main-root control |

## Test Plan

- Ran the full hook test suite for this file: 666/666 passed (660 pre-existing
  plus 6 new fixtures for this issue).
- Ran the dispatcher test suite: 12/12 passed.
- Syntax-checked both hook copies.
- Ran shellcheck against the canonical hook file: only pre-existing info-level
  notices on unrelated lines, no new warnings.
- Manually reproduced the exact false-ask scenario from the issue against a
  scratch repo with a real linked worktree, and confirmed the verdict flips
  from ask to allow after the fix for both affected operations, while a cd
  back into the main root, an unresolvable cd, and an explicit protected-name
  refspec push all still correctly ask.

Closes #5156
