### PR TITLE
test: isolate the machine-level daemon-bin fallback in 4 hermeticity fixtures

### DIFF
--- a/defaults/scripts/tests/test-clean-stale-binary.sh
+++ b/defaults/scripts/tests/test-clean-stale-binary.sh
@@ -246,8 +246,17 @@ mkdir -p "$STAGE/lib"
 cp "$CLEAN_SCRIPT" "$CLEANUP_SCRIPT" "$RECOVER_SCRIPT" "$STAGE/"
 cp "$SCRIPTS_DIR/lib/locate-daemon-bin.sh" "$STAGE/lib/"
 
+# Isolate step 4 of loom_locate_daemon_bin (the machine-level install fallback
+# under ${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}) too -- on a host with a real
+# machine-level Loom install, leaving $HOME untouched would let that step
+# resolve the real binary and defeat this "no resolvable binary" fixture
+# (#5183).
+EMPTY_HOME="$WORK/empty-home"
+mkdir -p "$EMPTY_HOME"
+
 for s in clean.sh cleanup.sh recover-orphaned-shepherds.sh; do
     out="$(LOOM_DAEMON_BIN="/nonexistent/loom-daemon" PATH="$STUB_DIR:$STRIPPED_PATH" \
+        HOME="$EMPTY_HOME" LOOM_DAEMON_BIN_DIR="/nonexistent" \
         "$STAGE/$s" 2>&1)"
     rc=$?
     if [[ "$rc" -ne 0 ]]; then

--- a/defaults/scripts/tests/test-config-tiers-cli-migration.sh
+++ b/defaults/scripts/tests/test-config-tiers-cli-migration.sh
@@ -76,7 +76,11 @@ mkdir -p "$ws/.loom-project"
 cat > "$ws/.loom-project/project.json" <<'JSON'
 {"terminals": [{"id": "cfgtier-t1", "name": "Builder", "roleConfig": {"roleFile": "builder.md"}}]}
 JSON
-out=$(cd "$ws" && "$LOOM_STATUS_SH" --json 2>&1) || true
+# stdout only: loom_locate_daemon_bin's resolution diagnostic (#4997) lands on
+# stderr and, on a host where it fires, would land ahead of the JSON payload
+# under a merged 2>&1 capture and break the jq -e parse below even though the
+# JSON on stdout is correct (#5183).
+out=$(cd "$ws" && "$LOOM_STATUS_SH" --json 2>/dev/null) || true
 if echo "$out" | jq -e '(.stopped + .running) | map(select(.id == "cfgtier-t1")) | length == 1' >/dev/null 2>&1; then
     pass "loom-status.sh --json lists a terminal sourced only from the project tier"
 else

--- a/defaults/scripts/tests/test-probe-tokens-fallback.sh
+++ b/defaults/scripts/tests/test-probe-tokens-fallback.sh
@@ -106,11 +106,20 @@ NO_DAEMON_WS="$(mktemp -d)"
 trap 'rm -rf "$NO_DAEMON_WS"' EXIT
 STRIPPED_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
+# An empty $HOME so step 4 of loom_locate_daemon_bin (the machine-level
+# install fallback under ${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}) can't fall
+# through to a real host's install -- on a host with a genuine machine-level
+# Loom install, leaving $HOME/LOOM_DAEMON_BIN_DIR untouched would defeat these
+# "no resolvable daemon binary" fixtures (#5183).
+EMPTY_HOME="$(mktemp -d)"
+trap 'rm -rf "$NO_DAEMON_WS" "$EMPTY_HOME"' EXIT
+
 # -------- Test 4: no capable daemon binary fails loudly (exit 1,
 #                   actionable message) --------
 echo "Test 4: no capable daemon binary -> exit 1"
 out="$(cd "$NO_DAEMON_WS" && LOOM_DAEMON_BIN="/nonexistent/loom-daemon" \
-    PATH="$STRIPPED_PATH" "$PROBE_SCRIPT" --json 2>&1)"
+    PATH="$STRIPPED_PATH" HOME="$EMPTY_HOME" LOOM_DAEMON_BIN_DIR="/nonexistent" \
+    "$PROBE_SCRIPT" --json 2>&1)"
 rc=$?
 if [[ "$rc" -eq 1 ]]; then
     pass "no resolvable daemon binary exits 1"
@@ -136,7 +145,8 @@ STALE_EOF
 chmod +x "$STALE_BIN_DIR/loom-tokens"
 
 stale_out="$(cd "$NO_DAEMON_WS" && LOOM_DAEMON_BIN="/nonexistent/loom-daemon" \
-    PATH="$STALE_BIN_DIR:$STRIPPED_PATH" "$PROBE_SCRIPT" --json 2>&1)"
+    PATH="$STALE_BIN_DIR:$STRIPPED_PATH" HOME="$EMPTY_HOME" LOOM_DAEMON_BIN_DIR="/nonexistent" \
+    "$PROBE_SCRIPT" --json 2>&1)"
 rc=$?
 rm -rf "$STALE_BIN_DIR"
 if [[ "$rc" -eq 1 ]]; then

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -540,9 +540,16 @@ fi
 echo "Test group 12c: absent daemon binary -> loud warning, apply still exits 0 (#4280)"
 REPO="$(make_fixture)"
 # Force the resolver to find nothing: no LOOM_DAEMON_BIN, no PATH loom-daemon,
-# no build-output under the fixture's SOURCE_ROOT (the fixture repo).
-OUT="$(cd "$REPO" && env -u LOOM_DAEMON_BIN PATH="/usr/bin:/bin" bash "$SCRIPT" 2>&1)"
+# no build-output under the fixture's SOURCE_ROOT (the fixture repo), and no
+# machine-level install fallback (step 4 of loom_locate_daemon_bin) -- on a
+# host with a genuine machine-level Loom install, leaving $HOME/
+# LOOM_DAEMON_BIN_DIR untouched would let that step resolve the real binary
+# and defeat this fixture (#5183).
+NO_BIN_HOME="$(mktemp -d)"
+OUT="$(cd "$REPO" && env -u LOOM_DAEMON_BIN PATH="/usr/bin:/bin" HOME="$NO_BIN_HOME" \
+    LOOM_DAEMON_BIN_DIR="/nonexistent" bash "$SCRIPT" 2>&1)"
 RC=$?
+rm -rf "$NO_BIN_HOME"
 if [[ $RC -eq 0 ]]; then
     pass "(#4280) apply still exits 0 when no daemon binary resolves"
 else


### PR DESCRIPTION
## Summary

Fixes test hermeticity in 4 `defaults/scripts/tests/` shell suites whose "no resolvable loom-daemon binary" fixtures could be defeated by a real machine-level `loom-daemon` install (e.g. `/Users/rwalters/.local/bin/loom-daemon` on this host) — invisible on a fresh CI runner, but a deterministic false-fail on any real fleet host.

## Root Cause

`loom_locate_daemon_bin` (`defaults/scripts/lib/locate-daemon-bin.sh`) resolves in this precedence:

1. `$LOOM_DAEMON_BIN`
2. (opt-in) repo-local build
3. `loom-daemon` on `$PATH`
4. `${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}/loom-daemon` (machine-level install)
5. repo-local build fallback

Three "isolate the daemon binary" fixtures overrode steps 1 and 3 (`$LOOM_DAEMON_BIN`, `$PATH`) but never step 4 (`$HOME`/`$LOOM_DAEMON_BIN_DIR`), so on a host with a real machine-level install, step 4 still resolved the real binary and silently defeated the "no daemon" simulation.

A fourth suite (`test-config-tiers-cli-migration.sh`) had a different root cause: it captured `loom-status.sh --json` with `2>&1`, so `loom_locate_daemon_bin`'s diagnostic stderr line (added in #4997) could land ahead of the JSON payload on stdout and break the test's `jq -e` parse — even though the underlying JSON was correct.

## Changes

- `defaults/scripts/tests/test-clean-stale-binary.sh` (Test 5): add `HOME=<empty tmp dir>` and `LOOM_DAEMON_BIN_DIR=/nonexistent` to the "no resolvable binary" fixture env.
- `defaults/scripts/tests/test-probe-tokens-fallback.sh` (Tests 4 and 5): same fix.
- `defaults/scripts/tests/test-resync-installed.sh` (Test group 12c): same fix.
- `defaults/scripts/tests/test-config-tiers-cli-migration.sh` (Test 1): capture `loom-status.sh --json`'s stdout only (`2>/dev/null` instead of `2>&1`) so the expected/desirable stderr diagnostic no longer corrupts the JSON assertion.

## Acceptance Criteria Verification

- [x] All 4 suites pass on this host, which has a genuine machine-level `loom-daemon` install reachable via `$PATH` (`/Users/rwalters/.local/bin/loom-daemon`).
- [x] No regression on a clean-host simulation (`env -i PATH=... HOME=<empty>` with no `loom-daemon` reachable anywhere) — reran all 4 suites under that simulation; all still pass (with the expected tmux/claude-dependent tests in suite 4 skipping, as before, when those tools aren't on `$PATH`).
- [x] Fix targets the actual fixture logic (env isolation), not `locate-daemon-bin.sh` itself — the diagnostic stderr line is intentional/desirable output, not a bug.

## Test Plan

Ran each suite standalone on this host (real machine-level `loom-daemon` install present):

```
bash defaults/scripts/tests/test-clean-stale-binary.sh        # 42/42 passed (was 34/42)
bash defaults/scripts/tests/test-probe-tokens-fallback.sh     # 8/8 passed (was 5/8)
bash defaults/scripts/tests/test-resync-installed.sh          # 114/114 passed (was 113/114)
bash defaults/scripts/tests/test-config-tiers-cli-migration.sh # 15/15 passed (was 14/15)
```

Also reran all 4 under `env -i PATH="/usr/bin:/bin:/usr/sbin:/sbin" HOME=<empty tmp dir>` (clean-host simulation) to confirm no regression — all pass identically.

Closes #5183
