### PR TITLE
fix(release): include .pem in manual-run artifact upload for keyless-signed Linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,8 +379,13 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: loom-daemon-${{ matrix.target }}
+          # Mirror the "Upload release assets" file list above, including the
+          # `.pem` glob (#5174): a keyless-signed Linux artifact needs its
+          # signing certificate to verify, and a manual backfill run onto an
+          # existing release can't complete without it.
           path: |
             dist/loom-daemon-${{ matrix.target }}
             dist/loom-daemon-${{ matrix.target }}.sha256
             dist/loom-daemon-${{ matrix.target }}*.sig
+            dist/loom-daemon-${{ matrix.target }}*.pem
           retention-days: 7


### PR DESCRIPTION
## Summary

While backfilling the v0.18.0 release's missing `loom-daemon-aarch64-unknown-linux-gnu` asset (per #5174), discovered that the `workflow_dispatch` "Upload artifacts (for manual runs)" step's `path:` glob list omits the `.pem` signing certificate that keyless cosign signing produces — unlike the release-triggered "Upload release assets" step immediately above it, which already includes `*.pem`.

Without this, a manual `workflow_dispatch` run against an existing release tag builds a correctly-signed artifact, but the signing certificate needed to verify it (`cosign verify-blob --certificate <target>.pem ...`) is never uploaded anywhere retrievable — it only exists transiently in the job's `dist/` directory.

## Change

One-line addition: `dist/loom-daemon-${{ matrix.target }}*.pem` to the manual-run artifact upload path list, mirroring the release-triggered step.

## Test plan

- [x] Verified via a live `workflow_dispatch` run (run 30869756613, tag=v0.18.0) that the aarch64-unknown-linux-gnu job's "Sign Linux artifact (cosign)" step runs in `keyless` mode and writes `dist/loom-daemon-aarch64-unknown-linux-gnu.pem`, which was absent from the downloadable Actions artifact prior to this fix.
- [ ] After merge, a follow-up `workflow_dispatch` run will confirm the `.pem` is now included in the downloaded artifact bundle (used to complete the #5174 backfill).

Closes #5174