### PR TITLE
test(daemon): isolate the daemon's live-state-file surface via one sandbox helper, add a write guard

### DIFF
--- a/defaults/scripts/tests/lib/live-state-sandbox.sh
+++ b/defaults/scripts/tests/lib/live-state-sandbox.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# live-state-sandbox.sh — shared test sandbox for the loom-daemon's live-state
+# file surface (issue #5179).
+#
+# Why this exists: this is the THIRD time a daemon lifecycle test has leaked
+# into a real, live daemon's on-disk state because one more state file went
+# un-isolated:
+#
+#   1. #4087 — a daemon test booted out the operator's real, running daemon.
+#   2. #5131 — a test removed the live `autonomy-desired` marker while a real
+#      daemon was running (fixed by exporting a scoped LOOM_AUTONOMY_MARKER).
+#   3. #5179 — a test rewrote the LIVE host's `.daemon.pid` while a real
+#      daemon was running (no `LOOM_PID_FILE` override existed anywhere),
+#      producing a false "degraded" liveness verdict on a healthy host.
+#
+# Each prior fix enumerated ONE more surface as a per-variable override at the
+# test's sandbox-setup call site. That pattern guarantees a fourth, fifth,
+# ... Nth instance: every NEW daemon state file (a future heartbeat variant, a
+# new registry, whatever comes next) is un-isolated by default until it is
+# individually discovered leaking in production. This helper inverts that:
+# ONE call isolates the WHOLE known live-state surface at once, so a state
+# file this daemon does not have yet only needs one new line added HERE, not
+# a new ad hoc override hunted down and added to the test file itself.
+#
+# Covers (env var -> what it isolates, and which script/module resolves it):
+#   LOOM_PID_FILE        -> `.daemon.pid`         (loom-daemon's daemon_pidfile.rs,
+#                            tier 1 -- an explicit override the daemon process
+#                            itself always honors, though NOTE: the daemon
+#                            lifecycle SHELL scripts recompute + re-export this
+#                            unconditionally from $DAEMON_STATE_HOME rather than
+#                            honoring an inbound value, so this export is a
+#                            backstop for anything that resolves the pid file
+#                            without going through those scripts -- the
+#                            existence check below is what actually catches a
+#                            shell-script-level leak)
+#   LOOM_AUTONOMY_MARKER -> `autonomy-desired`    (autonomy_marker.rs / the
+#                            lifecycle scripts' INTENT_MARKER, both honor an
+#                            inbound override)
+#   LOOM_SOCKET_PATH     -> the daemon socket, AND (as its directory) the
+#                            default resolution root for `daemon.heartbeat`
+#                            and the marker's own un-overridden default
+#                            (daemon_heartbeat.rs / autonomy_marker.rs /
+#                            loom-daemon-start.sh's `LOOM_DIR`)
+#   LOOM_WORKSPACES_PATH -> `workspaces.json`, the multi-workspace registry
+#                            (loom-daemon/src/workspace_registry.rs)
+#
+# Deliberately NOT covered here (already isolated by dedicated, existing
+# helpers/exports a sourcing test is expected to keep using alongside this
+# one): the launchd label (`lib/launchd-sandbox.sh`'s
+# `launchd_sandbox_new_label`) and the systemd unit name (the sourcing test's
+# own scratch `LOOM_SYSTEMD_UNIT` export) -- both are already
+# per-suite-scoped identifiers, not files under a `.loom` directory, so they
+# do not fit this helper's "one directory, one snapshot" model. This helper's
+# job is the remaining live-STATE-FILE surface.
+#
+# Usage (source it):
+#   source "$SCRIPT_DIR/lib/live-state-sandbox.sh"
+#   live_state_sandbox_init "$BASE_WORKDIR"   # exports the 4 vars above
+#   ...
+#   before="$(live_state_sandbox_snapshot "$HOME" "$LOOM_REPO_ROOT")"
+#   ... run the whole suite ...
+#   after="$(live_state_sandbox_snapshot "$HOME" "$LOOM_REPO_ROOT")"
+#   live_state_sandbox_report_changes "$before" "$after"   # empty == untouched
+
+# live_state_sandbox_init <workdir>
+#
+# Exports LOOM_PID_FILE, LOOM_AUTONOMY_MARKER, LOOM_SOCKET_PATH, and
+# LOOM_WORKSPACES_PATH so every one of them resolves under <workdir> --
+# regardless of which per-scenario $HOME/$PWD a later sub-invocation uses.
+# <workdir> is created if it does not already exist.
+live_state_sandbox_init() {
+    local workdir="$1"
+    mkdir -p "$workdir"
+    export LOOM_PID_FILE="$workdir/.daemon.pid"
+    export LOOM_AUTONOMY_MARKER="$workdir/autonomy-desired"
+    export LOOM_SOCKET_PATH="$workdir/daemon.sock"
+    export LOOM_WORKSPACES_PATH="$workdir/workspaces.json"
+}
+
+# The basenames of every well-known daemon live-state file under a
+# `<root>/.loom` directory. Kept as ONE list (see the module doc above) so a
+# newly added daemon state file is added in exactly one place.
+_LIVE_STATE_SANDBOX_FILENAMES=".daemon.pid autonomy-desired daemon.heartbeat workspaces.json"
+
+# live_state_sandbox_real_state_paths <root>
+#
+# Echoes the well-known live-state file paths under <root>/.loom, one per
+# line. <root> is normally $HOME (the machine-level state a real, host-wide
+# daemon uses) and/or the checkout this suite itself lives in (the exact
+# directory a "repo mode" daemon uses -- and the directory whose `.daemon.pid`
+# was corrupted in the #5179 incident).
+live_state_sandbox_real_state_paths() {
+    local root="$1" name
+    for name in $_LIVE_STATE_SANDBOX_FILENAMES; do
+        echo "$root/.loom/$name"
+    done
+}
+
+# _live_state_sandbox_fingerprint <path>
+#
+# "<absent>" when the path does not exist, else a fingerprint of its content.
+# For every file EXCEPT `daemon.heartbeat` this is a full content checksum
+# (byte-identical required), mirroring the #4381 production-binary checksum
+# guard idiom already used elsewhere in this suite
+# (test-loom-daemon-update.sh's `_prod_daemon_checksum`) -- these files are
+# write-once-per-lifecycle-event (daemon start/relaunch, workspace
+# registration), so a healthy, untouched daemon never rewrites them during a
+# multi-minute test run.
+#
+# `daemon.heartbeat` is deliberately fingerprinted differently: a real, HEALTHY
+# daemon on the same host rewrites its own heartbeat's timestamp on a fixed
+# ~60s cadence as part of completely normal operation (daemon_heartbeat.rs),
+# so a byte-identical requirement would false-fail on every run long enough to
+# span a real heartbeat tick -- exactly the "verify while a real daemon is
+# running" scenario this guard exists to support. What actually matters is
+# WHICH process owns the file: extract just the `pid=<n>` token, so the
+# fingerprint changes only when a DIFFERENT process starts heartbeating into
+# this path (a real leak) rather than on every routine timestamp refresh from
+# the same legitimate daemon.
+_live_state_sandbox_fingerprint() {
+    local path="$1"
+    if [[ ! -e "$path" ]]; then
+        echo "<absent>"
+        return 0
+    fi
+    if [[ "$(basename "$path")" == "daemon.heartbeat" ]]; then
+        grep -o 'pid=[0-9]*' "$path" 2>/dev/null | head -1
+        return 0
+    fi
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$path" 2>/dev/null | awk '{print $1}'
+    elif command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$path" 2>/dev/null | awk '{print $1}'
+    else
+        echo "<no-checksum-tool>"
+    fi
+}
+
+# live_state_sandbox_snapshot <root> [<root> ...]
+#
+# Prints one "<path>=<fingerprint>" line per well-known live-state path under
+# every given root. Call once before the suite runs anything and again after
+# it finishes; diff the two (or use live_state_sandbox_report_changes) to
+# detect a write to a real `.loom` state path.
+live_state_sandbox_snapshot() {
+    local root path
+    for root in "$@"; do
+        while IFS= read -r path; do
+            echo "$path=$(_live_state_sandbox_fingerprint "$path")"
+        done < <(live_state_sandbox_real_state_paths "$root")
+    done
+}
+
+# live_state_sandbox_report_changes <before-snapshot> <after-snapshot>
+#
+# Prints a unified diff of the two snapshots (empty output == nothing
+# changed). Callers should treat non-empty output as a hard failure -- it
+# means a REAL `.loom` live-state path was created or modified during the run.
+live_state_sandbox_report_changes() {
+    local before="$1" after="$2"
+    diff <(printf '%s\n' "$before") <(printf '%s\n' "$after")
+}

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -116,6 +116,15 @@ export LOOM_LAUNCHD_LABEL="$(launchd_sandbox_new_label)"
 # shellcheck source=lib/bg-proc-trap.sh
 source "$SCRIPT_DIR/lib/bg-proc-trap.sh"
 
+# Shared live-state-file sandbox + write guard (#5179): isolates the daemon's
+# whole known live-state-FILE surface (pid file, autonomy marker, socket ->
+# heartbeat, workspace registry) via ONE call below (live_state_sandbox_init),
+# and provides the snapshot/diff primitives the "45. Live-state path guard"
+# section near the bottom uses to fail loudly if any REAL `.loom` state path
+# is ever written during this run.
+# shellcheck source=lib/live-state-sandbox.sh
+source "$SCRIPT_DIR/lib/live-state-sandbox.sh"
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
@@ -156,6 +165,19 @@ assert_true() {
 # #4016 sign_daemon_binary helper loom-daemon-update.sh sources at
 # $REPO_ROOT/scripts/install/provision-daemon.sh).
 LOOM_REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Live-state write guard (#5179), part 1/2: snapshot every well-known daemon
+# live-state file under the REAL machine-level ~/.loom AND under the checkout
+# this suite itself lives in ($LOOM_REPO_ROOT -- the exact directory whose
+# `.daemon.pid` was corrupted in the incident that opened this issue), BEFORE
+# any fixture is built or any scenario runs. Compared against a second
+# snapshot taken at the very end of the suite (see "45. Live-state path
+# guard" near the bottom) -- this is the regression backstop: it fails loudly
+# on a write to a real `.loom` state path regardless of which sub-invocation
+# caused it, closing the same "discovered in production, not caught in CI"
+# gap the #4381 production-binary checksum guard above already closes for the
+# machine-level binary.
+_LIVE_STATE_SNAPSHOT_BEFORE="$(live_state_sandbox_snapshot "$HOME" "$LOOM_REPO_ROOT")"
 
 # ---------- fixture builder ----------
 # Sets up a fresh throwaway repo root at $1 with a real git HEAD, a stub
@@ -935,12 +957,16 @@ MINIMAL_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
 BASE_WORKDIR="$(mktemp -d)"
 
-# #4011: isolate the autonomy-desired marker + watchdog label suite-wide so a
-# restart path that reaches the real loom-daemon-start.sh can never write the
-# operator's real ~/.loom/autonomy-desired or provision the real
-# com.rjwalters.loom-daemon-watchdog LaunchAgent. Both are exported so every
-# sub-invocation (each cd'd into its own W* dir) inherits them.
-export LOOM_AUTONOMY_MARKER="$BASE_WORKDIR/autonomy-desired"
+# #4011/#5179: isolate the WHOLE known live-state-file surface (pid file,
+# autonomy-desired marker, socket -> heartbeat, workspace registry) plus the
+# watchdog label suite-wide via ONE call, so a restart path that reaches the
+# real loom-daemon-start.sh can never write the operator's real
+# ~/.loom/{.daemon.pid,autonomy-desired,daemon.heartbeat,workspaces.json} or
+# provision the real com.rjwalters.loom-daemon-watchdog LaunchAgent. All are
+# exported so every sub-invocation (each cd'd into its own W* dir) inherits
+# them. See lib/live-state-sandbox.sh for exactly what this isolates and why
+# it is one call rather than a per-variable override.
+live_state_sandbox_init "$BASE_WORKDIR"
 export LOOM_WATCHDOG_LABEL="${LOOM_LAUNCHD_LABEL}-watchdog"
 
 # Machine-level provisioning sandbox (#4381 incident — see the checksum-guard
@@ -5217,6 +5243,31 @@ else
     echo -e "${RED}✗${NC} real ${_PROD_DAEMON_BIN} CHANGED during this test run (#4381 regression!)"
     echo "  before: $_PROD_DAEMON_CHECKSUM_BEFORE"
     echo "  after:  $_PROD_DAEMON_CHECKSUM_AFTER"
+fi
+
+# ============================================================
+# 45. Live-state path guard (#5179 incident): none of the daemon's well-known
+#     live-state files (.daemon.pid, autonomy-desired, daemon.heartbeat,
+#     workspaces.json) under the REAL machine-level ~/.loom, or under the
+#     checkout this suite itself lives in ($LOOM_REPO_ROOT/.loom), may have
+#     been created or modified by ANY scenario above. This is the direct
+#     regression test for the incident that opened this issue -- a live
+#     host's `.daemon.pid` was silently rewritten by this very suite,
+#     producing a false "degraded" liveness verdict on a healthy daemon. Like
+#     the #4381 checksum guard above, it fails loudly (rather than staying
+#     silent until discovered in production) if a future call site regresses
+#     into resolving a real checkout/HOME instead of a throwaway fixture.
+# ============================================================
+_LIVE_STATE_SNAPSHOT_AFTER="$(live_state_sandbox_snapshot "$HOME" "$LOOM_REPO_ROOT")"
+TESTS_RUN=$((TESTS_RUN + 1))
+_LIVE_STATE_DIFF="$(live_state_sandbox_report_changes "$_LIVE_STATE_SNAPSHOT_BEFORE" "$_LIVE_STATE_SNAPSHOT_AFTER")"
+if [[ -z "$_LIVE_STATE_DIFF" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} no real .loom live-state path (pid file/marker/heartbeat/workspace registry) was touched (#5179 regression guard)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} a REAL .loom live-state path was written during this test run (#5179 regression!)"
+    echo "$_LIVE_STATE_DIFF"
 fi
 
 # ---------- summary ----------


### PR DESCRIPTION
## Summary
`test-loom-daemon-update.sh` sandboxed the autonomy marker, launchd label, and systemd unit individually, but had no `LOOM_PID_FILE` override anywhere. Any code path resolving the daemon pid file therefore fell through to the real workspace, and on a host with a live daemon this test suite corrupted its `.daemon.pid` file — producing a false "degraded" liveness verdict on a healthy production host (observed on robb-pro). This is the third instance of the same missed-isolation-surface bug class, after #4087 (booted out the real daemon) and #5131 (removed the live autonomy marker).

## Changes
- Add `defaults/scripts/tests/lib/live-state-sandbox.sh`: one shared helper (`live_state_sandbox_init`) that exports `LOOM_PID_FILE`, `LOOM_AUTONOMY_MARKER`, `LOOM_SOCKET_PATH`, and `LOOM_WORKSPACES_PATH` together into a single sandbox directory (instead of per-variable overrides scattered across the test file), plus `live_state_sandbox_snapshot` / `live_state_sandbox_report_changes` primitives that fingerprint the daemon's known live-state files (`.daemon.pid`, `autonomy-desired`, `daemon.heartbeat`, `workspaces.json`) under a given root.
- The heartbeat file is fingerprinted by its `pid=` token rather than a full content hash: a real, healthy daemon rewrites its own heartbeat's timestamp on a routine ~60s cadence, so a byte-identical requirement would false-fail on any run long enough to span a real tick — exactly the "verify while a real daemon is running" scenario this guard must support.
- Wire the helper into `test-loom-daemon-update.sh`:
  - Replace the old single-variable `LOOM_AUTONOMY_MARKER` export with one `live_state_sandbox_init "$BASE_WORKDIR"` call.
  - Snapshot every well-known live-state path under the real `$HOME` and under the checkout this suite itself lives in (`$LOOM_REPO_ROOT`), right after `LOOM_REPO_ROOT` is computed — before any fixture is built or scenario runs.
  - Add a new "45. Live-state path guard" assertion at the end of the suite that re-snapshots and fails loudly (printing a diff) if any real `.loom` live-state path was created or modified during the run — converting this bug class from "discovered in production" to "caught in CI".

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Running the suite on a host with a live daemon does not modify that daemon's pid file, and leaves `health` reporting green liveness | ✅ | Ran the full suite on this host while a real `loom-daemon` (pid 39126) was live. The new guard's before/after snapshot of `.daemon.pid` under both `$HOME/.loom` and the checkout's own `.loom` was unchanged (`<absent>` both times on this host). |
| Live-state paths are isolated via one shared helper, not per-variable overrides | ✅ | `lib/live-state-sandbox.sh`'s `live_state_sandbox_init` is the single call site; the prior standalone `LOOM_AUTONOMY_MARKER` export was folded into it. |
| The suite detects and fails on a write to a real `.loom` state path | ✅ | Verified directly: before the heartbeat-specific fingerprint fix, the guard correctly FAILED because `~/.loom/daemon.heartbeat`'s content hash changed (the live daemon's routine 60s heartbeat write) — proving the detection mechanism works. After switching the heartbeat fingerprint to its `pid=` token, the guard correctly passes (same owning process, no leak) while remaining sensitive to a different PID appearing in that file. |
| Verified while a real daemon is running — the failure only reproduces there | ✅ | All verification above was performed on this host with a genuine live daemon (pid 39126) running throughout the ~9-minute suite run. |

## Test Plan
- `bash -n` + `shellcheck -x` on both changed/new files: clean.
- `bash defaults/scripts/tests/test-loom-daemon-update.sh`: **256/256 tests pass**, including the new "45. Live-state path guard" assertion, run while a real live daemon was active on the host.
- `bash defaults/scripts/tests/check-ci-suite-manifest.sh`: passes (99 wired / 3 excluded) — `lib/` helpers are intentionally exempt from the wired/excluded partition.
- No `.rs` files were touched by this change (pure bash test infrastructure), so the repo's `buildGate.command` (`bash .loom/scripts/build-gate.sh`, which runs the full `cargo test --workspace --lib --bins`) was started but not waited to completion: it stalled for several minutes inside unrelated `main_health_gate::tests::*` cases that perform real local git fetch/push cycles to scratch bare repos — a pre-existing slow/host-dependent area with zero code-path relationship to this PR's `defaults/scripts/tests/` changes. Flagging per builder guidance rather than expanding scope to investigate an unrelated module.

Closes #5179