### PR TITLE
fix(guard): stop masking interpreter-fed heredoc bodies in gh-api-rawfield check

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -1629,12 +1629,55 @@ function mask_heredoc_bodies(s,   out, lines, nl, i, j, line, trimmed, body, del
 # `python3 <<EOF`, `eval <<EOF`, `source <<EOF`, `. <<EOF`) or the opener is
 # piped into one on the same line (`cat <<EOF | bash`). Deliberately a
 # whole-line, best-effort check (matching the "narrow / best-effort" style
-# of heredoc_delim_at() above), anchored so the interpreter name must start
-# a command segment (start of line, or right after `;`/`&`/`|`) rather than
-# matching an arbitrary substring -- e.g. `echo "installs bash" <<EOF` does
-# NOT match, since "bash" there is not itself a command word.
-function is_interpreter_opener(line) {
-    return (line ~ /(^|[;&|])[ \t]*(bash|sh|zsh|dash|ksh|python[0-9.]*|perl|ruby|node|nodejs|eval|source|\.)([ \t]|$)/)
+# of heredoc_delim_at() above): the interpreter must be the COMMAND WORD of
+# some segment of the line, not an arbitrary substring -- e.g.
+# `echo "installs bash" <<EOF` does NOT match, since "bash" there is a bare
+# argument, not the command word.
+#
+# Recognizing the command word robustly (#5205): the interpreter word is
+# matched against the path BASENAME of each segment command word, and any
+# leading `env`/`command`/`exec`/`builtin` wrapper (with its own flags and
+# `VAR=value` assignments) is stripped first -- none of those change what
+# actually executes. So a path-qualified or wrapped invocation of the same
+# interpreter (`/bin/bash <<EOF`, `env bash <<EOF`, `command bash <<EOF`,
+# `./bash <<EOF`, `/usr/bin/python3 <<EOF`) is caught too, closing the
+# evasion class where those forms slipped past the old first-token-only
+# regex and got their live bodies silently masked (i.e. ALLOWed).
+function _interp_basename(tok,   base) {
+    # Reduce a (possibly path-qualified) command word to its basename: the
+    # text after the last `/`. `/bin/bash` -> `bash`, `./bash` -> `bash`,
+    # `/usr/bin/python3` -> `python3`; a bare `bash` or `.` is unchanged.
+    base = tok
+    sub(/^.*\//, "", base)
+    return base
+}
+function is_interpreter_opener(line,   n, segs, i, seg, m, toks, j, base) {
+    # Split into command segments on ; & | (covers && and || too) so a piped
+    # or chained interpreter is caught in ANY position, e.g. `cat <<EOF | bash`.
+    n = split(line, segs, /[;&|]+/)
+    for (i = 1; i <= n; i++) {
+        seg = segs[i]
+        sub(/^[ \t]+/, "", seg)
+        m = split(seg, toks, /[ \t]+/)
+        if (m == 0) continue
+        # Strip leading command wrappers that do not change what runs:
+        # env / command / exec / builtin, each followed by its own -flags
+        # and (for env) VAR=value assignments, then the real command word.
+        j = 1
+        while (j <= m) {
+            if (toks[j] == "env" || toks[j] == "command" || toks[j] == "exec" || toks[j] == "builtin") {
+                j++
+                while (j <= m && (toks[j] ~ /^-/ || toks[j] ~ /^[A-Za-z_][A-Za-z0-9_]*=/)) j++
+                continue
+            }
+            break
+        }
+        if (j > m) continue
+        base = _interp_basename(toks[j])
+        if (base ~ /^(bash|sh|zsh|dash|ksh|python[0-9.]*|perl|ruby|node|nodejs|eval|source|\.)$/)
+            return 1
+    }
+    return 0
 }
 # Same closed-block detection as mask_heredoc_bodies(), but SKIPS masking
 # (leaves the body visible) for any block whose opener is interpreter-fed

--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -1516,6 +1516,20 @@ function unmask_ws(s) {
 #      script/stdin argument) is a materially larger, separate piece of work
 #      than this masking pass and is OUT OF SCOPE here; track it as its own
 #      follow-up rather than bolting a partial fix onto heredoc masking.
+#      This tradeoff (missed ASK, worst case) is unchanged for
+#      extract_write_targets() -- it still calls plain mask_heredoc_bodies()
+#      below and still masks interpreter-fed bodies. But #5192 later reused
+#      this same primitive for a CATASTROPHIC-tier DENY
+#      (gh-api-rawfield-body-literal-at, ~line 2234) without re-deriving this
+#      tradeoff for that tier: masking an interpreter-fed body there doesn't
+#      risk a missed ask, it silently flips a DENY to an ALLOW on the exact
+#      #4523/#4601/#4685 data-loss shape the check exists to catch (#5198).
+#      That is NOT an acceptable tradeoff for a catastrophic-tier check, so
+#      mask_heredoc_bodies_selective() below (used ONLY by that one check)
+#      recognizes an interpreter-fed opener and leaves that specific block's
+#      body UNMASKED (visible to the scan) instead of masking it -- narrowing
+#      still applies to every other (non-interpreter-fed) heredoc in the same
+#      command, so the #5181 false-positive fix stays intact.
 #
 #   2. Crafted false opener whose delimiter later appears. Opener detection
 #      (heredoc_delim_at()) runs on a single physical line, before qsplit()
@@ -1601,6 +1615,60 @@ function mask_heredoc_bodies(s,   out, lines, nl, i, j, line, trimmed, body, del
                 body = lines[j]
                 gsub(/./, MASKC, body)
                 lines[j] = body
+            }
+            i = closeat            # resume scanning after the delimiter line
+            break
+        }
+    }
+    out = lines[1]
+    for (i = 2; i <= nl; i++) out = out "\n" lines[i]
+    return out
+}
+# True when a heredoc OPENER line looks like it feeds an interpreter --
+# either the opener command itself (`bash <<EOF`, `sh -s <<EOF`,
+# `python3 <<EOF`, `eval <<EOF`, `source <<EOF`, `. <<EOF`) or the opener is
+# piped into one on the same line (`cat <<EOF | bash`). Deliberately a
+# whole-line, best-effort check (matching the "narrow / best-effort" style
+# of heredoc_delim_at() above), anchored so the interpreter name must start
+# a command segment (start of line, or right after `;`/`&`/`|`) rather than
+# matching an arbitrary substring -- e.g. `echo "installs bash" <<EOF` does
+# NOT match, since "bash" there is not itself a command word.
+function is_interpreter_opener(line) {
+    return (line ~ /(^|[;&|])[ \t]*(bash|sh|zsh|dash|ksh|python[0-9.]*|perl|ruby|node|nodejs|eval|source|\.)([ \t]|$)/)
+}
+# Same closed-block detection as mask_heredoc_bodies(), but SKIPS masking
+# (leaves the body visible) for any block whose opener is interpreter-fed
+# per is_interpreter_opener() -- see KNOWN LIMITATIONS #1 above. Used ONLY by
+# the gh-api-rawfield-body-literal-at catastrophic check (#5198);
+# extract_write_targets() keeps calling plain mask_heredoc_bodies() above,
+# unchanged.
+function mask_heredoc_bodies_selective(s,   out, lines, nl, i, j, line, trimmed, body, delim, closeat, p, off, MASKC) {
+    MASKC = sprintf("%c", 23) # ETB -- placeholder for inert heredoc-body text
+    nl = split(s, lines, "\n")
+    if (nl == 0) return ""
+    for (i = 1; i <= nl; i++) {
+        line = lines[i]
+        off = 1
+        while (1) {
+            p = index(substr(line, off), "<<")
+            if (p == 0) break
+            p = off + p - 1
+            off = p + 2
+            delim = heredoc_delim_at(line, p)
+            if (delim == "") continue
+            closeat = 0
+            for (j = i + 1; j <= nl; j++) {
+                trimmed = lines[j]
+                sub(/^\t+/, "", trimmed)
+                if (trimmed == delim) { closeat = j; break }
+            }
+            if (closeat == 0) continue
+            if (!is_interpreter_opener(line)) {
+                for (j = i + 1; j < closeat; j++) {
+                    body = lines[j]
+                    gsub(/./, MASKC, body)
+                    lines[j] = body
+                }
             }
             i = closeat            # resume scanning after the delimiter line
             break
@@ -2207,26 +2275,35 @@ if [[ "$COMMAND" == *"@"* ]]; then
     # `.../issues/{n}/comments`. Confirmed via the test suite's new
     # non-comments-endpoint case; no widening was needed here.
     #
-    # HEREDOC-MASKED SCAN (#5181): this check used to grep raw $COMMAND, so a
-    # heredoc BODY line that merely QUOTES the denied phrase as inert prose
-    # (e.g. a report `cat > f.md <<'EOF' ... gh api ... -f body=@x ... EOF`,
-    # nothing of which executes) tripped the same catastrophic-tier deny as a
-    # live invocation. Reuses mask_heredoc_bodies() (#5000, defined above)
-    # -- the same primitive extract_write_targets() already uses -- to build
-    # a heredoc-body-blanked working copy and scans THAT instead. Built
-    # lazily (only when '<<' is present, mirroring the COMMAND_NO_COMMENT
+    # HEREDOC-MASKED SCAN (#5181, refined #5198): this check used to grep raw
+    # $COMMAND, so a heredoc BODY line that merely QUOTES the denied phrase as
+    # inert prose (e.g. a report `cat > f.md <<'EOF' ... gh api ... -f
+    # body=@x ... EOF`, nothing of which executes) tripped the same
+    # catastrophic-tier deny as a live invocation. Reuses
+    # mask_heredoc_bodies_selective() (#5198, built on the mask_heredoc_bodies()
+    # primitive extract_write_targets() already uses, #5000) to build a
+    # heredoc-body-blanked working copy and scans THAT instead. Built lazily
+    # (only when '<<' is present, mirroring the COMMAND_NO_COMMENT
     # `#`-present hot-path guard below) and scoped to just this one check;
     # every other rule in this file keeps reading raw $COMMAND /
     # COMMAND_NO_COMMENT unchanged. Masking only ever narrows: a REAL
     # (non-heredoc) invocation is untouched and still denies, even sitting in
     # the same multi-line command as an unrelated heredoc (mirrors the #5000
     # "narrows, never widens" test at
-    # tests/hooks/test-guard-destructive.sh:2691).
+    # tests/hooks/test-guard-destructive.sh:2691). UNLIKE plain
+    # mask_heredoc_bodies(), the _selective() variant does NOT mask a heredoc
+    # body whose opener feeds an interpreter (`bash <<EOF`, `sh -s <<EOF`,
+    # `cat <<EOF | bash`, ...) -- that body is genuinely live code to the
+    # inner interpreter (KNOWN LIMITATIONS #1, above), so masking it here
+    # would silently turn a real `gh api ... -f body=@path` invocation into
+    # an ALLOW (#5198's regression). extract_write_targets() is unaffected --
+    # it still calls plain mask_heredoc_bodies() and still masks
+    # interpreter-fed bodies, an accepted tradeoff for its ask-tier use.
     # -------------------------------------------------------------------------
     if [[ "$COMMAND" == *"<<"* ]]; then
         COMMAND_HEREDOC_MASKED=$(printf '%s' "$COMMAND" | awk "$_MASKHEREDOC_AWK"'
         { buf = buf (NR > 1 ? "\n" : "") $0 }
-        END { printf "%s", mask_heredoc_bodies(buf) }')
+        END { printf "%s", mask_heredoc_bodies_selective(buf) }')
     else
         COMMAND_HEREDOC_MASKED="$COMMAND"
     fi

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1629,12 +1629,55 @@ function mask_heredoc_bodies(s,   out, lines, nl, i, j, line, trimmed, body, del
 # `python3 <<EOF`, `eval <<EOF`, `source <<EOF`, `. <<EOF`) or the opener is
 # piped into one on the same line (`cat <<EOF | bash`). Deliberately a
 # whole-line, best-effort check (matching the "narrow / best-effort" style
-# of heredoc_delim_at() above), anchored so the interpreter name must start
-# a command segment (start of line, or right after `;`/`&`/`|`) rather than
-# matching an arbitrary substring -- e.g. `echo "installs bash" <<EOF` does
-# NOT match, since "bash" there is not itself a command word.
-function is_interpreter_opener(line) {
-    return (line ~ /(^|[;&|])[ \t]*(bash|sh|zsh|dash|ksh|python[0-9.]*|perl|ruby|node|nodejs|eval|source|\.)([ \t]|$)/)
+# of heredoc_delim_at() above): the interpreter must be the COMMAND WORD of
+# some segment of the line, not an arbitrary substring -- e.g.
+# `echo "installs bash" <<EOF` does NOT match, since "bash" there is a bare
+# argument, not the command word.
+#
+# Recognizing the command word robustly (#5205): the interpreter word is
+# matched against the path BASENAME of each segment command word, and any
+# leading `env`/`command`/`exec`/`builtin` wrapper (with its own flags and
+# `VAR=value` assignments) is stripped first -- none of those change what
+# actually executes. So a path-qualified or wrapped invocation of the same
+# interpreter (`/bin/bash <<EOF`, `env bash <<EOF`, `command bash <<EOF`,
+# `./bash <<EOF`, `/usr/bin/python3 <<EOF`) is caught too, closing the
+# evasion class where those forms slipped past the old first-token-only
+# regex and got their live bodies silently masked (i.e. ALLOWed).
+function _interp_basename(tok,   base) {
+    # Reduce a (possibly path-qualified) command word to its basename: the
+    # text after the last `/`. `/bin/bash` -> `bash`, `./bash` -> `bash`,
+    # `/usr/bin/python3` -> `python3`; a bare `bash` or `.` is unchanged.
+    base = tok
+    sub(/^.*\//, "", base)
+    return base
+}
+function is_interpreter_opener(line,   n, segs, i, seg, m, toks, j, base) {
+    # Split into command segments on ; & | (covers && and || too) so a piped
+    # or chained interpreter is caught in ANY position, e.g. `cat <<EOF | bash`.
+    n = split(line, segs, /[;&|]+/)
+    for (i = 1; i <= n; i++) {
+        seg = segs[i]
+        sub(/^[ \t]+/, "", seg)
+        m = split(seg, toks, /[ \t]+/)
+        if (m == 0) continue
+        # Strip leading command wrappers that do not change what runs:
+        # env / command / exec / builtin, each followed by its own -flags
+        # and (for env) VAR=value assignments, then the real command word.
+        j = 1
+        while (j <= m) {
+            if (toks[j] == "env" || toks[j] == "command" || toks[j] == "exec" || toks[j] == "builtin") {
+                j++
+                while (j <= m && (toks[j] ~ /^-/ || toks[j] ~ /^[A-Za-z_][A-Za-z0-9_]*=/)) j++
+                continue
+            }
+            break
+        }
+        if (j > m) continue
+        base = _interp_basename(toks[j])
+        if (base ~ /^(bash|sh|zsh|dash|ksh|python[0-9.]*|perl|ruby|node|nodejs|eval|source|\.)$/)
+            return 1
+    }
+    return 0
 }
 # Same closed-block detection as mask_heredoc_bodies(), but SKIPS masking
 # (leaves the body visible) for any block whose opener is interpreter-fed

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1516,6 +1516,20 @@ function unmask_ws(s) {
 #      script/stdin argument) is a materially larger, separate piece of work
 #      than this masking pass and is OUT OF SCOPE here; track it as its own
 #      follow-up rather than bolting a partial fix onto heredoc masking.
+#      This tradeoff (missed ASK, worst case) is unchanged for
+#      extract_write_targets() -- it still calls plain mask_heredoc_bodies()
+#      below and still masks interpreter-fed bodies. But #5192 later reused
+#      this same primitive for a CATASTROPHIC-tier DENY
+#      (gh-api-rawfield-body-literal-at, ~line 2234) without re-deriving this
+#      tradeoff for that tier: masking an interpreter-fed body there doesn't
+#      risk a missed ask, it silently flips a DENY to an ALLOW on the exact
+#      #4523/#4601/#4685 data-loss shape the check exists to catch (#5198).
+#      That is NOT an acceptable tradeoff for a catastrophic-tier check, so
+#      mask_heredoc_bodies_selective() below (used ONLY by that one check)
+#      recognizes an interpreter-fed opener and leaves that specific block's
+#      body UNMASKED (visible to the scan) instead of masking it -- narrowing
+#      still applies to every other (non-interpreter-fed) heredoc in the same
+#      command, so the #5181 false-positive fix stays intact.
 #
 #   2. Crafted false opener whose delimiter later appears. Opener detection
 #      (heredoc_delim_at()) runs on a single physical line, before qsplit()
@@ -1601,6 +1615,60 @@ function mask_heredoc_bodies(s,   out, lines, nl, i, j, line, trimmed, body, del
                 body = lines[j]
                 gsub(/./, MASKC, body)
                 lines[j] = body
+            }
+            i = closeat            # resume scanning after the delimiter line
+            break
+        }
+    }
+    out = lines[1]
+    for (i = 2; i <= nl; i++) out = out "\n" lines[i]
+    return out
+}
+# True when a heredoc OPENER line looks like it feeds an interpreter --
+# either the opener command itself (`bash <<EOF`, `sh -s <<EOF`,
+# `python3 <<EOF`, `eval <<EOF`, `source <<EOF`, `. <<EOF`) or the opener is
+# piped into one on the same line (`cat <<EOF | bash`). Deliberately a
+# whole-line, best-effort check (matching the "narrow / best-effort" style
+# of heredoc_delim_at() above), anchored so the interpreter name must start
+# a command segment (start of line, or right after `;`/`&`/`|`) rather than
+# matching an arbitrary substring -- e.g. `echo "installs bash" <<EOF` does
+# NOT match, since "bash" there is not itself a command word.
+function is_interpreter_opener(line) {
+    return (line ~ /(^|[;&|])[ \t]*(bash|sh|zsh|dash|ksh|python[0-9.]*|perl|ruby|node|nodejs|eval|source|\.)([ \t]|$)/)
+}
+# Same closed-block detection as mask_heredoc_bodies(), but SKIPS masking
+# (leaves the body visible) for any block whose opener is interpreter-fed
+# per is_interpreter_opener() -- see KNOWN LIMITATIONS #1 above. Used ONLY by
+# the gh-api-rawfield-body-literal-at catastrophic check (#5198);
+# extract_write_targets() keeps calling plain mask_heredoc_bodies() above,
+# unchanged.
+function mask_heredoc_bodies_selective(s,   out, lines, nl, i, j, line, trimmed, body, delim, closeat, p, off, MASKC) {
+    MASKC = sprintf("%c", 23) # ETB -- placeholder for inert heredoc-body text
+    nl = split(s, lines, "\n")
+    if (nl == 0) return ""
+    for (i = 1; i <= nl; i++) {
+        line = lines[i]
+        off = 1
+        while (1) {
+            p = index(substr(line, off), "<<")
+            if (p == 0) break
+            p = off + p - 1
+            off = p + 2
+            delim = heredoc_delim_at(line, p)
+            if (delim == "") continue
+            closeat = 0
+            for (j = i + 1; j <= nl; j++) {
+                trimmed = lines[j]
+                sub(/^\t+/, "", trimmed)
+                if (trimmed == delim) { closeat = j; break }
+            }
+            if (closeat == 0) continue
+            if (!is_interpreter_opener(line)) {
+                for (j = i + 1; j < closeat; j++) {
+                    body = lines[j]
+                    gsub(/./, MASKC, body)
+                    lines[j] = body
+                }
             }
             i = closeat            # resume scanning after the delimiter line
             break
@@ -2207,26 +2275,35 @@ if [[ "$COMMAND" == *"@"* ]]; then
     # `.../issues/{n}/comments`. Confirmed via the test suite's new
     # non-comments-endpoint case; no widening was needed here.
     #
-    # HEREDOC-MASKED SCAN (#5181): this check used to grep raw $COMMAND, so a
-    # heredoc BODY line that merely QUOTES the denied phrase as inert prose
-    # (e.g. a report `cat > f.md <<'EOF' ... gh api ... -f body=@x ... EOF`,
-    # nothing of which executes) tripped the same catastrophic-tier deny as a
-    # live invocation. Reuses mask_heredoc_bodies() (#5000, defined above)
-    # -- the same primitive extract_write_targets() already uses -- to build
-    # a heredoc-body-blanked working copy and scans THAT instead. Built
-    # lazily (only when '<<' is present, mirroring the COMMAND_NO_COMMENT
+    # HEREDOC-MASKED SCAN (#5181, refined #5198): this check used to grep raw
+    # $COMMAND, so a heredoc BODY line that merely QUOTES the denied phrase as
+    # inert prose (e.g. a report `cat > f.md <<'EOF' ... gh api ... -f
+    # body=@x ... EOF`, nothing of which executes) tripped the same
+    # catastrophic-tier deny as a live invocation. Reuses
+    # mask_heredoc_bodies_selective() (#5198, built on the mask_heredoc_bodies()
+    # primitive extract_write_targets() already uses, #5000) to build a
+    # heredoc-body-blanked working copy and scans THAT instead. Built lazily
+    # (only when '<<' is present, mirroring the COMMAND_NO_COMMENT
     # `#`-present hot-path guard below) and scoped to just this one check;
     # every other rule in this file keeps reading raw $COMMAND /
     # COMMAND_NO_COMMENT unchanged. Masking only ever narrows: a REAL
     # (non-heredoc) invocation is untouched and still denies, even sitting in
     # the same multi-line command as an unrelated heredoc (mirrors the #5000
     # "narrows, never widens" test at
-    # tests/hooks/test-guard-destructive.sh:2691).
+    # tests/hooks/test-guard-destructive.sh:2691). UNLIKE plain
+    # mask_heredoc_bodies(), the _selective() variant does NOT mask a heredoc
+    # body whose opener feeds an interpreter (`bash <<EOF`, `sh -s <<EOF`,
+    # `cat <<EOF | bash`, ...) -- that body is genuinely live code to the
+    # inner interpreter (KNOWN LIMITATIONS #1, above), so masking it here
+    # would silently turn a real `gh api ... -f body=@path` invocation into
+    # an ALLOW (#5198's regression). extract_write_targets() is unaffected --
+    # it still calls plain mask_heredoc_bodies() and still masks
+    # interpreter-fed bodies, an accepted tradeoff for its ask-tier use.
     # -------------------------------------------------------------------------
     if [[ "$COMMAND" == *"<<"* ]]; then
         COMMAND_HEREDOC_MASKED=$(printf '%s' "$COMMAND" | awk "$_MASKHEREDOC_AWK"'
         { buf = buf (NR > 1 ? "\n" : "") $0 }
-        END { printf "%s", mask_heredoc_bodies(buf) }')
+        END { printf "%s", mask_heredoc_bodies_selective(buf) }')
     else
         COMMAND_HEREDOC_MASKED="$COMMAND"
     fi

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -622,6 +622,55 @@ gh api repos/o/r/issues/1/comments -f body=@/tmp/review.md
 EOF
 echo done'
 
+# --- #5205: is_interpreter_opener() must recognize a PATH-QUALIFIED or
+# WRAPPED interpreter, not just the interpreter as the bare first token ------
+#
+# #5198's is_interpreter_opener() only matched the interpreter word when it
+# was the literal first token of the opener line, so any path-qualified
+# (`/bin/bash`, `./bash`, `/usr/bin/python3`) or wrapper-prefixed
+# (`env bash`, `command bash`, `exec bash`) invocation of the SAME
+# interpreter slipped past detection: its heredoc body got masked and the
+# live `gh api ... -f body=@path` inside it silently ALLOWed -- reopening the
+# exact #4523/#4601/#4685 evasion class #5198 closed. Widened (#5205) to
+# strip a leading env/command/exec/builtin wrapper (with its flags and
+# VAR=value assignments) and to match on the command word's path BASENAME.
+# Each of these must DENY, exactly like the bare-`bash` control at line ~599.
+assert_deny "#5205: Absolute-path interpreter '/bin/bash <<EOF ... EOF' still denies" \
+    '/bin/bash <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5205: env-wrapped interpreter 'env bash <<EOF ... EOF' still denies" \
+    'env bash <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5205: 'command' builtin prefix 'command bash <<EOF ... EOF' still denies" \
+    'command bash <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5205: Relative-path interpreter './bash <<EOF ... EOF' still denies" \
+    './bash <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5205: Absolute-path python interpreter '/usr/bin/python3 <<EOF ... EOF' still denies" \
+    '/usr/bin/python3 <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+# The widening must NOT regress #5181: a path-qualified command word that is
+# NOT an interpreter and merely quotes the phrase as inert prose to a file
+# sink stays ALLOWED (the wrapper/basename logic only ever recognizes MORE
+# interpreters, never masks less for a genuine non-interpreter sink).
+assert_allow "#5205/#5181: A heredoc body to '/bin/cat > file' (path-qualified non-interpreter) that merely quotes the phrase stays allowed" \
+    '/bin/cat > /tmp/report3.md <<'"'"'EOF'"'"'
+Example of the anti-pattern:
+gh api repos/o/r/issues/1/comments -f body=@/tmp/review.md
+EOF
+echo done'
+
 # --- #4685: the same literal-@ loss on the `edit` subcommand — real-world
 # evidence is issue #4608's body being corrupted to the literal string
 # `@/tmp/issue4608_body_new.txt`. The #4523/#4601 rules above are hard-anchored

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -581,6 +581,47 @@ just some unrelated prose
 EOF
 gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md'
 
+# --- #5198: gh-api-rawfield-body-literal-at must still deny an INTERPRETER-FED
+# heredoc (`bash <<'EOF' ... EOF`) even though #5181's fix masks heredoc BODY
+# text before scanning ------------------------------------------------------
+#
+# mask_heredoc_bodies()'s own "KNOWN LIMITATIONS #1" (documented above,
+# #5117) is that a heredoc body handed to an interpreter (`bash <<'EOF' ...
+# EOF`, `sh -s <<EOF ... EOF`, `... | bash`) is genuinely LIVE code to that
+# inner interpreter, even though the outer shell never parses it as
+# redirection/separator syntax. Blind masking (as #5192 first shipped) turns
+# this into a silent evasion: the same `gh api ... -f body=@path` invocation
+# that denies unwrapped ALLOWs once wrapped in `bash <<'EOF' ... EOF`,
+# reopening exactly the #4523/#4601/#4685 data-loss shape this check exists
+# to prevent. mask_heredoc_bodies_selective() (#5198) fixes this by NOT
+# masking a heredoc block whose opener feeds an interpreter, so the live
+# invocation stays visible to the scan.
+assert_deny "#5198: A live gh api -f body=@path invocation wrapped in 'bash <<EOF ... EOF' still denies (interpreter-fed heredoc)" \
+    'bash <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5198: Same interpreter-fed-heredoc evasion via 'sh -s <<EOF ... EOF'" \
+    'sh -s <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5198: Same interpreter-fed-heredoc evasion piped into bash ('cat <<EOF | bash')" \
+    'cat <<'"'"'EOF'"'"' | bash
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+# The #5181 false-positive fix must still hold: a heredoc body destined for a
+# PLAIN FILE SINK (not an interpreter) that merely quotes the denied phrase as
+# inert prose must stay allowed — this is the same case already covered above
+# (line ~562), re-asserted here to make the #5198/#5181 co-existence explicit.
+assert_allow "#5198/#5181: A heredoc body destined for 'cat > file' (not an interpreter) that merely quotes the phrase stays allowed" \
+    'cat > /tmp/report2.md <<'"'"'EOF'"'"'
+Example of the anti-pattern:
+gh api repos/o/r/issues/1/comments -f body=@/tmp/review.md
+EOF
+echo done'
+
 # --- #4685: the same literal-@ loss on the `edit` subcommand — real-world
 # evidence is issue #4608's body being corrupted to the literal string
 # `@/tmp/issue4608_body_new.txt`. The #4523/#4601 rules above are hard-anchored


### PR DESCRIPTION
## Summary

PR #5192 scoped the `gh-api-rawfield-body-literal-at` catastrophic-tier check
in `guard-destructive-generic.sh` to scan a heredoc-body-masked copy of
`$COMMAND` (`mask_heredoc_bodies()`, #5000) instead of the raw command,
fixing a false positive (#5181) where the denied phrase appeared only as
inert quoted prose inside a heredoc body destined for a file.

That masking primitive has a documented limitation (#5117, "Known Limitation
#1 — interpreter-fed heredocs"): a heredoc body fed to an interpreter
(`bash <<'EOF' ... EOF`, `sh -s <<EOF ... EOF`, `... | bash`) is genuinely
LIVE code to that inner interpreter, even though the outer shell never
parses it as redirection/separator syntax. Masking it was an accepted
tradeoff for the ask-tier `extract_write_targets()` scanner it was originally
scoped to, but #5192 reused the same primitive for a catastrophic-tier DENY
without re-deriving that tradeoff — creating a silent evasion path: a
`gh api ... -f body=@path` invocation wrapped in `bash <<'EOF' ... EOF`
now ALLOWs where it should DENY.

## Fix Direction

Chose **direction 1** from the issue (detect interpreter-fed heredoc openers
and skip masking just those blocks) over direction 2 (revert to raw-command
scanning), because direction 2 would reintroduce the #5181 false positive
that #5192 fixed. Direction 1 closes the gap precisely without regressing
#5181.

Added `mask_heredoc_bodies_selective()` — identical closed-block detection to
`mask_heredoc_bodies()`, but skips masking (leaves the body visible) for any
heredoc whose opener line matches `is_interpreter_opener()` (a narrow,
best-effort check for `bash`/`sh`/`zsh`/`dash`/`ksh`/`python*`/`perl`/`ruby`/
`node`/`eval`/`source`/`.` as a command word, or piped into one, e.g.
`cat <<EOF | bash`). Only the `gh-api-rawfield-body-literal-at` check switches
to the selective variant; `extract_write_targets()` keeps calling the
original `mask_heredoc_bodies()` unchanged — a missed ask there remains an
accepted, pre-existing, documented tradeoff, out of scope for this fix.

## Changes

- `defaults/hooks/guard-destructive-generic.sh` / `.loom/hooks/guard-destructive-generic.sh`
  (kept byte-identical, per repo convention): add `is_interpreter_opener()` +
  `mask_heredoc_bodies_selective()`, switch `COMMAND_HEREDOC_MASKED`'s
  construction (the sole read site of that variable) to the selective
  variant, and update the "Known Limitation #1" / "HEREDOC-MASKED SCAN"
  comment blocks to document the exception.
- `tests/hooks/test-guard-destructive.sh`: add regression coverage for the
  interpreter-fed-heredoc evasion (`bash <<EOF`, `sh -s <<EOF`,
  `cat <<EOF | bash` forms) and re-assert the original #5181 false-positive
  case (a heredoc body destined for a plain file sink) stays allowed.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| Issue's exact reproduction (`bash <<'EOF' ... gh api ... -f body=@path ... EOF`) is denied | Yes | Ran the issue's Python repro script directly against `defaults/hooks/guard-destructive-generic.sh`; confirmed `permissionDecision: "deny"` (was empty stdout / silent ALLOW before this fix) |
| #5181 false positive (inert prose in a heredoc destined for a file) remains allowed | Yes | `assert_allow` test re-asserted; also manually verified with `cat > file <<'EOF' ... quoted gh api ... EOF` shape — empty stdout (allow) |
| New regression test added to `tests/hooks/test-guard-destructive.sh` covering the interpreter-fed heredoc shape | Yes | 4 new cases added near the existing #5181 block: `bash <<EOF`, `sh -s <<EOF`, `cat <<EOF \| bash`, and a re-assertion of the #5181 file-sink allow case |
| Full `tests/hooks/test-guard-destructive.sh` suite passes | Yes | 683/683 passed (679 pre-existing + 4 new), including existing #5181/#5192/#5000/#5087 coverage |
| No other catastrophic ALWAYS_BLOCK check reuses `COMMAND_HEREDOC_MASKED` with the same gap | Yes | `grep -n COMMAND_HEREDOC_MASKED` shows exactly one read site (the `gh-api-rawfield-body-literal-at` check). The only other `mask_heredoc_bodies()` call site is inside `extract_write_targets()`, the ask-tier scanner already explicitly scoped to accept this limitation per #5117 — confirmed by Curator on the issue as well |
| New test fails against pre-fix code (proves it's a real regression guard) | Yes | Temporarily reverted both hook files to `HEAD` (pre-fix), re-ran the suite: the 3 new deny cases FAILED as expected (680/683), the allow case still passed. Restored the fix afterward — 683/683 |

## Test Plan

```bash
./tests/hooks/test-guard-destructive.sh   # 683/683 passed
```

Manual reproduction (from the issue body):

```python
import json, subprocess
GUARD = "defaults/hooks/guard-destructive-generic.sh"
cmd = "bash <<'EOF'\ngh api repos/o/r/issues/123/comments -f body=@/tmp/review.md\nEOF"
payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": cmd}})
p = subprocess.run([GUARD], input=payload, capture_output=True, text=True)
print(repr(p.stdout))
# BEFORE this fix: '' (silent ALLOW -- the bug)
# AFTER this fix: {"hookSpecificOutput": {..., "permissionDecision": "deny", ...}}
```

Confirmed identically against both `defaults/hooks/guard-destructive-generic.sh`
and `.loom/hooks/guard-destructive-generic.sh` (kept in sync, both tracked and
committed together per repo convention, same as #5192).

**Note on scope**: this change touches zero `.rs` files (pure bash/awk edit to
a guard hook + its shell test suite), so the Rust portion of the local
`buildGate.command` (`cargo test --workspace --lib --bins`) is orthogonal to
this fix. It was started locally but did not finish within a reasonable wait
on this host (appears blocked on pre-existing, slow/flaky daemon tests
unrelated to this change — same class of pre-existing test-timing flakiness
documented in `.loom/scripts/build-gate.sh`'s own comments). The
`tests/hooks/test-guard-destructive.sh` suite (the actual coverage for the
file this PR modifies) passed cleanly at 683/683 both before and after a
rebase onto latest `origin/main`.

Closes #5198
