### PR TITLE
fix(clean): reap squash-merged worktrees and flag disk-bound dispatch

### DIFF
--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -390,6 +390,25 @@ _worktree_dirty_lines() {
     ' || true
 }
 
+# Whether $branch has a MERGED pull request on the forge (#5177 / #4889).
+#
+# This repo squash-merges, so once a PR lands, the branch's original commits are
+# never reachable from the squash commit on main — `git branch -d`'s "fully
+# merged" safety check therefore refuses to delete a genuinely-landed branch.
+# When the forge confirms the PR merged, the work IS landed and `git branch -D`
+# is safe, mirroring merge-pr.sh's existing squash-aware `-d`→`-D` fallback.
+#
+# Fail-closed: a missing gh, any gh error, or an empty result all return
+# non-zero ("not merged"), so a probe failure never escalates to a force-delete.
+_worktree_pr_is_merged() {
+    local repo_root="$1" branch="$2" count
+    [[ -n "$branch" ]] || return 1
+    command -v gh >/dev/null 2>&1 || return 1
+    count="$( (cd "$repo_root" 2>/dev/null && \
+        gh pr list --head "$branch" --state merged --json number --jq 'length' 2>/dev/null) )" || return 1
+    [[ -n "$count" && "$count" != "0" ]]
+}
+
 # remove_worktree_command [--keep-branch] [--force] [--json] <issue-number>
 #
 # Invoked from the early arg dispatch below. Returns 0 on success (including the
@@ -519,13 +538,27 @@ remove_worktree_command() {
 
     # 6. Remove the worktree.
     _rm_info "Removing worktree: $worktree_path"
-    local removed=false
-    if git -C "$repo_root" worktree remove "$worktree_path" --force >/dev/null 2>&1; then
+    local removed=false remove_err
+    if remove_err="$(git -C "$repo_root" worktree remove "$worktree_path" --force 2>&1)"; then
         removed=true
         _rm_success "Worktree removed"
         if [[ "$in_worktree" == true ]]; then
             _rm_warning "Your shell's working directory was inside the removed worktree."
             _rm_warning "Run this command to fix:  cd $repo_root"
+        fi
+    elif printf '%s' "$remove_err" | grep -qi "is not a working tree" && \
+         [[ -f "$worktree_path/.loom-managed" ]]; then
+        # #5177: git no longer tracks this path as a worktree (e.g. a stale
+        # `git worktree prune` left the directory on disk), so `git worktree
+        # remove` can never clean it and it accumulates forever. It is confirmed
+        # Loom-managed (the step-2 sentinel guard is re-checked here) and is by
+        # construction under the managed worktree root ($worktree_root_dir/issue-N),
+        # so remove the directory directly and prune the dangling registration.
+        if rm -rf "$worktree_path"; then
+            removed=true
+            _rm_success "Removed untracked worktree directory (no git worktree entry)"
+        else
+            _rm_warning "Could not remove untracked worktree directory at $worktree_path"
         fi
     else
         _rm_warning "Could not remove worktree at $worktree_path"
@@ -546,6 +579,17 @@ remove_worktree_command() {
         elif git -C "$repo_root" branch -d "$attached_branch" >/dev/null 2>&1; then
             _rm_success "Local branch '$attached_branch' deleted"
             branch_status="deleted"
+        elif _worktree_pr_is_merged "$repo_root" "$attached_branch"; then
+            # #5177 / #4889: `git branch -d` refused because a squash-merged
+            # branch is never "fully merged" by reachability — but the forge
+            # confirms its PR merged, so the work is landed and -D is safe.
+            if git -C "$repo_root" branch -D "$attached_branch" >/dev/null 2>&1; then
+                _rm_success "Local branch '$attached_branch' force-deleted (PR merged — squash-safe)"
+                branch_status="deleted"
+            else
+                _rm_warning "Could not delete local branch '$attached_branch' even after confirming its PR merged"
+                branch_status="unmerged"
+            fi
         else
             _rm_warning "Could not delete local branch '$attached_branch' (may have unmerged commits — use 'git branch -D' if intentional)"
             branch_status="unmerged"

--- a/loom-daemon/src/health.rs
+++ b/loom-daemon/src/health.rs
@@ -946,6 +946,27 @@ pub fn classify_missing_tick(inputs: &HealthInputs, status: &DaemonStatusReport)
     MissingTick::Dead
 }
 
+/// Whether `disk_headroom` is the **strictly** binding term of the dynamic
+/// concurrency cap `min(token_axis, disk_headroom, configured_max)` (#5177).
+///
+/// True only when disk headroom is smaller than *both* other terms — i.e. the
+/// scratch volume is throttling dispatch below what the token pool and the
+/// operator's configured admission ceiling would otherwise allow. A tie with
+/// `configured_max` is deliberately NOT flagged: that ceiling is the operator's
+/// own deliberate choice, not a disk fault. Mirrors the input shape of
+/// [`crate::work_finder::resolve_dynamic_max_concurrent`] so the two agree on
+/// what "binding" means.
+#[must_use]
+pub fn disk_binds_cap(
+    token_axis_limit: usize,
+    per_token_concurrency: usize,
+    disk_headroom: usize,
+    configured_max: usize,
+) -> bool {
+    let token_axis = token_axis_limit.saturating_mul(per_token_concurrency.max(1));
+    disk_headroom < token_axis && disk_headroom < configured_max
+}
+
 /// Assess the dispatch section: in-flight occupancy against the dynamic cap,
 /// plus the last work-finder tick's dispatch/skip-reason summary.
 #[must_use]
@@ -984,6 +1005,23 @@ pub fn assess_dispatch(inputs: &HealthInputs) -> HealthSection {
                 .clone()
                 .unwrap_or_else(|| "claude-wrapper preflight tripwire active".to_string()),
         );
+    }
+    // #5177: a small-disk host silently decays as merged worktrees leak their
+    // multi-GB target/ dirs, until disk headroom becomes the binding term of the
+    // cap and throttles the host to a fraction of its token/config capacity. That
+    // used to present as a green daemon dispatching at, say, cap 2 — a fault an
+    // operator had to notice in the `min(...)` breakdown. Name it as degraded.
+    if disk_binds_cap(
+        status.capacity.token_axis_limit,
+        status.per_token_concurrency,
+        status.disk_headroom,
+        status.configured_max,
+    ) {
+        degraded.push(format!(
+            "disk headroom is throttling dispatch (cap {} bound by disk headroom {} — free scratch \
+             disk; e.g. `loom-daemon clean --aggressive` / `--deep`)",
+            cap, status.disk_headroom
+        ));
     }
 
     // #4824: why the tick is missing, when it is. `None` whenever a tick was
@@ -2508,6 +2546,62 @@ mod tests {
         assert!(section
             .summary
             .contains("12 seen, 2 dispatched, 10 in-flight-skip"));
+    }
+
+    /// #5177 AC4: `disk_binds_cap` is the strict-minimum test — disk must be
+    /// smaller than BOTH other terms, never merely tied.
+    #[test]
+    fn disk_binds_cap_only_when_strictly_smallest() {
+        // token axis = 6 × 2 = 12, configured 12, disk 2 → disk binds.
+        assert!(disk_binds_cap(6, 2, 2, 12));
+        // disk ties configured_max → operator's own ceiling, not a disk fault.
+        assert!(!disk_binds_cap(6, 2, 12, 12));
+        // disk larger than the token axis → tokens bind, not disk.
+        assert!(!disk_binds_cap(1, 1, 5, 12));
+        // per-token 0 is clamped to 1 (mirrors resolve_dynamic_max_concurrent).
+        assert!(disk_binds_cap(6, 0, 2, 12));
+        // the healthy default fixture (disk 0, configured 0) must NOT trip it.
+        assert!(!disk_binds_cap(6, 0, 0, 0));
+    }
+
+    /// #5177 AC4: when disk headroom is the binding cap term, the dispatch
+    /// section is Degraded and names disk as the cause — not a silent green
+    /// daemon dispatching at a fraction of its token/config capacity.
+    #[test]
+    fn disk_bound_cap_produces_degraded_verdict_naming_disk() {
+        let mut inputs = healthy_inputs();
+        {
+            let status = inputs.status.as_mut().unwrap();
+            status.capacity.token_axis_limit = 6;
+            status.per_token_concurrency = 2; // token axis = 12
+            status.configured_max = 12;
+            status.disk_headroom = 2; // strictly the smallest term
+            status.dynamic_cap = 2;
+        }
+        let section = assess_dispatch(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(
+            section.summary.to_lowercase().contains("disk"),
+            "summary must name disk: {}",
+            section.summary
+        );
+    }
+
+    /// #5177 AC4 (negative): a cap bound by the operator's configured ceiling
+    /// (disk headroom ample) stays green — disk is not the culprit there.
+    #[test]
+    fn config_bound_cap_is_not_flagged_as_disk() {
+        let mut inputs = healthy_inputs();
+        {
+            let status = inputs.status.as_mut().unwrap();
+            status.capacity.token_axis_limit = 6;
+            status.per_token_concurrency = 2; // token axis = 12
+            status.configured_max = 4; // operator's own ceiling binds
+            status.disk_headroom = 50; // plenty of disk
+            status.dynamic_cap = 4;
+        }
+        let section = assess_dispatch(&inputs);
+        assert_eq!(section.verdict, Verdict::Green);
     }
 
     /// Inputs with no tick reported, a daemon well past the warm-up grace

--- a/loom-daemon/src/worktree_ops/aggressive.rs
+++ b/loom-daemon/src/worktree_ops/aggressive.rs
@@ -109,6 +109,10 @@ pub enum Reason {
     UserOwned,
     Uncommitted,
     ReachableFromOriginMain,
+    /// The branch's PR is merged (including squash-merged, whose original
+    /// commits are never reachable from `origin/main`) — the work is landed
+    /// regardless of git reachability (#5177).
+    PrMerged,
     TooRecent,
     UnreachableHead,
     ForceOverrideUnreachable,
@@ -125,6 +129,7 @@ impl Reason {
             Reason::UserOwned => "user_owned",
             Reason::Uncommitted => "uncommitted",
             Reason::ReachableFromOriginMain => "reachable_from_origin_main",
+            Reason::PrMerged => "pr_merged",
             Reason::TooRecent => "too_recent",
             Reason::UnreachableHead => "unreachable_head",
             Reason::ForceOverrideUnreachable => "force_override_unreachable",
@@ -150,8 +155,20 @@ pub const DEFAULT_AGGRESSIVE_MIN_AGE: u64 = 86400;
 /// 4. missing `.loom-managed` sentinel / non-canonical path -> keep
 /// 5. uncommitted changes (unless `force`) -> keep
 /// 6. HEAD reachable from origin/main -> remove
-/// 7. younger than `min_age_seconds` -> keep
-/// 8. fallback: `force` -> remove, else keep
+/// 7. PR merged (including squash-merged) -> remove (#5177)
+/// 8. younger than `min_age_seconds` -> keep
+/// 9. fallback: `force` -> remove, else keep
+///
+/// Step 7 is the squash-merge fix (#5177): this repo squash-merges, so a
+/// merged branch's original commits are never an ancestor of `origin/main`.
+/// Raw reachability (step 6) therefore cannot distinguish a safely-landed
+/// squash-merged worktree from one holding genuinely unmerged work, and the
+/// fallback (step 9) used to keep it forever under `UnreachableHead`. A merged
+/// PR means the work IS landed regardless of reachability. Placing it AFTER
+/// the uncommitted / open-PR / active-shepherd guards keeps it purely
+/// **additive**: it can only turn a would-be "unreachable, keep" into a
+/// remove, never override a guard that protects genuinely unmerged or
+/// uncommitted work.
 #[must_use]
 #[allow(clippy::too_many_arguments)]
 pub fn evaluate_aggressive_candidate(
@@ -163,6 +180,7 @@ pub fn evaluate_aggressive_candidate(
     has_sentinel: bool,
     is_uncommitted: bool,
     head_reachable: bool,
+    pr_merged: bool,
     age_seconds: Option<u64>,
     min_age_seconds: u64,
     force: bool,
@@ -194,6 +212,12 @@ pub fn evaluate_aggressive_candidate(
 
     if head_reachable {
         return (Decision::Remove, Reason::ReachableFromOriginMain);
+    }
+
+    // #5177: squash-merged work is landed even though its commits are never
+    // reachable from origin/main. Additive to the reachability check above.
+    if pr_merged {
+        return (Decision::Remove, Reason::PrMerged);
     }
 
     if let Some(age) = age_seconds {
@@ -239,6 +263,15 @@ fn decide_for_worktree(
         .head
         .as_deref()
         .is_some_and(|h| is_ancestor_of_origin_main(repo_root, h));
+    // #5177: only probe the forge for merged status when reachability already
+    // failed — a reachable HEAD is landed anyway, so the (rate-limited) forge
+    // call is pure waste there. This is the squash-merge escape hatch for the
+    // otherwise-`UnreachableHead` class.
+    let pr_merged = !head_reachable
+        && wt
+            .branch_short()
+            .and_then(|b| naming::issue_from_branch(&b))
+            .is_some_and(|n| pr_is_merged(repo_root, n));
     let age_seconds = worktree_age_seconds(&resolved_wt);
 
     evaluate_aggressive_candidate(
@@ -250,10 +283,29 @@ fn decide_for_worktree(
         has_sentinel,
         is_uncommitted,
         head_reachable,
+        pr_merged,
         age_seconds,
         min_age_seconds,
         force,
     )
+}
+
+/// Whether `issue_num`'s branch has a **merged** PR (including squash-merged).
+///
+/// Reuses `clean.rs`'s shared PR-merged probe (#5177) rather than building a
+/// second squash-detection path. REST first — the daemon-side reaper's
+/// rationale applies here too: `gh pr list` goes through the routinely-exhausted
+/// GraphQL quota, while `gh api .../pulls` uses the separate, less-contended
+/// REST pool — falling back to the GraphQL-backed probe only when REST cannot
+/// answer.
+fn pr_is_merged(repo_root: &Path, issue_num: u32) -> bool {
+    let status = match clean::repo_owner_rest(repo_root)
+        .map(|owner| clean::check_pr_merged_rest(repo_root, &owner, issue_num))
+    {
+        Some(clean::PrStatus::Unknown) | None => clean::check_pr_merged(repo_root, issue_num),
+        Some(status) => status,
+    };
+    matches!(status, clean::PrStatus::Merged { .. })
 }
 
 fn is_ancestor_of_origin_main(repo_root: &Path, head_sha: &str) -> bool {
@@ -404,7 +456,9 @@ pub fn clean_aggressive(
                             );
                         }
                     }
-                    Reason::ReachableFromOriginMain | Reason::ForceOverrideUnreachable => {
+                    Reason::ReachableFromOriginMain
+                    | Reason::PrMerged
+                    | Reason::ForceOverrideUnreachable => {
                         // Unreachable in Keep branch — defensive, never hit.
                         stats.record_error(
                             &label,
@@ -532,7 +586,7 @@ mod tests {
         let mut w = wt();
         w.bare = true;
         let (d, r) = evaluate_aggressive_candidate(
-            &w, false, None, false, true, true, false, true, None, 86400, false,
+            &w, false, None, false, true, true, false, true, false, None, 86400, false,
         );
         assert_eq!(d, Decision::Keep);
         assert_eq!(r, Reason::BareMainWorktree);
@@ -550,6 +604,7 @@ mod tests {
             true,
             false,
             true,
+            false,
             None,
             86400,
             true, // even with force
@@ -570,6 +625,7 @@ mod tests {
             true,
             false,
             true,
+            false,
             None,
             86400,
             false,
@@ -590,6 +646,7 @@ mod tests {
             true,
             false,
             true,
+            false,
             None,
             86400,
             false,
@@ -610,6 +667,7 @@ mod tests {
             false,
             false,
             true,
+            false,
             None,
             86400,
             false,
@@ -630,6 +688,7 @@ mod tests {
             true,
             false,
             true,
+            false,
             None,
             86400,
             false,
@@ -650,6 +709,7 @@ mod tests {
             true,
             true,
             true,
+            false,
             None,
             86400,
             false,
@@ -666,6 +726,7 @@ mod tests {
             true,
             true,
             true,
+            false,
             None,
             86400,
             true,
@@ -685,6 +746,7 @@ mod tests {
             true,
             false,
             true,
+            false,
             Some(1), // 1 second old — would fail the age gate if reached
             86400,
             false,
@@ -703,6 +765,7 @@ mod tests {
             false,
             true,
             true,
+            false,
             false,
             false,
             Some(10),
@@ -725,6 +788,7 @@ mod tests {
             true,
             false,
             false,
+            false,
             Some(999_999),
             86400,
             false,
@@ -745,12 +809,83 @@ mod tests {
             true,
             false,
             false,
+            false,
             Some(999_999),
             86400,
             true,
         );
         assert_eq!(d, Decision::Remove);
         assert_eq!(r, Reason::ForceOverrideUnreachable);
+    }
+
+    /// #5177 AC1: a squash-merged worktree has an unreachable HEAD (its commits
+    /// are never an ancestor of origin/main) yet its PR is merged — it must be
+    /// removed, not retained under `UnreachableHead`.
+    #[test]
+    fn unreachable_but_pr_merged_is_removed() {
+        let w = wt();
+        let (d, r) = evaluate_aggressive_candidate(
+            &w,
+            false,
+            Some((false, true)), // no OPEN pr, lookup ok
+            false,
+            true,
+            true,
+            false,         // not uncommitted
+            false,         // HEAD not reachable (squash-merged)
+            true,          // ...but the PR is merged
+            Some(999_999), // old enough that the age gate would otherwise not matter
+            86400,
+            false, // no --force needed
+        );
+        assert_eq!(d, Decision::Remove);
+        assert_eq!(r, Reason::PrMerged);
+    }
+
+    /// #5177 AC2: the merged-PR check is ADDITIVE — it must never override the
+    /// uncommitted-work guard. Uncommitted changes win even when the PR merged.
+    #[test]
+    fn uncommitted_is_kept_even_when_pr_merged() {
+        let w = wt();
+        let (d, r) = evaluate_aggressive_candidate(
+            &w,
+            false,
+            Some((false, true)),
+            false,
+            true,
+            true,
+            true,  // uncommitted work present
+            false, // HEAD not reachable
+            true,  // PR merged
+            None,
+            86400,
+            false, // not forced
+        );
+        assert_eq!(d, Decision::Keep);
+        assert_eq!(r, Reason::Uncommitted);
+    }
+
+    /// #5177 AC2: an open PR still beats the merged-PR path — a worktree whose
+    /// branch has an OPEN pr is kept regardless of any merged-status probe.
+    #[test]
+    fn open_pr_still_beats_pr_merged() {
+        let w = wt();
+        let (d, r) = evaluate_aggressive_candidate(
+            &w,
+            false,
+            Some((true, true)), // OPEN pr present
+            false,
+            true,
+            true,
+            false,
+            false,
+            true, // even if a merged-status probe somehow also said yes
+            None,
+            86400,
+            false,
+        );
+        assert_eq!(d, Decision::Keep);
+        assert_eq!(r, Reason::OpenPr);
     }
 
     #[test]

--- a/loom-daemon/src/worktree_ops/clean.rs
+++ b/loom-daemon/src/worktree_ops/clean.rs
@@ -634,6 +634,43 @@ pub fn production_probes<'a>(
     }
 }
 
+/// Whether a `git worktree remove` failure means "this path is not a git
+/// worktree" — the signature (#5177) of an orphaned `.loom/worktrees/*`
+/// directory git no longer tracks (e.g. a `git worktree prune` ran while the
+/// directory was left on disk). Any *other* removal failure (a lock, a busy
+/// path, a permission error) is NOT this case and must not trigger the
+/// direct-removal fallback.
+#[must_use]
+pub fn is_untracked_worktree_error(cause: &str) -> bool {
+    cause.to_ascii_lowercase().contains("is not a working tree")
+}
+
+/// Whether `worktree_path` is safely inside `repo_root`'s managed worktree root
+/// ([`crate::worktree_root::worktree_root`]). A precondition for the
+/// direct-removal fallback (#5177): even after confirming the git error and the
+/// `.loom-managed` sentinel, never `remove_dir_all` a path outside the tree
+/// Loom provisions worktrees into.
+#[must_use]
+pub fn is_under_worktree_root(repo_root: &Path, worktree_path: &Path) -> bool {
+    let root = crate::worktree_root::worktree_root(repo_root);
+    let root = root.canonicalize().unwrap_or(root);
+    let wt = worktree_path
+        .canonicalize()
+        .unwrap_or_else(|_| worktree_path.to_path_buf());
+    wt != root && wt.starts_with(&root)
+}
+
+/// Decide whether a failed `git worktree remove` should fall back to a direct
+/// directory removal (#5177). Pure, so the untracked-orphan path is testable
+/// without a git repo. All three conditions must hold — the specific "not a
+/// working tree" git error, the `.loom-managed` sentinel, and containment under
+/// the managed worktree root — so this never degrades into a blanket `rm -rf`
+/// on any removal failure.
+#[must_use]
+pub fn should_force_remove_orphan_dir(cause: &str, is_managed: bool, under_root: bool) -> bool {
+    is_untracked_worktree_error(cause) && is_managed && under_root
+}
+
 /// Remove a worktree and delete its feature branch.
 ///
 /// Exposed (issue #4876) so the daemon-side reaper performs the *same*
@@ -659,8 +696,38 @@ pub fn cleanup_worktree(
         .arg(worktree_path)
         .arg("--force")
         .current_dir(repo_root);
-    run_checked(remove)?;
-    println!("  Removed worktree: {}", worktree_path.display());
+    if let Err(cause) = run_checked(remove) {
+        // #5177: an orphaned `.loom/worktrees/*` directory git no longer tracks
+        // fails `git worktree remove` with "is not a working tree" and could
+        // never be cleaned by the normal path. Fall back to a direct removal —
+        // but ONLY when we can prove this is a Loom-managed worktree path (the
+        // specific git error + the `.loom-managed` sentinel + containment under
+        // the managed worktree root), never a blanket rm on any failure.
+        if should_force_remove_orphan_dir(
+            &cause,
+            is_loom_managed(worktree_path),
+            is_under_worktree_root(repo_root, worktree_path),
+        ) {
+            std::fs::remove_dir_all(worktree_path).map_err(|e| {
+                format!(
+                    "git worktree remove failed ({cause}); direct removal of the untracked \
+                     worktree directory also failed: {e}"
+                )
+            })?;
+            println!(
+                "  Removed untracked worktree directory (no git worktree entry): {}",
+                worktree_path.display()
+            );
+            let _ = Command::new("git")
+                .args(["worktree", "prune"])
+                .current_dir(repo_root)
+                .status();
+        } else {
+            return Err(cause);
+        }
+    } else {
+        println!("  Removed worktree: {}", worktree_path.display());
+    }
 
     let deleted = Command::new("git")
         .args(["branch", "-d", &branch_name])
@@ -1860,6 +1927,86 @@ mod tests {
         std::fs::write(tmp.path().join("README.md"), b"hi").unwrap();
         let reclaimed = reclaim_worktree_artifacts(tmp.path(), false);
         assert!(reclaimed.is_empty());
+    }
+
+    // --- untracked-orphan worktree removal (#5177 AC5) -------------------
+
+    #[test]
+    fn untracked_worktree_error_recognizes_gits_message() {
+        // git's actual message for a path that exists but is not a worktree.
+        assert!(is_untracked_worktree_error(
+            "fatal: '/repo/.loom/worktrees/issue-42' is not a working tree"
+        ));
+        assert!(is_untracked_worktree_error("IS NOT A WORKING TREE")); // case-insensitive
+                                                                       // Any other failure must NOT be treated as an orphan directory.
+        assert!(!is_untracked_worktree_error(
+            "fatal: validation failed, cannot remove working tree"
+        ));
+        assert!(!is_untracked_worktree_error("Permission denied (os error 13)"));
+        assert!(!is_untracked_worktree_error(""));
+    }
+
+    #[test]
+    fn force_remove_orphan_requires_all_three_conditions() {
+        let ok = "fatal: 'x' is not a working tree";
+        let other = "some other failure";
+        // All three present → fall back to direct removal.
+        assert!(should_force_remove_orphan_dir(ok, true, true));
+        // Missing any single guard → refuse (never a blanket rm -rf).
+        assert!(!should_force_remove_orphan_dir(ok, false, true)); // no sentinel
+        assert!(!should_force_remove_orphan_dir(ok, true, false)); // outside root
+        assert!(!should_force_remove_orphan_dir(other, true, true)); // different error
+    }
+
+    /// End-to-end: a directory under the managed worktree root that git no
+    /// longer tracks as a worktree (the #5177 "is not a working tree" orphan) is
+    /// removed by `cleanup_worktree` instead of erroring out.
+    #[test]
+    #[serial_test::serial]
+    fn cleanup_worktree_removes_untracked_orphan_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().canonicalize().unwrap();
+
+        // A real git repo so `git worktree remove` produces the genuine
+        // "is not a working tree" error rather than "not a git repository".
+        assert!(Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&repo_root)
+            .status()
+            .unwrap()
+            .success());
+
+        // An orphan worktree directory under the resolved (override-aware)
+        // managed root, carrying the `.loom-managed` sentinel — but with no
+        // corresponding `git worktree list` entry.
+        let orphan = crate::worktree_root::worktree_root(&repo_root).join("issue-999");
+        std::fs::create_dir_all(&orphan).unwrap();
+        std::fs::write(orphan.join(".loom-managed"), "test").unwrap();
+        std::fs::write(orphan.join("some-build-artifact"), "junk").unwrap();
+        assert!(orphan.is_dir());
+
+        let result = cleanup_worktree(&repo_root, &orphan, 999, false);
+        assert!(result.is_ok(), "orphan removal should succeed: {result:?}");
+        assert!(!orphan.exists(), "orphan directory should be gone");
+    }
+
+    /// A removal failure that is NOT the untracked-orphan signature must still
+    /// error (and must never trigger the direct-removal fallback), even for a
+    /// managed path under the root.
+    #[test]
+    #[serial_test::serial]
+    fn cleanup_worktree_does_not_force_remove_on_other_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path().canonicalize().unwrap();
+        // Not a git repository at all → `git worktree remove` fails with a
+        // "not a git repository" error, which is NOT the orphan signature.
+        let managed = crate::worktree_root::worktree_root(&repo_root).join("issue-1000");
+        std::fs::create_dir_all(&managed).unwrap();
+        std::fs::write(managed.join(".loom-managed"), "test").unwrap();
+
+        let result = cleanup_worktree(&repo_root, &managed, 1000, false);
+        assert!(result.is_err(), "non-orphan failure must propagate");
+        assert!(managed.exists(), "directory must be left in place on a non-orphan failure");
     }
 
     // --- tmux cleanup safety gates (#4890) -------------------------------


### PR DESCRIPTION
## Summary

A small-disk worker silently decayed to 1/6 capacity because `loom-daemon clean --aggressive` used raw git reachability (`is_ancestor_of_origin_main`) to decide whether a worktree's work had landed. This repo **squash-merges**, so a merged branch's original commits are never reachable from `origin/main` — `evaluate_aggressive_candidate` treated every merged worktree as "HEAD unreachable — would lose work" and never reaped it. Merged sweeps leaked their multi-GB `target/` dirs forever, until `disk headroom` became the binding term of the dynamic concurrency cap and throttled the host — while `health` still reported green.

This PR fixes the core squash-merge blind spot plus the disk-visibility and untracked-orphan gaps, reusing the PR-merged probe that `clean.rs` (the periodic reaper's path) already uses correctly.

## Changes

- **`aggressive.rs` (AC1, AC2)** — `evaluate_aggressive_candidate` now consults a `pr_merged` signal and reaps a worktree whose PR is merged (including squash-merged), *before* the `UnreachableHead` fallback. `decide_for_worktree` computes it via `clean::check_pr_merged_rest` (REST-first, GraphQL fallback) — reusing the existing shared probe rather than building parallel squash-detection. The check is placed **after** the uncommitted / open-PR / active-shepherd guards, so it is purely additive: genuinely unmerged/uncommitted work is still never removed. The forge is only probed when reachability already failed.
- **`clean.rs::cleanup_worktree` (AC5)** — when `git worktree remove` fails with "is not a working tree" (an orphaned `.loom/worktrees/*` dir git no longer tracks), fall back to a direct `remove_dir_all`, gated on the `.loom-managed` sentinel **and** containment under the managed worktree root (`should_force_remove_orphan_dir` — never a blanket `rm` on any failure).
- **`health.rs::assess_dispatch` (AC4)** — emit a `Degraded` verdict naming disk when `disk_headroom` is the **strictly**-binding term of the cap `min(token_axis, disk_headroom, configured_max)` (`disk_binds_cap`). A tie with `configured_max` (the operator's own ceiling) is deliberately not flagged.
- **`worktree.sh` remove (AC5 manual path + related #4889)** — squash-aware `git branch -d`→`-D` fallback once the forge confirms the branch's PR merged (mirrors `merge-pr.sh`), plus the same untracked-directory removal fallback.

## Acceptance Criteria Verification

- [x] **AC1** — a merged (incl. squash-merged) worktree is reaped, not held by the "HEAD unreachable" guard (`unreachable_but_pr_merged_is_removed`).
- [x] **AC2** — unmerged/uncommitted work still never removed; the merged check is additive (`uncommitted_is_kept_even_when_pr_merged`, `open_pr_still_beats_pr_merged`).
- [ ] **AC3** — `target/` reclamation without removing the worktree — **deferred** (greenfield); filed as #5187.
- [x] **AC4** — disk-bound cap produces a degraded verdict naming disk (`disk_bound_cap_produces_degraded_verdict_naming_disk`, `config_bound_cap_is_not_flagged_as_disk`, `disk_binds_cap_only_when_strictly_smallest`).
- [x] **AC5** — an untracked `.loom/worktrees/*` dir is cleanable instead of erroring (`cleanup_worktree_removes_untracked_orphan_directory`, `cleanup_worktree_does_not_force_remove_on_other_errors`, `untracked_worktree_error_recognizes_gits_message`, `force_remove_orphan_requires_all_three_conditions`).
- [x] **AC6** — verified via unit tests, no small-disk host required.

### Deferred scope

**AC3** (reclaim `target/` from a worktree that must otherwise be kept) is the one greenfield piece — it needs a new artifact-only reclamation pass built on `orphan_recovery.rs`'s `BUILD_ARTIFACT_PATTERNS`, distinct from the reap-decision fix that is the core of this issue. Deferred to **#5187** to keep this PR focused on the squash-merge root cause + the disk-visibility/orphan gaps. The core bug that caused the 1/6-capacity decay (never reaping merged worktrees) is fully fixed here.

## Test Plan

- `cargo test --lib` in `loom-daemon` — 3346 passed (one pre-existing flaky `daemon_install_state` pid-file test that reads live host pids passes in isolation; unrelated to this change).
- `cargo clippy --lib` clean; `cargo fmt` applied.
- `bash -n` + `shellcheck -S error` clean on `worktree.sh`.
- 10 new unit tests across `aggressive.rs`, `clean.rs`, `health.rs` (listed above).

Closes #5177
