### PR TITLE
test(daemon): serialize the LOOM_WORKTREE_ROOT env seam across worktree_root and worktree_reaper tests

### DIFF
--- a/loom-daemon/src/worktree_reaper.rs
+++ b/loom-daemon/src/worktree_reaper.rs
@@ -602,6 +602,15 @@ mod tests {
 
     /// Run a full reap pass against `repo` with scripted probes, recording
     /// which worktrees the (fake) remover was asked to delete.
+    ///
+    /// **Every test that calls this must be `#[serial]`** (the crate-default
+    /// unkeyed group). `reap_worktrees` -> `reap_repo` reads the process-wide
+    /// `LOOM_WORKTREE_ROOT` via `worktree_root::worktree_root()`, and
+    /// `worktree_root`'s own tests *set* that var for the duration of their
+    /// body. `#[serial]` only serializes against other `#[serial]` tests, so a
+    /// non-serial reader here can otherwise observe a sibling module's
+    /// override, resolve the wrong root, scan zero worktrees and flake
+    /// nondeterministically (#5164, same class as #5133).
     fn run_pass(repo: &Path, spec: &ProbeSpec, opts: &CleanOptions) -> (ReapReport, Vec<u32>) {
         let removed = Arc::new(Mutex::new(Vec::new()));
         let in_use_marker = |_: &Path| {
@@ -650,6 +659,7 @@ mod tests {
     // ===================================================================
 
     #[test]
+    #[serial]
     fn test_merged_pr_worktree_is_reaped_without_a_manual_clean() {
         let repo = make_repo(&[(100, true), (101, true)]);
         let (report, removed) = run_pass(repo.path(), &ProbeSpec::default(), &default_opts());
@@ -661,6 +671,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_reap_is_idempotent_second_pass_finds_nothing() {
         // The remover is a fake, so simulate the real effect by deleting the
         // directory ourselves and re-running: a second pass must be a no-op
@@ -677,6 +688,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_missing_worktree_root_is_a_clean_no_op() {
         let tmp = tempfile::tempdir().unwrap();
         let (report, removed) = run_pass(tmp.path(), &ProbeSpec::default(), &default_opts());
@@ -689,6 +701,7 @@ mod tests {
     // ===================================================================
 
     #[test]
+    #[serial]
     fn test_unmanaged_worktree_is_never_reaped() {
         // No `.loom-managed` sentinel ⇒ user-provisioned ⇒ preserved even
         // though every other gate says "removable".
@@ -700,6 +713,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_open_pr_worktree_is_never_reaped() {
         let repo = make_repo(&[(300, true)]);
         let spec = ProbeSpec {
@@ -712,6 +726,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_unmerged_and_absent_pr_worktrees_are_never_reaped() {
         for (status, expect) in [
             (PrStatus::ClosedNoMerge, "PR closed without merge"),
@@ -730,6 +745,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_open_issue_worktree_is_never_reaped() {
         let repo = make_repo(&[(302, true)]);
         let spec = ProbeSpec {
@@ -741,6 +757,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_uncommitted_changes_block_the_reap() {
         let repo = make_repo(&[(303, true)]);
         let spec = ProbeSpec {
@@ -753,6 +770,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_in_use_marker_blocks_the_reap() {
         let repo = make_repo(&[(304, true)]);
         let spec = ProbeSpec {
@@ -765,6 +783,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_live_claim_blocks_the_reap() {
         let repo = make_repo(&[(305, true)]);
         let spec = ProbeSpec {
@@ -779,6 +798,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_editable_install_blocks_the_reap() {
         let repo = make_repo(&[(306, true)]);
         let spec = ProbeSpec {
@@ -791,6 +811,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_grace_period_defers_a_just_merged_pr() {
         let repo = make_repo(&[(307, true)]);
         let spec = ProbeSpec {
@@ -805,6 +826,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_non_issue_directories_are_ignored() {
         let repo = make_repo(&[(400, true)]);
         fs::create_dir_all(repo.path().join(".loom/worktrees/scratch")).unwrap();

--- a/loom-daemon/src/worktree_root.rs
+++ b/loom-daemon/src/worktree_root.rs
@@ -122,6 +122,15 @@ mod tests {
 
     // std::env::set_var mutates process-global state; serialize env-touching
     // tests so parallel execution doesn't race on LOOM_WORKTREE_ROOT.
+    //
+    // ENV_LOCK alone is NOT sufficient: it is module-local, so it makes the
+    // mutation *look* contained while the var is in fact process-global and
+    // read by other modules' tests (`worktree_reaper::tests::run_pass` ->
+    // `reap_repo` -> `worktree_root()`). Every test below that calls
+    // `with_env` with a value therefore also carries `#[serial]` (the
+    // crate-default unkeyed group, shared with `worktree_reaper`'s reaper
+    // tests) so the two sides of that seam cannot interleave (#5164, same
+    // class as #5133).
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     /// Run `f` with LOOM_WORKTREE_ROOT set to `value` (or unset if None),
@@ -164,6 +173,7 @@ mod tests {
     use std::fs;
 
     #[test]
+    #[serial]
     fn default_when_no_override() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -176,6 +186,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn env_override_namespaces_by_basename() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -188,6 +199,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn env_override_strips_trailing_slash() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -200,6 +212,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn config_override_namespaces_by_basename() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -213,6 +226,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn env_beats_config() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -226,6 +240,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn relative_env_override_falls_back_to_default() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -238,6 +253,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn relative_config_override_falls_back_to_default() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -251,6 +267,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn empty_env_override_falls_back_to_config_then_default() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -264,6 +281,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn missing_config_key_uses_default() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -278,6 +296,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn malformed_config_uses_default() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -291,6 +310,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn gate_matches_default_path_worktree() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -303,6 +323,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn gate_matches_override_path_worktree() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");
@@ -315,6 +336,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn gate_matches_default_substring_even_with_override_set() {
         // Mixed setup: an override is configured, but a worktree still lives
         // under the historical .loom/worktrees base. The substring fallback
@@ -330,6 +352,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn gate_rejects_unrelated_path() {
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path().join("my-repo");


### PR DESCRIPTION
## Summary

`worktree_root::tests` mutate the **process-global** `LOOM_WORKTREE_ROOT`, but serialize only *among themselves* via a module-local `ENV_LOCK` mutex. That mutex makes the mutation look contained while the var is in fact process-global and read by another module's tests: `worktree_reaper::tests::run_pass` → `reap_worktrees` → `reap_repo` → `worktree_root::worktree_root()`. Under the default parallel harness a reaper test can observe a sibling's override, resolve a worktree root that does not exist, scan zero worktrees, and panic indexing an empty report.

This puts **both sides of the seam** on the crate-default unkeyed `#[serial]` group — the same remedy as the precedent fix in #5148 / #5133. Test-only, no production code touched.

## Changes

- `loom-daemon/src/worktree_root.rs` — `#[serial]` on the **14** tests that call `with_env(...)`. `ENV_LOCK` is deliberately **kept** (not replaced): the 4 `project_tier_*` / `local_tier_*` / `explicit_null_*` tests carry `#[serial(loom_config_env)]`, a *different* keyed group that does not serialize against the unkeyed one, and they still rely on `ENV_LOCK` for their `with_env(None, ...)` calls. The `ENV_LOCK` comment now spells out why the mutex alone is insufficient.
- `loom-daemon/src/worktree_reaper.rs` — `#[serial]` on the **13** tests that call `run_pass`, plus a doc note on `run_pass` itself recording the invariant ("every test that calls this must be `#[serial]`") so a future test does not silently re-open the seam.
- Untouched, per the issue's enumeration: `test_failed_removal_is_reported_not_silently_counted_as_removed` and `test_reaper_options_are_safe_never_forced_and_sentinel_gated` (call `reap_worktrees` / `reaper_clean_options` directly, never reaching `worktree_root()`), and the `test_config_*` / `test_resolve_*` tests (unrelated env surface, already correctly scoped).

## Acceptance Criteria Verification

- [x] **`cargo test` passes repeatedly (>= 10 consecutive runs) with no `worktree_reaper` flake** — verified with **20/20** clean runs post-fix (see Test Plan). A pre-fix baseline on the same host in the same session reproduced **3/10** failures.
- [x] **`worktree_root`'s env mutation can no longer interleave with any test that reads `LOOM_WORKTREE_ROOT`** — all 14 mutating tests and all 13 transitively-reading tests are now in the same unkeyed `#[serial]` group. The 4 keyed `#[serial(loom_config_env)]` tests only ever call `with_env(None, ...)` (never set a conflicting value), so they are not part of this race, and `ENV_LOCK` still covers them.
- [x] **No production (non-test) behaviour change** — the diff is entirely inside `#[cfg(test)] mod tests` blocks plus comments; only test attributes and documentation were added.

## Test Plan

**Baseline (pre-fix, this branch with the fix reverted, same host/session):** 3/10 runs failed, and the exposure was broader than the single test named in the issue's Symptom — **4 distinct** reaper tests panicked across the 3 failing runs, confirming the Curator's widened scope:

```
run 1: PASS   run 2: FAIL   run 3: PASS   run 4: PASS   run 5: FAIL
run 6: PASS   run 7: PASS   run 8: PASS   run 9: PASS   run 10: FAIL
BASELINE (pre-fix) failures: 3/10

worktree_reaper::tests::test_unmerged_and_absent_pr_worktrees_are_never_reaped  panicked at worktree_reaper.rs:728:38
worktree_reaper::tests::test_unmanaged_worktree_is_never_reaped                 panicked at worktree_reaper.rs:698:9
worktree_reaper::tests::test_reap_is_idempotent_second_pass_finds_nothing       panicked at worktree_reaper.rs:670:9
worktree_reaper::tests::test_live_claim_blocks_the_reap                         panicked at worktree_reaper.rs:776:31
```

**Post-fix — `cargo test -q -p loom-daemon --lib -- worktree_root:: worktree_reaper::` x 20 (double the required 10):**

```
run 1..20: PASS
POST-FIX failures: 0/20
test result: ok. 46 passed; 0 failed; 0 ignored; 0 measured; 3291 filtered out; finished in 0.05s
```

**Full suite — `cargo test -p loom-daemon --lib`:**

```
test result: ok. 3337 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 245.96s
```

**Edge case (per the issue's Test Plan):** the newly-`#[serial]`-marked tests still pass with identical assertions when run inside the crate's existing unkeyed `#[serial]` group — only ordering/interleaving changed, not outcomes. Serialization cost is negligible: the 46-test filtered set runs in 0.05s.

**Lint/format:** `cargo clippy -p loom-daemon --lib --all-targets` clean; `cargo fmt -p loom-daemon --check` clean.

**Manual verification:** N/A — test-only, non-behavioral change (issue AC3).

Closes #5164
