### PR TITLE
fix(guard): scope gh-api-rawfield-body-literal-at to a heredoc-masked command copy

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -2206,9 +2206,32 @@ if [[ "$COMMAND" == *"@"* ]]; then
     # `repos/{o}/{r}/pulls/{n}` (PR PATCH) exactly as it covers
     # `.../issues/{n}/comments`. Confirmed via the test suite's new
     # non-comments-endpoint case; no widening was needed here.
+    #
+    # HEREDOC-MASKED SCAN (#5181): this check used to grep raw $COMMAND, so a
+    # heredoc BODY line that merely QUOTES the denied phrase as inert prose
+    # (e.g. a report `cat > f.md <<'EOF' ... gh api ... -f body=@x ... EOF`,
+    # nothing of which executes) tripped the same catastrophic-tier deny as a
+    # live invocation. Reuses mask_heredoc_bodies() (#5000, defined above)
+    # -- the same primitive extract_write_targets() already uses -- to build
+    # a heredoc-body-blanked working copy and scans THAT instead. Built
+    # lazily (only when '<<' is present, mirroring the COMMAND_NO_COMMENT
+    # `#`-present hot-path guard below) and scoped to just this one check;
+    # every other rule in this file keeps reading raw $COMMAND /
+    # COMMAND_NO_COMMENT unchanged. Masking only ever narrows: a REAL
+    # (non-heredoc) invocation is untouched and still denies, even sitting in
+    # the same multi-line command as an unrelated heredoc (mirrors the #5000
+    # "narrows, never widens" test at
+    # tests/hooks/test-guard-destructive.sh:2691).
     # -------------------------------------------------------------------------
+    if [[ "$COMMAND" == *"<<"* ]]; then
+        COMMAND_HEREDOC_MASKED=$(printf '%s' "$COMMAND" | awk "$_MASKHEREDOC_AWK"'
+        { buf = buf (NR > 1 ? "\n" : "") $0 }
+        END { printf "%s", mask_heredoc_bodies(buf) }')
+    else
+        COMMAND_HEREDOC_MASKED="$COMMAND"
+    fi
     GH_API_RAWFIELD_BODY_AT_PATTERN="(^|[;&|[:space:]])gh[[:space:]]+api[^;&]*[[:space:]](-f|--raw-field)[[:space:]]*=?[[:space:]]*[\"']?body=[\"']?$GH_AT_PATHISH"
-    if echo "$COMMAND" | grep -qE "$GH_API_RAWFIELD_BODY_AT_PATTERN"; then
+    if echo "$COMMAND_HEREDOC_MASKED" | grep -qE "$GH_API_RAWFIELD_BODY_AT_PATTERN"; then
         deny "BLOCKED: 'gh api ... -f/--raw-field body=@<path>' does NOT read the file — only -F/--field gives '@<path>' its read-from-file meaning. As written this posts the literal string '@<path>' as the body (same silent data loss as PR #4457/issue #4608). Use '-F body=@<path>' instead." "gh-api-rawfield-body-literal-at"
     fi
 fi

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -2206,9 +2206,32 @@ if [[ "$COMMAND" == *"@"* ]]; then
     # `repos/{o}/{r}/pulls/{n}` (PR PATCH) exactly as it covers
     # `.../issues/{n}/comments`. Confirmed via the test suite's new
     # non-comments-endpoint case; no widening was needed here.
+    #
+    # HEREDOC-MASKED SCAN (#5181): this check used to grep raw $COMMAND, so a
+    # heredoc BODY line that merely QUOTES the denied phrase as inert prose
+    # (e.g. a report `cat > f.md <<'EOF' ... gh api ... -f body=@x ... EOF`,
+    # nothing of which executes) tripped the same catastrophic-tier deny as a
+    # live invocation. Reuses mask_heredoc_bodies() (#5000, defined above)
+    # -- the same primitive extract_write_targets() already uses -- to build
+    # a heredoc-body-blanked working copy and scans THAT instead. Built
+    # lazily (only when '<<' is present, mirroring the COMMAND_NO_COMMENT
+    # `#`-present hot-path guard below) and scoped to just this one check;
+    # every other rule in this file keeps reading raw $COMMAND /
+    # COMMAND_NO_COMMENT unchanged. Masking only ever narrows: a REAL
+    # (non-heredoc) invocation is untouched and still denies, even sitting in
+    # the same multi-line command as an unrelated heredoc (mirrors the #5000
+    # "narrows, never widens" test at
+    # tests/hooks/test-guard-destructive.sh:2691).
     # -------------------------------------------------------------------------
+    if [[ "$COMMAND" == *"<<"* ]]; then
+        COMMAND_HEREDOC_MASKED=$(printf '%s' "$COMMAND" | awk "$_MASKHEREDOC_AWK"'
+        { buf = buf (NR > 1 ? "\n" : "") $0 }
+        END { printf "%s", mask_heredoc_bodies(buf) }')
+    else
+        COMMAND_HEREDOC_MASKED="$COMMAND"
+    fi
     GH_API_RAWFIELD_BODY_AT_PATTERN="(^|[;&|[:space:]])gh[[:space:]]+api[^;&]*[[:space:]](-f|--raw-field)[[:space:]]*=?[[:space:]]*[\"']?body=[\"']?$GH_AT_PATHISH"
-    if echo "$COMMAND" | grep -qE "$GH_API_RAWFIELD_BODY_AT_PATTERN"; then
+    if echo "$COMMAND_HEREDOC_MASKED" | grep -qE "$GH_API_RAWFIELD_BODY_AT_PATTERN"; then
         deny "BLOCKED: 'gh api ... -f/--raw-field body=@<path>' does NOT read the file — only -F/--field gives '@<path>' its read-from-file meaning. As written this posts the literal string '@<path>' as the body (same silent data loss as PR #4457/issue #4608). Use '-F body=@<path>' instead." "gh-api-rawfield-body-literal-at"
     fi
 fi

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -546,6 +546,41 @@ assert_allow "#4601: Allow gh api --field body=@path (long form of -F, must not 
 assert_allow "#4601/#4577: Allow gh api -f body=\"@mention prose\" (not path-shaped)" \
     "gh api repos/o/r/issues/123/comments -f body=\"@rjwalters thanks for the review\""
 
+# --- #5181: gh-api-rawfield-body-literal-at fired on heredoc text that merely
+# QUOTES the denied phrase, with nothing executing --------------------------
+#
+# The check above used to grep raw $COMMAND, so a heredoc BODY line that
+# merely quotes 'gh api ... -f body=@path' as inert prose (e.g. a report
+# destined for a file, discussing the anti-pattern as an example of what NOT
+# to do) tripped the same catastrophic-tier deny as a live invocation — a
+# hard stall in headless runs, since there is no human to answer a
+# catastrophic-tier block. Confirmed in production: a prior agent's own
+# attempt to file the bug report about this false positive was itself denied
+# by it (its heredoc body quoted the phrase as an example). Fixed by scanning
+# a heredoc-body-masked working copy of $COMMAND (mask_heredoc_bodies(),
+# #5000) instead of the raw string.
+assert_allow "#5181: Allow a heredoc body that merely QUOTES 'gh api ... -f body=@path' as inert prose" \
+    'cat > /tmp/report.md <<'"'"'EOF'"'"'
+Discussing the anti-pattern, e.g. quoting:
+gh api repos/o/r/issues/1/comments -f body=@/tmp/review.md
+as an example of what NOT to do.
+EOF
+echo done'
+
+# Narrows, never widens: a REAL (non-heredoc) invocation must keep denying —
+# both standalone (regression guard for #4523/#4601/#4685, must not be
+# weakened) and sitting in the same multi-line command as an unrelated
+# heredoc (mirrors the #5000 "narrows, never widens" test at
+# tests/hooks/test-guard-destructive.sh:2691).
+assert_deny "#5181: A live (non-heredoc) gh api -f body=@path invocation still denies (regression guard)" \
+    "gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md"
+
+assert_deny "#5181: A real invocation AFTER an unrelated heredoc in the same command still denies" \
+    'cat <<'"'"'EOF'"'"'
+just some unrelated prose
+EOF
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md'
+
 # --- #4685: the same literal-@ loss on the `edit` subcommand — real-world
 # evidence is issue #4608's body being corrupted to the literal string
 # `@/tmp/issue4608_body_new.txt`. The #4523/#4601 rules above are hard-anchored


### PR DESCRIPTION
## Summary
The `gh-api-rawfield-body-literal-at` catastrophic-tier guard check in
`defaults/hooks/guard-destructive-generic.sh` grepped the raw `$COMMAND`
string, so it fired not only on a live `gh api ... -f/--raw-field
body=@<path>` invocation (the real #4523/#4601 data-loss shape) but also
whenever that exact substring merely appeared as quoted example text inside
a heredoc destined for a file (e.g. a report explaining the anti-pattern).
Nothing executed in that case, yet the guard denied the whole command at
catastrophic tier — a hard stall in headless runs since there is no human to
answer. This mirrors the same false-positive class already tracked for
sibling checks (#5158, #5172).

## Changes
- Build a heredoc-body-masked working copy of `$COMMAND`
  (`COMMAND_HEREDOC_MASKED`), reusing the existing `mask_heredoc_bodies()`
  primitive (added by #5000, already used by `extract_write_targets()`), built
  lazily only when `<<` is present in the command.
- Scope the `gh-api-rawfield-body-literal-at` check to scan
  `COMMAND_HEREDOC_MASKED` instead of raw `$COMMAND`. Every other check in
  the file is untouched.
- Apply the identical diff to both `defaults/hooks/guard-destructive-generic.sh`
  (source of truth) and the installed `.loom/hooks/guard-destructive-generic.sh`
  copy — both files were byte-identical before this change and are kept in
  lockstep, matching the pattern used by recent sibling guard PRs (e.g. #5176,
  #5161) that touch this same file.
- Add three regression tests to `tests/hooks/test-guard-destructive.sh`:
  1. a heredoc body that merely quotes the denied phrase as prose now allows,
  2. a live (non-heredoc) `gh api ... -f body=@path` invocation still denies,
  3. a real invocation sitting after an unrelated heredoc in the same
     multi-line command still denies (narrows, never widens — mirrors the
     #5000 "narrows, never widens" test pattern).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `gh-api-rawfield-body-literal-at` no longer denies a command where the denied substring appears only inside a heredoc body destined for a file | Passed | New `assert_allow` test reproduces the exact false-positive shape from the issue; guard now allows it |
| A live, non-heredoc `gh api ... -f/--raw-field body=@<path>` invocation still denies at catastrophic tier, unchanged | Passed | Existing `#4601`/`#4685` tests (lines 535-597, 979-980) still pass unmodified; new dedicated `#5181` regression test also confirms |
| A real (non-heredoc) invocation sitting in the same multi-line command as an unrelated heredoc still denies | Passed | New `#5181` "narrows, never widens" test |
| `tests/hooks/test-guard-destructive.sh` passes locally | Passed | Full suite: 679/679 passed |

## Test Plan
- `bash tests/hooks/test-guard-destructive.sh` — 679/679 passed, including
  the 3 new `#5181` cases.
- `bash tests/hooks/test-guard-destructive-dispatcher.sh` — 12/12 passed
  (unaffected by this change, run to confirm no dispatcher regression).
- `bash -n defaults/hooks/guard-destructive-generic.sh` and `shellcheck -S
  warning` — clean.
- Manual repro: reconstructed the exact false-positive shape from the issue
  (a `cat > report.md <<'EOF' ... EOF` heredoc whose body quotes the denied
  `gh api` phrase as prose) against the patched guard directly — now allows.
  Reconstructed a live invocation, and a live invocation immediately after an
  unrelated heredoc in the same command — both still deny.
- Confirmed `defaults/hooks/guard-destructive-generic.sh` and
  `.loom/hooks/guard-destructive-generic.sh` remain byte-identical after the
  edit.

Closes #5181
