### PR TITLE
fix(guard): thread a cd-prefix into stash-scope cwd resolution

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -1740,6 +1740,64 @@ parse_force_ops() {
     }'
 }
 
+# resolve_stash_cwd() — thread a `cd <dir> &&` prefix through $CWD resolution
+# for the STASH-STACK SCOPE block below, exactly mirroring parse_force_ops'
+# cd-tracking above (which itself mirrors extract_write_targets,
+# #4933/#4881/#5156/#5161). Without this, a command of the form `cd
+# .loom/worktrees/issue-N && git stash pop` — hook session cwd still the main
+# repo root, the common shape per this repo's own CLAUDE.md worktree workflow
+# — resolved stash scope against the WRONG checkout and asked as if the
+# operation targeted the main checkout (#5173).
+#
+# $1 = command text, $2 = starting cwd (the hook's own session cwd — callers
+# pass $CWD). Returns the cwd IN EFFECT once the FIRST `git stash
+# pop/drop/clear` segment is reached; if no such segment is found (should not
+# happen — callers only invoke this after the same grep match already
+# succeeded), returns the fully cd-threaded cwd after the LAST segment as a
+# deterministic fallback. `cd -` and a bare `cd` leave curcwd UNCHANGED —
+# same known limitation parse_force_ops documents, left unresolved rather
+# than guessed.
+#
+# A `git -C <path> stash ...` prefix is NOT threaded here (matches this
+# block's pre-existing KNOWN LIMITATION comment above the caller, a distinct
+# false-NEGATIVE direction out of this issue's scope) — only a `cd <dir>`
+# prefix is.
+resolve_stash_cwd() {
+    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK"'
+    BEGIN { curcwd = startcwd; found = 0 }
+    {
+        $0 = qsplit($0)   # quote-aware segmentation (#3755)
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            sub(/^[ \t]+/, "", seg)
+            if (seg == "") continue
+            m = split(seg, toks, /[ \t]+/)
+            if (m == 0) continue
+            # Thread a `cd <dir>` prefix through LATER segments of this same
+            # compound command (mirrors parse_force_ops above).
+            if (toks[1] == "cd") {
+                if (m >= 2 && toks[2] != "" && toks[2] != "-") {
+                    if (toks[2] ~ /^\//) {
+                        curcwd = toks[2]
+                    } else if (curcwd != "") {
+                        curcwd = curcwd "/" toks[2]
+                    }
+                }
+                continue
+            }
+            if (toks[1] == "git" && m >= 3 && toks[2] == "stash" && (toks[3] == "pop" || toks[3] == "drop" || toks[3] == "clear")) {
+                print curcwd
+                found = 1
+                exit
+            }
+        }
+    }
+    END { if (!found) print curcwd }'
+}
+
 # Redact the quoted VALUES of known text-carrying flags (--body, -m/--message,
 # --title, --notes, --comment) so a dangerous-looking phrase quoted INSIDE such a
 # value no longer trips the raw ALWAYS_BLOCK_PATTERNS substring scan (catastrophic
@@ -3298,6 +3356,18 @@ fi
 # ask inside a builder's own worktree too. The show-toplevel/common-dir
 # comparison sidesteps that entirely.
 #
+# CD-PREFIX THREADING (#5173): unlike the raw $CWD comparison this replaced,
+# resolve_stash_cwd() (defined above, mirrors parse_force_ops' cd-tracking
+# from #5156/#5161) threads a `cd <dir> &&` prefix earlier in the SAME
+# compound $COMMAND through to the stash pop/drop/clear invocation, so a
+# command like `cd .loom/worktrees/issue-N && git stash pop` — hook session
+# cwd still the main repo root, the common shape per this repo's own
+# CLAUDE.md worktree workflow — resolves scope against the cd TARGET, not the
+# hook's raw session cwd. Both the main-checkout ask below AND the
+# worktree-collision ask (#4821) further down consume the SAME
+# _stash_toplevel/_stash_common_parent values, so both get this treatment
+# for free.
+#
 # KNOWN LIMITATION: unlike the force-op parser (parse_force_ops), this check
 # does not thread a `git -C <path>` argument — `git -C <main-checkout-path>
 # stash pop` run from a worktree cwd is not caught today. Track any observed
@@ -3319,16 +3389,22 @@ fi
 # =============================================================================
 if echo "$COMMAND_ASK_SCAN" | grep -qE '(^|[;&|(]|[[:space:]])git[[:space:]]+stash[[:space:]]+(pop|drop|clear)([[:space:]]|$)' \
    && stash_scope_guard_enabled; then
+    _stash_effective_cwd="$CWD"
+    if [[ -n "$CWD" ]]; then
+        _stash_effective_cwd=$(resolve_stash_cwd "$COMMAND_NO_COMMENT" "$CWD")
+        [[ -z "$_stash_effective_cwd" ]] && _stash_effective_cwd="$CWD"
+    fi
+
     _stash_toplevel=""
     _stash_common_parent=""
-    if [[ -n "$CWD" && -d "$CWD" ]]; then
-        _stash_toplevel=$(cd "$CWD" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || _stash_toplevel=""
+    if [[ -n "$_stash_effective_cwd" && -d "$_stash_effective_cwd" ]]; then
+        _stash_toplevel=$(cd "$_stash_effective_cwd" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || _stash_toplevel=""
         [[ -n "$_stash_toplevel" && -d "$_stash_toplevel" ]] && \
             _stash_toplevel=$(cd "$_stash_toplevel" 2>/dev/null && pwd -P) || _stash_toplevel=""
 
-        _stash_common=$(cd "$CWD" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || _stash_common=""
+        _stash_common=$(cd "$_stash_effective_cwd" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || _stash_common=""
         if [[ -n "$_stash_common" ]]; then
-            _stash_common_parent=$(cd "$CWD" 2>/dev/null && cd "$_stash_common/.." 2>/dev/null && pwd -P) || _stash_common_parent=""
+            _stash_common_parent=$(cd "$_stash_effective_cwd" 2>/dev/null && cd "$_stash_common/.." 2>/dev/null && pwd -P) || _stash_common_parent=""
         fi
     fi
 
@@ -3349,6 +3425,12 @@ if echo "$COMMAND_ASK_SCAN" | grep -qE '(^|[;&|(]|[[:space:]])git[[:space:]]+sta
         if [[ "$_stash_worktree_count" -ge 2 ]]; then
             ask "Command requires confirmation: $COMMAND (git stash pop/drop/clear from a linked worktree can destroy ANOTHER builder's WIP — refs/stash is a single stack SHARED across every linked worktree of this repo, not per-worktree, and $_stash_worktree_count managed worktrees are currently active. Use './.loom/scripts/worktree.sh snapshot <issue-number>' instead of git stash for ad-hoc WIP; set guards.stashScope:false / LOOM_GUARD_STASH_SCOPE=0 to disable this ask)" "stash-scope:worktree-collision"
         fi
+    elif [[ "$_stash_effective_cwd" != "$CWD" ]]; then
+        # A `cd <dir>` prefix resolved to a target that does not exist or is
+        # not inside any git checkout — ambiguous. Never silently widen an
+        # ask into an allow (mirrors parse_force_ops' detached-HEAD fail-safe
+        # from #5156/#5161): fail toward asking rather than guessing.
+        ask "Command requires confirmation: $COMMAND (the cd target for this stash operation could not be resolved to a git checkout, so scope cannot be determined — refusing to silently allow an ambiguous stash pop/drop/clear; set guards.stashScope:false / LOOM_GUARD_STASH_SCOPE=0 to disable this ask)" "stash-scope:cd-unresolved"
     fi
 fi
 

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1740,6 +1740,64 @@ parse_force_ops() {
     }'
 }
 
+# resolve_stash_cwd() — thread a `cd <dir> &&` prefix through $CWD resolution
+# for the STASH-STACK SCOPE block below, exactly mirroring parse_force_ops'
+# cd-tracking above (which itself mirrors extract_write_targets,
+# #4933/#4881/#5156/#5161). Without this, a command of the form `cd
+# .loom/worktrees/issue-N && git stash pop` — hook session cwd still the main
+# repo root, the common shape per this repo's own CLAUDE.md worktree workflow
+# — resolved stash scope against the WRONG checkout and asked as if the
+# operation targeted the main checkout (#5173).
+#
+# $1 = command text, $2 = starting cwd (the hook's own session cwd — callers
+# pass $CWD). Returns the cwd IN EFFECT once the FIRST `git stash
+# pop/drop/clear` segment is reached; if no such segment is found (should not
+# happen — callers only invoke this after the same grep match already
+# succeeded), returns the fully cd-threaded cwd after the LAST segment as a
+# deterministic fallback. `cd -` and a bare `cd` leave curcwd UNCHANGED —
+# same known limitation parse_force_ops documents, left unresolved rather
+# than guessed.
+#
+# A `git -C <path> stash ...` prefix is NOT threaded here (matches this
+# block's pre-existing KNOWN LIMITATION comment above the caller, a distinct
+# false-NEGATIVE direction out of this issue's scope) — only a `cd <dir>`
+# prefix is.
+resolve_stash_cwd() {
+    printf '%s' "$1" | awk -v startcwd="$2" "$_QSPLIT_AWK"'
+    BEGIN { curcwd = startcwd; found = 0 }
+    {
+        $0 = qsplit($0)   # quote-aware segmentation (#3755)
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            sub(/^[ \t]+/, "", seg)
+            if (seg == "") continue
+            m = split(seg, toks, /[ \t]+/)
+            if (m == 0) continue
+            # Thread a `cd <dir>` prefix through LATER segments of this same
+            # compound command (mirrors parse_force_ops above).
+            if (toks[1] == "cd") {
+                if (m >= 2 && toks[2] != "" && toks[2] != "-") {
+                    if (toks[2] ~ /^\//) {
+                        curcwd = toks[2]
+                    } else if (curcwd != "") {
+                        curcwd = curcwd "/" toks[2]
+                    }
+                }
+                continue
+            }
+            if (toks[1] == "git" && m >= 3 && toks[2] == "stash" && (toks[3] == "pop" || toks[3] == "drop" || toks[3] == "clear")) {
+                print curcwd
+                found = 1
+                exit
+            }
+        }
+    }
+    END { if (!found) print curcwd }'
+}
+
 # Redact the quoted VALUES of known text-carrying flags (--body, -m/--message,
 # --title, --notes, --comment) so a dangerous-looking phrase quoted INSIDE such a
 # value no longer trips the raw ALWAYS_BLOCK_PATTERNS substring scan (catastrophic
@@ -3298,6 +3356,18 @@ fi
 # ask inside a builder's own worktree too. The show-toplevel/common-dir
 # comparison sidesteps that entirely.
 #
+# CD-PREFIX THREADING (#5173): unlike the raw $CWD comparison this replaced,
+# resolve_stash_cwd() (defined above, mirrors parse_force_ops' cd-tracking
+# from #5156/#5161) threads a `cd <dir> &&` prefix earlier in the SAME
+# compound $COMMAND through to the stash pop/drop/clear invocation, so a
+# command like `cd .loom/worktrees/issue-N && git stash pop` — hook session
+# cwd still the main repo root, the common shape per this repo's own
+# CLAUDE.md worktree workflow — resolves scope against the cd TARGET, not the
+# hook's raw session cwd. Both the main-checkout ask below AND the
+# worktree-collision ask (#4821) further down consume the SAME
+# _stash_toplevel/_stash_common_parent values, so both get this treatment
+# for free.
+#
 # KNOWN LIMITATION: unlike the force-op parser (parse_force_ops), this check
 # does not thread a `git -C <path>` argument — `git -C <main-checkout-path>
 # stash pop` run from a worktree cwd is not caught today. Track any observed
@@ -3319,16 +3389,22 @@ fi
 # =============================================================================
 if echo "$COMMAND_ASK_SCAN" | grep -qE '(^|[;&|(]|[[:space:]])git[[:space:]]+stash[[:space:]]+(pop|drop|clear)([[:space:]]|$)' \
    && stash_scope_guard_enabled; then
+    _stash_effective_cwd="$CWD"
+    if [[ -n "$CWD" ]]; then
+        _stash_effective_cwd=$(resolve_stash_cwd "$COMMAND_NO_COMMENT" "$CWD")
+        [[ -z "$_stash_effective_cwd" ]] && _stash_effective_cwd="$CWD"
+    fi
+
     _stash_toplevel=""
     _stash_common_parent=""
-    if [[ -n "$CWD" && -d "$CWD" ]]; then
-        _stash_toplevel=$(cd "$CWD" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || _stash_toplevel=""
+    if [[ -n "$_stash_effective_cwd" && -d "$_stash_effective_cwd" ]]; then
+        _stash_toplevel=$(cd "$_stash_effective_cwd" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || _stash_toplevel=""
         [[ -n "$_stash_toplevel" && -d "$_stash_toplevel" ]] && \
             _stash_toplevel=$(cd "$_stash_toplevel" 2>/dev/null && pwd -P) || _stash_toplevel=""
 
-        _stash_common=$(cd "$CWD" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || _stash_common=""
+        _stash_common=$(cd "$_stash_effective_cwd" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || _stash_common=""
         if [[ -n "$_stash_common" ]]; then
-            _stash_common_parent=$(cd "$CWD" 2>/dev/null && cd "$_stash_common/.." 2>/dev/null && pwd -P) || _stash_common_parent=""
+            _stash_common_parent=$(cd "$_stash_effective_cwd" 2>/dev/null && cd "$_stash_common/.." 2>/dev/null && pwd -P) || _stash_common_parent=""
         fi
     fi
 
@@ -3349,6 +3425,12 @@ if echo "$COMMAND_ASK_SCAN" | grep -qE '(^|[;&|(]|[[:space:]])git[[:space:]]+sta
         if [[ "$_stash_worktree_count" -ge 2 ]]; then
             ask "Command requires confirmation: $COMMAND (git stash pop/drop/clear from a linked worktree can destroy ANOTHER builder's WIP — refs/stash is a single stack SHARED across every linked worktree of this repo, not per-worktree, and $_stash_worktree_count managed worktrees are currently active. Use './.loom/scripts/worktree.sh snapshot <issue-number>' instead of git stash for ad-hoc WIP; set guards.stashScope:false / LOOM_GUARD_STASH_SCOPE=0 to disable this ask)" "stash-scope:worktree-collision"
         fi
+    elif [[ "$_stash_effective_cwd" != "$CWD" ]]; then
+        # A `cd <dir>` prefix resolved to a target that does not exist or is
+        # not inside any git checkout — ambiguous. Never silently widen an
+        # ask into an allow (mirrors parse_force_ops' detached-HEAD fail-safe
+        # from #5156/#5161): fail toward asking rather than guessing.
+        ask "Command requires confirmation: $COMMAND (the cd target for this stash operation could not be resolved to a git checkout, so scope cannot be determined — refusing to silently allow an ambiguous stash pop/drop/clear; set guards.stashScope:false / LOOM_GUARD_STASH_SCOPE=0 to disable this ask)" "stash-scope:cd-unresolved"
     fi
 fi
 

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -3335,6 +3335,85 @@ rm -rf "$ST2_REPO" "$ST2_REPO_OFF"
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Stash-stack scope: cd-prefix threading (#5173) ---${NC}"
+# =========================================================================
+#
+# Regression: the hook's reported session cwd can still be the MAIN repo root
+# while the COMMAND itself first `cd`s into a linked worktree and restores a
+# stash entry there — a routine, safe operation per this repo's own CLAUDE.md
+# worktree workflow (`cd .loom/worktrees/issue-N && git stash pop`). Before
+# the #5173 fix, main-checkout/worktree-collision scope resolution fell back
+# to the raw session cwd whenever no `cd` prefix was accounted for, so it
+# queried the MAIN checkout (protected) instead of the worktree the command
+# actually targets, and incorrectly asked citing the main checkout. Mirrors
+# the fixture pattern from #5156/PR #5161's cd-tracking fix for
+# parse_force_ops(). A REAL linked `git worktree add` fixture is used (not a
+# plain subdirectory) so the worktree genuinely has its own toplevel/common-dir
+# divergence, mirroring make_wt_repo_linked above.
+
+CD_ST_REPO=$(make_wt_repo_linked)
+CD_ST_WT_DIR="$CD_ST_REPO/.loom/worktrees/issue-1"
+
+# Hook cwd = MAIN repo root; command cd's into the worktree, then restores a
+# stash entry there -> must ALLOW (the false-ask this issue fixes). Only ONE
+# managed worktree exists, so the worktree-collision branch (#4821) must not
+# fire either.
+assert_allow "stash-scope (#5173): cd into worktree then stash pop allows (hook cwd=main root)" \
+    "cd $CD_ST_WT_DIR && git stash pop" "$CD_ST_REPO"
+assert_allow "stash-scope (#5173): cd into worktree then stash drop allows (hook cwd=main root)" \
+    "cd $CD_ST_WT_DIR && git stash drop" "$CD_ST_REPO"
+assert_allow "stash-scope (#5173): cd into worktree then stash clear allows (hook cwd=main root)" \
+    "cd $CD_ST_WT_DIR && git stash clear" "$CD_ST_REPO"
+# A read-only prefix ahead of the cd must not break resolution.
+assert_allow "stash-scope (#5173): chained 'cd <worktree> && git status && git stash pop' allows (hook cwd=main root)" \
+    "cd $CD_ST_WT_DIR && git status && git stash pop" "$CD_ST_REPO"
+
+# Same effective operation with the hook cwd already AT the worktree -> must
+# also ALLOW (already correct pre-fix; kept as a matching control, #5161-style).
+assert_allow "stash-scope (#5173): cd into worktree (redundant) then stash pop allows (hook cwd=worktree already)" \
+    "cd $CD_ST_WT_DIR && git stash pop" "$CD_ST_WT_DIR"
+
+# Control: cd-ing BACK into the main (protected) checkout root must still ASK
+# citing the main-checkout reason -- the fix must never widen an allow past a
+# genuine main-checkout stash restore.
+assert_ask_reason_matches "stash-scope (#5173): cd into main root then stash pop still asks (hook cwd=worktree)" \
+    "cd $CD_ST_REPO && git stash pop" "MAIN checkout" "$CD_ST_WT_DIR"
+
+# Control: cd into a directory that does not exist / is not a git checkout
+# must stay ambiguous -> ASK, never silently allow ("never widen a deny/ask
+# into an allow").
+assert_ask_reason_matches "stash-scope (#5173): cd into an unresolvable directory still asks (ambiguous)" \
+    "cd /nonexistent-dir-5173-does-not-exist && git stash pop" "could not be resolved" "$CD_ST_REPO"
+
+rm -rf "$CD_ST_REPO"
+
+# Worktree-collision (#4821) consistency: the SAME cd-threaded
+# _stash_toplevel/_stash_common_parent resolution feeds both checks, so a
+# cd-prefixed stash op resolving into a linked worktree (not the main
+# checkout) while >=2 managed worktrees are active must ask citing the
+# COLLISION reason -- not the main-checkout reason a raw-cwd-only resolution
+# would have (incorrectly) produced.
+CD_ST2_REPO=$(make_wt_repo_two_linked)
+CD_ST2_WT1_DIR="$CD_ST2_REPO/.loom/worktrees/issue-1"
+CD_ST2_WT2_DIR="$CD_ST2_REPO/.loom/worktrees/issue-2"
+
+assert_ask_reason_matches "stash-scope (#5173): cd into worktree-1 then stash pop asks with collision reason (hook cwd=main root, >=2 worktrees)" \
+    "cd $CD_ST2_WT1_DIR && git stash pop" "ANOTHER builder's WIP" "$CD_ST2_REPO"
+assert_ask_reason_matches "stash-scope (#5173): cd from worktree-1 into worktree-2 then stash drop asks with collision reason" \
+    "cd $CD_ST2_WT2_DIR && git stash drop" "ANOTHER builder's WIP" "$CD_ST2_WT1_DIR"
+
+# Toggle opt-out also covers the cd-prefixed form (guards.stashScope:false /
+# LOOM_GUARD_STASH_SCOPE=0, default on).
+mkdir -p "$CD_ST2_REPO/.loom"
+printf '%s' '{"guards":{"stashScope":false}}' > "$CD_ST2_REPO/.loom/config.json"
+assert_allow "stash-scope (#5173): guards.stashScope:false -> allow for cd-prefixed stash pop into worktree" \
+    "cd $CD_ST2_WT1_DIR && git stash pop" "$CD_ST2_REPO"
+
+rm -rf "$CD_ST2_REPO"
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- Performance check ---${NC}"
 # =========================================================================
 


### PR DESCRIPTION
## Summary

`.loom/hooks/guard-destructive-generic.sh`'s `stash-scope:main-checkout` check
(and its `stash-scope:worktree-collision` sibling, #4821) resolved
`_stash_toplevel` / `_stash_common_parent` purely from the hook's raw session
`$CWD`, ignoring any `cd <dir> &&` prefix earlier in the same compound
`$COMMAND` string. A command of the form `cd .loom/worktrees/issue-N && git
stash pop` — hook session cwd still the main repo root, the common shape per
this repo's own CLAUDE.md worktree workflow — resolved scope against the
main checkout instead of the cd target, and asked as if the operation
targeted the main checkout.

This is the same class of bug already fixed for `parse_force_ops()` in
#5156/PR #5161 ("thread a cd-prefix into force-op cwd/branch-identity
resolution"); this PR mirrors that fix's cd-tracking approach for the
stash-scope block.

## Changes

- `defaults/hooks/guard-destructive-generic.sh`: adds `resolve_stash_cwd()`,
  a new helper mirroring `parse_force_ops()`'s cd-tracking (which itself
  mirrors `extract_write_targets()`, #4933/#4881). It threads a `cd <dir>`
  prefix through the compound command and returns the cwd in effect at the
  `git stash pop/drop/clear` segment. The `stash-scope:main-checkout` block
  now resolves `_stash_toplevel`/`_stash_common_parent` from this
  cd-threaded effective cwd instead of the raw `$CWD`. The
  `stash-scope:worktree-collision` check (#4821) consumes the same shared
  `_stash_toplevel`/`_stash_common_parent` values, so it gets the same
  treatment automatically. A new branch handles the case where the cd
  target cannot be resolved to a git checkout (does not exist, or is not a
  repo) — it now asks explicitly (`stash-scope:cd-unresolved`) rather than
  silently falling through to allow, matching `parse_force_ops`'
  detached-HEAD fail-safe.
- `.loom/hooks/guard-destructive-generic.sh`: same change, kept byte-identical
  to the canonical `defaults/` copy.
- `tests/hooks/test-guard-destructive.sh`: new regression fixtures using a
  real linked worktree repo (mirrors #5161's fixture pattern) — cd into a
  worktree then stash pop/drop/clear (hook cwd = main root) allows; the same
  op with hook cwd already at the worktree allows; a chained read-only prefix
  before the cd still resolves correctly; cd-ing back into the main
  (protected) root still asks with the main-checkout reason; an unresolvable
  cd target still asks (ambiguous, never silently allowed); a cd-prefixed
  stash op resolving into a linked worktree with >=2 managed worktrees active
  asks with the worktree-collision reason (not main-checkout); the
  `guards.stashScope:false` toggle still covers the cd-prefixed form.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| `cd <worktree> && <stash-restore-command>` (hook cwd = main root) no longer fires `stash-scope:main-checkout` when the cd target is a genuine linked worktree | Done | New fixtures: cd into worktree then stash pop/drop/clear allows |
| A command that cd's back into the main checkout root still asks | Done | New fixture: cd into main root then stash pop still asks, verified via `assert_ask_reason_matches` on the main-checkout reason text |
| An unresolvable/ambiguous cd target still asks (never silently widen a deny/ask into an allow) | Done | New `stash-scope:cd-unresolved` branch + fixture: cd into a nonexistent directory still asks |
| `stash-scope:worktree-collision` updated consistently | Done | Both checks share the same cd-threaded `_stash_toplevel`/`_stash_common_parent`; new fixtures confirm the collision reason (not main-checkout) fires for a cd-prefixed op resolving into a linked worktree with >=2 managed worktrees |
| Both hook copies stay byte-identical | Done | `diff defaults/hooks/... .loom/hooks/...` confirms identical |

## Test Plan

- Ran the full hook test suite for this file: 676/676 passed (666 pre-existing
  plus 10 new fixtures for this issue).
- Ran `tests/hooks/test-guard-destructive-dispatcher.sh`: 12/12 passed.
- Ran `tests/hooks/test-guard-loom-workflow.sh`: 42/42 passed.
- Ran `tests/install/test-hooks-preserve.sh`: 10/10 passed.
- Syntax-checked both hook copies (`bash -n`).
- Ran shellcheck against the canonical hook file: same 5 pre-existing
  info-level notices as `main`, no new warnings.
- Manually exercised `resolve_stash_cwd()` in isolation against absolute/
  relative/chained/unresolvable cd-prefix inputs to confirm resolution
  matches expectations before wiring it into the guard block.

Closes #5173