### PR TITLE
fix(champion): exclude loom:operator-only/loom:blocked from Priority 2/3 discovery queries

### DIFF
--- a/defaults/.claude/commands/loom/champion.md
+++ b/defaults/.claude/commands/loom/champion.md
@@ -39,10 +39,15 @@ If found, **read and follow instructions in `.claude/commands/loom/champion-pr-m
 ### Priority 2: Quality Issues Ready to Promote
 
 If no PRs need merging, check for curated issues. Exclude `loom:evaluating` (a
-fresh claim from a concurrent Champion evaluation, #4954) so a batch doesn't
-re-discover work another pass already claimed — `title`/`body` feed
-`champion-issue-promo.md`'s body-hash idempotency check (the issue's aggregate
-`updatedAt` is deliberately NOT used for it, #4966):
+fresh claim from a concurrent Champion evaluation, #4954), as well as
+`loom:operator-only` and `loom:blocked` — both put an issue permanently outside
+Champion's promotion authority per `champion-issue-promo.md`'s "When NOT to
+Promote", so there is no reason to hand them into the evaluation pass at all
+(#5163). Excluding them here, not just in the evaluation step, so a batch
+doesn't re-discover work another pass already claimed or that is already
+terminal — `title`/`body` feed `champion-issue-promo.md`'s body-hash
+idempotency check (the issue's aggregate `updatedAt` is deliberately NOT used
+for it, #4966):
 
 ```bash
 gh issue list \
@@ -51,6 +56,8 @@ gh issue list \
   --limit=500 \
   --json number,title,body,labels,comments \
   --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
+  select([.labels[].name] | contains(["loom:operator-only"]) | not) |
+  select([.labels[].name] | contains(["loom:blocked"]) | not) |
   "#\(.number) \(.title)"'
 ```
 
@@ -59,7 +66,8 @@ If found, **read and follow instructions in `.claude/commands/loom/champion-issu
 ### Priority 3: Architect/Hermit/Auditor Proposals Ready to Promote
 
 If no curated issues need promotion, check for well-formed proposals. Same
-`loom:evaluating` exclusion and `title`/`body` fetch as Priority 2 above:
+`loom:evaluating`/`loom:operator-only`/`loom:blocked` exclusion and
+`title`/`body` fetch as Priority 2 above:
 
 ```bash
 # Check for Architect proposals
@@ -69,6 +77,8 @@ gh issue list \
   --limit=500 \
   --json number,title,body,labels,comments \
   --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
+  select([.labels[].name] | contains(["loom:operator-only"]) | not) |
+  select([.labels[].name] | contains(["loom:blocked"]) | not) |
   "#\(.number) \(.title) [architect]"'
 
 # Check for Hermit proposals
@@ -78,6 +88,8 @@ gh issue list \
   --limit=500 \
   --json number,title,body,labels,comments \
   --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
+  select([.labels[].name] | contains(["loom:operator-only"]) | not) |
+  select([.labels[].name] | contains(["loom:blocked"]) | not) |
   "#\(.number) \(.title) [hermit]"'
 
 # Check for Auditor bug reports
@@ -87,6 +99,8 @@ gh issue list \
   --limit=500 \
   --json number,title,body,labels,comments \
   --jq '.[] | select([.labels[].name] | contains(["loom:evaluating"]) | not) |
+  select([.labels[].name] | contains(["loom:operator-only"]) | not) |
+  select([.labels[].name] | contains(["loom:blocked"]) | not) |
   "#\(.number) \(.title) [auditor]"'
 ```
 


### PR DESCRIPTION
## Summary

Champion's Priority 2 (`loom:curated`) and Priority 3 (`loom:architect`/`loom:hermit`/`loom:auditor`) discovery queries in `champion.md` filtered out only `loom:evaluating`. Issues already routed to `loom:operator-only` or `loom:blocked` — both of which put an issue permanently outside Champion's promotion authority per `champion-issue-promo.md`'s "When NOT to Promote" — kept re-entering the evaluation pass every cycle, wasting tokens on already-terminal no-ops. A real Champion pass on 2026-08-03 burned a 49k-token evaluation dispatch on 17 curated-queue issues that were all already-terminal (16 `loom:operator-only`, 1 `loom:blocked`).

## Changes

- `defaults/.claude/commands/loom/champion.md` (this repo's `.claude/commands/loom/champion.md` is a symlink to this file, so no separate installed-copy edit is needed):
  - Priority 2 (`loom:curated`) discovery query: added `select([.labels[].name] | contains(["loom:operator-only"]) | not)` and `select([.labels[].name] | contains(["loom:blocked"]) | not)`, mirroring the existing `loom:evaluating` exclusion pattern.
  - Priority 3 discovery queries (architect / hermit / auditor): same two-filter addition applied to all three.
  - Updated the prose above each query block to describe the new three-way exclusion.
- No changes to `champion-issue-promo.md`'s evaluation/idempotency logic.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Priority 2 query excludes `loom:operator-only` and `loom:blocked` alongside `loom:evaluating` | ✅ | `defaults/.claude/commands/loom/champion.md` lines ~47-59 (the installed `.claude/commands/loom/champion.md` is a symlink to this file in this repo, so it updates automatically) |
| Priority 3 queries (architect/hermit/auditor) get the same three-way exclusion | ✅ | All three `gh issue list` blocks under "Priority 3" updated identically |
| No change to `champion-issue-promo.md`'s evaluation/idempotency logic | ✅ | `git diff` for this PR touches only `defaults/.claude/commands/loom/champion.md`; `champion-issue-promo.md` is untouched |

## Test Plan

- Ran the updated jq filter chain against a synthetic 4-issue JSON fixture (one issue with `loom:operator-only`, one with `loom:blocked`, one with `loom:evaluating`, one with none) — confirmed only the issue with no exclusionary label survives the filter.
- `bash scripts/check-docs-defaults-parity.sh` — OK.
- `bash scripts/check-claude-md-budget.sh` — OK (unaffected by this change; ran for completeness).
- Confirmed `champion-issue-promo.md` has zero diff in this PR (`git diff --stat`).

Closes #5163