### PR TITLE
fix(curator): exclude loom:operator-only from Priority 2 fallback discovery

### DIFF
--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -199,9 +199,9 @@ gh issue list --label="loom:triage" --state=open --limit 500 --json number,title
 ```
 
 If nothing carries `loom:triage`, fall back to any issue that is not already
-in-flight, a proposal awaiting Champion evaluation, approved, or blocked. The
-exclusion set must match CLAUDE.md's own curator discovery query so an autonomous
-Curator never "curates" an issue being built or awaiting evaluation:
+in-flight, a proposal awaiting Champion evaluation, approved, blocked, or
+reserved for a human operator, so an autonomous Curator never "curates" an
+issue being built, awaiting evaluation, or outside its authority entirely:
 
 ```bash
 gh issue list --state=open --limit 500 --json number,title,labels \
@@ -215,9 +215,16 @@ gh issue list --state=open --limit 500 --json number,title,labels \
     ([.labels[].name] | contains(["loom:auditor"]) | not) and
     ([.labels[].name] | contains(["loom:epic"]) | not) and
     ([.labels[].name] | contains(["loom:blocked"]) | not) and
+    ([.labels[].name] | contains(["loom:operator-only"]) | not) and
     ([.labels[].name] | contains(["external"]) | not)
   ) | "#\(.number) \(.title)"'
 ```
+
+Note: `loom:blocked` stays excluded here but is *not* dropped entirely from
+Curator's purview — the "Checking Dependencies" section below handles
+`loom:blocked` issues separately (dependency re-checks, unblock-on-resolve).
+`loom:operator-only` (host/cert/secret provisioning meant for a human, not a
+Builder) has no such re-check workflow, so it is excluded outright.
 
 **Workflow**:
 1. Try Priority 1 search first


### PR DESCRIPTION
## Summary

Curator's Priority 2 fallback discovery query (`defaults/.claude/commands/loom/curator.md`) excluded `loom:curated`, `loom:curating`, `loom:issue`, `loom:building`, `loom:architect`, `loom:hermit`, `loom:auditor`, `loom:epic`, `loom:blocked`, and `external` — but not `loom:operator-only`. This is the same defect class already fixed for Champion in #5163/PR #5165: `loom:operator-only` issues (host/cert/secret provisioning meant for a human, not a Builder) kept surfacing in Curator's fallback query with nothing to filter them out.

## Changes

- `defaults/.claude/commands/loom/curator.md` (this repo's `.claude/commands/loom/curator.md` is a symlink to this file — confirmed via `git check-ignore -v`, so no separate installed-copy edit is needed):
  - Added `select([.labels[].name] | contains(["loom:operator-only"]) | not)` to the Priority 2 fallback query.
  - Added a short note clarifying that `loom:blocked` stays excluded from *discovery* but is still handled by the "Checking Dependencies" section (unchanged behavior) — `loom:operator-only` has no such re-check workflow and is excluded outright.
  - Fixed the surrounding prose, which asserted "the exclusion set must match CLAUDE.md's own curator discovery query." I verified this claim is stale: `git log -S'Priority 2: Triage & Unlabeled Issues' -- CLAUDE.md` and `git log -S'gh issue list --state=open --limit 500 --json number,title,labels' -- CLAUDE.md` both return no hits — CLAUDE.md never contained this query verbatim, and the detailed "Curator Workflow" section was condensed to a brief pointer in #4919 (`fd667f63`). **CLAUDE.md required no edit for this issue** — this mirrors PR #5165, which likewise only touched `champion.md` for the analogous Champion fix, since CLAUDE.md doesn't mirror Champion's discovery queries either.

## Deviation from issue's suggested scope

Issue #5175 asked for a matching edit to a "Priority 2: Triage & Unlabeled Issues (Fallback)" section in `CLAUDE.md`. That section does not exist in `CLAUDE.md` (confirmed via `git log -S` against the file's full history) — the issue's premise on this point is stale. The actual bug (missing `loom:operator-only` exclusion) lives entirely in `curator.md`, which is fixed here.

## Acceptance Criteria Verification

| Criterion | Status | Notes |
|-----------|--------|-------|
| Priority 2 fallback query in `defaults/.claude/commands/loom/curator.md` excludes `loom:operator-only` | Done | See diff |
| Mirrored query in CLAUDE.md's Priority 2 fallback section excludes `loom:operator-only` | N/A | No such section exists in CLAUDE.md; see "Deviation" above |
| No change to how Curator handles `loom:blocked` issues | Done | `loom:blocked` exclusion unchanged; "Checking Dependencies" section untouched |
| No change to Priority 1 query | Done | Priority 1 query untouched |

## Test Plan

- Ran the updated jq filter against a synthetic 4-issue JSON fixture (`loom:operator-only`, `loom:blocked`, `loom:curated`, and one plain issue) — confirmed only the plain issue survives the filter.
- `bash scripts/check-docs-defaults-parity.sh` — OK.
- This is a prompt/doc-only change; no code build/test affected.

Closes #5175