### PR TITLE
docs(curator,builder): date-stamp volatile facts in curated issues

### DIFF
--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -574,6 +574,14 @@ Before claiming, check for these warning signs:
 
 **Reading comments is not optional** - it's where Curators put the detailed spec that makes issues truly ready for implementation.
 
+### Re-Verify Date-Stamped Facts Before Acting
+
+Curator guidance requires volatile facts (counts, version numbers, file/line references, "no X is needed" claims) to carry an "as of `<sha/date>`" stamp — e.g. `"24 verbs as of \`289be45\`, 2026-08-04"` rather than a bare `"24 verbs"` (see `curator.md` → "Date-stamp volatile facts"). Treat that stamp as a **prompt to re-verify**, not a substitute for verification — a fact that was true "as of" curation time can already be stale by the time you implement, especially in a repo with several concurrently active worktrees.
+
+**Before acting on a stamped fact whose value is embedded directly in an acceptance criterion's output** — e.g. "CHANGELOG lists 13 new verbs", "no schema_version bump needed" — re-derive it against the current tree first: re-run the same grep/count/check the curator used, don't just eyeball the date and move on. This matters most when the action you're about to take **can't be undone** (a version bump, a tag push, a publish, an external API write): a stale count baked into a permanent artifact cannot be un-shipped afterward. This guards against exactly the failure in 2AMLogic/klayout-tools#342 — a correctly-curated verb count and a "no bump needed" claim both went stale within two days, ahead of an irrevocable PyPI publish.
+
+If re-verification finds the stamped fact has drifted, update the acceptance criterion / your PR description to match the current tree (and note the discrepancy) rather than silently completing the original wording.
+
 ## Checking Dependencies Before Claiming
 
 Before claiming a `loom:issue` issue, check if it has a **Dependencies** section.

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -540,6 +540,19 @@ The Builder's complexity-assessment path (`defaults/.claude/commands/loom/builde
 > - If the issue has no `## Affected Files` section yet, this check is a no-op for this tick — add the section in the same pass and let the next curator tick run the verification.
 > - The `loom:blocked` label is the right escape hatch: it's already in the workflow, and is removed by the user (not by Loom) once the underlying files are committed and pushed.
 
+### Date-stamp volatile facts
+
+> **Date-stamp volatile facts.** Counts, version numbers, file/line references, and "no X is needed" claims are point-in-time observations, not durable truths — a repo with several concurrently active worktrees can invalidate them within days. Write every volatile fact with the commit or date you verified it against, not as a bare assertion, so a later reader knows which claims to re-verify rather than trust:
+>
+> ```markdown
+> Before: "The parser exposes 18 verbs (13 net-new)."
+>
+> After: "The parser exposes 24 verbs (19 net-new) as of `289be45`, 2026-08-04 —
+> re-count against the current tree before relying on this number."
+> ```
+>
+> This applies to: raw counts ("18 verbs"), version numbers ("schema_version is 1"), file/line citations ("see parser.py:142"), and negative claims ("no schema_version bump is needed"). The incident this convention guards against: 2AMLogic/klayout-tools#342 curated "18 verbs / 13 net-new" and "no schema_version bump needed" as bare facts; both were correct when written and both had gone stale two days later — after `eval` and `lef-abstract` landed and `schema_version` bumped 1 -> 2 — ahead of an irrevocable PyPI publish that could not be re-uploaded for that version. Neither was a curation error; the facts simply weren't marked as snapshots. See "Complexity routing marker" below for when skipping the stamp on an irrevocable-output issue is itself a curation defect.
+
 ### Running Measurement / Board-Pipeline Reproductions (worktree-or-restore, #4991)
 
 **The Curator runs in the main checkout, not a fresh worktree** (unlike the
@@ -760,6 +773,7 @@ There are **three, and only three**, cost-of-being-wrong strata (issue #4238 add
 - **Hard bounds** (the router's authority is deliberately bounded): **never resolves to `fable`, and never a label.** The frontier model is reserved for the objective escalation ladder on Judge rejection or an explicit operator param. A `roleConfig.model` pin or explicit dispatch param (tiers 1–2) still overrides the marker.
 - **Cheap when the tier map is unconfigured.** With no `sweep.tierModels` in `.loom/config.json` and no `sweep.optimization` profile set (or set to `balanced`, the default), the marker is inert and dispatch falls through to the role default exactly as before — so adding markers is safe even before a workspace opts into cost/speed routing. A workspace opts in either by hand-authoring `sweep.tierModels`, or by setting `sweep.optimization: cost | speed` (a policy switch that materializes a preset over the same map — see `model-selection.md` "Optimization profile switch").
 - **Use sparingly / take the higher tier when torn.** Marking everything `complex` defeats the cheap-first default; marking real judgement calls `mechanical` risks a cheap model on expensive-to-be-wrong work. When genuinely torn, take the higher tier.
+- **`complex` + irrevocable output ⇒ date-stamp any volatile fact in the acceptance criteria.** When a `complex` issue's cost-of-being-wrong comes from an action that cannot be undone (a version/tag push, a package publish, an external API write), and its acceptance criteria embed a volatile fact (a count, a version number, a "no X is needed" claim), that fact **must** carry the "as of `<sha>`, `<date>`" stamp from "Date-stamp volatile facts" above — not a bare assertion. A Builder who trusts a stale bare count on a `complex`/irrevocable issue ships the wrong permanent artifact with no error signal to catch it (see 2AMLogic/klayout-tools#342, the incident that motivated both this rule and the stamping convention).
 
 **Required before applying `loom:curated`**: run the validator below and confirm exit 0. This is not optional — do not apply `loom:curated` if it fails:
 


### PR DESCRIPTION
## Summary

Curated issues sometimes embed volatile facts (counts, version numbers, file/line refs, "no X is needed" claims) as bare assertions. In a repo with several concurrently active worktrees, these can go stale between curation and implementation without any signal that they should be re-checked — 2AMLogic/klayout-tools#342 is a concrete incident: a curated "18 verbs / 13 net-new" and "no schema_version bump needed" were both correct when written and both stale two days later, ahead of an irrevocable PyPI publish. This PR adds a "date-stamp volatile facts" convention to Curator guidance and a matching re-verification step to Builder guidance.

## Changes

- `defaults/.claude/commands/loom/curator.md`: new "Date-stamp volatile facts" subsection (alongside "Verify enumerations", ~line 502) instructing that counts, versions, file/line refs, and "no X is needed" claims be written with the commit/date verified against (e.g. `"24 verbs as of \`289be45\`, 2026-08-04"`), with a concrete before/after phrasing example.
- `defaults/.claude/commands/loom/curator.md`: extended the complexity-marker section's `complex` tier discussion (~line 762) with a new bullet tying the date-stamp convention to irrevocable-output issues (a publish, tag push, external API write), citing the 2AMLogic/klayout-tools#342 incident.
- `defaults/.claude/commands/loom/builder.md`: new "Re-Verify Date-Stamped Facts Before Acting" subsection instructing Builders to re-derive an "as of `<sha/date>`" stamped fact against the current tree before acting on it when it's embedded directly in an acceptance criterion's output, especially before an irrevocable action.
- Installed copies (`.claude/commands/loom/curator.md`, `.claude/commands/loom/builder.md`): no separate edit needed — in this repo `.claude/commands/loom` is a **symlink** to `defaults/.claude/commands/loom` (see `.gitignore` "Dogfood scoped symlink" comment), so editing `defaults/` is the sync; `diff` against the main checkout confirms byte-identical.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| curator.md gains "Date-stamp volatile facts" subsection near "Verify enumerations" (~line 502) | done | Added at line 543, right after the "Verify enumerations" blockquote ends |
| complex tier discussion (~line 750) ties this to irrevocable-output issues | done | New bullet added after the "Use sparingly" bullet in the complexity-marker section, referencing publish/tag-push/API-write and the linked incident |
| builder.md gains re-verification guidance for "as of" stamped facts before irrevocable actions | done | New "Re-Verify Date-Stamped Facts Before Acting" subsection added after the "Reading Issues" section's "Why This Matters" |
| One concrete correct-vs-incorrect phrasing example, mirroring "Curation Patterns" before/after style | done | Included in the curator.md subsection (Before/After markdown block) |
| Installed copies kept byte-identical (diff clean) | done | `.claude/commands/loom/{curator,builder}.md` are symlinks to the `defaults/` files in this repo, so they're identical by construction — verified with `diff` against the main checkout |

## Test Plan

```
grep -n "Date-stamp volatile facts" defaults/.claude/commands/loom/curator.md
# -> 543:### Date-stamp volatile facts

grep -n "as of" defaults/.claude/commands/loom/curator.md
# -> includes the "... as of `289be45`, 2026-08-04" example and the complex-tier bullet

grep -n "Re-Verify Date-Stamped Facts" defaults/.claude/commands/loom/builder.md
# -> 577:### Re-Verify Date-Stamped Facts Before Acting

diff .claude/commands/loom/curator.md defaults/.claude/commands/loom/curator.md   # empty (symlink)
diff .claude/commands/loom/builder.md defaults/.claude/commands/loom/builder.md   # empty (symlink)
```

Also ran the repo's own doc-sync guards (`scripts/check-docs-defaults-parity.sh`, `scripts/check-agents-md-sync.sh`, `scripts/check-claude-md-budget.sh`) — all pass unaffected by this change.

Closes #5195