### PR TITLE
fix(release): install cross target on the pinned toolchain, not stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,20 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      # dtolnay/rust-toolchain's `targets:` input installs the target onto
+      # whatever toolchain the action itself resolves — here, `stable`. This
+      # repo pins `channel = "1.96.0"` in rust-toolchain.toml, so `cargo`
+      # actually builds under 1.96.0, a toolchain the step above never
+      # touched — leaving cross targets like aarch64-unknown-linux-gnu
+      # without std and failing with `error[E0463]: can't find crate for
+      # core` (#5167). `rustup target add` (unlike the action's `targets:`
+      # input) operates on the directory's *active* toolchain, which rustup
+      # resolves via rust-toolchain.toml, so it correctly lands the target on
+      # 1.96.0 instead. The toolchain channel remains pinned in exactly one
+      # place: rust-toolchain.toml.
+      - name: Add Rust target for pinned toolchain
+        run: rustup target add ${{ matrix.target }}
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
@@ -119,6 +133,19 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      # Fast preflight (#5167 acceptance criterion): confirm the pinned
+      # toolchain actually has this target's std installed before kicking off
+      # the full `cargo build`, so a future toolchain/target mismatch fails in
+      # seconds instead of after several minutes of dependency compilation.
+      - name: Verify target std is installed
+        run: |
+          set -euo pipefail
+          if ! rustup target list --installed | grep -qx "${{ matrix.target }}"; then
+            echo "::error::rustup did not install std for target '${{ matrix.target }}' on the active toolchain ($(rustc --version)). Check that rust-toolchain.toml's pinned channel supports this target." >&2
+            exit 1
+          fi
+          echo "Confirmed: ${{ matrix.target }} std is installed for $(rustc --version)."
 
       - name: Build loom-daemon
         env:


### PR DESCRIPTION
## Summary

`.github/workflows/release.yml`'s `build-daemon` job used `dtolnay/rust-toolchain@stable` with `targets: ${{ matrix.target }}`, which installs the target onto the **stable** toolchain. But the repo pins `1.96.0` via `rust-toolchain.toml`, so `cargo build` actually compiles under 1.96.0 — a toolchain that never got `aarch64-unknown-linux-gnu`'s std installed, producing `error[E0463]: can't find crate for core`. This only affected the cross target; the two native targets (`x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`) already had their runner's own std present regardless of which toolchain resolved.

## Changes

- Added an `Add Rust target for pinned toolchain` step (`rustup target add ${{ matrix.target }}`) right after `Setup Rust`. Unlike the action's `targets:` input, `rustup target add` operates on the directory's *active* toolchain — which rustup resolves via `rust-toolchain.toml` — so it correctly lands the target on the pinned 1.96.0 toolchain instead of stable.
- Added a `Verify target std is installed` fast preflight step (checks `rustup target list --installed`) right before the `Build loom-daemon` step, so a future toolchain/target mismatch fails within seconds with a clear `::error::` message instead of after several minutes of full dependency compilation.
- The toolchain channel remains pinned in exactly one place: `rust-toolchain.toml`. No duplicated channel string was introduced.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| A release builds and publishes `loom-daemon-aarch64-unknown-linux-gnu` plus its `.sha256`/`.sig`/`.pem` | Not verifiable from this session | This is a CI-workflow-only change with no local Rust cross-toolchain available; requires a real `workflow_dispatch` or new-tag run against `release.yml` to confirm end-to-end. Root cause and fix mechanism (`rustup target add` resolves the pinned toolchain, matching how `rust-toolchain.toml` is honored) are verified by inspection against the documented failure (`error[E0463]`). |
| The toolchain pin lives in exactly one place — no duplicated channel string | Verified | Only `rust-toolchain.toml` declares `channel = "1.96.0"`; the new steps reference no channel/version, they only add a target to whatever toolchain is already active. |
| Cross-target std availability is verified before the long build step (fast preflight) | Verified | New `Verify target std is installed` step runs `rustup target list --installed` (near-instant) immediately before `Build loom-daemon`, failing fast with `::error::` on a mismatch. |
| v0.18.0's missing asset is backfilled, or the gap is recorded in release notes | Noted, not actioned | Out of scope for this PR (a release-asset action, not a repo file change) — see note below. |
| Confirm no other workflow needs the same fix | Verified | Per the issue's Curator enhancement (already verified against `origin/main`): `security.yml` and `ci.yml` also use `dtolnay/rust-toolchain@stable`, but neither passes a `targets:` input (both build natively for the runner's own architecture), so neither is exposed to this bug. No changes needed there. |

## Test Plan

- Automated tests: N/A — CI-workflow-only change, no application code or unit/integration test surface (per the issue's own Test Plan).
- YAML validity: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — parses successfully.
- Manual verification (out of scope for this automated PR, requires a maintainer-triggered run): trigger `release.yml` via `workflow_dispatch` or a new tag and confirm all three targets — `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu` — build and publish their artifact + `.sha256` (and `.sig`/`.pem` for Linux).

## Note on v0.18.0's missing asset

The v0.18.0 GitHub Release is missing `loom-daemon-aarch64-unknown-linux-gnu` (+ its `.sha256`/`.sig`/`.pem`) due to this bug. Backfilling it is a release-asset action against an already-published release, not a repository file change, so it's out of scope for this PR. Recommend either re-running the fixed `release.yml` against the `v0.18.0` tag once this merges, or noting the gap in the v0.18.0 release notes.

Closes #5167