### PR TITLE
test(daemon): sandbox every live daemon state path behind one helper + guard

### DIFF
--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -61,6 +61,7 @@ test-install-source-guard.sh
 test-install-stash-scope.sh
 test-install-sync-labels.sh
 test-judge-fanout-experiment.sh
+test-live-state-sandbox.sh
 test-locate-daemon-bin.sh
 test-loom-daemon-launchd-plist.sh
 test-loom-daemon-start.sh

--- a/defaults/scripts/tests/lib/live-state-sandbox.sh
+++ b/defaults/scripts/tests/lib/live-state-sandbox.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# live-state-sandbox.sh — ONE shared "sandbox every live daemon state path"
+# helper for the loom-daemon lifecycle test suites (issue #5179).
+#
+# ## Why this exists
+#
+# The daemon lifecycle suites deliberately execute the REAL
+# loom-daemon-start.sh / loom-daemon-stop.sh / loom-daemon-update.sh (not
+# mocks), so every state path those scripts resolve is a path the test can
+# write. Three separate incidents were each fixed by enumerating ONE more
+# surface after it leaked:
+#
+#   1. #4078/#4087 — a daemon test booted out the operator's PRODUCTION daemon
+#      (launchd label + label-blind pgrep; fixed in lib/launchd-sandbox.sh).
+#   2. #5131 — the live `autonomy-desired` marker was removed under a running
+#      daemon (fixed by a per-suite LOOM_AUTONOMY_MARKER export).
+#   3. #5179 — the live `.daemon.pid` was rewritten under a running daemon,
+#      producing a FALSE `degraded` liveness verdict for the operator and
+#      poisoning the watchdog's (#5118/#5126) primary input.
+#
+# The recurring root cause is not "one more variable was forgotten"; it is that
+# a Loom agent session EXPORTS the live paths into every child process it
+# spawns (observed on a worker host: `LOOM_PID_FILE=$HOME/.loom/.daemon.pid`,
+# `LOOM_WORKSPACE=<the real checkout>`, `LOOM_DAEMON_BIN=<the real binary>`).
+# A test suite that merely *omits* an override therefore does not get a neutral
+# default — it INHERITS the production path, and `LOOM_PID_FILE` is tier 1 of
+# the daemon's own resolver (`daemon_pidfile.rs`), ahead of every other tier.
+# #4902 fixed exactly this shape for LOOM_DAEMON_BIN; this helper generalizes
+# it so a state path added to the daemon later is isolated by construction.
+#
+# ## What it covers
+#
+# `live_state_sandbox_init` owns the filesystem STATE PATHS:
+#
+#   LOOM_PID_FILE          -> <dir>/.daemon.pid          (daemon_pidfile.rs tier 1)
+#   LOOM_AUTONOMY_MARKER   -> <dir>/autonomy-desired     (#4011/#5131)
+#   LOOM_SOCKET_PATH       -> <dir>/loom-daemon.sock     (its parent is the
+#                             daemon's `loom_dir`, so the heartbeat, machine-level
+#                             logs and every `resolve_loom_dir()` consumer follow)
+#   LOOM_DAEMON_BIN_DIR    -> <dir>/machine-level-bin-sandbox (#4381)
+#   LOOM_DAEMON_BIN        -> UNSET  (#4902: the ambient value names the REAL binary)
+#   LOOM_WORKSPACE         -> UNSET  (pid-file tier 3; each sub-invocation must
+#                             resolve its OWN fixture repo root instead)
+#   LOOM_MACHINE_CHECKOUT  -> UNSET  (pid-file tier 2 + the scripts' machine
+#                             mode, whose state home is the real $HOME/.loom)
+#
+# Supervisor IDENTITY (launchd label, systemd unit, the LOOM_DAEMON_LAUNCHD /
+# LOOM_DAEMON_SYSTEMD knobs) is intentionally NOT handled here — those are not
+# filesystem state paths and are already owned by lib/launchd-sandbox.sh and
+# the per-suite systemd/launchd knobs.
+#
+# ## The guard
+#
+# Isolation alone is unfalsifiable — the previous three fixes all *looked*
+# complete. `live_state_sandbox_snapshot` fingerprints every live state path
+# reachable from the AMBIENT environment BEFORE the sandbox is installed, and
+# `live_state_sandbox_assert_untouched` re-fingerprints them at the end of the
+# run, so a write to a real `.loom` state path (or the CREATION of one that was
+# absent) fails the suite LOUDLY instead of being discovered in production.
+#
+# Only files a healthy daemon does NOT continuously rewrite are guarded
+# (see LIVE_STATE_SANDBOX_GUARDED_FILES): `daemon.heartbeat`, `daemon.log`,
+# `sweeps.json` and `activity.db` are deliberately excluded because a live
+# daemon updates them on its own cadence, which would make the guard flap.
+#
+# ## Usage (source it)
+#
+#   source "$SCRIPT_DIR/lib/live-state-sandbox.sh"
+#   live_state_sandbox_snapshot                      # BEFORE any sandbox export
+#   ...
+#   live_state_sandbox_init "$BASE_WORKDIR/live-state"
+#   ... run the suite ...
+#   live_state_sandbox_assert_untouched              # rc 0 = clean, 1 = leaked
+
+# State files that identify/steer a daemon and are written only at lifecycle
+# transitions — safe to compare before/after even while a real daemon runs.
+LIVE_STATE_SANDBOX_GUARDED_FILES=".daemon.pid .daemon.flags autonomy-desired"
+
+# Newline-separated "<path><TAB><fingerprint>" records captured by
+# live_state_sandbox_snapshot. Empty until the snapshot runs.
+_LSS_SNAPSHOT=""
+_LSS_SNAPSHOT_TAKEN=0
+
+# ---------------------------------------------------------------------------
+# internals
+# ---------------------------------------------------------------------------
+
+# Print <path>'s mtime as an epoch second, portably: GNU `stat -c %Y` first,
+# then BSD/macOS `stat -f %m`, else `?`. Each result is validated as digits-only
+# BEFORE it is accepted — GNU stat's `-f` is "filesystem status" (it SUCCEEDS
+# with multi-line output rather than failing), so a naive `-f || -c` chain
+# silently injects newlines into the fingerprint and makes every record
+# unparseable.
+_lss_mtime() {
+    local m
+    m=$(stat -c %Y "$1" 2>/dev/null)
+    case "$m" in ''|*[!0-9]*) m=$(stat -f %m "$1" 2>/dev/null) ;; esac
+    case "$m" in ''|*[!0-9]*) m="?" ;; esac
+    printf '%s' "$m"
+}
+
+# Print <path>'s sha256, using whichever checksum tool exists (mirrors the
+# #4381 production-binary guard's tool selection).
+_lss_checksum() {
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+    elif command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" 2>/dev/null | awk '{print $1}'
+    else
+        echo "<no-checksum-tool>"
+    fi
+}
+
+# Print a stable fingerprint of <path>: `<absent>` when it does not exist,
+# `<non-regular>` for sockets/dirs (content is meaningless there), else
+# size + mtime + checksum so ANY rewrite — including one that restores the
+# same bytes at a later mtime — is visible.
+_lss_fingerprint() {
+    local path="$1"
+    [[ -e "$path" ]] || { echo "<absent>"; return 0; }
+    [[ -f "$path" ]] || { echo "<non-regular>"; return 0; }
+    local size
+    size=$(wc -c < "$path" 2>/dev/null | tr -d ' ')
+    echo "size=${size:-?} mtime=$(_lss_mtime "$path") sha=$(_lss_checksum "$path")"
+}
+
+# Walk up from <dir> to the nearest repo root, mirroring the `find_repo_root()`
+# in loom-daemon-{start,stop,update}.sh (a `.git` OR `.loom` directory). Prints
+# the root; returns 1 when none is found.
+_lss_repo_root_from() {
+    local dir="$1"
+    while [[ -n "$dir" && "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" || -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+# Print (one per line) every live state path reachable from the CURRENT
+# environment. Called only from live_state_sandbox_snapshot, i.e. while the
+# environment is still the ambient/production one.
+_lss_enumerate_live_paths() {
+    local root file
+
+    # Explicit ambient overrides — the highest-precedence tiers, and the exact
+    # vars a Loom agent session exports at the REAL paths (#5179).
+    if [[ -n "${LOOM_PID_FILE:-}" ]]; then printf '%s\n' "$LOOM_PID_FILE"; fi
+    if [[ -n "${LOOM_AUTONOMY_MARKER:-}" ]]; then printf '%s\n' "$LOOM_AUTONOMY_MARKER"; fi
+
+    # State roots the scripts/daemon resolve on their own.
+    {
+        printf '%s\n' "$HOME/.loom"
+        if [[ -n "${LOOM_SOCKET_PATH:-}" ]]; then printf '%s\n' "$(dirname "$LOOM_SOCKET_PATH")"; fi
+        if [[ -n "${LOOM_WORKSPACE:-}" ]]; then printf '%s\n' "$LOOM_WORKSPACE/.loom"; fi
+        if [[ -n "${LOOM_MACHINE_CHECKOUT:-}" ]]; then printf '%s\n' "$LOOM_MACHINE_CHECKOUT/.loom"; fi
+        # $PWD's repo root: the un-sandboxed cwd is how a sub-invocation that
+        # forgets to `cd` into its fixture resolves REPO_ROOT — and therefore
+        # DAEMON_STATE_HOME="$REPO_ROOT/.loom" — straight onto the live checkout.
+        if root="$(_lss_repo_root_from "$PWD")"; then printf '%s\n' "$root/.loom"; fi
+        # The checkout this helper itself lives in (the suite may be launched
+        # from anywhere, e.g. `bash /path/to/checkout/defaults/scripts/tests/...`).
+        if root="$(_lss_repo_root_from "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")"; then
+            printf '%s\n' "$root/.loom"
+        fi
+    } | while IFS= read -r root; do
+        [[ -n "$root" ]] || continue
+        for file in $LIVE_STATE_SANDBOX_GUARDED_FILES; do
+            printf '%s\n' "$root/$file"
+        done
+    done
+}
+
+# ---------------------------------------------------------------------------
+# public API
+# ---------------------------------------------------------------------------
+
+# Fingerprint every live state path. MUST be called BEFORE
+# live_state_sandbox_init (it reads the ambient LOOM_* vars to discover which
+# paths are the live ones) and before the suite runs anything.
+live_state_sandbox_snapshot() {
+    local path
+    _LSS_SNAPSHOT=""
+    while IFS= read -r path; do
+        [[ -n "$path" ]] || continue
+        _LSS_SNAPSHOT="${_LSS_SNAPSHOT}${path}"$'\t'"$(_lss_fingerprint "$path")"$'\n'
+    done < <(_lss_enumerate_live_paths | sort -u)
+    _LSS_SNAPSHOT_TAKEN=1
+}
+
+# Redirect every live state path into <dir>. Exports are inherited by every
+# sub-invocation, so a call site that forgets to sandbox something still cannot
+# reach a production path.
+live_state_sandbox_init() {
+    local dir="$1"
+    [[ -n "$dir" ]] || { echo "live_state_sandbox_init: missing <dir>" >&2; return 1; }
+    mkdir -p "$dir" "$dir/logs" "$dir/machine-level-bin-sandbox"
+
+    export LOOM_PID_FILE="$dir/.daemon.pid"
+    export LOOM_AUTONOMY_MARKER="$dir/autonomy-desired"
+    export LOOM_SOCKET_PATH="$dir/loom-daemon.sock"
+    export LOOM_DAEMON_BIN_DIR="$dir/machine-level-bin-sandbox"
+
+    # Unset (not re-pointed): each sub-invocation must resolve these from its
+    # OWN fixture. An ambient value here silently outranks the fixture — that
+    # is the #4902 shape, and for LOOM_MACHINE_CHECKOUT it additionally flips
+    # both lifecycle scripts into machine mode, whose state home is the REAL
+    # $HOME/.loom. Tests that need them pin them inline per invocation.
+    unset LOOM_WORKSPACE
+    unset LOOM_MACHINE_CHECKOUT
+    unset LOOM_DAEMON_BIN
+}
+
+# Print the sandboxed values (one `NAME=value` per line) — handy in CI logs and
+# for asserting the sandbox is actually installed.
+live_state_sandbox_describe() {
+    printf 'LOOM_PID_FILE=%s\n' "${LOOM_PID_FILE:-}"
+    printf 'LOOM_AUTONOMY_MARKER=%s\n' "${LOOM_AUTONOMY_MARKER:-}"
+    printf 'LOOM_SOCKET_PATH=%s\n' "${LOOM_SOCKET_PATH:-}"
+    printf 'LOOM_DAEMON_BIN_DIR=%s\n' "${LOOM_DAEMON_BIN_DIR:-}"
+    printf 'LOOM_WORKSPACE=%s\n' "${LOOM_WORKSPACE:-<unset>}"
+    printf 'LOOM_MACHINE_CHECKOUT=%s\n' "${LOOM_MACHINE_CHECKOUT:-<unset>}"
+    printf 'LOOM_DAEMON_BIN=%s\n' "${LOOM_DAEMON_BIN:-<unset>}"
+}
+
+# Print how many live paths the snapshot covers (0 before a snapshot).
+live_state_sandbox_snapshot_size() {
+    [[ -n "$_LSS_SNAPSHOT" ]] || { echo 0; return 0; }
+    printf '%s' "$_LSS_SNAPSHOT" | grep -c ''
+}
+
+# Re-fingerprint every snapshotted live path. Returns 0 when all are
+# byte-and-mtime identical (including "still absent"), 1 when ANY changed —
+# printing each offender's before/after to stderr.
+live_state_sandbox_assert_untouched() {
+    local line path before after dirty=0
+    if [[ "$_LSS_SNAPSHOT_TAKEN" != "1" ]]; then
+        echo "live-state-sandbox: no snapshot taken — call live_state_sandbox_snapshot first" >&2
+        return 1
+    fi
+    while IFS= read -r line; do
+        [[ -n "$line" ]] || continue
+        path="${line%%$'\t'*}"
+        before="${line#*$'\t'}"
+        after="$(_lss_fingerprint "$path")"
+        if [[ "$before" != "$after" ]]; then
+            dirty=1
+            printf 'live-state-sandbox: LIVE daemon state path was written during this run: %s\n' "$path" >&2
+            printf '    before: %s\n' "$before" >&2
+            printf '    after:  %s\n' "$after" >&2
+        fi
+    done <<< "$_LSS_SNAPSHOT"
+    return "$dirty"
+}

--- a/defaults/scripts/tests/test-live-state-sandbox.sh
+++ b/defaults/scripts/tests/test-live-state-sandbox.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# test-live-state-sandbox.sh — tests for lib/live-state-sandbox.sh (issue #5179).
+#
+# The helper is the daemon lifecycle suites' single "sandbox every live-state
+# path" seam, and its guard half is what converts the recurring
+# "a test wrote the live host's daemon state" class (#4087, #5131, #5179) from
+# "an operator discovers a degraded host" into "the suite fails loudly". A
+# guard that cannot itself be shown to FAIL is worthless, so the cases below
+# prove both directions: clean run -> rc 0, and each way a live path can be
+# touched -> rc 1 with the offending path named.
+#
+# Every case runs in a subshell with a FAKE $HOME and a FAKE repo root, and
+# with the ambient LOOM_* state vars neutralized, so the suite never depends on
+# (or touches) the real host's daemon state.
+#
+# Usage:
+#   ./defaults/scripts/tests/test-live-state-sandbox.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/live-state-sandbox.sh
+source "$SCRIPT_DIR/lib/live-state-sandbox.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} $1"
+    [[ -n "${2:-}" ]] && echo "  $2"
+}
+
+check() { # <condition-rc> <message> [detail]
+    if [[ "$1" -eq 0 ]]; then pass "$2"; else fail "$2" "${3:-}"; fi
+}
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# A throwaway "live host": a fake $HOME with a ~/.loom state dir, and a fake
+# checkout with its own .loom (the repo-mode state home).
+FAKE_HOME="$WORKDIR/home"
+FAKE_REPO="$WORKDIR/checkout"
+mkdir -p "$FAKE_HOME/.loom" "$FAKE_REPO/.loom" "$FAKE_REPO/.git"
+echo "4242" > "$FAKE_HOME/.loom/.daemon.pid"
+echo "--work-finder" > "$FAKE_HOME/.loom/.daemon.flags"
+echo "desired=true" > "$FAKE_HOME/.loom/autonomy-desired"
+
+# Neutralize the ambient agent-session state vars for every case (the real
+# values point at THIS host's live daemon — exactly what must never be read or
+# written from a test).
+NEUTRAL_ENV='unset LOOM_PID_FILE LOOM_AUTONOMY_MARKER LOOM_SOCKET_PATH LOOM_WORKSPACE LOOM_MACHINE_CHECKOUT LOOM_DAEMON_BIN LOOM_DAEMON_BIN_DIR'
+
+# ============================================================
+# 1. live_state_sandbox_init redirects every state path into the sandbox dir
+#    and unsets the ambient vars that would outrank a per-fixture value.
+# ============================================================
+init_out=$(
+    eval "$NEUTRAL_ENV"
+    export HOME="$FAKE_HOME"
+    export LOOM_WORKSPACE="$FAKE_REPO"
+    export LOOM_MACHINE_CHECKOUT="$FAKE_REPO"
+    export LOOM_DAEMON_BIN="$FAKE_HOME/.local/bin/loom-daemon"
+    export LOOM_PID_FILE="$FAKE_HOME/.loom/.daemon.pid"
+    live_state_sandbox_init "$WORKDIR/sandbox1" >/dev/null
+    live_state_sandbox_describe
+)
+check "$([[ "$init_out" == *"LOOM_PID_FILE=$WORKDIR/sandbox1/.daemon.pid"* ]] && echo 0 || echo 1)" \
+    "init redirects LOOM_PID_FILE into the sandbox (the #5179 leak)" "$init_out"
+check "$([[ "$init_out" == *"LOOM_AUTONOMY_MARKER=$WORKDIR/sandbox1/autonomy-desired"* ]] && echo 0 || echo 1)" \
+    "init redirects LOOM_AUTONOMY_MARKER into the sandbox (#4011/#5131)" "$init_out"
+check "$([[ "$init_out" == *"LOOM_SOCKET_PATH=$WORKDIR/sandbox1/loom-daemon.sock"* ]] && echo 0 || echo 1)" \
+    "init redirects LOOM_SOCKET_PATH (and with it the daemon's loom_dir)" "$init_out"
+check "$([[ "$init_out" == *"LOOM_DAEMON_BIN_DIR=$WORKDIR/sandbox1/machine-level-bin-sandbox"* ]] && echo 0 || echo 1)" \
+    "init redirects LOOM_DAEMON_BIN_DIR (#4381)" "$init_out"
+check "$([[ "$init_out" == *"LOOM_WORKSPACE=<unset>"* && "$init_out" == *"LOOM_MACHINE_CHECKOUT=<unset>"* \
+    && "$init_out" == *"LOOM_DAEMON_BIN=<unset>"* ]] && echo 0 || echo 1)" \
+    "init unsets the ambient LOOM_WORKSPACE / LOOM_MACHINE_CHECKOUT / LOOM_DAEMON_BIN (#4902 shape)" "$init_out"
+
+# ============================================================
+# 2. A run that touches nothing leaves the guard green.
+# ============================================================
+(
+    eval "$NEUTRAL_ENV"
+    export HOME="$FAKE_HOME"
+    cd "$FAKE_REPO" || exit 1
+    live_state_sandbox_snapshot
+    live_state_sandbox_init "$WORKDIR/sandbox2" >/dev/null
+    # A well-behaved suite writes ONLY inside the sandbox.
+    echo "99999" > "$LOOM_PID_FILE"
+    echo "desired=false" > "$LOOM_AUTONOMY_MARKER"
+    live_state_sandbox_assert_untouched
+) 2>"$WORKDIR/case2.err"
+check $? "clean run (writes confined to the sandbox) passes the guard" "$(cat "$WORKDIR/case2.err")"
+
+# ============================================================
+# 3. Rewriting an EXISTING live state file fails the guard, loudly.
+#    This is the #5179 shape on a machine-mode host: ~/.loom/.daemon.pid gets
+#    a test fixture's pid, and the operator sees a false `degraded` verdict.
+# ============================================================
+case3_err="$WORKDIR/case3.err"
+(
+    eval "$NEUTRAL_ENV"
+    export HOME="$FAKE_HOME"
+    cd "$FAKE_REPO" || exit 1
+    live_state_sandbox_snapshot
+    live_state_sandbox_init "$WORKDIR/sandbox3" >/dev/null
+    # The leak: something resolved the LIVE pid file and claimed it.
+    echo "86050" > "$FAKE_HOME/.loom/.daemon.pid"
+    live_state_sandbox_assert_untouched
+) 2>"$case3_err"
+rc3=$?
+check "$([[ "$rc3" -ne 0 ]] && echo 0 || echo 1)" \
+    "rewriting the live ~/.loom/.daemon.pid FAILS the guard (rc=$rc3)"
+check "$(grep -q "$FAKE_HOME/.loom/.daemon.pid" "$case3_err" && echo 0 || echo 1)" \
+    "the guard names the offending live path in its failure output" "$(cat "$case3_err")"
+check "$(grep -q 'before:' "$case3_err" && grep -q 'after:' "$case3_err" && echo 0 || echo 1)" \
+    "the guard prints before/after fingerprints for the offender" "$(cat "$case3_err")"
+# Restore for the later cases.
+echo "4242" > "$FAKE_HOME/.loom/.daemon.pid"
+
+# ============================================================
+# 4. CREATING a live state path that was absent fails too — the repo-mode
+#    shape, where an un-cd'd sub-invocation resolves REPO_ROOT from the live
+#    checkout and writes <checkout>/.loom/.daemon.pid where none existed.
+# ============================================================
+case4_err="$WORKDIR/case4.err"
+(
+    eval "$NEUTRAL_ENV"
+    export HOME="$FAKE_HOME"
+    cd "$FAKE_REPO" || exit 1
+    live_state_sandbox_snapshot
+    live_state_sandbox_init "$WORKDIR/sandbox4" >/dev/null
+    echo "3745" > "$FAKE_REPO/.loom/.daemon.pid"
+    live_state_sandbox_assert_untouched
+) 2>"$case4_err"
+rc4=$?
+check "$([[ "$rc4" -ne 0 ]] && echo 0 || echo 1)" \
+    "creating a previously-absent <checkout>/.loom/.daemon.pid FAILS the guard (rc=$rc4)"
+check "$(grep -q '<absent>' "$case4_err" && echo 0 || echo 1)" \
+    "the guard reports the absent->present transition" "$(cat "$case4_err")"
+rm -f "$FAKE_REPO/.loom/.daemon.pid"
+
+# ============================================================
+# 5. An AMBIENT LOOM_PID_FILE (what a Loom agent session exports — the real
+#    root cause of #5179) is both (a) covered by the snapshot and (b)
+#    redirected by init, so the suite writes the sandbox copy instead.
+# ============================================================
+case5_err="$WORKDIR/case5.err"
+AMBIENT_PID_FILE="$WORKDIR/ambient-live/.daemon.pid"
+mkdir -p "$(dirname "$AMBIENT_PID_FILE")"
+echo "850106" > "$AMBIENT_PID_FILE"
+(
+    eval "$NEUTRAL_ENV"
+    export HOME="$FAKE_HOME"
+    export LOOM_PID_FILE="$AMBIENT_PID_FILE"
+    cd "$FAKE_REPO" || exit 1
+    live_state_sandbox_snapshot
+    live_state_sandbox_init "$WORKDIR/sandbox5" >/dev/null
+    # A daemon spawned by the suite claims whatever LOOM_PID_FILE names.
+    echo "$$" > "$LOOM_PID_FILE"
+    live_state_sandbox_assert_untouched
+) 2>"$case5_err"
+rc5=$?
+check "$([[ "$rc5" -eq 0 ]] && echo 0 || echo 1)" \
+    "an ambient LOOM_PID_FILE is redirected, so the live pid file survives (rc=$rc5)" "$(cat "$case5_err")"
+check "$([[ "$(cat "$AMBIENT_PID_FILE")" == "850106" ]] && echo 0 || echo 1)" \
+    "the live pid file still records the live daemon's pid, byte-for-byte"
+
+# The same case WITHOUT the sandbox is what production looked like: prove the
+# snapshot half would have caught it.
+case5b_err="$WORKDIR/case5b.err"
+(
+    eval "$NEUTRAL_ENV"
+    export HOME="$FAKE_HOME"
+    export LOOM_PID_FILE="$AMBIENT_PID_FILE"
+    cd "$FAKE_REPO" || exit 1
+    live_state_sandbox_snapshot
+    # No live_state_sandbox_init: the pre-#5179 suite, inheriting the live path.
+    echo "86050" > "$LOOM_PID_FILE"
+    live_state_sandbox_assert_untouched
+) 2>"$case5b_err"
+rc5b=$?
+check "$([[ "$rc5b" -ne 0 ]] && echo 0 || echo 1)" \
+    "without init, a write through the ambient LOOM_PID_FILE FAILS the guard (rc=$rc5b)" "$(cat "$case5b_err")"
+echo "850106" > "$AMBIENT_PID_FILE"
+
+# ============================================================
+# 6. Asserting without a snapshot fails loudly rather than silently passing —
+#    a suite that forgets the snapshot must not look green.
+# ============================================================
+case6_err="$WORKDIR/case6.err"
+(
+    eval "$NEUTRAL_ENV"
+    export HOME="$FAKE_HOME"
+    live_state_sandbox_assert_untouched
+) 2>"$case6_err"
+rc6=$?
+check "$([[ "$rc6" -ne 0 ]] && echo 0 || echo 1)" \
+    "assert without a prior snapshot fails (rc=$rc6)"
+check "$(grep -qi 'no snapshot' "$case6_err" && echo 0 || echo 1)" \
+    "the no-snapshot failure explains what is missing" "$(cat "$case6_err")"
+
+# ============================================================
+# 7. Volatile daemon-written files are deliberately NOT guarded (a live
+#    daemon rewrites them on its own cadence, which would make the guard flap).
+# ============================================================
+(
+    eval "$NEUTRAL_ENV"
+    export HOME="$FAKE_HOME"
+    cd "$FAKE_REPO" || exit 1
+    echo "ts=1" > "$FAKE_HOME/.loom/daemon.heartbeat"
+    live_state_sandbox_snapshot
+    live_state_sandbox_init "$WORKDIR/sandbox7" >/dev/null
+    echo "ts=2" > "$FAKE_HOME/.loom/daemon.heartbeat"
+    live_state_sandbox_assert_untouched
+) 2>"$WORKDIR/case7.err"
+check $? "a live daemon's own heartbeat churn does not flap the guard" "$(cat "$WORKDIR/case7.err")"
+
+# ============================================================
+# 8. The snapshot actually covers something (a silently-empty path list would
+#    make every assertion above vacuously true).
+# ============================================================
+snap_size=$(
+    eval "$NEUTRAL_ENV"
+    export HOME="$FAKE_HOME"
+    cd "$FAKE_REPO" || exit 1
+    live_state_sandbox_snapshot
+    live_state_sandbox_snapshot_size
+)
+check "$([[ "${snap_size:-0}" -ge 6 ]] && echo 0 || echo 1)" \
+    "snapshot covers both the \$HOME/.loom and the checkout state roots ($snap_size paths)"
+
+echo
+echo "Ran $TESTS_RUN tests: $TESTS_PASSED passed, $TESTS_FAILED failed"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -116,6 +116,17 @@ export LOOM_LAUNCHD_LABEL="$(launchd_sandbox_new_label)"
 # shellcheck source=lib/bg-proc-trap.sh
 source "$SCRIPT_DIR/lib/bg-proc-trap.sh"
 
+# Shared live-state sandbox (#5179). The snapshot MUST run here — before
+# live_state_sandbox_init below rewrites the LOOM_* state vars, and before any
+# sub-invocation can write anything — because it discovers WHICH paths are the
+# live ones by reading the ambient environment (a Loom agent session exports
+# LOOM_PID_FILE / LOOM_WORKSPACE / LOOM_DAEMON_BIN at the REAL production
+# paths, so this suite inherits them unless it says otherwise). The matching
+# live_state_sandbox_assert_untouched runs as the suite's final guard.
+# shellcheck source=lib/live-state-sandbox.sh
+source "$SCRIPT_DIR/lib/live-state-sandbox.sh"
+live_state_sandbox_snapshot
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
@@ -935,37 +946,49 @@ MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
 BASE_WORKDIR="$(mktemp -d)"
 
-# #4011: isolate the autonomy-desired marker + watchdog label suite-wide so a
-# restart path that reaches the real loom-daemon-start.sh can never write the
-# operator's real ~/.loom/autonomy-desired or provision the real
-# com.rjwalters.loom-daemon-watchdog LaunchAgent. Both are exported so every
-# sub-invocation (each cd'd into its own W* dir) inherits them.
-export LOOM_AUTONOMY_MARKER="$BASE_WORKDIR/autonomy-desired"
-export LOOM_WATCHDOG_LABEL="${LOOM_LAUNCHD_LABEL}-watchdog"
-
-# Machine-level provisioning sandbox (#4381 incident — see the checksum-guard
-# comment near the top of this file for the full writeup). loom-daemon-update.sh
-# resolves its machine-level install destination as
-# `${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}` whenever LOOM_DAEMON_BIN is unset.
-# Most tests below pin LOOM_DAEMON_BIN explicitly (so this is inert for them),
-# but the ff-sync/staleness-detection tests (37/39/43) deliberately exercise the
-# no-LOOM_DAEMON_BIN path, and until this fix that meant an UNSANDBOXED
-# provision_machine_daemon() call landed on the operator's real
-# ~/.local/bin/loom-daemon. Exporting this suite-wide closes the hole for every
-# current call site AND any future one that forgets to set LOOM_DAEMON_BIN —
-# belt-and-braces with the checksum guard at both the top and bottom of this
-# file, which would otherwise be the only thing catching a regression.
+# ---------- live daemon state sandbox (#5179) ----------
+# ONE helper owns EVERY live-state path this suite could otherwise reach, so a
+# state file added to the daemon later is isolated by construction rather than
+# after it leaks in production. It supersedes the per-variable overrides that
+# used to live here, and covers (see lib/live-state-sandbox.sh for the full
+# rationale per variable):
 #
-# `unset LOOM_DAEMON_BIN` closes the other half of the hole (#4902): every
-# live Loom agent session (Builder/Judge/Doctor, ...) inherits an ambient
-# LOOM_DAEMON_BIN pointing at the real production binary, and
-# loom-daemon-update.sh's `PROVISION_TARGET="${LOOM_DAEMON_BIN:-$DEST_DIR/...}"`
-# lets that ambient value win over the LOOM_DAEMON_BIN_DIR sandbox above,
-# silently defeating it. Tests below that need LOOM_DAEMON_BIN pin it inline
-# on their own invocation (e.g. `LOOM_DAEMON_BIN="$W1/..." bash ...`), which
-# still applies regardless of this ambient unset.
-export LOOM_DAEMON_BIN_DIR="$BASE_WORKDIR/machine-level-bin-sandbox"
-unset LOOM_DAEMON_BIN
+#   LOOM_PID_FILE          the #5179 leak itself. The ambient value a Loom
+#                          agent session exports names the REAL .daemon.pid,
+#                          and it is tier 1 of daemon_pidfile.rs's resolver —
+#                          ahead of every other tier — so an un-overridden
+#                          suite does not get a neutral default, it inherits
+#                          the live path and rewrites it under a running
+#                          daemon (observed: a false `degraded` liveness
+#                          verdict on a healthy host, plus a poisoned input
+#                          for the #5118/#5126 watchdog).
+#   LOOM_AUTONOMY_MARKER   #4011/#5131: a restart path that reaches the real
+#                          loom-daemon-start.sh must never write the
+#                          operator's ~/.loom/autonomy-desired.
+#   LOOM_SOCKET_PATH       its parent is the daemon's `loom_dir`, so the
+#                          heartbeat + machine-level logs follow it into the
+#                          sandbox (start.sh documents this seam explicitly).
+#   LOOM_DAEMON_BIN_DIR    #4381 incident (see the checksum-guard writeup at
+#                          the top of this file): update.sh resolves its
+#                          machine-level install destination as
+#                          `${LOOM_DAEMON_BIN_DIR:-$HOME/.local/bin}` whenever
+#                          LOOM_DAEMON_BIN is unset, and tests 37/39/43
+#                          deliberately exercise that no-LOOM_DAEMON_BIN path.
+#   LOOM_DAEMON_BIN        #4902: unset, because the ambient agent-session
+#                          value names the real production binary and would
+#                          win over LOOM_DAEMON_BIN_DIR.
+#   LOOM_WORKSPACE /       unset, so each sub-invocation resolves its own
+#   LOOM_MACHINE_CHECKOUT  fixture instead of the live checkout / machine-mode
+#                          state home. Tests that need either pin it inline.
+#
+# Tests below that need a pinned value still set it on their own invocation
+# (e.g. `LOOM_DAEMON_BIN="$W1/..." bash ...`), which applies regardless.
+live_state_sandbox_init "$BASE_WORKDIR/live-state"
+
+# Supervisor identity, not a state path — the watchdog LaunchAgent must be
+# provisioned under the scratch label so a restart path can never touch the
+# real com.rjwalters.loom-daemon-watchdog job (#4011/#4078).
+export LOOM_WATCHDOG_LABEL="${LOOM_LAUNCHD_LABEL}-watchdog"
 
 # Binary-format sanity gate bypass (#4397, deferred from #4381's incident
 # review): provision_machine_daemon now refuses to install anything that
@@ -5217,6 +5240,28 @@ else
     echo -e "${RED}✗${NC} real ${_PROD_DAEMON_BIN} CHANGED during this test run (#4381 regression!)"
     echo "  before: $_PROD_DAEMON_CHECKSUM_BEFORE"
     echo "  after:  $_PROD_DAEMON_CHECKSUM_AFTER"
+fi
+
+# ============================================================
+# 45. Live daemon state guard (#5179): every live `.loom` state path reachable
+#     from the ambient environment (the real $HOME/.loom, the live checkout's
+#     .loom, an ambient LOOM_PID_FILE / LOOM_WORKSPACE / LOOM_MACHINE_CHECKOUT)
+#     must be byte-and-mtime identical to its pre-suite snapshot — and a path
+#     that was ABSENT must still be absent. This is what converts the whole
+#     "state file leaked into production" class (#4087, #5131, #5179) from
+#     "discovered by an operator on a degraded host" into "caught by the suite":
+#     isolation alone is unfalsifiable, since each of the previous three fixes
+#     also LOOKED complete.
+# ============================================================
+TESTS_RUN=$((TESTS_RUN + 1))
+if live_state_sandbox_assert_untouched; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} no live .loom daemon state path was written during the suite ($(live_state_sandbox_snapshot_size) paths guarded, #5179)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} a LIVE .loom daemon state path was written during this test run (#5179 regression!)"
+    echo "  sandbox in effect during the run:"
+    live_state_sandbox_describe | sed 's/^/    /'
 fi
 
 # ---------- summary ----------


### PR DESCRIPTION
## Summary

`test-loom-daemon-update.sh` could rewrite the **live** host's `.daemon.pid`, producing a false `degraded` liveness verdict for the operator and poisoning the #5118/#5126 watchdog's primary input.

Root cause (verified on a live worker host, not just from the issue text): the suite runs inside a Loom agent session, and that session **exports the live state paths into every child it spawns** —

```
LOOM_PID_FILE=/home/ubuntu/.loom/.daemon.pid     <- the REAL pid file
LOOM_WORKSPACE=/home/ubuntu/GitHub/loom          <- the REAL checkout
LOOM_DAEMON_BIN=/home/ubuntu/.local/bin/loom-daemon
```

So a missing override is not a neutral default — it is an **inherited production path**, and `LOOM_PID_FILE` is *tier 1* of the daemon's own resolver (`daemon_pidfile.rs:97-119`), ahead of every other tier. This is the identical shape #4902 fixed for `LOOM_DAEMON_BIN`, and the sibling suite `test-loom-daemon-watchdog.sh:108-118` already pins `LOOM_PID_FILE=`/`LOOM_WORKSPACE=`/`LOOM_MACHINE_CHECKOUT=` empty for exactly this reason ("an inherited `LOOM_PID_FILE` pointed every case at the [live pid file]").

Per the issue's preferred direction, this takes the **shared-helper** route rather than adding a fourth per-variable override (after #4078, #5131, #4902), and pairs it with a guard so the class is caught rather than rediscovered in production.

## Changes

**`defaults/scripts/tests/lib/live-state-sandbox.sh` (new)** — one seam for both halves:

- `live_state_sandbox_init <dir>` redirects `LOOM_PID_FILE`, `LOOM_AUTONOMY_MARKER`, `LOOM_SOCKET_PATH` (its parent is the daemon's `loom_dir`, so heartbeat + machine-level logs follow) and `LOOM_DAEMON_BIN_DIR` into the sandbox, and **unsets** the ambient `LOOM_WORKSPACE` / `LOOM_MACHINE_CHECKOUT` / `LOOM_DAEMON_BIN` that outrank each fixture's own value (`LOOM_MACHINE_CHECKOUT` additionally flips both lifecycle scripts into machine mode, whose state home is the real `$HOME/.loom`).
- `live_state_sandbox_snapshot` / `live_state_sandbox_assert_untouched` fingerprint (size + mtime + sha256) every live `.loom` state path reachable from the **ambient** env — `$HOME/.loom`, `$LOOM_WORKSPACE/.loom`, `$LOOM_MACHINE_CHECKOUT/.loom`, `$(dirname $LOOM_SOCKET_PATH)`, `$PWD`'s repo root, the suite's own checkout — before the run, and re-check them after. A write to a real state path, **or the creation of one that was absent**, fails loudly with the offender named. Volatile daemon-written files (heartbeat, log, `sweeps.json`, `activity.db`) are deliberately excluded so a healthy live daemon cannot flap the guard.

**`defaults/scripts/tests/test-loom-daemon-update.sh`** — snapshots before any export (line ~119), replaces the per-variable overrides with `live_state_sandbox_init "$BASE_WORKDIR/live-state"`, and ends with the guard as case 45. `LOOM_WATCHDOG_LABEL` stays put (supervisor identity, not a state path — that axis is owned by `lib/launchd-sandbox.sh`).

**`defaults/scripts/tests/test-live-state-sandbox.sh` (new, wired into `ci-wired.txt`)** — 18 cases proving the guard in *both* directions, because a guard that cannot be shown to fail is worthless.

## Acceptance Criteria Verification

- [x] **Running the suite on a host with a live daemon does not modify that daemon's pid file, and leaves `health` reporting the same liveness.** Verified twice on this host (live daemon pid 850106, machine-mode state in `~/.loom`): `~/.loom/.daemon.pid` is byte-and-mtime identical before/after both runs (`8453`, `2026-08-04 02:08:01.250588126`), the daemon is still alive, and `loom-daemon health`'s liveness line is unchanged (it was already DEGRADED **before** any test ran, from a pre-existing #4774 supervisor-relaunch staleness — the suite neither caused nor worsened it).
- [x] **Live-state paths are isolated via one shared helper, not per-variable overrides.** `live_state_sandbox_init` is the only place the update suite names a state var; a new daemon state file is isolated by adding it there once.
- [x] **The suite detects and fails on a write to a real `.loom` state path.** Case 45 of the update suite (`12 paths guarded` on this host), and proven to actually fail in `test-live-state-sandbox.sh` cases 3/4/5b — rewriting a live `~/.loom/.daemon.pid`, creating a previously-absent `<checkout>/.loom/.daemon.pid`, and the **pre-fix shape** (a write through the ambient `LOOM_PID_FILE` with no sandbox) each return rc 1 with the offending path plus before/after fingerprints. Case 6 covers "assert without a snapshot must not look green."
- [x] **Verified while a real daemon is running.** Both full-suite runs above were made against the live daemon on this host.

## Test Plan

- [x] `defaults/scripts/tests/test-loom-daemon-update.sh` — **254/254 passed** with the fix (run 1 had one unrelated flake, `--help documents --check/--dry-run/--no-restart`, under host contention; it passes on re-run and also passes on unmodified `main`).
- [x] Unmodified `main` copy of the suite run for comparison — 253/253, confirming no case regressed and that the single flake is not attributable to this change.
- [x] `defaults/scripts/tests/test-live-state-sandbox.sh` — 18/18 passed.
- [x] `defaults/scripts/tests/check-ci-suite-manifest.sh` — OK (103 suites, 100 wired, 3 excluded).
- [x] `shellcheck --severity=warning` (CI's severity) clean on all three touched/added scripts.

## Notes for the reviewer

- **Sibling suites are still exposed** (out of scope here): `test-loom-daemon-start.sh` and `test-loom-daemon-stop.sh` also have zero `LOOM_PID_FILE` overrides and pin state paths per-invocation rather than suite-wide, so an ambient value still reaches their sub-invocations. Adopting this helper there is the obvious follow-up.
- **Observed during this work** (not caused by it, guard confirms): the live `~/.loom/autonomy-desired` marker on this host disappeared **before** either suite run started (the snapshot recorded it already absent, and the guard reported no changes during the runs). That is the still-open #5131 shape on a host running many concurrent sweeps; the daemon's #4331 healing has restored it twice before per `daemon.log`.
- The main checkout was already dirty at session start (`M mcp-loom/package-lock.json`, `?? loom-tools/`) — pre-existing, untouched by this work; all changes here are in the issue worktree.

Closes #5179
