### PR TITLE
feat(worktree-reaper): reclaim build artifacts from kept worktrees

### DIFF
--- a/loom-daemon/src/worktree_ops/clean.rs
+++ b/loom-daemon/src/worktree_ops/clean.rs
@@ -1410,6 +1410,59 @@ pub fn clean_build_artifacts(repo_root: &Path, dry_run: bool) {
     }
 }
 
+/// One build-artifact directory [`reclaim_worktree_artifacts`] removed (or
+/// would remove, under `dry_run`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReclaimedArtifact {
+    /// Top-level directory name relative to the worktree root, e.g. `"target"`.
+    pub name: String,
+    /// Human-readable size, matching [`clean_build_artifacts`]'s report format.
+    pub size_human: String,
+}
+
+/// Reclaim regenerable build-artifact directories (`target/`, `node_modules`,
+/// `.venv`, `coverage/`, ...) from **inside one worktree** without removing
+/// the worktree itself — the AC3 follow-up carved out of #5177 into #5187.
+///
+/// Unlike [`clean_build_artifacts`] (which only ever reclaims from
+/// `repo_root` itself, wired to `--deep`), this walks
+/// [`super::orphan_recovery::BUILD_ARTIFACT_PATTERNS`] against
+/// `worktree_path`'s **top-level** entries, trims a trailing `/`, and removes
+/// only entries that are directories — a same-named file (`Cargo.lock`,
+/// `pnpm-lock.yaml`, `.loom-checkpoint`, `.loom-in-use`) is never touched, so
+/// reusing the dirty-detection pattern list here is safe even though most of
+/// its entries are files rather than reclaimable directories.
+///
+/// Pure I/O, no eligibility gate of its own — callers (the worktree reaper's
+/// artifact-reclaim pass) decide *whether* a worktree is eligible via
+/// [`classify_worktree`] / [`WorktreeDecision`] before calling this.
+#[must_use]
+pub fn reclaim_worktree_artifacts(worktree_path: &Path, dry_run: bool) -> Vec<ReclaimedArtifact> {
+    let mut reclaimed = Vec::new();
+    for pattern in super::orphan_recovery::BUILD_ARTIFACT_PATTERNS {
+        let name = pattern.trim_end_matches('/');
+        let dir = worktree_path.join(name);
+        if !dir.is_dir() {
+            continue;
+        }
+        let size_human = dir_size_human(&dir);
+        if dry_run {
+            reclaimed.push(ReclaimedArtifact {
+                name: name.to_string(),
+                size_human,
+            });
+            continue;
+        }
+        if std::fs::remove_dir_all(&dir).is_ok() {
+            reclaimed.push(ReclaimedArtifact {
+                name: name.to_string(),
+                size_human,
+            });
+        }
+    }
+    reclaimed
+}
+
 fn spawn_loop_locks_dir(repo_root: &Path) -> std::path::PathBuf {
     super::liveness::locks_dir(repo_root)
 }
@@ -1746,6 +1799,67 @@ mod tests {
     fn dir_size_human_handles_missing_dir() {
         // A missing directory contributes 0 bytes, not an error.
         assert_eq!(dir_size_human(Path::new("/does/not/exist/at/all")), "0B");
+    }
+
+    // --- reclaim_worktree_artifacts (#5187) ------------------------------
+
+    #[test]
+    fn reclaim_removes_target_and_node_modules_but_nothing_else() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("target/debug")).unwrap();
+        std::fs::write(tmp.path().join("target/debug/binary"), b"x").unwrap();
+        std::fs::create_dir_all(tmp.path().join("node_modules/.bin")).unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        std::fs::write(tmp.path().join("src/main.rs"), b"fn main() {}").unwrap();
+        std::fs::write(tmp.path().join("Cargo.lock"), b"lockfile").unwrap();
+
+        let reclaimed = reclaim_worktree_artifacts(tmp.path(), false);
+        let names: Vec<_> = reclaimed.iter().map(|a| a.name.as_str()).collect();
+        assert_eq!(
+            names.into_iter().collect::<std::collections::HashSet<_>>(),
+            std::collections::HashSet::from(["target", "node_modules"])
+        );
+        assert!(!tmp.path().join("target").exists());
+        assert!(!tmp.path().join("node_modules").exists());
+        // Everything else — git history stand-ins, source, lockfiles — is untouched.
+        assert!(tmp.path().join("src/main.rs").is_file());
+        assert!(tmp.path().join("Cargo.lock").is_file());
+    }
+
+    #[test]
+    fn reclaim_never_removes_a_same_named_file() {
+        // `Cargo.lock` and `pnpm-lock.yaml` are both entries in
+        // BUILD_ARTIFACT_PATTERNS, but they are files, not directories — the
+        // reclaim pass must never `remove_dir_all` a file.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("Cargo.lock"), b"lockfile").unwrap();
+        std::fs::write(tmp.path().join("pnpm-lock.yaml"), b"lockfile").unwrap();
+        std::fs::write(tmp.path().join(".loom-in-use"), b"{}").unwrap();
+
+        let reclaimed = reclaim_worktree_artifacts(tmp.path(), false);
+        assert!(reclaimed.is_empty(), "{reclaimed:?}");
+        assert!(tmp.path().join("Cargo.lock").is_file());
+        assert!(tmp.path().join("pnpm-lock.yaml").is_file());
+        assert!(tmp.path().join(".loom-in-use").is_file());
+    }
+
+    #[test]
+    fn reclaim_dry_run_reports_without_removing() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("target")).unwrap();
+
+        let reclaimed = reclaim_worktree_artifacts(tmp.path(), true);
+        assert_eq!(reclaimed.len(), 1);
+        assert_eq!(reclaimed[0].name, "target");
+        assert!(tmp.path().join("target").is_dir(), "dry-run must not remove");
+    }
+
+    #[test]
+    fn reclaim_with_no_artifact_dirs_is_a_clean_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("README.md"), b"hi").unwrap();
+        let reclaimed = reclaim_worktree_artifacts(tmp.path(), false);
+        assert!(reclaimed.is_empty());
     }
 
     // --- tmux cleanup safety gates (#4890) -------------------------------

--- a/loom-daemon/src/worktree_ops/orphan_recovery.rs
+++ b/loom-daemon/src/worktree_ops/orphan_recovery.rs
@@ -26,6 +26,26 @@ pub const DEFAULT_LABEL_GRACE_PERIOD_SECS: i64 = 600;
 pub const DEFAULT_STALE_BUILDING_HOURS: f64 = 4.0;
 pub const ORPHAN_COMMENT_DEDUP_SECONDS: i64 = 300;
 
+/// Paths that mark an uncommitted change as "regenerable build output" rather
+/// than real work — [`cleanup_stale_worktree`] uses this to decide whether a
+/// zero-commits-ahead worktree's dirty tree is safe to discard outright, and
+/// [`super::clean::reclaim_worktree_artifacts`] (issue #5187) reuses the same
+/// list to select which top-level directories a **kept** worktree's build
+/// artifacts can be reclaimed from without removing the worktree itself.
+///
+/// Hoisted to module scope (was a `cleanup_stale_worktree`-local const) so a
+/// second consumer never drifts from this one — see #5187.
+pub(crate) const BUILD_ARTIFACT_PATTERNS: &[&str] = &[
+    "node_modules",
+    "pnpm-lock.yaml",
+    ".venv",
+    "target/",
+    "Cargo.lock",
+    "coverage/",
+    ".loom-checkpoint",
+    ".loom-in-use",
+];
+
 fn heartbeat_stale_threshold() -> i64 {
     std::env::var("LOOM_HEARTBEAT_STALE_THRESHOLD")
         .ok()
@@ -358,16 +378,6 @@ fn cleanup_stale_worktree(repo_root: &Path, issue: u32) -> bool {
     if !status_out.status.success() {
         return false;
     }
-    const BUILD_ARTIFACT_PATTERNS: &[&str] = &[
-        "node_modules",
-        "pnpm-lock.yaml",
-        ".venv",
-        "target/",
-        "Cargo.lock",
-        "coverage/",
-        ".loom-checkpoint",
-        ".loom-in-use",
-    ];
     for line in String::from_utf8_lossy(&status_out.stdout).trim().lines() {
         // porcelain lines look like "XY path" (or "XY orig -> new" for renames);
         // take the path portion after the two-char status + space.

--- a/loom-daemon/src/worktree_reaper.rs
+++ b/loom-daemon/src/worktree_reaper.rs
@@ -336,6 +336,136 @@ pub fn reap_worktrees(
     report
 }
 
+// ============================================================================
+// Artifact reclaim pass (AC3 of #5177 — #5187)
+// ============================================================================
+
+/// What one artifact-reclaim pass over one repo did.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReclaimReport {
+    /// `issue-<N>` worktree directories examined.
+    pub scanned: usize,
+    /// Issue number -> reclaimed top-level directory names (e.g. `"target"`,
+    /// `"node_modules"`), for worktrees that had at least one.
+    pub reclaimed: Vec<(u32, Vec<String>)>,
+    /// Worktrees this pass left untouched, keyed by why.
+    pub skipped: Vec<(u32, String)>,
+}
+
+impl ReclaimReport {
+    /// A compact one-line summary for the daemon log.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        format!(
+            "scanned={} reclaimed={} skipped={}",
+            self.scanned,
+            self.reclaimed.len(),
+            self.skipped.len()
+        )
+    }
+}
+
+/// Reclaim `target/`/`node_modules/`/... from every **kept** worktree under
+/// `repo_root`'s worktree root — a worktree the removal pass ([`reap_worktrees`])
+/// is *not* deleting, and that nothing is actively using.
+///
+/// Shares [`clean::classify_worktree`] with [`reap_worktrees`] (same `opts`,
+/// same `probes`) rather than inventing a parallel eligibility check, so this
+/// pass can never disagree with the removal gates about what "in use" means:
+///
+/// - [`WorktreeDecision::Remove`]: skipped here. [`reap_worktrees`] deletes
+///   the whole worktree (artifacts included), so reclaiming from it
+///   separately would either race a directory about to vanish or, if the
+///   removal already ran this tick, simply find nothing (the directory is
+///   already gone).
+/// - [`WorktreeDecision::SkipInUse`] (live spawn-loop claim-lock, a
+///   `.loom-in-use` marker, or an active process): skipped — this is the one
+///   outcome the acceptance criteria say must never be touched.
+/// - Every other skip reason (open issue, open/unmerged/absent PR, grace
+///   period, uncommitted changes, unmanaged, editable install, unknown PR
+///   status): a **kept, idle** worktree — reclaim its build artifacts via
+///   [`clean::reclaim_worktree_artifacts`].
+pub fn reclaim_kept_worktree_artifacts(
+    repo_root: &Path,
+    opts: &CleanOptions,
+    probes: &WorktreeProbes<'_>,
+    dry_run: bool,
+) -> ReclaimReport {
+    let mut report = ReclaimReport::default();
+
+    let worktrees_dir = crate::worktree_root::worktree_root(repo_root);
+    let Ok(entries) = std::fs::read_dir(&worktrees_dir) else {
+        // No worktree root yet (or unreadable) — nothing to reclaim, not an error.
+        return report;
+    };
+
+    let mut worktree_dirs: Vec<_> = entries
+        .flatten()
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+        .collect();
+    worktree_dirs.sort_by_key(std::fs::DirEntry::path);
+
+    for entry in worktree_dirs {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let Some(issue_num) = crate::worktree_ops::naming::issue_from_worktree(&name) else {
+            continue;
+        };
+        report.scanned += 1;
+
+        let worktree_path = entry.path().canonicalize().unwrap_or_else(|_| entry.path());
+        let decision = clean::classify_worktree(&worktree_path, issue_num, opts, probes);
+
+        match &decision {
+            WorktreeDecision::Remove => {
+                report.skipped.push((
+                    issue_num,
+                    "eligible for full removal (handled by the directory reap pass)".to_string(),
+                ));
+                continue;
+            }
+            WorktreeDecision::SkipInUse(reason) => {
+                report.skipped.push((issue_num, reason.clone()));
+                continue;
+            }
+            _ => {}
+        }
+
+        let reclaimed = clean::reclaim_worktree_artifacts(&worktree_path, dry_run);
+        if reclaimed.is_empty() {
+            continue;
+        }
+        report
+            .reclaimed
+            .push((issue_num, reclaimed.into_iter().map(|a| a.name).collect()));
+    }
+
+    report
+}
+
+/// Log an artifact-reclaim pass's outcome, mirroring [`log_report`]'s shape.
+pub fn log_reclaim_report(repo_root: &Path, report: &ReclaimReport) {
+    if report.reclaimed.is_empty() {
+        log::debug!(
+            "worktree_reaper: {} artifact reclaim: nothing to reclaim ({})",
+            repo_root.display(),
+            report.summary()
+        );
+    } else {
+        log::info!(
+            "worktree_reaper: {} artifact reclaim: {} reclaimed={:?}",
+            repo_root.display(),
+            report.summary(),
+            report.reclaimed
+        );
+    }
+    for (issue, reason) in &report.skipped {
+        log::debug!(
+            "worktree_reaper: {} artifact reclaim skipping issue-{issue}: {reason}",
+            repo_root.display()
+        );
+    }
+}
+
 /// Run one production reap pass over `repo_root`.
 ///
 /// Wires the real probes (REST-first forge lookups — see the module docs) and
@@ -377,6 +507,15 @@ pub fn reap_repo(repo_root: &Path, config: &WorktreeReaperConfig) -> ReapReport 
 
     let mut report = reap_worktrees(repo_root, &opts, &probes, &remover);
     report.free_gb = crate::disk_headroom::worktree_root_free_gb(repo_root);
+
+    // AC3 of #5177 (#5187): worktrees this pass just decided to *keep*
+    // (everything except `Remove`) may still be sitting on GBs of
+    // regenerable `target/`/`node_modules/` — reclaim those without
+    // removing the worktree. Reuses the exact same probes/decision so
+    // eligibility never drifts from the removal gates above.
+    let reclaim_report = reclaim_kept_worktree_artifacts(repo_root, &opts, &probes, false);
+    log_reclaim_report(repo_root, &reclaim_report);
+
     report
 }
 
@@ -653,6 +792,47 @@ mod tests {
         reaper_clean_options(DEFAULT_GRACE_PERIOD_SECS)
     }
 
+    /// Same scripted-probe shape as [`run_pass`], but drives
+    /// [`reclaim_kept_worktree_artifacts`] instead of [`reap_worktrees`].
+    fn run_reclaim_pass(repo: &Path, spec: &ProbeSpec, opts: &CleanOptions) -> ReclaimReport {
+        let in_use_marker = |_: &Path| {
+            spec.in_use.then(|| InUseMarker {
+                task_id: "t".to_string(),
+                pid: "1".to_string(),
+            })
+        };
+        let processes_using = |_: &Path| Vec::new();
+        let editable_installs = |_: &Path| spec.editable.clone();
+        let is_managed = |p: &Path| clean::is_loom_managed(p);
+        let issue_state = |_: u32| spec.issue_state.clone();
+        let pr_status = |_: u32| spec.pr_status.clone();
+        let uncommitted = |_: &Path| spec.uncommitted;
+
+        let probes = WorktreeProbes {
+            active_issues: &spec.active,
+            in_use_marker: &in_use_marker,
+            processes_using: &processes_using,
+            editable_installs: &editable_installs,
+            is_managed: &is_managed,
+            issue_state: &issue_state,
+            pr_status: &pr_status,
+            uncommitted: &uncommitted,
+            now: Utc::now(),
+        };
+
+        reclaim_kept_worktree_artifacts(repo, opts, &probes, false)
+    }
+
+    /// Populate `issue-<N>`'s worktree with a `target/` and `node_modules/`
+    /// directory plus an untouchable `Cargo.lock` file, so tests can assert
+    /// on what a reclaim pass did and did not remove.
+    fn populate_build_artifacts(repo: &Path, issue: u32) {
+        let wt = repo.join(".loom/worktrees").join(format!("issue-{issue}"));
+        fs::create_dir_all(wt.join("target/debug")).unwrap();
+        fs::create_dir_all(wt.join("node_modules/.bin")).unwrap();
+        fs::write(wt.join("Cargo.lock"), b"lockfile").unwrap();
+    }
+
     // ===================================================================
     // The core defect: a merged PR's worktree is reclaimed with no manual
     // `clean` and no merge-pr.sh side effect on this host.
@@ -863,6 +1043,162 @@ mod tests {
         let report = reap_worktrees(repo.path(), &opts, &probes, &|_, _| false);
         assert!(report.removed.is_empty());
         assert_eq!(report.failed, vec![500]);
+    }
+
+    // ===================================================================
+    // Artifact reclaim pass (#5187, AC3 of #5177) — reclaim target/,
+    // node_modules/, ... from a KEPT worktree without removing it.
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_reclaim_never_touches_an_in_use_marked_worktree() {
+        let repo = make_repo(&[(600, true)]);
+        populate_build_artifacts(repo.path(), 600);
+        let spec = ProbeSpec {
+            in_use: true,
+            ..ProbeSpec::default()
+        };
+        let report = run_reclaim_pass(repo.path(), &spec, &default_opts());
+        assert!(report.reclaimed.is_empty());
+        assert!(report.skipped[0].1.contains("in use by shepherd"));
+        // Nothing was removed — the marker alone must veto the reclaim.
+        let wt = repo.path().join(".loom/worktrees/issue-600");
+        assert!(wt.join("target").is_dir());
+        assert!(wt.join("node_modules").is_dir());
+    }
+
+    #[test]
+    #[serial]
+    fn test_reclaim_never_touches_an_actively_building_worktree() {
+        // A live spawn-loop claim/lock is the "actively building" signal.
+        let repo = make_repo(&[(601, true)]);
+        populate_build_artifacts(repo.path(), 601);
+        let spec = ProbeSpec {
+            active: HashSet::from([601]),
+            ..ProbeSpec::default()
+        };
+        let report = run_reclaim_pass(repo.path(), &spec, &default_opts());
+        assert!(report.reclaimed.is_empty());
+        assert!(report.skipped[0]
+            .1
+            .contains("spawn-loop task or claim-lock"));
+        let wt = repo.path().join(".loom/worktrees/issue-601");
+        assert!(wt.join("target").is_dir());
+    }
+
+    #[test]
+    #[serial]
+    fn test_reclaim_removes_artifacts_from_a_finished_but_kept_worktree() {
+        // Open issue ⇒ `classify_worktree` never returns `Remove` (the
+        // worktree is kept), and nothing marks it in-use ⇒ the sweep is
+        // finished. This is the exact "kept worktree" case AC3 targets.
+        let repo = make_repo(&[(602, true)]);
+        populate_build_artifacts(repo.path(), 602);
+        let spec = ProbeSpec {
+            issue_state: "OPEN".to_string(),
+            ..ProbeSpec::default()
+        };
+        let report = run_reclaim_pass(repo.path(), &spec, &default_opts());
+        assert_eq!(report.scanned, 1);
+        assert!(report.skipped.is_empty(), "{:?}", report.skipped);
+        assert_eq!(report.reclaimed.len(), 1);
+        let (issue, dirs) = &report.reclaimed[0];
+        assert_eq!(*issue, 602);
+        assert_eq!(
+            dirs.iter()
+                .map(String::as_str)
+                .collect::<std::collections::HashSet<_>>(),
+            std::collections::HashSet::from(["node_modules", "target"])
+        );
+        let wt = repo.path().join(".loom/worktrees/issue-602");
+        assert!(!wt.join("target").exists());
+        assert!(!wt.join("node_modules").exists());
+        // The worktree itself — and non-artifact files inside it — survive.
+        assert!(wt.is_dir());
+        assert!(wt.join("Cargo.lock").is_file());
+    }
+
+    #[test]
+    #[serial]
+    fn test_reclaim_still_runs_when_the_worktree_has_uncommitted_changes() {
+        // `SkipUncommitted` is a removal gate, not an in-use gate — the test
+        // plan explicitly calls out that a kept worktree with uncommitted
+        // work elsewhere still has its build-artifact dirs reclaimed.
+        let repo = make_repo(&[(603, true)]);
+        populate_build_artifacts(repo.path(), 603);
+        let spec = ProbeSpec {
+            uncommitted: true,
+            ..ProbeSpec::default()
+        };
+        let report = run_reclaim_pass(repo.path(), &spec, &default_opts());
+        assert_eq!(report.reclaimed.len(), 1);
+        let wt = repo.path().join(".loom/worktrees/issue-603");
+        assert!(!wt.join("target").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn test_reclaim_skips_a_worktree_eligible_for_full_removal() {
+        // `ProbeSpec::default()` classifies as `Remove` (closed issue, merged
+        // PR, grace period passed, no uncommitted changes) — the directory
+        // reap pass takes the whole worktree, so the reclaim pass must not
+        // separately touch it.
+        let repo = make_repo(&[(604, true)]);
+        populate_build_artifacts(repo.path(), 604);
+        let report = run_reclaim_pass(repo.path(), &ProbeSpec::default(), &default_opts());
+        assert!(report.reclaimed.is_empty());
+        assert!(report.skipped[0].1.contains("eligible for full removal"));
+        let wt = repo.path().join(".loom/worktrees/issue-604");
+        assert!(wt.join("target").is_dir(), "reclaim pass must not touch it");
+    }
+
+    #[test]
+    #[serial]
+    fn test_reclaim_with_no_build_artifact_dirs_is_a_clean_no_op() {
+        let repo = make_repo(&[(605, true)]);
+        // No `populate_build_artifacts` call — nothing to reclaim.
+        let spec = ProbeSpec {
+            issue_state: "OPEN".to_string(),
+            ..ProbeSpec::default()
+        };
+        let report = run_reclaim_pass(repo.path(), &spec, &default_opts());
+        assert_eq!(report.scanned, 1);
+        assert!(report.reclaimed.is_empty());
+        assert!(report.skipped.is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn test_reclaim_missing_worktree_root_is_a_clean_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let report = run_reclaim_pass(tmp.path(), &ProbeSpec::default(), &default_opts());
+        assert_eq!(report, ReclaimReport::default());
+    }
+
+    #[test]
+    fn test_reclaim_summary_is_compact_and_complete() {
+        let report = ReclaimReport {
+            scanned: 3,
+            reclaimed: vec![(1, vec!["target".to_string()])],
+            skipped: vec![(2, "in use".to_string())],
+        };
+        assert_eq!(report.summary(), "scanned=3 reclaimed=1 skipped=1");
+    }
+
+    #[test]
+    fn test_log_reclaim_report_handles_every_shape() {
+        // Smoke: no panics on the empty / non-empty branches.
+        let tmp = tempfile::tempdir().unwrap();
+        log_reclaim_report(tmp.path(), &ReclaimReport::default());
+        log_reclaim_report(
+            tmp.path(),
+            &ReclaimReport {
+                scanned: 1,
+                reclaimed: vec![(1, vec!["target".to_string(), "node_modules".to_string()])],
+                skipped: vec![(2, "PR still open".to_string())],
+            },
+        );
     }
 
     // ===================================================================


### PR DESCRIPTION
## Summary

- Adds `reclaim_worktree_artifacts` (`loom-daemon/src/worktree_ops/clean.rs`) that removes `target/`, `node_modules/`, and other `BUILD_ARTIFACT_PATTERNS` top-level directories from *inside* a single worktree without removing the worktree itself.
- Wires a new `reclaim_kept_worktree_artifacts` pass into the periodic worktree reaper (`loom-daemon/src/worktree_reaper.rs`) so a long-lived **kept** worktree (a `WorktreeDecision` other than `Remove`/`SkipInUse`) does not hold GBs of regenerable build output forever.
- Hoists `BUILD_ARTIFACT_PATTERNS` from a `cleanup_stale_worktree`-local `const` to module scope in `loom-daemon/src/worktree_ops/orphan_recovery.rs` so the existing dirty-detection use and the new reclaim pass share one list instead of two copies that could drift.

## Changes

- `loom-daemon/src/worktree_ops/orphan_recovery.rs`: hoist `BUILD_ARTIFACT_PATTERNS` to `pub(crate)` module scope.
- `loom-daemon/src/worktree_ops/clean.rs`: add `ReclaimedArtifact` + `reclaim_worktree_artifacts(worktree_path, dry_run)`. Walks `BUILD_ARTIFACT_PATTERNS`, trims a trailing `/`, and removes only entries that are actually directories — a same-named file (`Cargo.lock`, `pnpm-lock.yaml`, `.loom-checkpoint`, `.loom-in-use`) is never touched.
- `loom-daemon/src/worktree_reaper.rs`: add `ReclaimReport` + `reclaim_kept_worktree_artifacts(repo_root, opts, probes, dry_run)`, called from `reap_repo` right after `reap_worktrees`. It shares `classify_worktree` / `WorktreeDecision` and the same `WorktreeProbes` as the removal pass instead of inventing a parallel eligibility check:
  - `WorktreeDecision::Remove` → skipped (the removal pass takes the whole worktree, artifacts included).
  - `WorktreeDecision::SkipInUse` (live spawn-loop claim-lock, `.loom-in-use` marker, or an active process) → skipped — the one outcome that must never be touched.
  - Every other skip reason (open issue, open/unmerged/absent PR, grace period, uncommitted changes, unmanaged, editable install, unknown PR status) → a kept, idle worktree — its artifact dirs are reclaimed.
- `log_reclaim_report` mirrors the existing `log_report`'s shape for the daemon log.

## Acceptance Criteria Verification

- [x] `target/` (and other `BUILD_ARTIFACT_PATTERNS` dirs) inside a finished sweep's worktree can be reclaimed without removing the worktree — `test_reclaim_removes_artifacts_from_a_finished_but_kept_worktree`, `test_reclaim_still_runs_when_the_worktree_has_uncommitted_changes`.
- [x] An actively-building / in-use worktree is never touched — `test_reclaim_never_touches_an_in_use_marked_worktree`, `test_reclaim_never_touches_an_actively_building_worktree`.
- [x] Unit tests cover the eligibility + selection logic — see Test Plan below.

## Test Plan

- `cargo test --lib` in `loom-daemon`: 3350 passed, 0 failed (includes 8 new `worktree_reaper::tests::test_reclaim_*` tests and 4 new `worktree_ops::clean::tests::reclaim_*` tests).
- `cargo clippy --lib --all-targets`: clean, no warnings.
- `cargo fmt -- --check`: clean.
- New unit tests (dependency-injection style, matching `worktree_reaper.rs`'s existing `ProbeSpec`/`run_pass` pattern):
  - `test_reclaim_never_touches_an_in_use_marked_worktree` / `test_reclaim_never_touches_an_actively_building_worktree` — in-use marker / live claim-lock veto the reclaim.
  - `test_reclaim_removes_artifacts_from_a_finished_but_kept_worktree` — open issue (kept, idle) has `target/`/`node_modules/` reclaimed; `Cargo.lock` and the worktree itself survive.
  - `test_reclaim_still_runs_when_the_worktree_has_uncommitted_changes` — `SkipUncommitted` is a removal gate, not an in-use gate; artifacts are still reclaimed.
  - `test_reclaim_skips_a_worktree_eligible_for_full_removal` — a `Remove`-classified worktree is left alone by the reclaim pass (the removal pass handles it).
  - `test_reclaim_with_no_build_artifact_dirs_is_a_clean_no_op` / `test_reclaim_missing_worktree_root_is_a_clean_no_op` — no-op edge cases.
  - `worktree_ops::clean::tests::reclaim_removes_target_and_node_modules_but_nothing_else`, `reclaim_never_removes_a_same_named_file`, `reclaim_dry_run_reports_without_removing`, `reclaim_with_no_artifact_dirs_is_a_clean_no_op` — the underlying directory-only removal logic, including the "never remove a same-named file" edge case (`Cargo.lock`, `pnpm-lock.yaml`).
- Not run: a live manual dry-run against a real populated worktree (no such worktree available in this sandbox) — the unit tests above exercise the same code path against a scratch `tempdir`.

Closes #5187