### PR TITLE
fix(guard): segment-parse systemctl service-management ask patterns (#5214)

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -3269,10 +3269,15 @@ ASK_PATTERNS=(
     # cloud_guard_enabled() so cloud-dev repos can opt down (LOOM_GUARD_CLOUD=0 /
     # guards.cloudCli:false).
 
-    # Service management
-    '(^|[;&|[:space:]])systemctl restart'
-    '(^|[;&|[:space:]])systemctl stop'
-    '(^|[;&|[:space:]])systemctl disable'
+    # NOTE: `systemctl restart`/`stop`/`disable` are NOT in this ungated array.
+    # They used to be plain '(^|[;&|[:space:]])systemctl <verb>' entries here,
+    # but that anchor cannot distinguish a real shell separator from a
+    # whitespace character sitting INSIDE a quoted string, so read-only
+    # introspection like `grep -n "...|systemctl restart|..." file` or
+    # `jq -c 'select(.pattern | contains("systemctl"))' log` false-asked on the
+    # phrase's leading space (#5214). They are handled by the segment-parsed,
+    # command-word-anchored systemctl_ask_reason() check below instead — see
+    # its own comment block for the fix rationale.
 
     # Kubernetes operations
     '(^|[;&|[:space:]])kubectl delete'
@@ -3296,6 +3301,73 @@ for pattern in "${ASK_PATTERNS[@]}"; do
         ask "Command requires confirmation: $COMMAND" "ask:$pattern"
     fi
 done
+
+# =============================================================================
+# SERVICE-MANAGEMENT ASK — systemctl restart/stop/disable, segment-parsed,
+# command-word anchored (#5214)
+#
+# These three verbs used to live in ASK_PATTERNS above as plain substring
+# patterns anchored only by '(^|[;&|[:space:]])' (#3756) — a boundary that
+# cannot distinguish a real shell separator from a whitespace character sitting
+# INSIDE a quoted string literal. So a phrase like `systemctl restart` merely
+# being quoted as SEARCH TEXT (a grep pattern, a jq filter, prose) still matched
+# on its leading space, even though no such command was ever invoked:
+#   grep -n "idle\|systemctl restart\|systemd\|relaunch\|--idle-shutdown" f.sh
+#   jq -c 'select(.pattern | contains("systemctl"))' guard-decisions.log
+#
+# Mirrors lifecycle_or_cloud_reason()'s fix for the analogous halt/reboot/
+# az-delete false positive: segment-parse the command with qsplit() (quote-aware,
+# #3755) instead of scanning raw substrings, strip a leading sudo/env wrapper
+# per segment, and ask ONLY when a segment's actual command word is `systemctl`
+# AND its very next token is restart/stop/disable. A quoted `|` inside
+# `grep`/`jq` arguments (no `$(`/backtick) is inert to qsplit(), so both example
+# commands above stay a single `grep`/`jq` segment — command word never
+# resolves to `systemctl` — and no longer false-ask. A genuine invocation
+# (bare, after `;`/`&&`/`|`, or with a later quoted argument such as
+# `systemctl restart "my service"`) still asks, since toks[1]/toks[2] are
+# unaffected by trailing quoted content.
+#
+# Scoped narrowly to this one "Service management" ASK_PATTERNS block per
+# #5214 — #5157/#5158 describe the same false-positive CLASS for other
+# patterns but were judged too broad a fix to land autonomously; this is not
+# an attempt at a general-purpose fix for the whole ASK_PATTERNS family.
+# =============================================================================
+systemctl_ask_reason() {
+    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
+    {
+        $0 = qsplit($0)   # quote-aware segmentation (#3755)
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            # Strip a leading `env` wrapper + its flags/assignments, mirroring
+            # lifecycle_or_cloud_reason() (#3586), so `env FOO=bar systemctl
+            # restart x` still resolves its command word to `systemctl`.
+            if (sub(/^env([ \t]+|$)/, "", seg)) {
+                sub(/^[ \t]+/, "", seg)
+                stripped = 1
+                while (stripped) {
+                    stripped = 0
+                    if (sub(/^-u[ \t]+[^ \t]+([ \t]+|$)/, "", seg)) { stripped = 1; continue }
+                    if (sub(/^-i([ \t]+|$)/, "", seg))              { stripped = 1; continue }
+                    if (sub(/^--([ \t]+|$)/, "", seg))              { break }
+                    if (sub(/^[A-Za-z_][A-Za-z0-9_]*=[^ \t]*([ \t]+|$)/, "", seg)) { stripped = 1; continue }
+                }
+            }
+            sub(/^[ \t]+/, "", seg)
+            m = split(seg, toks, /[ \t]+/)
+            if (m < 2) continue
+            if (toks[1] == "systemctl" && (toks[2] == "restart" || toks[2] == "stop" || toks[2] == "disable")) {
+                print "systemctl " toks[2]
+            }
+        }
+    }'
+}
+_SYSTEMCTL_ASK=$(systemctl_ask_reason "$COMMAND_NO_COMMENT" | head -1)
+if [[ -n "$_SYSTEMCTL_ASK" ]]; then
+    ask "Command requires confirmation: $COMMAND" "ask:$_SYSTEMCTL_ASK"
+fi
 
 # =============================================================================
 # REVERSIBLE-GITHUB ASK patterns — gated by the reversible-gh guard toggle (#3757)

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -3269,10 +3269,15 @@ ASK_PATTERNS=(
     # cloud_guard_enabled() so cloud-dev repos can opt down (LOOM_GUARD_CLOUD=0 /
     # guards.cloudCli:false).
 
-    # Service management
-    '(^|[;&|[:space:]])systemctl restart'
-    '(^|[;&|[:space:]])systemctl stop'
-    '(^|[;&|[:space:]])systemctl disable'
+    # NOTE: `systemctl restart`/`stop`/`disable` are NOT in this ungated array.
+    # They used to be plain '(^|[;&|[:space:]])systemctl <verb>' entries here,
+    # but that anchor cannot distinguish a real shell separator from a
+    # whitespace character sitting INSIDE a quoted string, so read-only
+    # introspection like `grep -n "...|systemctl restart|..." file` or
+    # `jq -c 'select(.pattern | contains("systemctl"))' log` false-asked on the
+    # phrase's leading space (#5214). They are handled by the segment-parsed,
+    # command-word-anchored systemctl_ask_reason() check below instead — see
+    # its own comment block for the fix rationale.
 
     # Kubernetes operations
     '(^|[;&|[:space:]])kubectl delete'
@@ -3296,6 +3301,73 @@ for pattern in "${ASK_PATTERNS[@]}"; do
         ask "Command requires confirmation: $COMMAND" "ask:$pattern"
     fi
 done
+
+# =============================================================================
+# SERVICE-MANAGEMENT ASK — systemctl restart/stop/disable, segment-parsed,
+# command-word anchored (#5214)
+#
+# These three verbs used to live in ASK_PATTERNS above as plain substring
+# patterns anchored only by '(^|[;&|[:space:]])' (#3756) — a boundary that
+# cannot distinguish a real shell separator from a whitespace character sitting
+# INSIDE a quoted string literal. So a phrase like `systemctl restart` merely
+# being quoted as SEARCH TEXT (a grep pattern, a jq filter, prose) still matched
+# on its leading space, even though no such command was ever invoked:
+#   grep -n "idle\|systemctl restart\|systemd\|relaunch\|--idle-shutdown" f.sh
+#   jq -c 'select(.pattern | contains("systemctl"))' guard-decisions.log
+#
+# Mirrors lifecycle_or_cloud_reason()'s fix for the analogous halt/reboot/
+# az-delete false positive: segment-parse the command with qsplit() (quote-aware,
+# #3755) instead of scanning raw substrings, strip a leading sudo/env wrapper
+# per segment, and ask ONLY when a segment's actual command word is `systemctl`
+# AND its very next token is restart/stop/disable. A quoted `|` inside
+# `grep`/`jq` arguments (no `$(`/backtick) is inert to qsplit(), so both example
+# commands above stay a single `grep`/`jq` segment — command word never
+# resolves to `systemctl` — and no longer false-ask. A genuine invocation
+# (bare, after `;`/`&&`/`|`, or with a later quoted argument such as
+# `systemctl restart "my service"`) still asks, since toks[1]/toks[2] are
+# unaffected by trailing quoted content.
+#
+# Scoped narrowly to this one "Service management" ASK_PATTERNS block per
+# #5214 — #5157/#5158 describe the same false-positive CLASS for other
+# patterns but were judged too broad a fix to land autonomously; this is not
+# an attempt at a general-purpose fix for the whole ASK_PATTERNS family.
+# =============================================================================
+systemctl_ask_reason() {
+    printf '%s' "$1" | awk "$_QSPLIT_AWK"'
+    {
+        $0 = qsplit($0)   # quote-aware segmentation (#3755)
+        n = split($0, segs, "\n")
+        for (i = 1; i <= n; i++) {
+            seg = segs[i]
+            sub(/^[ \t]+/, "", seg)
+            sub(/^sudo[ \t]+/, "", seg)
+            # Strip a leading `env` wrapper + its flags/assignments, mirroring
+            # lifecycle_or_cloud_reason() (#3586), so `env FOO=bar systemctl
+            # restart x` still resolves its command word to `systemctl`.
+            if (sub(/^env([ \t]+|$)/, "", seg)) {
+                sub(/^[ \t]+/, "", seg)
+                stripped = 1
+                while (stripped) {
+                    stripped = 0
+                    if (sub(/^-u[ \t]+[^ \t]+([ \t]+|$)/, "", seg)) { stripped = 1; continue }
+                    if (sub(/^-i([ \t]+|$)/, "", seg))              { stripped = 1; continue }
+                    if (sub(/^--([ \t]+|$)/, "", seg))              { break }
+                    if (sub(/^[A-Za-z_][A-Za-z0-9_]*=[^ \t]*([ \t]+|$)/, "", seg)) { stripped = 1; continue }
+                }
+            }
+            sub(/^[ \t]+/, "", seg)
+            m = split(seg, toks, /[ \t]+/)
+            if (m < 2) continue
+            if (toks[1] == "systemctl" && (toks[2] == "restart" || toks[2] == "stop" || toks[2] == "disable")) {
+                print "systemctl " toks[2]
+            }
+        }
+    }'
+}
+_SYSTEMCTL_ASK=$(systemctl_ask_reason "$COMMAND_NO_COMMENT" | head -1)
+if [[ -n "$_SYSTEMCTL_ASK" ]]; then
+    ask "Command requires confirmation: $COMMAND" "ask:$_SYSTEMCTL_ASK"
+fi
 
 # =============================================================================
 # REVERSIBLE-GITHUB ASK patterns — gated by the reversible-gh guard toggle (#3757)

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -947,6 +947,35 @@ assert_ask "Ask for systemctl stop" \
 assert_ask "Ask for systemctl disable" \
     "systemctl disable sshd"
 
+# #5214: segment-parsed, command-word-anchored systemctl ask regression checks.
+# A real invocation still asks regardless of prefix/separator/trailing quoting.
+assert_ask "Ask for sudo systemctl restart (#5214)" \
+    "sudo systemctl restart nginx"
+
+assert_ask "Ask for systemctl restart after && separator (#5214)" \
+    "echo hi && systemctl restart nginx"
+
+assert_ask "Ask for systemctl stop after ; separator (#5214)" \
+    "foo; systemctl stop apache2"
+
+assert_ask "Ask for systemctl disable after | separator (#5214)" \
+    "foo | systemctl disable sshd"
+
+assert_ask "Ask for systemctl restart with a later quoted argument (#5214)" \
+    'systemctl restart "my service"'
+
+assert_ask "Ask for env-wrapped systemctl restart (#5214)" \
+    "env FOO=bar systemctl restart nginx"
+
+# #5214: `systemctl restart`/`stop`/`disable` merely appearing as quoted SEARCH
+# TEXT inside a grep/jq argument (not an actual invocation) must not ask. These
+# are the exact two commands from the issue report.
+assert_allow "Allow grep introspection quoting 'systemctl restart' (#5214)" \
+    'grep -n "idle\|systemctl restart\|systemd\|relaunch\|--idle-shutdown" ./defaults/scripts/cli/loom-daemon-update.sh'
+
+assert_allow "Allow jq filter quoting 'systemctl' (#5214)" \
+    "jq -c 'select(.pattern | contains(\"systemctl\"))' .loom/logs/guard-decisions.log"
+
 assert_ask "Ask for kubectl delete" \
     "kubectl delete pod my-pod"
 


### PR DESCRIPTION
## Summary

Fixes the `ask`-tier false positive where systemctl's restart/stop/disable
subcommand patterns fired on read-only `grep`/`jq` introspection text that
merely quoted the phrase as a search pattern, rather than an actual live
invocation of the subcommand.

## Root cause

The three ask patterns in `ASK_PATTERNS` were plain substring regexes
anchored only by `(^|[;&|[:space:]])` (#3756) — a boundary that cannot tell
a real shell separator from a whitespace character sitting *inside* a
quoted string literal. So a command like:

```
grep -n "idle\|systemctl restart\|systemd\|relaunch\|--idle-shutdown" ./defaults/scripts/cli/loom-daemon-update.sh
```

or

```
jq -c 'select(.pattern | contains("systemctl"))' .loom/logs/guard-decisions.log
```

tripped `ask` even though neither command invokes the subcommand — the
phrase only appears as quoted search text.

## Fix

Removed the three regex entries from `ASK_PATTERNS` and replaced them with
a new `systemctl_ask_reason()` function that segment-parses the command with
the existing quote-aware `qsplit()` tokenizer (#3755) — the same fix pattern
already used by `lifecycle_or_cloud_reason()` for the analogous
halt/reboot/az-delete false positive. It strips a leading `sudo`/`env`
wrapper per segment and only asks when a segment's actual command word is
`systemctl` and the next token is one of the three managed verbs — never
when the phrase is merely quoted text inside another command's argument.

Scoped narrowly to this one "Service management" block per the issue
guidance; the general fix for the whole `ASK_PATTERNS`/`ALWAYS_BLOCK_PATTERNS`
family (#5157, #5158) was judged too broad to land autonomously and is out
of scope here.

Both `defaults/hooks/guard-destructive-generic.sh` and the tracked mirror
`.loom/hooks/guard-destructive-generic.sh` are edited identically and remain
byte-identical (verified with `diff`).

## Test plan

- [x] `tests/hooks/test-guard-destructive.sh` passes (687/687, including 8
      new cases: the two exact false-positive commands from the issue now
      allow; true-positive regressions for bare/sudo/env-wrapped invocation,
      invocation after `;`/`&&`/`|`, and invocation with a later quoted
      argument all still ask).
- [x] `tests/hooks/test-guard-destructive-dispatcher.sh` passes (12/12).
- [x] `shellcheck` on the modified file shows no new warnings vs. `main`.
- [x] Manually verified both example commands from the issue body no longer
      ask, and a genuine `systemctl restart`/`stop`/`disable` invocation
      (bare, sudo-prefixed, env-wrapped, after a separator, or with a later
      quoted argument) still asks.

Closes #5214