### PR TITLE
docs(claude-md): mirror quarantine-safety pointer into defaults/.loom/CLAUDE.md

### DIFF
--- a/defaults/.loom/CLAUDE.md
+++ b/defaults/.loom/CLAUDE.md
@@ -337,14 +337,19 @@ exits `78` (`EX_CONFIG`). Full reference:
 ## Troubleshooting
 
 See [`.loom/docs/troubleshooting.md`](.loom/docs/troubleshooting.md) for stale
-worktrees, stuck agents, daemon registry/reaper issues, and common fixes. Quick
-fixes:
+worktrees, stuck agents, daemon registry/reaper issues, quarantine safety, and
+common fixes. Quick fixes:
 
 ```bash
 loom-clean --force                              # stale worktrees/branches
 loom-recover-orphans --recover                   # orphaned loom:building issues
 gh label sync --file .github/labels.yml          # re-sync labels
 ```
+
+**Branching does not protect uncommitted edits in the primary clone from
+quarantine** — see [`.loom/docs/troubleshooting.md` → Uncommitted work in the
+primary clone can be quarantined at any
+time](.loom/docs/troubleshooting.md).
 
 CI-specific guidance (headless/non-interactive runs) is in
 [`.loom/docs/ci-integration.md`](.loom/docs/ci-integration.md); tool-use


### PR DESCRIPTION
## Summary

Mirrors the quarantine-safety discoverability pointer from PR #5202 into
`defaults/.loom/CLAUDE.md`'s `## Troubleshooting` section. That file is the
templated source for `.loom/CLAUDE.md` in every consumer repo — PR #5202 only
updated this repo's own root `CLAUDE.md` (the dogfood copy), so the same
discoverability gap that caused issue #5194 persisted in every consumer repo.

## Changes

- `defaults/.loom/CLAUDE.md`: added "quarantine safety" to the topic list in
  the `## Troubleshooting` section's opening pointer, and added the
  "**Branching does not protect uncommitted edits in the primary clone from
  quarantine**" sentence pointing at `.loom/docs/troubleshooting.md` →
  "Uncommitted work in the primary clone can be quarantined at any time",
  mirroring the phrasing merged into root `CLAUDE.md` by PR #5202.

## Acceptance Criteria Verification

- [x] Add an equivalent one-line pointer to `defaults/.loom/CLAUDE.md`'s
      `## Troubleshooting` section — done, phrasing mirrors root `CLAUDE.md`.
- [x] ~~Regenerate `defaults/.loom/AGENTS.md`~~ — verified unnecessary per
      Curator's analysis: the Troubleshooting section (line 337+) falls
      outside both `agents-md:include:start`/`:end` marker ranges (14-39,
      137-220). Ran `scripts/check-agents-md-sync.sh` anyway to confirm — it
      passes with no changes needed.
- [x] ~~Verify `./scripts/check-claude-md-budget.sh` still passes for
      `defaults/.loom/CLAUDE.md`~~ — verified inapplicable per Curator's
      analysis: that script's `TARGET` is hardcoded to the root `CLAUDE.md`,
      not `defaults/.loom/CLAUDE.md`. Ran it anyway; it passes (checks the
      root file, unaffected by this change).

## Test Plan

- Manual diff of `defaults/.loom/CLAUDE.md`'s Troubleshooting section against
  root `CLAUDE.md`'s — pointer language and target anchor
  (`.loom/docs/troubleshooting.md` → quarantine-safety section) are
  equivalent in substance.
- `bash scripts/check-agents-md-sync.sh` — passes (exit 0).
- `bash scripts/check-claude-md-budget.sh` — passes (exit 0, root CLAUDE.md
  295/320 lines, unaffected by this docs-only edit to a different file).

Closes #5207