### PR TITLE
fix(daemon): reject unregistered dispatch_sweep workspace_root with a structured error

### DIFF
--- a/loom-daemon/src/errors.rs
+++ b/loom-daemon/src/errors.rs
@@ -129,6 +129,7 @@ impl ErrorCode {
     pub const CONFIG_INVALID_VALUE: &'static str = "CONFIG_INVALID_VALUE";
     pub const CONFIG_FILE_NOT_FOUND: &'static str = "CONFIG_FILE_NOT_FOUND";
     pub const CONFIG_WORKSPACE_AMBIGUOUS: &'static str = "CONFIG_WORKSPACE_AMBIGUOUS";
+    pub const CONFIG_WORKSPACE_UNREGISTERED: &'static str = "CONFIG_WORKSPACE_UNREGISTERED";
 
     // Activity database error codes
     pub const ACTIVITY_DB_LOCKED: &'static str = "ACTIVITY_DB_LOCKED";
@@ -409,6 +410,42 @@ impl DaemonError {
         .with_recovery_hint(
             "Specify the target repo explicitly: `loom-daemon dispatch <N> --workspace <path>` \
              (CLI) or `workspace_root` (MCP dispatch_sweep).",
+        )
+    }
+
+    /// Creates a "requested `workspace_root` is not a registered workspace" error.
+    ///
+    /// Companion to [`Self::workspace_ambiguous`] (#4299) for the complementary
+    /// case (#5210): an **explicit** `workspace_root` was passed but does not
+    /// name any workspace the daemon has registered. Left unchecked, dispatch
+    /// falls through to `WorkspacePool::get_or_provision`, which happily
+    /// provisions a registry for any path — including one with no
+    /// `.loom/scripts/spawn-worker.sh` — so the failure only surfaces many
+    /// steps later as an opaque "failed to spawn sweep child".
+    #[must_use]
+    pub fn workspace_unregistered(
+        root: &std::path::Path,
+        registered: &[std::path::PathBuf],
+    ) -> Self {
+        let roots: Vec<String> = registered.iter().map(|p| p.display().to_string()).collect();
+        let root_display = root.display().to_string();
+        let roots_summary = if roots.is_empty() {
+            "no workspaces are registered".to_string()
+        } else {
+            format!("{} workspace(s) are registered ({})", roots.len(), roots.join(", "))
+        };
+        Self::new(
+            ErrorDomain::Configuration,
+            ErrorCode::CONFIG_WORKSPACE_UNREGISTERED,
+            format!(
+                "dispatch target '{root_display}' is not a registered workspace — {roots_summary}"
+            ),
+        )
+        .recoverable(false)
+        .with_details(serde_json::json!({ "requested_root": root_display, "registered": roots }))
+        .with_recovery_hint(
+            "Register the workspace first (`loom-daemon workspace add <path>`), or pass a \
+             `workspace_root` that matches one of the registered roots listed above.",
         )
     }
 

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1922,8 +1922,14 @@ fn resolve_registry(
 /// cwd for the explicit-param-absent case. It consults the on-disk
 /// [`WorkspaceRegistry`] instead:
 ///
-/// - `workspace_root` `Some(non-empty)` -> unchanged: normalize and
-///   provision/return that repo's registry (explicit param always wins).
+/// - `workspace_root` `Some(non-empty)` -> normalize and, if the path is a
+///   **registered** workspace, provision/return that repo's registry
+///   (explicit param always wins over the default). If the normalized path is
+///   *not* registered, returns a structured `workspace_unregistered` error
+///   naming the offending path and every registered root (#5210) instead of
+///   silently provisioning a registry for an arbitrary directory — which
+///   previously surfaced only much later, as an opaque "failed to spawn sweep
+///   child" once `resolve_spawn_bin` found no `spawn-worker.sh` there.
 /// - `workspace_root` `None`/empty -> [`WorkspaceRegistry::resolve_dispatch_root`]
 ///   against the seeded default (`default`'s own `workspace_root`) decides:
 ///   empty registry or seeded-default-is-registered both resolve back to
@@ -1952,6 +1958,24 @@ fn resolve_dispatch_registry(
     if let Some(root) = workspace_root {
         if !root.trim().is_empty() {
             let normalized = crate::workspace_registry::normalize_path(Path::new(root));
+            // #5210: an explicit `workspace_root` must actually be a
+            // registered workspace. Without this check, an unregistered path
+            // (e.g. a typo, or a repo the daemon simply hasn't been told
+            // about) sails straight through `get_or_provision` — which
+            // provisions a registry for *any* path, registered or not — and
+            // the caller only learns something is wrong many steps later,
+            // via an opaque "failed to spawn sweep child" once
+            // `resolve_spawn_bin` can't find `spawn-worker.sh` under the
+            // bogus root.
+            let registry = WorkspaceRegistry::load_default().unwrap_or_default();
+            if !registry.contains(&normalized) {
+                let registered: Vec<std::path::PathBuf> =
+                    registry.workspaces.iter().map(|w| w.root.clone()).collect();
+                return Err(Response::StructuredError(DaemonError::workspace_unregistered(
+                    &normalized,
+                    &registered,
+                )));
+            }
             return Ok(workspace_pool.get_or_provision(&normalized));
         }
     }
@@ -2981,7 +3005,13 @@ fn handle_request(
                 Err(e) => match e.downcast::<crate::runtime_admission::RuntimeRejection>() {
                     Ok(rejection) => Response::RuntimeRejected(rejection),
                     Err(e) => Response::Error {
-                        message: format!("dispatch_sweep failed: {e}"),
+                        // #5210: `{e:#}` (anyhow's alternate Display) walks the
+                        // full `.context()` chain instead of printing only the
+                        // outermost context, so a specific inner failure (e.g.
+                        // `resolve_spawn_bin`'s "spawn-worker.sh not found under
+                        // ...") reaches the MCP client instead of being
+                        // silently collapsed into "failed to spawn sweep child".
+                        message: format!("dispatch_sweep failed: {e:#}"),
                     },
                 },
             }
@@ -4018,6 +4048,12 @@ exit 0
         pool.seed(root_a, sr_default.clone());
         pool.seed(root_b.clone(), sr_b.clone());
 
+        // #5210: an explicit `workspace_root` on DispatchSweep must now name a
+        // *registered* workspace (`seed_temp_registry` is defined below in this
+        // module; it also points `WorkspaceRegistry::load_default()` at a temp
+        // file so this test never touches the real `~/.loom/workspaces.json`).
+        let _guard = seed_temp_registry(&[dir_b.path()]);
+
         // Dispatch issue #42 into repo B explicitly.
         let dispatched = handle_request(
             Request::DispatchSweep {
@@ -4281,6 +4317,126 @@ exit 0
                 );
             }
             other => panic!("Expected StructuredError, got: {other:?}"),
+        }
+    }
+
+    /// Issue #5210, AC #1 — an explicit `workspace_root` that names a path the
+    /// daemon has never registered must return a structured
+    /// `workspace_unregistered` error naming both the offending path and every
+    /// registered root, instead of silently provisioning a registry for an
+    /// arbitrary directory via `get_or_provision`.
+    #[test]
+    #[serial_test::serial]
+    fn test_dispatch_sweep_unregistered_explicit_workspace_root_is_structured_error() {
+        let (tm, db, _, bus) = setup_test_context();
+        let (sr_default, dir_a, _rec_a) = setup_sweep_registry_in_tempdir();
+        let dir_unregistered = tempdir().unwrap();
+        let root_a = crate::workspace_registry::normalize_path(dir_a.path());
+        let unregistered = crate::workspace_registry::normalize_path(dir_unregistered.path());
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(root_a, sr_default.clone());
+
+        // Only repo A is registered; `dir_unregistered` is never added.
+        let _guard = seed_temp_registry(&[dir_a.path()]);
+
+        let dispatched = handle_request(
+            Request::DispatchSweep {
+                kind: SweepKind::Issue(5210),
+                idempotency_key: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                workspace_root: Some(dir_unregistered.path().to_string_lossy().into_owned()),
+                force: false,
+            },
+            &tm,
+            &db,
+            &sr_default,
+            &bus,
+            &pool,
+        );
+        match dispatched {
+            Response::StructuredError(err) => {
+                assert_eq!(err.code.0, crate::errors::ErrorCode::CONFIG_WORKSPACE_UNREGISTERED);
+                assert!(
+                    err.message.contains(&unregistered.display().to_string()),
+                    "error must name the offending unregistered path, got: {}",
+                    err.message
+                );
+                assert!(
+                    err.message.contains(&dir_a.path().display().to_string())
+                        || err
+                            .details
+                            .as_ref()
+                            .and_then(|d| d.get("registered"))
+                            .map(|v| v.to_string())
+                            .unwrap_or_default()
+                            .contains(&dir_a.path().display().to_string()),
+                    "error must list the registered roots, got message={} details={:?}",
+                    err.message,
+                    err.details
+                );
+            }
+            other => panic!("Expected StructuredError, got: {other:?}"),
+        }
+    }
+
+    /// Issue #5210, AC #2/#3 — once an unregistered root is filtered out by AC
+    /// #1, a spawn failure unrelated to registration (a *registered* workspace
+    /// missing `spawn-worker.sh`) must still surface `resolve_spawn_bin`'s
+    /// specific message through `dispatch_sweep failed: {e:#}` — distinct from
+    /// the AC #1 registration error and no longer collapsed into the opaque
+    /// "failed to spawn sweep child" outer context alone.
+    #[test]
+    #[serial_test::serial]
+    fn test_dispatch_sweep_registered_workspace_missing_spawn_bin_surfaces_inner_error() {
+        let (tm, db, _, bus) = setup_test_context();
+        let dir = tempdir().unwrap();
+        // Deliberately do NOT create `.loom/scripts/spawn-worker.sh` (or
+        // `defaults/scripts/spawn-worker.sh`), and leave `spawn_bin` unset —
+        // this workspace IS registered, but is misconfigured.
+        let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        config.skip_label_flip = true; // bypass runtime admission / #4027 guard, not spawn_bin resolution
+        config.journal_path = Some(dir.path().join("test-sweeps-journal.json"));
+        let sr = Arc::new(Mutex::new(SweepRegistry::new(config)));
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        let root = crate::workspace_registry::normalize_path(dir.path());
+        pool.seed(root, sr.clone());
+        let _guard = seed_temp_registry(&[dir.path()]);
+
+        // Isolate from a stray real `LOOM_SWEEP_SPAWN_BIN` in the test env.
+        std::env::remove_var(crate::sweep_registry::SPAWN_BIN_ENV);
+
+        let dispatched = handle_request(
+            Request::DispatchSweep {
+                kind: SweepKind::Issue(5210),
+                idempotency_key: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                workspace_root: Some(dir.path().to_string_lossy().into_owned()),
+                force: false,
+            },
+            &tm,
+            &db,
+            &sr,
+            &bus,
+            &pool,
+        );
+        match dispatched {
+            Response::Error { message } => {
+                assert!(
+                    message.contains("spawn-worker.sh not found under"),
+                    "expected the specific resolve_spawn_bin message to survive `{{e:#}}`, got: {message}"
+                );
+                assert!(
+                    message.contains("failed to spawn sweep child"),
+                    "outer context should still be present alongside the inner detail, got: {message}"
+                );
+            }
+            other => panic!("Expected Response::Error, got: {other:?}"),
         }
     }
 

--- a/mcp-loom/src/tools/sweeps.test.ts
+++ b/mcp-loom/src/tools/sweeps.test.ts
@@ -14,6 +14,7 @@ import {
   extractRuntimeRejection,
   formatDispatchTokenLine,
   formatRuntimeRejection,
+  formatStructuredError,
   type RuntimeRejection,
 } from "./sweeps.js";
 
@@ -121,5 +122,38 @@ describe("formatDispatchTokenLine", () => {
 
   it("renders a real token name unchanged", () => {
     expect(formatDispatchTokenLine("agent3-2amlogic")).toBe("Token:      agent3-2amlogic");
+  });
+});
+
+/**
+ * Issue #5210: `extractError` used to read only `payload?.message` for a
+ * `StructuredError` response, discarding `details`/`recovery_hint` — so a
+ * `workspace_unregistered` error's registered-roots list and "how to fix
+ * this" hint never reached the MCP client. `formatStructuredError` is the
+ * seam that keeps that context attached to the rendered line, mirroring how
+ * `formatRuntimeRejection` (#4494) does the same for `RuntimeRejected`.
+ */
+describe("formatStructuredError", () => {
+  it("appends the recovery hint and details to the base message", () => {
+    const line = formatStructuredError({
+      domain: "configuration",
+      code: "CONFIG_WORKSPACE_UNREGISTERED",
+      message: "dispatch target '/Users/rwalters/GitHub/lean-genius' is not a registered workspace",
+      recoverable: false,
+      details: { requested_root: "/Users/rwalters/GitHub/lean-genius", registered: ["/Users/rwalters/GitHub/loom"] },
+      recovery_hint:
+        "Register the workspace first (`loom-daemon workspace add <path>`), or pass a `workspace_root` that matches one of the registered roots listed above.",
+    });
+    expect(line).toContain("not a registered workspace");
+    expect(line).toContain("Register the workspace first");
+    expect(line).toContain("/Users/rwalters/GitHub/loom");
+  });
+
+  it("degrades to a generic message when everything but message is absent", () => {
+    expect(formatStructuredError({ message: "boom" })).toBe("boom");
+  });
+
+  it("never throws on a fully empty payload", () => {
+    expect(formatStructuredError({})).toBe("Unknown structured error");
   });
 });

--- a/mcp-loom/src/tools/sweeps.ts
+++ b/mcp-loom/src/tools/sweeps.ts
@@ -218,9 +218,25 @@ interface ErrorResponse {
   message?: string;
 }
 
+/**
+ * `DaemonError` (loom-daemon/src/errors.rs) mirrored on the TS side. Every
+ * field but `message` is optional here defensively — the wire payload is
+ * still untyped JSON from the bridge's point of view.
+ */
+export interface StructuredError {
+  domain?: string;
+  code?: string;
+  message?: string;
+  recoverable?: boolean;
+  /** Extra machine-readable context, e.g. `{ registered: string[] }`. */
+  details?: unknown;
+  /** Operator/agent-facing next step, e.g. how to register a workspace. */
+  recovery_hint?: string;
+}
+
 interface StructuredErrorResponse {
   type: "StructuredError";
-  payload: { message?: string };
+  payload: StructuredError;
 }
 
 interface SweepStatusResponse {
@@ -367,6 +383,24 @@ export function formatRuntimeRejection(rejection: RuntimeRejection): string {
   );
 }
 
+/**
+ * Render a `StructuredError` (loom-daemon `DaemonError`) as a single
+ * actionable line (issue #5210). Before this, `extractError` read only
+ * `payload?.message`, so a `workspace_unregistered` (or any other structured)
+ * error's `details`/`recovery_hint` — the registered-roots list, the "how to
+ * fix this" hint — never reached the MCP client, mirroring the same discard
+ * pattern `formatRuntimeRejection` fixed for `RuntimeRejected` in #4494.
+ */
+export function formatStructuredError(payload: StructuredError): string {
+  const base = payload.message || "Unknown structured error";
+  const hint = payload.recovery_hint ? ` ${payload.recovery_hint}` : "";
+  const details =
+    payload.details !== undefined && payload.details !== null
+      ? ` Details: ${JSON.stringify(payload.details)}`
+      : "";
+  return `${base}${hint}${details}`;
+}
+
 function extractError(response: DaemonResponse): string | null {
   if (response.type === "Error") {
     const r = response as ErrorResponse;
@@ -374,7 +408,7 @@ function extractError(response: DaemonResponse): string | null {
   }
   if (response.type === "StructuredError") {
     const r = response as StructuredErrorResponse;
-    return r.payload?.message || "Unknown structured error";
+    return formatStructuredError(r.payload ?? {});
   }
   const rejection = extractRuntimeRejection(response);
   if (rejection) {


### PR DESCRIPTION
## Summary

`mcp__loom__dispatch_sweep` with an explicit `workspace_root` pointing at a repo the daemon does not have registered used to return only an opaque `dispatch_sweep failed: failed to spawn sweep child`. This PR adds a registration check on the explicit-`workspace_root` dispatch path and stops discarding the inner failure detail, so the caller gets a structured, actionable error instead.

## Changes

- **`loom-daemon/src/errors.rs`**: added `DaemonError::workspace_unregistered(root, registered)`, modeled on the existing `workspace_ambiguous` (#4299) precedent — `Configuration`-domain, names the offending path, lists every registered root in `details`, and gives a `recovery_hint` (`loom-daemon workspace add <path>` or pass a registered root).
- **`loom-daemon/src/ipc.rs`**:
  - `resolve_dispatch_registry`'s `Some(root)` branch now loads `WorkspaceRegistry::load_default()` and checks `.contains(&normalized)` before calling `workspace_pool.get_or_provision`; an unregistered root now returns `Response::StructuredError(DaemonError::workspace_unregistered(...))` instead of silently provisioning a registry for an arbitrary directory.
  - `format!("dispatch_sweep failed: {e}")` → `format!("dispatch_sweep failed: {e:#}")` so anyhow's alternate `Display` walks the full `.context()` chain — the specific `resolve_spawn_bin` message ("spawn-worker.sh not found under ...") now reaches the client instead of being silently dropped.
  - Updated `test_sweep_requests_route_to_explicit_workspace_root` to register its target workspace via `seed_temp_registry`, since an explicit `workspace_root` must now be a registered workspace to dispatch successfully.
- **`mcp-loom/src/tools/sweeps.ts`**: added an exported `StructuredError` type mirroring the daemon's `DaemonError`, and a new `formatStructuredError` helper (mirroring the existing `formatRuntimeRejection`/#4494 precedent) that renders `message` + `recovery_hint` + `details` instead of the bare `payload?.message` `extractError` previously read.
- **`mcp-loom/src/tools/sweeps.test.ts`**: unit tests for `formatStructuredError`.

## Acceptance Criteria Verification

- [x] AC #1 — unregistered explicit `workspace_root` returns a structured error naming the offending path and the registered roots: `test_dispatch_sweep_unregistered_explicit_workspace_root_is_structured_error` (loom-daemon).
- [x] AC #2 — spawn failures unrelated to registration carry distinct text: `test_dispatch_sweep_registered_workspace_missing_spawn_bin_surfaces_inner_error` dispatches into a *registered* but misconfigured workspace (no `spawn-worker.sh`) and asserts the resulting error is `resolve_spawn_bin`'s specific message, not the AC #1 registration error — the two stay distinguishable.
- [x] AC #3 — the error reaches the MCP client verbatim: `{e:#}` change on the Rust side plus `formatStructuredError` threading `details`/`recovery_hint` on the TS side (`mcp-loom/src/tools/sweeps.test.ts`).

## Test Plan

- `cargo test` (loom-daemon, full workspace): 3362 + 106 + … tests pass, 0 failed.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `pnpm test` (mcp-loom, vitest): 54 tests pass, including the 3 new `formatStructuredError` tests.
- `pnpm typecheck` / `pnpm build` (mcp-loom): clean.
- Manual reasoning: confirmed `loom-daemon workspace add <path>` is a real CLI command (the recovery hint stays accurate) via `grep` against `workspace_registry.rs`'s doc comment.

Closes #5210