### PR TITLE
feat(scripts): warn when local main is ahead of origin, not just behind

### DIFF
--- a/defaults/scripts/check-main-freshness.sh
+++ b/defaults/scripts/check-main-freshness.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# check-main-freshness.sh - Warn when local default branch is behind origin.
+# check-main-freshness.sh - Warn when local default branch is behind OR ahead
+# of origin.
 #
 # This is a NON-BLOCKING, advisory check. During a long-running /loom:sweep
 # session, other PRs can merge to origin's default branch — and because the
@@ -9,6 +10,12 @@
 # recently-merged logic (see #3770 for the incident: worktree.sh --base (#3742)
 # and merge-pr.sh auto-reconcile (#3752) were absent from the copies the session
 # was actually running, even though both had merged to origin/main).
+#
+# Ahead is the more dangerous direction (#5182): worktree.sh sets
+# BASE_REF="origin/$DEFAULT_BRANCH", so every builder worktree branches off
+# origin, not local. Unpushed local commits are invisible to every builder
+# dispatched this session — a silent, wave-wide correctness gap, not just
+# stale tooling.
 #
 # It is invoked at the start of /loom:sweep, alongside check-host-sleep.sh
 # (#3350). It MUST NOT block — even if git / the network fails, it returns 0 and
@@ -58,7 +65,7 @@ for arg in "$@"; do
             QUIET=1
             ;;
         --help|-h)
-            sed -n '2,27p' "$0" | sed 's/^# //; s/^#//'
+            sed -n '2,33p' "$0" | sed 's/^# //; s/^#//'
             exit 0
             ;;
         *)
@@ -128,35 +135,62 @@ if ! git show-ref --verify --quiet "refs/remotes/$REMOTE_REF" 2>/dev/null; then
     exit 0
 fi
 
-# ---------- compute how far behind ----------
+# ---------- compute how far behind AND how far ahead ----------
 
 N="$(git rev-list --count "${BRANCH}..${REMOTE_REF}" 2>/dev/null || echo 0)"
 if ! [[ "$N" =~ ^[0-9]+$ ]]; then
     N=0
 fi
 
-if [[ "$N" -eq 0 ]]; then
+# Ahead is the dangerous direction (#5182): worktree.sh sets
+# BASE_REF="origin/$DEFAULT_BRANCH", so every builder worktree branches off
+# REMOTE_REF, not local BRANCH. Unpushed local commits are simply absent from
+# every builder's base — silently, with no error anywhere in the pipeline.
+A="$(git rev-list --count "${REMOTE_REF}..${BRANCH}" 2>/dev/null || echo 0)"
+if ! [[ "$A" =~ ^[0-9]+$ ]]; then
+    A=0
+fi
+
+if [[ "$N" -eq 0 && "$A" -eq 0 ]]; then
     info_oneliner "${GREEN}[freshness-check] local ${BRANCH} is up to date with ${REMOTE_REF}.${NC}"
     exit 0
 fi
 
-# ---------- N > 0: warn (non-blocking) ----------
+# ---------- behind and/or ahead: warn (non-blocking) ----------
 
-warn ""
-warn "${YELLOW}${BOLD}========================================================================${NC}"
-warn "${YELLOW}${BOLD}  WARNING: local ${BRANCH} is behind ${REMOTE_REF} (#3770)${NC}"
-warn "${YELLOW}${BOLD}========================================================================${NC}"
-warn "${YELLOW}Local ${BRANCH} is ${N} commit(s) behind ${REMOTE_REF}.${NC}"
-warn "${YELLOW}The installed .loom/scripts/ and .loom/hooks/ copies are synced from${NC}"
-warn "${YELLOW}defaults/ at install time, so this session may be executing STALE${NC}"
-warn "${YELLOW}orchestration scripts that silently lack recently-merged logic.${NC}"
-warn ""
-warn "${BOLD}Remediation (read-only advisory — this script never pulls for you):${NC}"
-warn "      ${BOLD}git merge --ff-only ${REMOTE_REF}${NC}"
-warn "  then refresh the installed .loom/ copies from defaults/ (#3777):"
-warn "      ${BOLD}./.loom/scripts/resync-installed.sh${NC}"
-warn "  (preview first with ${BOLD}--dry-run${NC}; it only touches files present in defaults/)."
-warn ""
+if [[ "$N" -gt 0 ]]; then
+    warn ""
+    warn "${YELLOW}${BOLD}========================================================================${NC}"
+    warn "${YELLOW}${BOLD}  WARNING: local ${BRANCH} is behind ${REMOTE_REF} (#3770)${NC}"
+    warn "${YELLOW}${BOLD}========================================================================${NC}"
+    warn "${YELLOW}Local ${BRANCH} is ${N} commit(s) behind ${REMOTE_REF}.${NC}"
+    warn "${YELLOW}The installed .loom/scripts/ and .loom/hooks/ copies are synced from${NC}"
+    warn "${YELLOW}defaults/ at install time, so this session may be executing STALE${NC}"
+    warn "${YELLOW}orchestration scripts that silently lack recently-merged logic.${NC}"
+    warn ""
+    warn "${BOLD}Remediation (read-only advisory — this script never pulls for you):${NC}"
+    warn "      ${BOLD}git merge --ff-only ${REMOTE_REF}${NC}"
+    warn "  then refresh the installed .loom/ copies from defaults/ (#3777):"
+    warn "      ${BOLD}./.loom/scripts/resync-installed.sh${NC}"
+    warn "  (preview first with ${BOLD}--dry-run${NC}; it only touches files present in defaults/)."
+    warn ""
+fi
+
+if [[ "$A" -gt 0 ]]; then
+    warn ""
+    warn "${YELLOW}${BOLD}========================================================================${NC}"
+    warn "${YELLOW}${BOLD}  WARNING: local ${BRANCH} is ahead of ${REMOTE_REF} (#5182)${NC}"
+    warn "${YELLOW}${BOLD}========================================================================${NC}"
+    warn "${YELLOW}Local ${BRANCH} is ${A} commit(s) ahead of ${REMOTE_REF} — unpushed.${NC}"
+    warn "${YELLOW}worktree.sh sets BASE_REF=\"origin/\$DEFAULT_BRANCH\", so every builder${NC}"
+    warn "${YELLOW}worktree branches off ${REMOTE_REF}, NOT local ${BRANCH}. These unpushed${NC}"
+    warn "${YELLOW}commits are invisible to every builder dispatched this session — a${NC}"
+    warn "${YELLOW}silent, wave-wide correctness gap, not just stale tooling.${NC}"
+    warn ""
+    warn "${BOLD}Remediation (read-only advisory — this script never pushes for you):${NC}"
+    warn "      ${BOLD}git push origin ${BRANCH}${NC}"
+    warn ""
+fi
 
 # ---------- stretch goal: best-effort installed-vs-defaults drift note ----------
 #
@@ -213,7 +247,13 @@ fi
 warn "${YELLOW}========================================================================${NC}"
 warn ""
 
-info_oneliner "${YELLOW}[freshness-check] WARNING: local ${BRANCH} is ${N} commit(s) behind ${REMOTE_REF}. See stderr for details.${NC}"
+if [[ "$N" -gt 0 && "$A" -gt 0 ]]; then
+    info_oneliner "${YELLOW}[freshness-check] WARNING: local ${BRANCH} has DIVERGED from ${REMOTE_REF} (${N} behind, ${A} ahead/unpushed). See stderr for details.${NC}"
+elif [[ "$N" -gt 0 ]]; then
+    info_oneliner "${YELLOW}[freshness-check] WARNING: local ${BRANCH} is ${N} commit(s) behind ${REMOTE_REF}. See stderr for details.${NC}"
+else
+    info_oneliner "${YELLOW}[freshness-check] WARNING: local ${BRANCH} is ${A} commit(s) ahead of ${REMOTE_REF} (unpushed). See stderr for details.${NC}"
+fi
 
 # Always succeed — this script is advisory only.
 exit 0

--- a/defaults/scripts/tests/test-check-main-freshness.sh
+++ b/defaults/scripts/tests/test-check-main-freshness.sh
@@ -3,10 +3,12 @@
 #
 # Unlike test-check-host-sleep.sh (which probes the live host), this harness
 # constructs throwaway local git repos with a synthetic `origin` remote so it can
-# deterministically exercise the three load-bearing cases:
+# deterministically exercise the load-bearing cases:
 #   (a) up-to-date  -> exit 0, no stderr warning
 #   (b) behind      -> exit 0, prints the "behind" warning to stderr
 #   (c) fetch fails -> exit 0 (never blocks) even when origin is unreachable
+#   (d) ahead       -> exit 0, prints the "ahead" warning to stderr (#5182)
+#   (e) diverged    -> exit 0, prints BOTH warnings (#5182)
 # Plus the flag/contract checks mirrored from test-check-host-sleep.sh:
 #   - always exits 0
 #   - --quiet suppresses the stdout one-liner
@@ -99,6 +101,16 @@ advance_origin() {
     git -C "$seed" push -q origin main
 }
 
+# Advance the clone's local main by one commit WITHOUT pushing (simulating the
+# #5182 incident: unpushed local work that worktree.sh's BASE_REF=origin/<branch>
+# would never see).
+advance_clone() {
+    local clone="$WORKDIR/clone"
+    echo "local-$RANDOM" >> "$clone/file.txt"
+    git -C "$clone" add file.txt
+    git -C "$clone" commit -q -m "local unpushed commit"
+}
+
 # -------- Test 1: script exists and is executable --------
 echo "Test 1: script exists and is executable"
 if [[ -x "$SCRIPT" ]]; then
@@ -158,8 +170,80 @@ else
     fail "behind warning missing --ff-only remediation"
 fi
 
-# -------- Test 4: fetch failure -> still exit 0 (never blocks) --------
-echo "Test 4: fetch failure still exits 0 (never blocks)"
+# -------- Test 4: ahead -> exit 0 and warns (#5182) --------
+echo "Test 4: ahead case exits 0 and prints the warning"
+make_fixture
+advance_clone   # local main now has an unpushed commit; origin/main untouched
+stderr_out="$(cd "$WORKDIR/clone" && "$SCRIPT" 2>&1 >/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "ahead exit code is 0"
+else
+    fail "ahead expected exit 0, got $rc"
+fi
+if printf '%s' "$stderr_out" | grep -qi "ahead"; then
+    pass "ahead prints the 'ahead' warning to stderr"
+else
+    fail "ahead did not warn. Got: $stderr_out"
+fi
+if printf '%s' "$stderr_out" | grep -q "5182"; then
+    pass "ahead warning references issue #5182"
+else
+    fail "ahead warning missing #5182 reference"
+fi
+if printf '%s' "$stderr_out" | grep -q "BASE_REF"; then
+    pass "ahead warning names worktree.sh's BASE_REF consequence"
+else
+    fail "ahead warning missing BASE_REF consequence explanation"
+fi
+if printf '%s' "$stderr_out" | grep -q -- "git push origin"; then
+    pass "ahead warning suggests git push origin remediation"
+else
+    fail "ahead warning missing git push origin remediation"
+fi
+if ! printf '%s' "$stderr_out" | grep -qi "behind"; then
+    pass "ahead-only case does not also print a 'behind' warning"
+else
+    fail "ahead-only case unexpectedly warned about being behind: $stderr_out"
+fi
+stdout_out="$(cd "$WORKDIR/clone" && "$SCRIPT" 2>/dev/null)"
+if printf '%s' "$stdout_out" | grep -qi "ahead"; then
+    pass "ahead prints an ahead one-liner to stdout"
+else
+    fail "ahead missing stdout one-liner. Got: $stdout_out"
+fi
+
+# -------- Test 5: diverged (both ahead and behind) -> exit 0, warns both (#5182) --------
+echo "Test 5: diverged case exits 0 and prints both warnings"
+make_fixture
+advance_origin   # origin/main gets a commit the clone doesn't have
+advance_clone    # clone's local main gets a commit origin doesn't have
+stderr_out="$(cd "$WORKDIR/clone" && "$SCRIPT" 2>&1 >/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "diverged exit code is 0"
+else
+    fail "diverged expected exit 0, got $rc"
+fi
+if printf '%s' "$stderr_out" | grep -qi "behind"; then
+    pass "diverged prints the 'behind' warning to stderr"
+else
+    fail "diverged did not warn about behind. Got: $stderr_out"
+fi
+if printf '%s' "$stderr_out" | grep -qi "ahead"; then
+    pass "diverged prints the 'ahead' warning to stderr"
+else
+    fail "diverged did not warn about ahead. Got: $stderr_out"
+fi
+stdout_out="$(cd "$WORKDIR/clone" && "$SCRIPT" 2>/dev/null)"
+if printf '%s' "$stdout_out" | grep -qi "diverged"; then
+    pass "diverged prints a diverged one-liner to stdout"
+else
+    fail "diverged missing stdout one-liner. Got: $stdout_out"
+fi
+
+# -------- Test 6: fetch failure -> still exit 0 (never blocks) --------
+echo "Test 6: fetch failure still exits 0 (never blocks)"
 make_fixture
 advance_origin
 # Point origin at an unreachable path so `git fetch` fails; the local
@@ -174,8 +258,8 @@ else
     fail "fetch-failure expected exit 0, got $rc"
 fi
 
-# -------- Test 5: --quiet suppresses stdout, still exits 0 --------
-echo "Test 5: --quiet suppresses stdout"
+# -------- Test 7: --quiet suppresses stdout, still exits 0 --------
+echo "Test 7: --quiet suppresses stdout"
 make_fixture
 stdout_quiet="$(cd "$WORKDIR/clone" && "$SCRIPT" --quiet 2>/dev/null)"
 rc=$?
@@ -190,8 +274,8 @@ else
     fail "--quiet produced stdout: $stdout_quiet"
 fi
 
-# -------- Test 6: --help prints usage and exits 0 --------
-echo "Test 6: --help prints usage and exits 0"
+# -------- Test 8: --help prints usage and exits 0 --------
+echo "Test 8: --help prints usage and exits 0"
 help_out="$("$SCRIPT" --help 2>&1 || true)"
 rc=$?
 if [[ "$rc" -eq 0 ]]; then
@@ -205,8 +289,8 @@ else
     fail "--help did not mention Usage. Got: $help_out"
 fi
 
-# -------- Test 7: unknown args do not break it --------
-echo "Test 7: unknown args do not break the script"
+# -------- Test 9: unknown args do not break it --------
+echo "Test 9: unknown args do not break the script"
 make_fixture
 rc=0
 ( cd "$WORKDIR/clone" && "$SCRIPT" --some-nonsense-flag --another 99 >/dev/null 2>&1 ) || rc=$?
@@ -216,8 +300,8 @@ else
     fail "unknown args caused non-zero exit ($rc)"
 fi
 
-# -------- Test 8: outside a git repo -> exit 0, skip gracefully --------
-echo "Test 8: outside a git repo exits 0"
+# -------- Test 10: outside a git repo -> exit 0, skip gracefully --------
+echo "Test 10: outside a git repo exits 0"
 non_git="$WORKDIR/not-a-repo"
 mkdir -p "$non_git"
 rc=0


### PR DESCRIPTION
## Summary

`check-main-freshness.sh` only computed how far the local default branch was *behind* `origin/<branch>` and never how far it was *ahead*. Ahead is the dangerous direction: `worktree.sh` sets `BASE_REF="origin/$DEFAULT_BRANCH"`, so every builder worktree branches off `origin/<branch>` — unpushed local commits are silently invisible to every dispatched builder, while the script's own output reassuringly says "up to date."

## Changes

- `defaults/scripts/check-main-freshness.sh`:
  - Compute the ahead count (`git rev-list --count "${REMOTE_REF}..${BRANCH}"`) alongside the existing behind count.
  - Gate the "up to date" message on **both** counts being zero.
  - Add a new ahead-warning block (mirroring the existing behind block) that names the actual consequence — `worktree.sh`'s `BASE_REF=origin/<branch>` means unpushed commits are invisible to every builder — with `git push origin <branch>` as remediation.
  - Print both warnings when a branch has diverged (ahead > 0 AND behind > 0 simultaneously, e.g. after a rebase or force-push elsewhere).
  - Updated the closing stdout one-liner to summarize behind-only, ahead-only, or diverged.
  - No change to the exit-code contract: `set -uo pipefail` (no `-e`), always exits 0, still read-only (no push/merge/reset), still degrades gracefully offline.
- `defaults/scripts/tests/test-check-main-freshness.sh`:
  - Added an `advance_clone()` fixture helper (creates an unpushed local commit).
  - New Test 4 ("ahead"): unpushed local commit → exit 0, warns with "ahead", references `#5182`, names `BASE_REF`, suggests `git push origin`, and does NOT also print a "behind" warning.
  - New Test 5 ("diverged"): both directions advanced → exit 0, prints both "behind" and "ahead" warnings, and a "diverged" one-liner on stdout.
  - Renumbered the remaining tests (old 4–8 → 6–10) to stay sequential.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Reports the ahead count as well as behind, and warns when non-zero | ✅ | New `A="$(git rev-list --count "${REMOTE_REF}..${BRANCH}")"` computation + warning block gated on `A -gt 0` |
| Warning names the `worktree.sh` `BASE_REF=origin/<default>` consequence with `git push origin <default>` as remediation | ✅ | Warning text explicitly quotes `BASE_REF="origin/$DEFAULT_BRANCH"` and recommends `git push origin ${BRANCH}`; verified by Test 4's `BASE_REF` and `git push origin` assertions |
| Advisory-only and exit 0, consistent with existing contract / `check-host-sleep.sh` | ✅ | No `set -e`; `exit 0` at every path; Test 4/5 both assert `rc -eq 0` |
| Read-only: no `git push`, no auto-reconcile | ✅ | No mutating git commands added — only `git rev-list --count` (read-only) |
| Degrades gracefully offline | ✅ | Reuses the existing bounded `git fetch` fallback (unchanged) — offline still falls back to whatever `refs/remotes/origin/<branch>` is already known locally, same as the pre-existing behind-check |

## Test Plan

```
$ ./defaults/scripts/tests/test-check-main-freshness.sh
...
Results: 26/26 passed
OK: all tests passed
```

Also verified:
- `bash -n` on both changed files (syntax check)
- `shellcheck` on both changed files — zero warnings
- Manual read-through of the diverged case output confirms both warning blocks render together with no truncation

Closes #5182