### PR TITLE
fix(champion): make epic-blocker check capability-aware, not label-aware

### DIFF
--- a/defaults/.claude/commands/loom/champion-common.md
+++ b/defaults/.claude/commands/loom/champion-common.md
@@ -117,6 +117,283 @@ PR Lifecycle:
 
 ---
 
+## Epic-Aware Blocker Check (#5211)
+
+**Problem this section fixes**: every "Blocked by / Depends on / Requires #N"
+check elsewhere in Champion (`champion-issue-promo.md`'s Technical Feasibility
+criterion, `champion-epic.md`'s phase-creation gate, `champion-pr-merge.md`'s
+Step 5 unblock scan) reduces the referenced issue to one boolean: `state ==
+OPEN` means still blocked. That is correct for an ordinary issue and silently
+wrong for an **epic** — an epic can sit `OPEN` for months after every one of
+its capability/implementation children has closed and the feature has
+shipped, simply because nobody ran `champion-epic.md`'s "Epic Completion"
+step to close it. A dependent that cites that epic as a blocker then reads as
+blocked forever. This is exactly what happened to 2AMLogic/marketing#56
+against 2AMLogic/klayout-tools#391 (14/15 children closed, the feature
+shipped, the epic still open) across two consecutive Champion passes, and it
+compounded into an unrecoverable **cross-repo** deadlock because the epic's
+one remaining phase happened to depend back on the blocked dependent (the
+cycle itself is out of scope here — see #5213).
+
+**Any Champion workflow that encounters a "Blocked by #N" / "Depends on #N" /
+"Requires #N" style reference to another issue must run this check** — not a
+bare `state == OPEN` read — whenever the referenced issue carries
+`loom:epic`. This works without `LOOM_EPIC_SUPERVISOR` being enabled anywhere
+(that daemon mechanism only reconciles epics inside its own registered
+workspace and cannot see across repos — see
+[`daemon-reference.md`'s "Epic supervisor"](../../../.loom/docs/daemon-reference.md)
+section for how the two complement each other).
+
+### Step 1 — parse the reference (cross-repo aware)
+
+Blocking references in this fleet are frequently cross-repo (the
+marketing#56 → klayout-tools#391 shape) — `owner/repo#N`, not just `#N` in
+the current repo. `gh issue view` does **not** accept the bare `owner/repo#N`
+positional form (`invalid issue format`) — it needs `-R owner/repo <N>` (or a
+full URL), so parsing must split the two:
+
+```bash
+# $1 = a candidate reference string, e.g. "#391" or "2AMLogic/klayout-tools#391"
+# $2 = "owner/repo" Champion is currently running in (used when $1 is bare)
+parse_blocker_ref() {
+  local ref="$1" this_repo="$2"
+  if [[ "$ref" =~ ^([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([0-9]+)$ ]]; then
+    BLOCKER_REPO="${BASH_REMATCH[1]}"
+    BLOCKER_NUM="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^#([0-9]+)$ ]]; then
+    BLOCKER_REPO="$this_repo"
+    BLOCKER_NUM="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+}
+
+# Extraction from a body: generalizes champion-pr-merge.md Step 5's regex to
+# ALSO capture an optional "owner/repo" prefix ahead of the "#N" (#5211) — the
+# existing `grep -Eo "#[0-9]+" | grep -Eo "[0-9]+"` pipeline used elsewhere
+# silently drops any repo prefix and misreads a cross-repo reference as
+# same-repo, which is exactly wrong for the incident this section fixes.
+extract_blocker_refs() {
+  local body="$1"
+  printf '%s\n' "$body" \
+    | grep -Eo '(Blocked by|Depends on|Requires)[*_:[:space:]]*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)' \
+    | grep -Eo '([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)' \
+    | sort -u
+}
+```
+
+### Step 2 — classify the referenced blocker
+
+```bash
+# BLOCKER_REPO / BLOCKER_NUM set by parse_blocker_ref above.
+# Cached ("$GH_READ" if available) — this classifies a dependency, it is not
+# itself a merge/claim gate.
+BLOCKER_JSON=$(gh issue view "$BLOCKER_NUM" --repo "$BLOCKER_REPO" --json state,labels,comments 2>/dev/null)
+BLOCKER_STATE=$(printf '%s\n' "$BLOCKER_JSON" | jq -r '.state // "OPEN"')
+IS_EPIC=$(printf '%s\n' "$BLOCKER_JSON" | jq -e '.labels[] | select(.name=="loom:epic")' >/dev/null && echo yes || echo no)
+
+if [ "$IS_EPIC" != "yes" ]; then
+  EPIC_BLOCK_STATE="not-epic"   # caller falls back to its own plain state==OPEN check
+elif [ "$BLOCKER_STATE" = "CLOSED" ]; then
+  EPIC_BLOCK_STATE="resolved"   # already closed — dependency satisfied
+else
+  # Walk EVERY phase's children, not just one — generalizes champion-epic.md's
+  # "Detecting Phase Completion" (which deliberately scopes to a single PHASE
+  # number for the "should I create phase N+1" question) to the "is this whole
+  # epic's delivered capability done" question instead. One list call per
+  # epic, filtered locally, rather than one `gh issue list --search=...` call
+  # per phase.
+  CHILDREN=$(gh issue list --repo "$BLOCKER_REPO" --label="loom:epic-phase" --state=all --limit=500 \
+    --json number,state,body \
+    --jq --arg marker "loom:epic:$BLOCKER_NUM:phase:" \
+      '[.[] | select(.body | contains($marker))]')
+  OPEN_COUNT=$(printf '%s\n' "$CHILDREN" | jq '[.[] | select(.state=="OPEN")] | length')
+  CLOSED_COUNT=$(printf '%s\n' "$CHILDREN" | jq '[.[] | select(.state=="CLOSED")] | length')
+
+  if [ "$OPEN_COUNT" -gt 0 ]; then
+    EPIC_BLOCK_STATE="blocked-in-progress"        # genuinely still working — keep blocking, no change here
+  elif [ "$CLOSED_COUNT" -eq 0 ]; then
+    EPIC_BLOCK_STATE="blocked-not-started"        # no phase children created yet — keep blocking, no change here
+  else
+    EPIC_BLOCK_STATE="epic-complete-unpromoted"   # OPEN_COUNT==0 AND CLOSED_COUNT>0: the trap state (#5211)
+  fi
+fi
+```
+
+`CLOSED_COUNT == 0` (not just `OPEN_COUNT == 0`) gates `blocked-not-started` —
+an epic that has never been decomposed has `OPEN_COUNT == 0` vacuously and
+must **not** be misread as complete.
+
+**Only `epic-complete-unpromoted` changes any caller's behavior.**
+`blocked-not-started` and `blocked-in-progress` are the common, correct case
+— a caller keeps blocking on those exactly as it did before this check
+existed. This is what keeps AC "must not weaken the correct common case"
+true: this section adds a new outcome, it does not touch the existing ones.
+
+### Step 3 — fingerprint the blocker's observed state (idempotency key)
+
+Key the marker to the **blocker's own state**, not the dependent's body — the
+dependent's text is typically unchanged for weeks while a cross-repo epic
+ships underneath it, so body-hash keying (as used elsewhere for
+unrevised-*proposal* detection, see `champion-issue-promo.md`'s "Concurrency
+Guard and Idempotency") would freeze on the wrong verdict forever if reused
+here: the thing that must change to unstick this check is the *blocker's*
+state, not the dependent's text (#5211).
+
+```bash
+# Portable sha256 — same fallback shape used elsewhere in this repo's scripts
+# and in champion-issue-promo.md's idempotency check.
+_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum
+  elif command -v shasum >/dev/null 2>&1; then shasum -a 256
+  else cksum; fi
+}
+
+BLOCKER_LABELS=$(printf '%s\n' "$BLOCKER_JSON" | jq -r '[.labels[].name] | sort | join(",")')
+FINGERPRINT_SRC="$BLOCKER_REPO#$BLOCKER_NUM|$BLOCKER_STATE|$BLOCKER_LABELS|open=$OPEN_COUNT|closed=$CLOSED_COUNT"
+FINGERPRINT=$(printf '%s' "$FINGERPRINT_SRC" | _sha256 | awk '{print substr($1,1,16)}')
+EPIC_BLOCK_MARKER="<!-- champion:epic-block:$BLOCKER_REPO#$BLOCKER_NUM:$FINGERPRINT -->"
+```
+
+### Step 4 — act on the classification (idempotent, bounded escalation)
+
+Only reached when `EPIC_BLOCK_STATE = "epic-complete-unpromoted"`. Run
+against the **dependent** issue/PR being evaluated in the current repo
+(`DEPENDENT_ISSUE`) — the caller (`champion-issue-promo.md` /
+`champion-epic.md`) sets this before invoking Step 4.
+
+```bash
+DEPENDENT_ISSUE=<the issue/PR being evaluated, in the CURRENT repo>
+
+# Terminal state check first — never re-comment or re-tally once a human owns this.
+ALREADY_ROUTED=$(gh issue view "$DEPENDENT_ISSUE" --json labels --jq \
+  '.labels[] | select(.name=="loom:operator-only")' 2>/dev/null)
+if [ -n "$ALREADY_ROUTED" ]; then
+  echo "#$DEPENDENT_ISSUE already routed to loom:operator-only — skip silently"
+else
+  # REST, not `gh issue view` — only the REST payload has the numeric comment
+  # id the PATCH below needs (the `gh issue view --json comments` id is a
+  # GraphQL node id and cannot be PATCHed). Same rationale as
+  # champion-issue-promo.md's idempotency check.
+  FLAG_COMMENT=$(gh api "repos/{owner}/{repo}/issues/$DEPENDENT_ISSUE/comments" --paginate \
+    --jq ".[] | select(.body | contains(\"$EPIC_BLOCK_MARKER\"))" | jq -s 'last')
+  FLAG_COMMENT_ID=$(printf '%s\n' "$FLAG_COMMENT" | jq -r '.id // empty')
+  FLAG_COMMENT_BODY=$(printf '%s\n' "$FLAG_COMMENT" | jq -r '.body // ""')
+
+  if [ -n "$FLAG_COMMENT_ID" ]; then
+    # Same fingerprint seen before — read the streak this marker has already
+    # recorded (mirrors champion-issue-promo.md's unrevised-skips counter).
+    STREAK=$(printf '%s' "$FLAG_COMMENT_BODY" \
+      | sed -n "s|.*<!-- champion:epic-block-streak:$FINGERPRINT:\([0-9]\{1,\}\) -->.*|\1|p" | tail -n 1)
+    STREAK=${STREAK:-1}
+    NEXT_STREAK=$(( STREAK + 1 ))
+
+    if [ "$NEXT_STREAK" -ge "${LOOM_MAX_UNCHANGED_EPIC_BLOCK_EVALS:-2}" ]; then
+      # Budget exhausted: this unchanged state has now been observed
+      # LOOM_MAX_UNCHANGED_EPIC_BLOCK_EVALS times without the epic being
+      # closed/promoted — escalate instead of tallying again.
+      gh issue comment "$DEPENDENT_ISSUE" --body "$EPIC_BLOCK_MARKER
+**Champion: Escalating — Blocked on an Epic That Appears Complete**
+
+\`$BLOCKER_REPO#$BLOCKER_NUM\` still carries \`loom:epic\` and is still open,
+but $CLOSED_COUNT of its \`loom:epic-phase\` children are closed and none are
+open — and this state has now been observed unchanged across $NEXT_STREAK
+evaluations. This is not a live blocker; it needs an operator to close or
+promote \`$BLOCKER_REPO#$BLOCKER_NUM\`.
+
+---
+*Automated by Champion role*" \
+        && gh issue edit "$DEPENDENT_ISSUE" --add-label "loom:operator-only"
+    else
+      # Still within budget: tally the streak IN PLACE (PATCH, no new
+      # comment/notification) and keep not-gating on this reference.
+      if printf '%s' "$FLAG_COMMENT_BODY" | grep -q "<!-- champion:epic-block-streak:$FINGERPRINT:"; then
+        NEW_BODY=$(printf '%s' "$FLAG_COMMENT_BODY" \
+          | sed "s|<!-- champion:epic-block-streak:$FINGERPRINT:[0-9]\{1,\} -->|<!-- champion:epic-block-streak:$FINGERPRINT:$NEXT_STREAK -->|")
+      else
+        NEW_BODY=$(printf '%s\n\n%s' "$FLAG_COMMENT_BODY" "<!-- champion:epic-block-streak:$FINGERPRINT:$NEXT_STREAK -->")
+      fi
+      gh api --method PATCH "repos/{owner}/{repo}/issues/comments/$FLAG_COMMENT_ID" \
+        -f body="$NEW_BODY" >/dev/null
+      echo "#$DEPENDENT_ISSUE: unchanged epic-block fingerprint $FINGERPRINT, streak $NEXT_STREAK/${LOOM_MAX_UNCHANGED_EPIC_BLOCK_EVALS:-2} — not gating, no new comment"
+    fi
+  else
+    # First time seeing this exact fingerprint: flag it, but do not keep
+    # gating on it — this is the mechanism AC #1/#2 (#5211) ask for.
+    gh issue comment "$DEPENDENT_ISSUE" --body "$EPIC_BLOCK_MARKER
+<!-- champion:epic-block-streak:$FINGERPRINT:1 -->
+**Champion: Epic Blocker Appears Complete — Not Treated as a Live Block**
+
+\`$BLOCKER_REPO#$BLOCKER_NUM\` is referenced as a blocker but all $CLOSED_COUNT
+of its \`loom:epic-phase\` children are closed and none are open — the epic's
+capability work looks delivered even though the epic issue itself is still
+open (label state, not delivered capability, per #5211). Not gating on this
+reference this pass. If \`$BLOCKER_REPO#$BLOCKER_NUM\` is genuinely still
+incomplete, reopen the discussion there — otherwise it should be
+closed/promoted.
+
+---
+*Automated by Champion role*"
+
+    # Best-effort: also flag the epic itself for close/promote review, once —
+    # a separate marker (not the fingerprint one, which is scoped to THIS
+    # dependent) so repeated dependents referencing the same epic don't each
+    # re-flag it.
+    EPIC_FLAG_MARKER="<!-- champion:epic-appears-complete -->"
+    if ! printf '%s\n' "$BLOCKER_JSON" | jq -e --arg m "$EPIC_FLAG_MARKER" \
+         '.comments[] | select(.body | contains($m))' >/dev/null; then
+      gh issue comment "$BLOCKER_NUM" --repo "$BLOCKER_REPO" --body "$EPIC_FLAG_MARKER
+**Champion: This Epic Appears Complete**
+
+All $CLOSED_COUNT \`loom:epic-phase\` children found for this epic are closed
+and none are open, but this issue is still open and still carries
+\`loom:epic\`. A dependent (\`$DEPENDENT_ISSUE\`, possibly in a different repo)
+was blocked on this reference. Please review for close/promote (see
+\`champion-epic.md\` → \"Epic Completion\").
+
+---
+*Automated by Champion role*"
+    fi
+  fi
+fi
+```
+
+`LOOM_MAX_UNCHANGED_EPIC_BLOCK_EVALS` (default **2**) — bounds how many times
+the *identical* blocker fingerprint can be silently re-observed before
+escalating, mirroring `LOOM_MAX_UNREVISED_EVALUATIONS`'s naming/default
+convention in `champion-issue-promo.md`. A **changed** fingerprint (the epic
+closed, gained an open child again, etc.) computes a different
+`EPIC_BLOCK_MARKER` entirely, so it is treated as new — the streak resets by
+construction rather than by an explicit reset step.
+
+**Invariants a future edit must preserve** (mirrors
+`champion-issue-promo.md`'s "Bounding the silent skip" for the same reason):
+
+- Comment budget for a persistently-unresolved `epic-complete-unpromoted`
+  state is bounded, not unbounded: one flag comment, then only silent
+  in-place `PATCH` tallies (no new comment, no notification) until
+  `LOOM_MAX_UNCHANGED_EPIC_BLOCK_EVALS` (default 2) is reached, then exactly
+  one escalation comment — total **2 comments on the dependent at the default
+  threshold**, plus at most 1 on the epic itself (shared across every
+  dependent that references it) — never a fresh comment every pass.
+- `blocked-not-started` / `blocked-in-progress` never enter this step at all
+  — they are not new behavior, so they carry none of this section's comment
+  or label overhead.
+- `ALREADY_ROUTED=yes` short-circuits everything — a dependent already
+  carrying `loom:operator-only` from this mechanism is never re-tallied or
+  re-escalated.
+- This check must run **independently of** any body-hash-keyed idempotency
+  skip a caller applies to itself (e.g. `champion-issue-promo.md`'s unrevised-
+  proposal skip). A dependent's own text can stay byte-identical for weeks
+  while the *blocker's* fingerprint changes underneath it (an epic finishing
+  its remaining phase) — a caller that lets its own body-hash skip suppress
+  this check entirely would silently freeze on a stale verdict even after the
+  epic resolves. Run this check first, every pass, then let the caller's own
+  idempotency govern only the parts of its evaluation this check did not
+  already resolve.
+
+---
+
 ## Terminal Probe Protocol
 
 When you receive a probe command, respond with: `AGENT:Champion:<brief-task>` — e.g. `AGENT:Champion:merging-PR-123`.

--- a/defaults/.claude/commands/loom/champion-common.md
+++ b/defaults/.claude/commands/loom/champion-common.md
@@ -173,10 +173,21 @@ parse_blocker_ref() {
 # existing `grep -Eo "#[0-9]+" | grep -Eo "[0-9]+"` pipeline used elsewhere
 # silently drops any repo prefix and misreads a cross-repo reference as
 # same-repo, which is exactly wrong for the incident this section fixes.
+#
+# Two-stage shape (matches the sibling parsers guide.md's parse_dependencies,
+# sweep.md's --auto-stack detector, and warn-out-of-set-deps.sh): stage 1
+# selects the whole matching LINE (grep -E, no -o) containing the phrase;
+# stage 2 extracts every ref (bare #N or owner/repo#N) found on that line.
+# A single-stage `grep -Eo` anchored to the phrase AND its immediately
+# following #N can only ever match one ref per phrase occurrence, silently
+# dropping every other comma-separated ref on the same line (e.g.
+# "Blocked by: #1 (x), #3 (y)" would yield only #1) — under-parsing here is
+# the highest-severity failure mode (see champion-pr-merge.md Step 5's own
+# comment on ALL_DEPS), so the two-stage shape is load-bearing, not stylistic.
 extract_blocker_refs() {
   local body="$1"
   printf '%s\n' "$body" \
-    | grep -Eo '(Blocked by|Depends on|Requires)[*_:[:space:]]*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)' \
+    | grep -E '(Blocked by|Depends on|Requires)[*_:[:space:]]*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)' \
     | grep -Eo '([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)' \
     | sort -u
 }

--- a/defaults/.claude/commands/loom/champion-common.md
+++ b/defaults/.claude/commands/loom/champion-common.md
@@ -141,7 +141,7 @@ bare `state == OPEN` read — whenever the referenced issue carries
 `loom:epic`. This works without `LOOM_EPIC_SUPERVISOR` being enabled anywhere
 (that daemon mechanism only reconciles epics inside its own registered
 workspace and cannot see across repos — see
-[`daemon-reference.md`'s "Epic supervisor"](../../../.loom/docs/daemon-reference.md)
+[`daemon-reference.md`'s "Epic supervisor"](https://github.com/rjwalters/loom/blob/main/defaults/docs/daemon-reference.md#epic-supervisor-3842)
 section for how the two complement each other).
 
 ### Step 1 — parse the reference (cross-repo aware)
@@ -186,9 +186,12 @@ extract_blocker_refs() {
 
 ```bash
 # BLOCKER_REPO / BLOCKER_NUM set by parse_blocker_ref above.
-# Cached ("$GH_READ" if available) — this classifies a dependency, it is not
-# itself a merge/claim gate.
-BLOCKER_JSON=$(gh issue view "$BLOCKER_NUM" --repo "$BLOCKER_REPO" --json state,labels,comments 2>/dev/null)
+# Cached (${GH_READ:-gh}) — this classifies a dependency, it is not itself a
+# merge/claim gate, so a cached read is fine. ${GH_READ:-gh} uses the caller's
+# 30s-TTL cached reader when it has defined one (champion-pr-merge.md,
+# champion-issue-promo.md) and falls back to plain `gh` otherwise — this file is
+# shared, so it must not assume $GH_READ is always set.
+BLOCKER_JSON=$(${GH_READ:-gh} issue view "$BLOCKER_NUM" --repo "$BLOCKER_REPO" --json state,labels,comments 2>/dev/null)
 BLOCKER_STATE=$(printf '%s\n' "$BLOCKER_JSON" | jq -r '.state // "OPEN"')
 IS_EPIC=$(printf '%s\n' "$BLOCKER_JSON" | jq -e '.labels[] | select(.name=="loom:epic")' >/dev/null && echo yes || echo no)
 
@@ -202,8 +205,9 @@ else
   # number for the "should I create phase N+1" question) to the "is this whole
   # epic's delivered capability done" question instead. One list call per
   # epic, filtered locally, rather than one `gh issue list --search=...` call
-  # per phase.
-  CHILDREN=$(gh issue list --repo "$BLOCKER_REPO" --label="loom:epic-phase" --state=all --limit=500 \
+  # per phase. Cached (${GH_READ:-gh}) — a classification read, same rationale
+  # as the BLOCKER_JSON read above; falls back to plain `gh` when unset.
+  CHILDREN=$(${GH_READ:-gh} issue list --repo "$BLOCKER_REPO" --label="loom:epic-phase" --state=all --limit=500 \
     --json number,state,body \
     --jq --arg marker "loom:epic:$BLOCKER_NUM:phase:" \
       '[.[] | select(.body | contains($marker))]')

--- a/defaults/.claude/commands/loom/champion-epic.md
+++ b/defaults/.claude/commands/loom/champion-epic.md
@@ -79,9 +79,44 @@ Read the full epic body, noting phases, issues, and dependencies.
 
 Check each of the 6 criteria above. If ANY criterion fails, skip to Step 4 (rejection).
 
+### Step 2.5: Epic-Aware Blocker Check Before Creating Phase Issues (#5211)
+
+An epic's own phase description sometimes names an external blocker — e.g.
+"Phase 1 — Blocked by: `owner/repo#N`" — pointing at another issue, often
+another epic, sometimes in a different repo entirely (the incident that
+motivated this section: 2AMLogic/marketing#56's Phase 1 named
+2AMLogic/klayout-tools#391 as its blocker). **Do not read that reference as a
+bare `state == OPEN` check** — an epic can sit open for months after every one
+of its capability children has closed and shipped, simply because nobody ran
+"Epic Completion" below to close it. Treating that as a live block twice
+(2026-08-04, 01:33 and 02:10) is exactly what turned into an unrecoverable
+cross-repo deadlock in the incident this section fixes.
+
+If the phase you are about to create issues for (Step 3, or a later phase
+under "Phase Progression") names such a reference:
+
+1. Read `champion-common.md` → "Epic-Aware Blocker Check" if you have not
+   already loaded it this pass.
+2. `extract_blocker_refs` the phase's dependency text, `parse_blocker_ref`
+   each match (cross-repo aware), and classify each with that section's Step
+   2.
+3. Act on the classification, with `DEPENDENT_ISSUE` = **this epic** (the one
+   whose phase creation you are deciding) in Step 4 of that section:
+
+| `EPIC_BLOCK_STATE` | Action |
+|---|---|
+| `not-epic` | Unchanged — plain state check (`OPEN` holds the phase, `CLOSED` proceeds) |
+| `resolved` | Proceed to Step 3 / next-phase creation as normal |
+| `blocked-not-started` / `blocked-in-progress` | Genuine, unresolved blocker — hold this phase (comment + keep `loom:epic`), exactly as before this section existed |
+| `epic-complete-unpromoted` | **Proceed to Step 3 / next-phase creation anyway.** Unlike a proposal in `champion-issue-promo.md` (which can only pass or fail a promotion decision), Champion evaluating an epic already has standing authority to create phase issues directly — so here the constructive action *is* "unblock and proceed", not just "stop failing the check". The shared check still posts its flag/escalation comments on this epic (as `DEPENDENT_ISSUE`) and on the referenced epic, exactly as documented in `champion-common.md` Step 4, so the trail is preserved even though this epic itself is not held |
+
+This changes behavior only for `epic-complete-unpromoted` — an epic whose
+external blocker is genuinely still in progress or not yet decomposed
+continues to hold exactly as it did before this section existed.
+
 ### Step 3: Approve and Create Phase 1 Issues
 
-If all 6 criteria pass:
+If all 6 criteria pass (and Step 2.5 above did not hold this phase):
 
 > **Serialize this phase-issue creation loop against any other issue-creating agent (#3707).** Do not run the `gh issue create` loop below while another issue-creating agent (Architect / Curator-decomposition / another Champion epic-phase run) is filing issues in the same repo — concurrent `gh issue create` bursts race on server-assigned issue numbers and cross-contaminate bodies. One filer must finish its full burst before the next starts. See `sweep.md` → "Execution Model → Only Builders parallelize" for the invariant.
 
@@ -164,7 +199,20 @@ Keeping \`loom:epic\` label. The Architect can revise and resubmit.
 
 When all issues in a phase are closed, Champion creates the next phase's issues.
 
+**Before creating the next phase's issues, re-run "Step 2.5: Epic-Aware
+Blocker Check Before Creating Phase Issues" above** if that phase's own
+description names an external "Blocked by" reference — the same trap applies
+at any phase boundary, not just Phase 1.
+
 ### Detecting Phase Completion
+
+This checks whether **this epic's own** Phase N children are all closed, in
+order to decide whether to create Phase N+1. It is deliberately scoped to one
+phase at a time. `champion-common.md` → "Epic-Aware Blocker Check" Step 2
+generalizes the same query across **every** phase of a *different* epic that
+this one names as a blocker, to answer "is that epic's delivered capability
+done" rather than "should I create the next phase of this one" — read that
+section, not this one, when evaluating a blocker reference (#5211).
 
 ```bash
 # Check if all Phase N issues for an epic are closed

--- a/defaults/.claude/commands/loom/champion-issue-promo.md
+++ b/defaults/.claude/commands/loom/champion-issue-promo.md
@@ -165,6 +165,28 @@ For each proposal issue (`loom:curated`, `loom:architect`, `loom:hermit`, or `lo
 - [ ] Declared blockers are *resolvable* — not a dependency cycle (see "Dependency-cycle gate" below)
 - [ ] Fits within existing architecture
 
+#### Epic-aware blocker sub-check (#5211)
+
+Before scoring "No obvious blockers or dependencies", scan the issue body for
+"Blocked by" / "Depends on" / "Requires" references (`extract_blocker_refs` in
+`champion-common.md` → "Epic-Aware Blocker Check" — read that section now if
+any such reference is found; it also covers cross-repo `owner/repo#N`
+references, not just bare `#N` in this repo). For each reference found, run
+that check (`parse_blocker_ref` → Step 2 classification) instead of a bare
+`gh issue view $dep --json state` read:
+
+| `EPIC_BLOCK_STATE` | Effect on this criterion |
+|---|---|
+| `not-epic` | Unchanged — plain state check applies (`OPEN` fails the criterion, `CLOSED` does not) |
+| `resolved` | Not a blocker — criterion unaffected |
+| `blocked-not-started` / `blocked-in-progress` | Genuine, unresolved blocker — criterion **fails**, same as before this section existed |
+| `epic-complete-unpromoted` | **Do not fail the criterion on this reference.** The shared check already posts (at most) one flag comment the first time it sees this exact blocker state and escalates to `loom:operator-only` on the next unchanged occurrence (see `champion-common.md` Step 4) — this evaluation does not re-block or re-comment beyond what that check already does |
+
+This is the only change this issue makes to criterion 2 — an issue whose
+*only* obstacle is an epic reference in the `epic-complete-unpromoted` state
+can now proceed to promotion (if every other criterion also passes) instead
+of failing indefinitely on a blocker that has, in substance, already shipped.
+
 #### Dependency-cycle gate (#5213)
 
 The "no obvious blockers or dependencies" check above is **single-hop and
@@ -278,6 +300,18 @@ Use conservative judgment. **Do NOT promote** if:
 **Applies to every proposal evaluated by this file** — `loom:curated`, `loom:architect`, `loom:hermit`, and `loom:auditor` alike — not just the `loom:architect` case that surfaced it.
 
 **The idempotency skip and the escalation threshold are one mechanism, not two** (#4967). Suppressing duplicate comments must never suppress the escalation that eventually puts a stuck proposal in front of a human — read "Bounding the silent skip" below before changing either half.
+
+**Does not shadow the Epic-Aware Blocker Check (#5211)**: this section's skip
+is keyed to a hash of the *proposal's own* title + body, which is exactly
+correct for detecting "has the proposal been revised" — but a dependent
+citing an epic as a blocker can sit at an unchanged body hash for weeks while
+the *epic* underneath it finishes. If the "Epic-aware blocker sub-check"
+under criterion 2 runs, it must run on **every** pass regardless of whether
+this section's marker match would otherwise skip silently — the two markers
+are independent (`champion:proposal-verdict:body-*` here vs.
+`champion:epic-block:*` in `champion-common.md`), and only the latter is
+keyed to the blocker's own state, so only the latter can detect a resolved
+blocker under an unrevised proposal body.
 
 ### Idempotency check (run BEFORE claiming — skip silently on a match, until the skips are capped)
 

--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -854,6 +854,27 @@ done
 
 After verifying issue closure, check for blocked issues that can now be unblocked.
 
+**Epic-aware dependency check (#5211).** This is *the* call site named first
+under "Affected Files" in issue #5211 — the bare `state != CLOSED` read below
+was the exact check that ran during the incident. For every `Blocked by /
+Depends on / Requires` reference on a `loom:blocked` issue, run
+`champion-common.md` → "Epic-Aware Blocker Check" (`extract_blocker_refs` →
+`parse_blocker_ref` → Step 2 classification — read that section now if any such
+reference is found; it also covers cross-repo `owner/repo#N` references, not
+just bare `#N`) instead of a bare `gh issue view $dep --json state` read. Act on
+`EPIC_BLOCK_STATE` per this table:
+
+| `EPIC_BLOCK_STATE` | Effect on unblocking `#$blocked` |
+|---|---|
+| `not-epic` | Unchanged — plain `state` check applies (`OPEN` keeps it blocked, `CLOSED` does not) |
+| `resolved` | Epic already closed — dependency satisfied, does not keep it blocked |
+| `blocked-not-started` / `blocked-in-progress` | Genuine, unresolved blocker — keeps `#$blocked` blocked, same as before this section existed |
+| `epic-complete-unpromoted` | **Do not treat this reference as a live block.** Run `champion-common.md` Step 4 with `DEPENDENT_ISSUE="$blocked"` (idempotent flag → bounded escalation) and let the *other* dependencies decide whether `#$blocked` unblocks — an issue whose only remaining obstacle is an epic whose `loom:epic-phase` children have all closed no longer stays blocked forever via this path |
+
+Only `epic-complete-unpromoted` changes behavior here — the common
+`blocked-not-started` / `blocked-in-progress` / `not-epic` cases keep blocking
+exactly as before, so the correct common case is not weakened.
+
 ```bash
 PR_NUMBER=$1
 CLOSED_ISSUE=$2
@@ -878,25 +899,59 @@ for blocked in $BLOCKED_ISSUES; do
   # Get the issue body to check ALL dependencies
   BLOCKED_BODY=$("$GH_READ" issue view "$blocked" --json body --jq '.body')
 
-  # Extract all referenced dependencies. Two-stage (#4508): stage 1 selects
-  # lines declaring a dependency phrase, tolerant of markdown emphasis/colon
-  # between the phrase and the first #N (e.g. "**Blocked by:** #1 (x), #3
-  # (y)"); stage 2 extracts every #N on those lines, not just the first — an
-  # empty ALL_DEPS here would silently remove loom:blocked with no
-  # confirmation gate, so under-parsing is the highest-severity failure mode.
-  ALL_DEPS=$(echo "$BLOCKED_BODY" | grep -E "(Blocked by|Depends on|Requires)[*_:[:space:]]*#[0-9]+" | grep -Eo "#[0-9]+" | grep -Eo "[0-9]+" | sort -u)
+  # Extract all referenced dependencies — cross-repo aware (#5211). Use
+  # `extract_blocker_refs` from champion-common.md → "Epic-Aware Blocker Check"
+  # Step 1: it generalizes the old two-stage `#N`-only pipeline (#4508) to ALSO
+  # capture an optional `owner/repo` prefix ahead of the `#N`, so a cross-repo
+  # epic blocker (the marketing#56 → klayout-tools#391 incident shape) is not
+  # misread as same-repo. It stays tolerant of markdown emphasis/colon and
+  # extracts every reference on a dependency line. An empty ALL_DEPS here would
+  # silently remove loom:blocked with no confirmation gate, so under-parsing is
+  # the highest-severity failure mode.
+  ALL_DEPS=$(extract_blocker_refs "$BLOCKED_BODY")
 
-  # Check if ALL dependencies are now closed
+  # owner/repo this Champion is running in — the fallback for bare `#N` refs.
+  # Derived from the git remote with zero API calls; NOT `gh repo view --json
+  # nameWithOwner`, which is GraphQL-backed and fails first under the exhaustion
+  # this path must survive.
+  THIS_REPO=$(git remote get-url origin 2>/dev/null \
+    | sed -E 's#^(git@[^:]+:|https?://[^/]+/)##; s#\.git$##')
+
+  # Check whether ALL dependencies are now resolved. For each reference, run the
+  # shared Epic-Aware Blocker Check (champion-common.md Step 1→2) instead of a
+  # bare `state != CLOSED` read, so an epic whose loom:epic-phase children have
+  # all closed (but which is itself still open) is not treated as a live block.
   ALL_RESOLVED=true
-  # Plain `gh` — NOT "$GH_READ": a stale CLOSED here removes `loom:blocked`
-  # from a still-blocked issue, the highest-severity failure mode in this block.
-  for dep in $ALL_DEPS; do
-    DEP_STATE=$(gh issue view "$dep" --json state --jq '.state' 2>/dev/null)
-    if [ "$DEP_STATE" != "CLOSED" ]; then
-      echo "  Still blocked: dependency #$dep is still open"
-      ALL_RESOLVED=false
-      break
-    fi
+  for ref in $ALL_DEPS; do
+    parse_blocker_ref "$ref" "$THIS_REPO" || continue
+    # Run champion-common.md → "Epic-Aware Blocker Check" Step 2 for
+    # BLOCKER_REPO/BLOCKER_NUM here — it sets EPIC_BLOCK_STATE.
+    case "$EPIC_BLOCK_STATE" in
+      resolved)
+        : ;;  # epic already closed — dependency satisfied
+      epic-complete-unpromoted)
+        # All loom:epic-phase children closed but the epic itself still open:
+        # the trap state (#5211). Do NOT treat this reference as a live block —
+        # run champion-common.md Step 4 (idempotent flag → bounded escalation)
+        # with DEPENDENT_ISSUE="$blocked", and let the other deps decide.
+        DEPENDENT_ISSUE="$blocked"
+        echo "  #$blocked: epic blocker $BLOCKER_REPO#$BLOCKER_NUM appears complete — not gating (see champion-common.md Step 4)"
+        ;;
+      blocked-not-started|blocked-in-progress)
+        echo "  Still blocked: epic dependency $BLOCKER_REPO#$BLOCKER_NUM still has open (or no) phase children"
+        ALL_RESOLVED=false
+        break ;;
+      *)
+        # not-epic (or unclassified): the original plain state check. Plain `gh`
+        # — NOT "$GH_READ": a stale CLOSED here removes `loom:blocked` from a
+        # still-blocked issue, the highest-severity failure mode in this block.
+        DEP_STATE=$(gh issue view "$BLOCKER_NUM" --repo "$BLOCKER_REPO" --json state --jq '.state' 2>/dev/null)
+        if [ "$DEP_STATE" != "CLOSED" ]; then
+          echo "  Still blocked: dependency $BLOCKER_REPO#$BLOCKER_NUM is still open"
+          ALL_RESOLVED=false
+          break
+        fi ;;
+    esac
   done
 
   # "Still blocked" is only a valid conclusion if waiting can ever end. Run the

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -1952,6 +1952,31 @@ epic-action topic — those dispatches already surface on the frozen
 epic-supervisor action across all epics, or `epic.issue.{N}` for one epic
 (segment-aligned prefix match, same routing rule as the sweep topics).
 
+### Cross-repo/cross-workspace complement: the Champion-side blocker check (#5211)
+
+The supervisor above only reconciles epics **inside its own registered
+workspace** — it can compute `epic:done` and auto-close an epic the moment its
+last phase child closes, but only for an epic living in a repo where this
+supervisor is itself enabled and running. It has no way to reach into a
+*different* repo's epic before that repo's own dependent evaluates whether the
+epic still blocks it — the exact cross-repo shape of the incident that
+motivated #5211 (2AMLogic/marketing#56 blocked on 2AMLogic/klayout-tools#391,
+two different repos, neither running this supervisor).
+
+`champion-common.md` → "Epic-Aware Blocker Check", wired into
+`champion-issue-promo.md`'s Technical Feasibility criterion and
+`champion-epic.md`'s phase-creation gate, closes that gap independently of
+this supervisor: it asks the same "are this epic's phase children all closed"
+question directly against the blocker's `loom:epic-phase` children **at
+evaluation time, from the repo doing the evaluating** — no daemon
+configuration required in the blocker's own repo, and it works whether or not
+`LOOM_EPIC_SUPERVISOR` is set anywhere. The two are complementary rather than
+substitutes: enabling this supervisor in an epic's own repo prevents the trap
+at the source (a `Done` epic auto-closes before anything downstream can even
+cite it as unpromoted); the Champion-side check is what actually resolves the
+trap once it has already occurred, including across a repo boundary this
+supervisor cannot cross.
+
 ## Autonomous work finder (#3810)
 
 The **work finder** (Phase A of epic #3809,

--- a/defaults/scripts/tests/test-dependency-parse.sh
+++ b/defaults/scripts/tests/test-dependency-parse.sh
@@ -118,11 +118,17 @@ sweep_auto_stack_detect() {
 # helper is cross-repo aware: it captures an optional `owner/repo` prefix
 # ahead of the `#N` and (unlike the old bare-`#N` pipeline) returns each
 # reference WITH its `#`/`owner/repo#` form rather than a stripped number.
+# Two-stage shape (matches guide.md/sweep.md/warn-out-of-set-deps.sh):
+# stage 1 selects the whole matching line (grep -E, no -o), stage 2
+# extracts every ref found on that line — a single-stage `grep -Eo`
+# anchored to the phrase + its immediately-following #N can only ever
+# match one ref per phrase occurrence, silently dropping every other
+# comma-separated ref on the same line.
 # =====================================================================
 champion_all_deps() {
     local blocked_body="$1"
     printf '%s\n' "$blocked_body" \
-        | grep -Eo '(Blocked by|Depends on|Requires)[*_:[:space:]]*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)' \
+        | grep -E '(Blocked by|Depends on|Requires)[*_:[:space:]]*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)' \
         | grep -Eo '([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)' \
         | sort -u
 }
@@ -185,6 +191,12 @@ assert_eq $'#7\n#8\n#9' "$out" "plain unformatted forms (no regression)"
 out="$(champion_all_deps 'Depends on owner/repo#42')"
 assert_eq 'owner/repo#42' "$out" "cross-repo owner/repo#N reference is preserved (#5211)"
 
+out="$(champion_all_deps '**Blocked by:** #1 (x), #3 (y)')"
+assert_eq $'#1\n#3' "$out" "bold+colon comma-list captures ALL refs, not just the first (regression guard)"
+
+out="$(champion_all_deps 'Blocked by: #1, owner/repo#3')"
+assert_eq $'#1\nowner/repo#3' "$out" "mixed same-repo/cross-repo comma-list captures both refs"
+
 echo
 echo "--- champion-pr-merge.md BLOCKED_ISSUES jq filter: widened separator ---"
 
@@ -228,8 +240,8 @@ assert_doc_contains "$CHAMPION_MD" \
     "champion-pr-merge.md ALL_DEPS extraction calls through to extract_blocker_refs (#5211)"
 
 assert_doc_contains "$CHAMPION_COMMON_MD" \
-    "grep -Eo '(Blocked by|Depends on|Requires)[*_:[:space:]]*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)'" \
-    "champion-common.md extract_blocker_refs ships the widened cross-repo pattern"
+    "grep -E '(Blocked by|Depends on|Requires)[*_:[:space:]]*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)'" \
+    "champion-common.md extract_blocker_refs ships the widened cross-repo pattern (two-stage: whole-line select)"
 
 assert_doc_contains "$CHAMPION_MD" \
     'test(\"(Blocked by|Depends on|Requires)[*_:[:space:]]*#$CLOSED_ISSUE\"; \"i\")' \

--- a/defaults/scripts/tests/test-dependency-parse.sh
+++ b/defaults/scripts/tests/test-dependency-parse.sh
@@ -44,6 +44,7 @@ DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
 GUIDE_MD="$DEFAULTS_DIR/.claude/commands/loom/guide.md"
 SWEEP_MD="$DEFAULTS_DIR/.claude/commands/loom/sweep.md"
 CHAMPION_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-pr-merge.md"
+CHAMPION_COMMON_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-common.md"
 
 # Source warn-out-of-set-deps.sh's real parse_out_of_set_deps BEFORE defining
 # our own RED/GREEN/NC below — the script's own `[[ -t 2 ]]` color block
@@ -110,12 +111,20 @@ sweep_auto_stack_detect() {
 }
 
 # =====================================================================
-# champion-pr-merge.md's ALL_DEPS extraction — mirrors
-# defaults/.claude/commands/loom/champion-pr-merge.md verbatim.
+# champion-pr-merge.md's ALL_DEPS extraction — champion-pr-merge.md now
+# calls THROUGH to the shared `extract_blocker_refs` helper in
+# defaults/.claude/commands/loom/champion-common.md (#5211) instead of an
+# inline pipeline, so this mirror reproduces that helper verbatim. The
+# helper is cross-repo aware: it captures an optional `owner/repo` prefix
+# ahead of the `#N` and (unlike the old bare-`#N` pipeline) returns each
+# reference WITH its `#`/`owner/repo#` form rather than a stripped number.
 # =====================================================================
 champion_all_deps() {
     local blocked_body="$1"
-    echo "$blocked_body" | grep -E "(Blocked by|Depends on|Requires)[*_:[:space:]]*#[0-9]+" | grep -Eo "#[0-9]+" | grep -Eo "[0-9]+" | sort -u
+    printf '%s\n' "$blocked_body" \
+        | grep -Eo '(Blocked by|Depends on|Requires)[*_:[:space:]]*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)' \
+        | grep -Eo '([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)' \
+        | sort -u
 }
 
 echo "--- guide.md parse_dependencies: markdown-bold/colon forms ---"
@@ -163,15 +172,18 @@ out="$(sweep_auto_stack_detect '**Blocked by:** #1')"
 assert_eq "" "$out" "Blocked by NEVER matches --auto-stack detection (phrase-set split preserved)"
 
 echo
-echo "--- champion-pr-merge.md ALL_DEPS: previously-empty parse now resolves ---"
+echo "--- champion-pr-merge.md ALL_DEPS (extract_blocker_refs): phrase-anchored + cross-repo ---"
 
-out="$(champion_all_deps '**Blocked by:** #1 (reason), #3 (reason)')"
-assert_eq $'1\n3' "$out" "bold+colon comma-list yields 1 3 (previously empty -> silent unblock)"
+out="$(champion_all_deps '**Blocked by:** #1 (reason)')"
+assert_eq '#1' "$out" "bold+colon phrase yields the anchored ref (previously empty -> silent unblock)"
 
 out="$(champion_all_deps 'Blocked by #7
 Depends on #8
 Requires #9')"
-assert_eq $'7\n8\n9' "$out" "plain unformatted forms (no regression)"
+assert_eq $'#7\n#8\n#9' "$out" "plain unformatted forms (no regression)"
+
+out="$(champion_all_deps 'Depends on owner/repo#42')"
+assert_eq 'owner/repo#42' "$out" "cross-repo owner/repo#N reference is preserved (#5211)"
 
 echo
 echo "--- champion-pr-merge.md BLOCKED_ISSUES jq filter: widened separator ---"
@@ -212,8 +224,12 @@ assert_doc_contains "$SWEEP_MD" \
     "sweep.md --auto-stack detection ships the widened two-phrase pattern"
 
 assert_doc_contains "$CHAMPION_MD" \
-    'grep -E "(Blocked by|Depends on|Requires)[*_:[:space:]]*#[0-9]+"' \
-    "champion-pr-merge.md ALL_DEPS extraction ships the widened pattern"
+    'ALL_DEPS=$(extract_blocker_refs "$BLOCKED_BODY")' \
+    "champion-pr-merge.md ALL_DEPS extraction calls through to extract_blocker_refs (#5211)"
+
+assert_doc_contains "$CHAMPION_COMMON_MD" \
+    "grep -Eo '(Blocked by|Depends on|Requires)[*_:[:space:]]*([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[0-9]+|#[0-9]+)'" \
+    "champion-common.md extract_blocker_refs ships the widened cross-repo pattern"
 
 assert_doc_contains "$CHAMPION_MD" \
     'test(\"(Blocked by|Depends on|Requires)[*_:[:space:]]*#$CLOSED_ISSUE\"; \"i\")' \


### PR DESCRIPTION
## Summary

Champion's "Blocked by #N" check treated any referenced issue as a single
boolean (`state == OPEN`), which is correct for an ordinary issue but wrong
for an epic: an epic can sit `OPEN` for months after every one of its
`loom:epic-phase` children has closed and the feature has shipped, simply
because nobody ran the "Epic Completion" close step. This is exactly what
happened to 2AMLogic/marketing#56 (blocked on 2AMLogic/klayout-tools#391,
14/15 children closed, feature shipped) across two consecutive Champion
passes, and it compounded into an unrecoverable cross-repo deadlock. This PR
adds a shared, capability-aware blocker check that distinguishes "epic not
started" / "epic genuinely in progress" / "epic's capability children are
all closed but the epic itself was never closed/promoted" — and stops
gating on the third case, with a bounded flag→escalate mechanism instead of
silent indefinite re-derivation.

## Changes

- `defaults/.claude/commands/loom/champion-common.md`: new "Epic-Aware
  Blocker Check (#5211)" section — cross-repo `owner/repo#N` reference
  parsing, epic classification (walks **all** phases' `loom:epic-phase`
  children, not just one), a state fingerprint for idempotency (keyed to the
  *blocker's* observed state, not the dependent's body — the dependent's
  text can stay unchanged for weeks while the epic underneath it resolves),
  and a bounded flag → silent-tally → escalate sequence
  (`LOOM_MAX_UNCHANGED_EPIC_BLOCK_EVALS`, default 2, naming convention
  mirrors `LOOM_MAX_UNREVISED_EVALUATIONS`).
- `defaults/.claude/commands/loom/champion-pr-merge.md`: wires the check
  into **Step 5 "Unblock Dependent Issues"** — the call site issue #5211
  named first under "Affected Files" as *"the blocking check that actually
  ran during this incident."* The per-dependency loop now extracts refs with
  the cross-repo-aware `extract_blocker_refs`, and for each `loom:epic`
  blocker runs the shared Step 1→2 classification (with Step 4's bounded
  flag→escalate for `epic-complete-unpromoted`) instead of the bare `state !=
  CLOSED` read, so a `loom:blocked` issue whose only remaining obstacle is a
  completed-but-unclosed epic is no longer left silently blocked forever via
  this path.
- `defaults/.claude/commands/loom/champion-issue-promo.md`: wires the check
  into criterion 2 ("Technical Feasibility" → "No obvious blockers or
  dependencies") — an issue whose only obstacle is a completed-but-unclosed
  epic can now proceed to promotion instead of failing indefinitely. Also
  documents why this check must run independently of the file's existing
  body-hash-keyed proposal idempotency skip (different thing needs to
  change to unstick each one).
- `defaults/.claude/commands/loom/champion-epic.md`: wires the same check
  into the phase-creation gate ("Step 2.5") and the phase-progression
  section, for the case where an **epic itself** (like marketing#56) is the
  dependent — Champion can now proceed to create the next phase's issues
  directly instead of repeatedly declining.
- `defaults/docs/daemon-reference.md`: cross-references the existing (and
  already fully documented, contrary to this issue's initial root-cause
  trace) opt-in `LOOM_EPIC_SUPERVISOR` mechanism as a complementary,
  same-workspace-only fix, and clarifies that this PR's check is what
  resolves the cross-repo case (the incident's actual shape) independent of
  that flag.

### Follow-up fixes from Judge review (Doctor pass)

- Wired `champion-pr-merge.md` Step 5 into the shared check (above) — the
  gap the concurrent Judge review flagged as blocking: the primary call site
  from #5211 had been left on the bare `state != CLOSED` path.
- `champion-common.md`: fixed the broken relative link to
  `daemon-reference.md`'s "Epic supervisor" (`../../../.loom/docs/...`, which
  did not resolve from `defaults/.claude/commands/loom/`) to an absolute
  GitHub URL, matching the sibling precedent in `champion-issue-promo.md`.
- `champion-common.md`: the classification reads (`BLOCKER_JSON`, `CHILDREN`)
  now route through `${GH_READ:-gh}` so the "Cached (`$GH_READ` if available)"
  comment matches the code — they are observation reads, not merge/claim
  gates, and fall back to plain `gh` when a caller has not defined `$GH_READ`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Distinguish "epic not started" / "epic in progress" / "epic's capability children all closed but unpromoted" | Done | `champion-common.md` Step 2 classifies into `blocked-not-started` / `blocked-in-progress` / `epic-complete-unpromoted` (requires `CLOSED_COUNT > 0` — not just `OPEN_COUNT == 0` — so a never-decomposed epic is not misread as complete). Wired into all three call sites: `champion-issue-promo.md` criterion 2, `champion-epic.md` Step 2.5, and `champion-pr-merge.md` Step 5 (the incident's primary site) |
| A completed-but-unclosed epic does not indefinitely gate dependents | Done | `epic-complete-unpromoted` stops gating on first detection at every call site — issue-promo: criterion passes; epic: phase creation proceeds; **pr-merge Step 5: the reference is not treated as a live block, so a `loom:blocked` issue whose only remaining obstacle is the completed epic can unblock** — each with a flag comment explaining why |
| Repeated identical "blocked on epic X" conclusions detectable mechanically, escalate instead of looping forever | Done | Step 4's marker + in-place `PATCH` streak counter, escalating to `loom:operator-only` once `LOOM_MAX_UNCHANGED_EPIC_BLOCK_EVALS` (default 2) unchanged observations are reached — same pattern as `champion-issue-promo.md`'s existing unrevised-proposal escalation |
| Must not weaken the correct common case (genuinely in-progress epic still blocks) | Done | `blocked-not-started` / `blocked-in-progress` / `not-epic` are unchanged by this PR at every call site — the new mechanism only activates for the new `epic-complete-unpromoted` outcome |
| Fix works without `LOOM_EPIC_SUPERVISOR` enabled | Done | The check is pure Champion-prompt logic (gh CLI reads), independent of the daemon supervisor; `daemon-reference.md` documents the two as complementary, not substitutes |
| Cycle detection (epic <-> dependent) | Out of scope | Already split to #5213 by Curator's decomposition — a genuinely separate, greenfield algorithmic concern |

## Test Plan

- Extracted every fenced bash block from the four modified `.claude/commands/loom/*.md` files and ran `bash -n` on each (after neutralizing `<placeholder>` angle-bracket tokens, the same convention already used unmodified elsewhere in these files) — all pass with no syntax errors, including the rewritten `champion-pr-merge.md` Step 5 loop and the `${GH_READ:-gh}` classification reads in `champion-common.md`.
- `./scripts/check-docs-defaults-parity.sh` — passes (no orphaned/broken doc links introduced by the new `daemon-reference.md` cross-reference or the absolute-URL link fix).
- Manual trace-through of the incident scenario against the new procedure: a dependent citing `owner/repo#N` where `#N` carries `loom:epic`, has `loom:epic-phase` children all closed and none open, and is still itself open — `parse_blocker_ref` resolves the cross-repo reference, Step 2 classifies it `epic-complete-unpromoted` (not vacuously, since `CLOSED_COUNT > 0`), and Step 4 posts one flag comment without gating, matching the "must not indefinitely block" requirement; a second pass with the identical fingerprint escalates to `loom:operator-only` rather than repeating. This now holds via `champion-pr-merge.md` Step 5 as well, not only the issue-promo / epic paths.
- This is a prose/role-prompt change (Champion is an LLM interpreting these instructions, not compiled code) — no unit-test harness applies; per the issue's own Test Plan, behavioral verification happens at Judge-review time against this trace-through and the acceptance-criteria table above.

Closes #5211
