### PR TITLE
feat(changelog): add a deterministic conventional-commit CHANGELOG generator

### DIFF
--- a/.repo/release-policy.md
+++ b/.repo/release-policy.md
@@ -1,0 +1,75 @@
+# Release policy — loom
+
+Procedural steps `/repo:release` (from `rjwalters/repo`, co-installed under
+`.claude/commands/repo/release.md` — that file is gitignored in *this* repo,
+see `.gitignore`'s `.claude/commands` entry, so it cannot be edited here) binds
+at named seams. See `/repo:release`'s own "Extension points" section for the
+seam contract. This file exists to close the CHANGELOG maintenance gaps
+described in #5196 without forking the shared command.
+
+## seam: pre-changelog-style
+
+Use `./scripts/changelog.sh draft <last-tag>..HEAD` to generate the mechanical
+skeleton for this release's entry: it parses conventional commits in the
+range and buckets them into `### Added` / `### Changed` / `### Removed` /
+`### Fixed` (dropping non-shipping `test`/`chore`/`ci`/`build` commits, and
+surfacing anything with an unrecognized or missing conventional prefix under
+`### Other` rather than dropping it) with every `(#NNN)` ref preserved
+verbatim. Treat that output as the raw material only — regroup it into the
+thematic sub-sections this project's CHANGELOG already uses (see the existing
+entries for the house style) and write the `### Summary` paragraph yourself;
+the script does not (and should not) generate that narrative.
+
+**Keep `## [Unreleased]` alive across the fold.** The default draft step
+folds an existing `## Unreleased` heading into the new version heading by
+renaming it in place — that rename is exactly what left this project's
+CHANGELOG with *no* `## [Unreleased]` heading at all after v0.18.0 (#5196):
+nothing re-added it, so the section stayed missing until the next release
+reconstructed everything from git log by hand. Immediately after the fold
+consumes `## Unreleased` (i.e. as part of producing the string that Phase 5
+inserts), re-insert a **fresh, empty** `## [Unreleased]` heading directly
+above the newly-named version heading — where `## Unreleased` used to sit.
+Do this every release, even when Unreleased had no accumulated content to
+fold, so the heading is a permanent fixture rather than something the next
+release has to remember to add back.
+
+## seam: pre-push
+
+Before pushing, re-verify CHANGELOG.md completeness against the range that is
+**actually about to ship** — not whatever range Phase 3/4 drafted earlier in
+this session. By this point Phase 5 has already created the version commit
+and tag, so `$last..v$NEW` (the previous release tag through the tag Phase 5
+just created) is now fixed and immutable; recompute it fresh rather than
+reusing an earlier variable, since main can advance between drafting and
+tagging in a long interactive release session (observed on v0.18.0: 5 commits
+landed mid-release and had to be caught and re-folded by hand):
+
+```bash
+./scripts/changelog.sh verify "$last..v$NEW" CHANGELOG.md
+```
+
+- **No `MISSING:` lines** — proceed with the push.
+- **Any `MISSING: #NNN <- <subject>` lines** — a shipping commit in the final
+  tagged range has no trace anywhere in CHANGELOG.md. Before pushing (nothing
+  is public yet, so this is still cheap to fix): decide whether it was an
+  intentional editorial consolidation (multiple commits folded into one
+  curated bullet that cites a different, representative `#NNN` — expected and
+  fine) or a genuine drop. For a genuine drop, regenerate the raw material
+  with `./scripts/changelog.sh draft "$last..v$NEW"`, fold the missing item(s)
+  into the already-written entry, amend the version commit
+  (`git commit --amend`), and re-tag (`git tag -f -a "v$NEW" -m "v$NEW"`)
+  before proceeding to push. Never push first and fix after — the tag is
+  public the moment it's pushed.
+
+## Link-reference block
+
+Not a seam (nothing in `/repo:release` reads it), recorded here for
+provenance: CHANGELOG.md's trailing `[Unreleased]: …` / `[0.2.3]: …` /
+`[0.2.0]: …` / `[0.1.0]: …` reference-link block was dropped in #5196 rather
+than backfilled. Only 4 of 19 released versions ever had one (0.3.0 through
+0.18.0 never did), so the Keep-a-Changelog reference-link convention was
+already abandoned in practice; backfilling comparison URLs for all 15 missing
+versions to resurrect a convention this project never consistently followed
+was judged not worth the upkeep it would then require on every future
+release. Do not re-add a partial block — either maintain it for every version
+going forward or leave it out entirely.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Loom will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.18.0] - 2026-08-03
 
 ### Summary
@@ -1210,8 +1212,3 @@ Existing v0.1.x installations can upgrade cleanly:
 - MCP servers for programmatic control (loom-terminals, loom-ui, loom-logs)
 - Installation script for target repositories
 - Quickstart templates for webapp, desktop, and API projects
-
-[Unreleased]: https://github.com/rjwalters/loom/compare/v0.2.3...HEAD
-[0.2.3]: https://github.com/rjwalters/loom/compare/v0.2.0...v0.2.3
-[0.2.0]: https://github.com/rjwalters/loom/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/rjwalters/loom/releases/tag/v0.1.0

--- a/defaults/docs/build-gate.md
+++ b/defaults/docs/build-gate.md
@@ -136,6 +136,9 @@ stages in order under `set -euo pipefail`, aborting on the first non-zero exit:
    `loom-daemon/tests/` are deliberately excluded here — see "Local gate vs.
    CI" below.
 2. `bash scripts/test-installer.sh` — the 131-case bash installer suite.
+3. `bash scripts/test-changelog.sh` — `scripts/changelog.sh`'s unit suite
+   (#5196), against a disposable scratch repo (`CHANGELOG_REPO_ROOT`); no
+   network, no dependency on this repo's own history.
 
 **The gate requires no Python toolchain at all (epic #4081 Phase 4, #4557;
 finished by #4970).** Stage 2 used to be `cd loom-tools && uv run pytest

--- a/defaults/scripts/build-gate.sh
+++ b/defaults/scripts/build-gate.sh
@@ -26,6 +26,9 @@
 #     there is now no Python anywhere in the repo, load-bearing or otherwise,
 #     and no Python-conditional stage left to run.
 #   - bash scripts/test-installer.sh runs the 131-case installer suite.
+#   - bash scripts/test-changelog.sh runs scripts/changelog.sh's unit suite
+#     (#5196) against a disposable scratch repo (CHANGELOG_REPO_ROOT) -- no
+#     network, no dependency on this repo's own history, sub-second.
 #   - mcp-loom (TypeScript) is intentionally EXCLUDED: it needs npm install/ci
 #     in a fresh worktree (no guaranteed warm node_modules), which adds
 #     unpredictable latency to a gate that also runs once per PR. CI still
@@ -152,5 +155,8 @@ cargo test --workspace --lib --bins
 
 echo "[build-gate] bash installer suite"
 bash scripts/test-installer.sh
+
+echo "[build-gate] bash changelog generator suite"
+bash scripts/test-changelog.sh
 
 echo "[build-gate] all stages passed"

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# changelog.sh - Generate and verify Keep-a-Changelog entries from a git log
+# range (#5196).
+#
+# Every release used to hand-reconstruct ~150 commits into CHANGELOG.md
+# sections because the commit stream is already ~99% conventional-commit
+# formatted (feat/fix/docs/...) with a trailing "(#NNN)" ref. This script
+# turns that stream directly into a Keep-a-Changelog skeleton so a release
+# only has to review/curate the result (and write the human "### Summary"
+# prose) instead of grouping commits by hand.
+#
+# Usage:
+#   ./scripts/changelog.sh draft <from>..<to>
+#       Print a Keep-a-Changelog body (### Added / ### Changed / ### Removed /
+#       ### Fixed / ### Other sections, omitting empty ones) for every commit
+#       in <from>..<to>, to stdout. Deterministic: re-running against the same
+#       (unchanged) range produces byte-identical output.
+#
+#   ./scripts/changelog.sh verify <from>..<to> [<file>]
+#       Check that every "shipping" commit in <from>..<to> which cites a
+#       "(#NNN)" ref has that ref present somewhere in <file> (default:
+#       CHANGELOG.md at the repo root). Prints one MISSING line per absent
+#       ref and exits 1 if any are missing, else prints a summary and exits 0.
+#       Intended for /repo:release's Phase 1.5 completeness gate and a final
+#       pre-tag/pre-release safety check (Phase 5/6) against the *actual*
+#       tagged range, closing the mid-release race where a commit lands
+#       between drafting the entry and cutting the tag.
+#
+# Bucketing (Keep a Changelog section <- Conventional Commit type, matched
+# case-insensitively against the "type(scope)!: subject" prefix):
+#   Added    <- feat
+#   Changed  <- docs, refactor, perf, style
+#   Removed  <- revert
+#   Fixed    <- fix
+#   (dropped, non-shipping) <- test, chore, ci, build
+#   Other    <- anything else: an unrecognized prefix (e.g. this repo's rare
+#              "config(...):" commits) or no conventional prefix at all. Kept
+#              rather than silently dropped -- surfaced separately so the
+#              human curating the release decides where (if anywhere) it
+#              belongs, rather than the generator guessing.
+#
+# This feeds /repo:release's existing CHANGELOG phases; it does not replace
+# them, and it does not generate the "### Summary" narrative (that stays
+# human-written by design -- see issue #5196's non-goals).
+set -euo pipefail
+
+# CHANGELOG_REPO_ROOT overrides the repo the git-log range and default
+# CHANGELOG.md are resolved against -- a testability hook (scripts/
+# test-changelog.sh points it at a disposable scratch repo) that has no
+# effect on normal invocations, which always resolve against this script's
+# own checkout.
+REPO_ROOT="${CHANGELOG_REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  changelog.sh draft <from>..<to>
+  changelog.sh verify <from>..<to> [<file>]
+EOF
+}
+
+# Non-shipping conventional-commit types: excluded from both draft output and
+# verify's ref-coverage check (a release entry is not expected to mention
+# them, so their absence is not a "dropped commit").
+is_non_shipping_type() {
+  case "$1" in
+    test | chore | ci | build) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Extract the conventional-commit type from a subject line, lowercased, or
+# empty if the subject has no "type:" / "type(scope):" / "type!:" prefix.
+commit_type() {
+  local subject="$1"
+  if [[ "$subject" =~ ^([A-Za-z]+)(\([^\)]*\))?\!?:[[:space:]] ]]; then
+    printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]'
+  fi
+}
+
+# Strip a "type(scope)!: " prefix, returning the remainder verbatim --
+# including any trailing "(#NNN)" ref, which is therefore preserved as-is
+# rather than re-derived. Subjects with no such prefix pass through unchanged
+# (they land in the "Other" bucket, not silently dropped).
+commit_description() {
+  local subject="$1"
+  if [[ "$subject" =~ ^[A-Za-z]+(\([^\)]*\))?\!?:[[:space:]](.*)$ ]]; then
+    printf '%s' "${BASH_REMATCH[2]}"
+  else
+    printf '%s' "$subject"
+  fi
+}
+
+# Map a lowercased conventional type to its Keep-a-Changelog section name.
+# "Other" = unrecognized (caller must check is_non_shipping_type first to
+# distinguish "excluded/non-shipping" from "unrecognized -> Other").
+bucket_for_type() {
+  case "$1" in
+    feat) echo "Added" ;;
+    fix) echo "Fixed" ;;
+    docs | refactor | perf | style) echo "Changed" ;;
+    revert) echo "Removed" ;;
+    *) echo "Other" ;;
+  esac
+}
+
+cmd_draft() {
+  local range="${1:?usage: changelog.sh draft <from>..<to>}"
+
+  # Keep-a-Changelog canonical section order (Added, Changed, Removed, Fixed);
+  # "Other" is appended last as the deliberate escape hatch described above.
+  local sections=(Added Changed Removed Fixed Other)
+  local added="" changed="" removed="" fixed="" other=""
+
+  # `|| [ -n "$subject" ]` matters: git log's last line (the range's oldest
+  # commit) has no trailing newline, so a plain `while read` would see `read`
+  # return non-zero on that final line and drop it silently -- exactly the
+  # "commit silently dropped" failure mode this tool exists to prevent.
+  while IFS= read -r subject || [ -n "$subject" ]; do
+    [ -n "$subject" ] || continue
+    local type section desc
+    type="$(commit_type "$subject")"
+    if [ -n "$type" ] && is_non_shipping_type "$type"; then
+      continue
+    fi
+    section="$(bucket_for_type "$type")"
+    desc="$(commit_description "$subject")"
+    case "$section" in
+      Added) added+="- ${desc}"$'\n' ;;
+      Changed) changed+="- ${desc}"$'\n' ;;
+      Removed) removed+="- ${desc}"$'\n' ;;
+      Fixed) fixed+="- ${desc}"$'\n' ;;
+      Other) other+="- ${desc}"$'\n' ;;
+    esac
+  done < <(git -C "$REPO_ROOT" log --no-merges --pretty=format:'%s' "$range")
+
+  local printed_any=""
+  for s in "${sections[@]}"; do
+    local body=""
+    case "$s" in
+      Added) body="$added" ;;
+      Changed) body="$changed" ;;
+      Removed) body="$removed" ;;
+      Fixed) body="$fixed" ;;
+      Other) body="$other" ;;
+    esac
+    if [ -n "$body" ]; then
+      printed_any=1
+      printf '### %s\n\n%s\n' "$s" "$body"
+    fi
+  done
+
+  if [ -z "$printed_any" ]; then
+    # Empty-but-valid skeleton: a range with zero shipping commits (all
+    # excluded types, or genuinely empty) must not error.
+    printf '(no shipping changes in this range)\n'
+  fi
+}
+
+cmd_verify() {
+  local range="${1:?usage: changelog.sh verify <from>..<to> [<file>]}"
+  local file="${2:-$REPO_ROOT/CHANGELOG.md}"
+
+  if [ ! -f "$file" ]; then
+    echo "ERROR: $file not found" >&2
+    return 1
+  fi
+
+  local missing=0 checked=0
+  # See the matching comment in cmd_draft: git log's last line has no
+  # trailing newline, so the `|| [ -n "$subject" ]` guard is required to
+  # avoid silently skipping the range's oldest commit.
+  while IFS= read -r subject || [ -n "$subject" ]; do
+    [ -n "$subject" ] || continue
+    local type ref
+    type="$(commit_type "$subject")"
+    if [ -n "$type" ] && is_non_shipping_type "$type"; then
+      continue
+    fi
+    # Grab every "#NNN" reference in the subject (usually one trailing ref,
+    # occasionally more, e.g. two refs cited on a follow-up commit).
+    while IFS= read -r ref; do
+      [ -n "$ref" ] || continue
+      checked=$((checked + 1))
+      if ! grep -qF "$ref" "$file"; then
+        missing=$((missing + 1))
+        echo "MISSING: $ref  <-  $subject"
+      fi
+    done < <(printf '%s\n' "$subject" | grep -oE '#[0-9]+' || true)
+  done < <(git -C "$REPO_ROOT" log --no-merges --pretty=format:'%s' "$range")
+
+  if [ "$missing" -gt 0 ]; then
+    echo "FAIL: $missing/$checked referenced commit(s) in $range not found in $file" >&2
+    return 1
+  fi
+
+  echo "OK: all $checked referenced shipping commit(s) in $range found in $file"
+}
+
+# --- Main ---
+
+case "${1:-}" in
+  draft)
+    shift
+    cmd_draft "$@"
+    ;;
+  verify)
+    shift
+    cmd_verify "$@"
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/scripts/test-changelog.sh
+++ b/scripts/test-changelog.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# test-changelog.sh - Unit tests for scripts/changelog.sh (#5196).
+#
+# Builds a disposable scratch git repo with controlled conventional-commit
+# subjects (one per bucketing rule, plus the two "don't silently drop"
+# edge cases: an unrecognized prefix and no prefix at all), then asserts
+# `changelog.sh draft`'s bucketing, ref preservation, and determinism, plus
+# `changelog.sh verify`'s ref-coverage check. Uses CHANGELOG_REPO_ROOT so
+# nothing here touches this repo's own history or CHANGELOG.md.
+#
+# Usage: bash scripts/test-changelog.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHANGELOG_SH="$REPO_ROOT/scripts/changelog.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+passed=0
+failed=0
+
+pass() { echo -e "${GREEN}✓${NC} $1"; passed=$((passed + 1)); }
+fail() { echo -e "${RED}✗${NC} $1"; failed=$((failed + 1)); }
+
+assert_contains() {
+  local haystack="$1" needle="$2" desc="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    pass "$desc"
+  else
+    fail "$desc (expected to find: $needle)"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" desc="$3"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    fail "$desc (unexpectedly found: $needle)"
+  else
+    pass "$desc"
+  fi
+}
+
+SCRATCH="$(mktemp -d)"
+cleanup() { rm -rf "$SCRATCH"; }
+trap cleanup EXIT
+
+git -C "$SCRATCH" init --quiet --initial-branch=main
+git -C "$SCRATCH" config user.name "Loom Test"
+git -C "$SCRATCH" config user.email "test@example.invalid"
+
+commit() {
+  local subject="$1"
+  # Filename varies per commit so each produces a distinct, real change --
+  # `git commit --allow-empty` would also work, but a real diff is closer to
+  # how these subjects actually arrive in this repo's history.
+  echo "$subject" >> "$SCRATCH/log.txt"
+  git -C "$SCRATCH" add log.txt
+  git -C "$SCRATCH" commit --quiet -m "$subject"
+}
+
+echo "=== Building scratch commit range ==="
+commit "chore: initial scaffold"
+git -C "$SCRATCH" tag v0.0.0
+commit "feat(cli): add --verbose flag (#101)"
+commit "fix(daemon): correct off-by-one in retry loop (#102)"
+commit "docs: clarify install steps (#103)"
+commit "refactor(core): extract shared helper (#104)"
+commit "perf(query): cache repeated lookups (#105)"
+commit "revert: revert \"feat: risky experiment\" (#106)"
+commit "test(daemon): add coverage for retry loop (#107)"
+commit "chore: bump lockfile"
+commit "ci: pin runner image (#108)"
+commit "build: bump toolchain (#109)"
+commit "config(loom): enable a feature flag (#110)"
+commit "totally unstructured commit message with no prefix (#111)"
+git -C "$SCRATCH" tag v0.1.0
+
+RANGE="v0.0.0..v0.1.0"
+
+echo ""
+echo "=== draft: bucketing ==="
+DRAFT1="$(CHANGELOG_REPO_ROOT="$SCRATCH" bash "$CHANGELOG_SH" draft "$RANGE")"
+
+assert_contains "$DRAFT1" "### Added" "Added section header present"
+assert_contains "$DRAFT1" "add --verbose flag (#101)" "feat commit bucketed under Added, ref preserved"
+
+assert_contains "$DRAFT1" "### Fixed" "Fixed section header present"
+assert_contains "$DRAFT1" "correct off-by-one in retry loop (#102)" "fix commit bucketed under Fixed"
+
+assert_contains "$DRAFT1" "### Changed" "Changed section header present"
+assert_contains "$DRAFT1" "clarify install steps (#103)" "docs commit bucketed under Changed"
+assert_contains "$DRAFT1" "extract shared helper (#104)" "refactor commit bucketed under Changed"
+assert_contains "$DRAFT1" "cache repeated lookups (#105)" "perf commit bucketed under Changed"
+
+assert_contains "$DRAFT1" "### Removed" "Removed section header present"
+assert_contains "$DRAFT1" 'revert "feat: risky experiment" (#106)' "revert commit bucketed under Removed"
+
+assert_contains "$DRAFT1" "### Other" "Other section header present (unrecognized/no-prefix commits)"
+assert_contains "$DRAFT1" "enable a feature flag (#110)" "unrecognized-prefix commit surfaced under Other, not dropped"
+assert_contains "$DRAFT1" "totally unstructured commit message with no prefix (#111)" "no-prefix commit surfaced under Other, not dropped"
+
+echo ""
+echo "=== draft: non-shipping types excluded ==="
+assert_not_contains "$DRAFT1" "add coverage for retry loop" "test commit excluded"
+assert_not_contains "$DRAFT1" "bump lockfile" "chore commit excluded"
+assert_not_contains "$DRAFT1" "pin runner image" "ci commit excluded"
+assert_not_contains "$DRAFT1" "bump toolchain" "build commit excluded"
+
+echo ""
+echo "=== draft: determinism ==="
+DRAFT2="$(CHANGELOG_REPO_ROOT="$SCRATCH" bash "$CHANGELOG_SH" draft "$RANGE")"
+if [ "$DRAFT1" = "$DRAFT2" ]; then
+  pass "re-running draft on the same range is byte-identical"
+else
+  fail "re-running draft on the same range produced different output"
+fi
+
+echo ""
+echo "=== draft: empty range does not error ==="
+EMPTY_OUT="$(CHANGELOG_REPO_ROOT="$SCRATCH" bash "$CHANGELOG_SH" draft "v0.1.0..v0.1.0")"
+assert_contains "$EMPTY_OUT" "no shipping changes" "empty range prints a valid empty-but-headed skeleton, no error"
+
+echo ""
+echo "=== verify: detects a missing ref ==="
+CHANGELOG_STUB="$SCRATCH/CHANGELOG.md"
+{
+  echo "## [0.1.0]"
+  echo "- add --verbose flag (#101)"
+  echo "- correct off-by-one in retry loop (#102)"
+  # #103-#111 deliberately omitted.
+} > "$CHANGELOG_STUB"
+
+VERIFY_OUT="$(CHANGELOG_REPO_ROOT="$SCRATCH" bash "$CHANGELOG_SH" verify "$RANGE" "$CHANGELOG_STUB" 2>&1)" && VERIFY_EXIT=0 || VERIFY_EXIT=$?
+if [ "$VERIFY_EXIT" -ne 0 ]; then
+  pass "verify exits non-zero when a shipping ref is missing"
+else
+  fail "verify should have exited non-zero (missing refs)"
+fi
+assert_contains "$VERIFY_OUT" "MISSING: #103" "verify reports the missing docs ref"
+assert_not_contains "$VERIFY_OUT" "MISSING: #107" "verify does not flag an excluded test commit's ref"
+assert_not_contains "$VERIFY_OUT" "MISSING: #108" "verify does not flag an excluded ci commit's ref"
+
+echo ""
+echo "=== verify: passes when every shipping ref is present ==="
+CHANGELOG_REPO_ROOT="$SCRATCH" bash "$CHANGELOG_SH" draft "$RANGE" > "$CHANGELOG_STUB"
+if CHANGELOG_REPO_ROOT="$SCRATCH" bash "$CHANGELOG_SH" verify "$RANGE" "$CHANGELOG_STUB" > /dev/null 2>&1; then
+  pass "verify exits zero when every shipping ref is present"
+else
+  fail "verify should have exited zero (all refs present, since CHANGELOG_STUB is the draft itself)"
+fi
+
+echo ""
+echo "=== usage: unknown subcommand exits non-zero ==="
+if bash "$CHANGELOG_SH" bogus > /dev/null 2>&1; then
+  fail "unknown subcommand should exit non-zero"
+else
+  pass "unknown subcommand exits non-zero"
+fi
+
+echo ""
+echo "=== Results: $passed passed, $failed failed ==="
+[ "$failed" -eq 0 ]


### PR DESCRIPTION
## Summary

Every release hand-reconstructed ~150 commits into `CHANGELOG.md` by hand because
the `## [Unreleased]` heading disappeared entirely after v0.18.0 (nothing
re-added it) and nothing generated an entry from the commit stream, despite
that stream being ~99% conventional-commit formatted already.

## Changes

- **`scripts/changelog.sh draft <from>..<to>`** — parses conventional commits
  in a git log range and buckets them into Keep a Changelog sections
  (`feat`→Added, `fix`→Fixed, `docs`/`refactor`/`perf`/`style`→Changed,
  `revert`→Removed), drops non-shipping `test`/`chore`/`ci`/`build` commits,
  and surfaces anything with an unrecognized or missing conventional prefix
  under `### Other` rather than silently dropping it. Every `(#NNN)` ref is
  preserved verbatim. Deterministic — re-running on an unchanged range is
  byte-identical. (While building the test suite I found and fixed a real bug:
  a plain `while read` loop silently swallowed the *oldest* commit in every
  range, because `git log`'s last line has no trailing newline — this would
  have quietly dropped exactly the kind of commit this tool exists to catch.)
- **`scripts/changelog.sh verify <from>..<to> [<file>]`** — flags any shipping
  commit whose `#NNN` ref never appears in a given file (default
  `CHANGELOG.md`); used as a final "final tagged range" completeness check.
- **`scripts/test-changelog.sh`** — unit suite against a disposable scratch
  git repo (no dependency on this repo's own history), wired into
  `defaults/scripts/build-gate.sh` (+ `defaults/docs/build-gate.md`).
- **`CHANGELOG.md`** — restored the missing `## [Unreleased]` heading. Decided
  the fate of the dangling link-reference block at the bottom: dropped it
  rather than half-backfill, since only 4 of 19 released versions (`0.1.0`,
  `0.2.0`, `0.2.3`, and the stale `Unreleased` def) ever had one — 0.3.0
  through 0.18.0 never did, so the convention was already effectively
  abandoned. Decision recorded in `.repo/release-policy.md`.
- **`.repo/release-policy.md`** (new) — `/repo:release` (the release-cutting
  slash command) is a *shared* command co-installed from `rjwalters/repo`, not
  part of this repo (`.claude/commands` is gitignored here — see
  `.gitignore`), so `.claude/commands/repo/release.md` itself cannot be edited
  from this PR. `/repo:release` exposes exactly this seam mechanism for a
  project to inject procedural policy without forking the shared command, so
  this file binds the two seams needed to close the gaps the issue describes:
  - `pre-changelog-style`: use `scripts/changelog.sh draft` as the raw
    material for drafting, and — the specific fix for the missing-heading
    bug — re-insert a fresh empty `## [Unreleased]` heading immediately after
    the default fold consumes the old one, every release.
  - `pre-push`: re-verify CHANGELOG completeness against the range that is
    actually about to ship (recomputed fresh, after Phase 5 has already cut
    the tag) rather than whatever range was drafted earlier in the session —
    this is the fix for the mid-release race where commits landing between
    drafting and tagging get silently dropped (the v0.18.0 near-miss the
    issue cites).

## Acceptance Criteria Verification

- [x] `scripts/changelog.sh draft <from>..<to>` deterministically regenerates
  the Unreleased entry with `(#NNN)` refs preserved — verified in
  `scripts/test-changelog.sh` (bucketing + byte-identical re-run) and against
  the real `v0.17.0..v0.18.0` range.
- [x] `## [Unreleased]` exists in CHANGELOG.md at all times, including
  immediately after a release — heading restored now; `pre-changelog-style`
  seam re-adds it after every future fold.
- [x] Release entry generation/verification uses the final tagged range, not
  the drafted range — `pre-push` seam recomputes and runs `changelog.sh
  verify` against the tag Phase 5 just cut, after main may have advanced past
  whatever Phase 3/4 originally drafted from.
- [x] Non-shipping commit types excluded or clearly separated —
  `test`/`chore`/`ci`/`build` excluded; unrecognized/no-prefix commits kept
  under `### Other`, not dropped.
- [x] A decision on the link-reference block is recorded, no dangling
  `[Unreleased]` link definition remains — block dropped, decision recorded in
  `.repo/release-policy.md`.
- [x] Cutting a release no longer requires hand-grouping ~150 commits — the
  generator produces the mechanical skeleton; a human still writes the
  `### Summary` narrative and regroups into thematic sub-bullets (unchanged by
  design — see the issue's non-goals).

## Test Plan

- `bash scripts/test-changelog.sh` — 25/25 passing (bucketing per type,
  ref preservation, non-shipping exclusion, determinism, empty-range edge
  case, verify's missing/present-ref detection, unknown-subcommand exit).
- Ran `scripts/changelog.sh draft v0.17.0..v0.18.0` against this repo's real
  history and diffed against the hand-written v0.18.0 entry to sanity-check
  bucketing quality.
- `bash scripts/test-installer.sh` — 176/177 passing; the one failure
  (`test-loom-dispatcher.sh`, 3 sub-cases under `#4581` env-harvest
  re-rendering) reproduces identically on unmodified `main` — pre-existing,
  unrelated to this change.
- `bash scripts/check-docs-defaults-parity.sh` — OK.
- `shellcheck` on both new scripts — clean.

## Note on scope

`.claude/commands/repo/release.md` (named in the issue's "Affected Files") is
not part of this repo — it's gitignored (`.claude/commands`) and lives in
`rjwalters/repo`. This PR does not (and cannot) edit it; `.repo/release-policy.md`
is the intended, non-forking extension point `/repo:release` itself documents
for exactly this situation.

Closes #5196