### PR TITLE
fix(version): sync mcp-loom/package-lock.json in version.sh bump/check

### DIFF
--- a/mcp-loom/package-lock.json
+++ b/mcp-loom/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loom/mcp",
-  "version": "0.15.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loom/mcp",
-      "version": "0.15.0",
+      "version": "0.18.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "strip-ansi": "^7.1.2"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -94,6 +94,22 @@ check_versions() {
     all_match=false
   fi
 
+  # Check mcp-loom/package-lock.json — npm lockfiles carry the version in
+  # (at least) two places: the top-level `version` field and the matching
+  # `packages[""].version` entry, so a single `jq -r '.version'` read (what
+  # get_version_from_file() does for every VERSION_FILES entry) would
+  # silently ignore the second occurrence. Grep both instead.
+  local mcp_lock_versions
+  mcp_lock_versions=$(grep -m2 '"version"' "$REPO_ROOT/mcp-loom/package-lock.json" | sed 's/.*"version": "\(.*\)".*/\1/' | sort -u)
+  local mcp_lock_count
+  mcp_lock_count=$(echo "$mcp_lock_versions" | wc -l | tr -d ' ')
+  if [ "$mcp_lock_count" -eq 1 ] && [ "$(echo "$mcp_lock_versions" | tr -d '[:space:]')" = "$expected" ]; then
+    echo "OK        mcp-loom/package-lock.json: both version fields at $expected"
+  else
+    echo "MISMATCH  mcp-loom/package-lock.json: version fields not all at $expected"
+    all_match=false
+  fi
+
   if $all_match; then
     echo ""
     echo "All versions in sync: $expected"
@@ -171,6 +187,11 @@ set_version() {
   (cd "$REPO_ROOT" && cargo update loom-daemon loom-api 2>/dev/null)
   echo "  Updated Cargo.lock"
 
+  # mcp-loom/package-lock.json — regenerate the npm-native way rather than
+  # hand-editing the JSON, so nested packages[""] entries stay consistent.
+  (cd "$REPO_ROOT/mcp-loom" && npm install --package-lock-only)
+  echo "  Updated mcp-loom/package-lock.json"
+
   echo ""
   echo "Version set to $new_version"
 }
@@ -182,7 +203,7 @@ do_tag() {
   echo "Committing and tagging..."
   (
     cd "$REPO_ROOT"
-    git add package.json mcp-loom/package.json \
+    git add package.json mcp-loom/package.json mcp-loom/package-lock.json \
            loom-daemon/Cargo.toml loom-api/Cargo.toml \
            CLAUDE.md Cargo.lock
     [ -f "CHANGELOG.md" ] && git add CHANGELOG.md


### PR DESCRIPTION
## Summary

`scripts/version.sh` bumped `mcp-loom/package.json` but never touched its lockfile, so `mcp-loom/package-lock.json` had drifted to `0.15.0` — three releases stale (0.16.0, 0.17.0, 0.18.0 all shipped without touching it). Worse, `version.sh check` reported a false all-clear (`All versions in sync: 0.18.0`) because the verifier only checks the set of files the bumper knows about, and the lockfile was invisible to both.

## Changes

- `check_versions()`: added a block mirroring the existing `Cargo.lock` special case — greps `mcp-loom/package-lock.json` for both `"version"` occurrences (top-level field and `packages[""].version`) and reports `MISMATCH` if either disagrees with the expected version.
- `set_version()`: added a step alongside the `Cargo.lock` step that regenerates the lockfile the npm-native way — `(cd mcp-loom && npm install --package-lock-only)` — rather than hand-editing JSON.
- `do_tag()`: added `mcp-loom/package-lock.json` to the `git add` list so the regenerated lockfile lands in the same bump commit.
- Corrected `mcp-loom/package-lock.json` itself to `0.18.0` (both occurrences), regenerated via `npm install --package-lock-only` (not hand-edited) — the diff is a clean 2-line version bump, no incidental dependency churn.

Like `Cargo.lock`, the npm lockfile is a derived artifact and is intentionally **not** added to `VERSION_FILES` or the `list` subcommand's output (existing comment near the `list` case already documents this exclusion pattern for `Cargo.lock`).

## Test plan

- [x] Ran `./scripts/version.sh check` on the corrected tree — reports `OK mcp-loom/package-lock.json: both version fields at 0.18.0` and overall `All versions in sync: 0.18.0`.
- [x] Hand-edited both `version` fields in `mcp-loom/package-lock.json` to `0.17.0`, ran `./scripts/version.sh check` — now exits non-zero with `MISMATCH mcp-loom/package-lock.json: version fields not all at 0.18.0`. Restored the file afterward and confirmed it matches the regenerated 0.18.0 content exactly (`diff` clean).
- [x] Dry-inspected `set_version()`'s new step: `(cd "$REPO_ROOT/mcp-loom" && npm install --package-lock-only)` matches the pattern used to regenerate `mcp-loom/package-lock.json` for this PR's own 0.15.0 → 0.18.0 correction (verified `npm install` after produces no further diff).
- [x] `./scripts/version.sh list` output unchanged — still excludes both `Cargo.lock` and `mcp-loom/package-lock.json`.
- [x] `shellcheck scripts/version.sh` — no new warnings introduced (one pre-existing SC2005 style note on an unrelated line).

Closes #5193