### PR TITLE
feat(worktree): add per-issue stash-push/stash-pop clean-baseline pair

### DIFF
--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -311,6 +311,25 @@ writes your WIP as a patch file under
 `<worktree-root>/.snapshots/issue-<N>-<timestamp>.patch`, scoped to your own
 worktree, so there is no shared stack to collide on.
 
+**For a "clean baseline vs. my diff" comparison** — temporarily clearing your
+WIP to run a clippy/shellcheck/test baseline, then restoring it — `snapshot`
+is *not* enough (it captures a patch but does not reset the working tree).
+Use the clean-and-restore pair instead of `git stash` / `git stash pop`
+(#5217):
+
+```bash
+./.loom/scripts/worktree.sh stash-push <issue-number>   # capture WIP, reset to clean HEAD
+<run the baseline check>                                # e.g. cargo clippy > /tmp/baseline.txt
+./.loom/scripts/worktree.sh stash-pop <issue-number>    # restore exactly what was captured
+```
+
+It anchors your WIP to a **per-issue** ref (`refs/loom/stash-baseline/issue-<N>`),
+never `refs/stash`, so another builder's concurrent stash cannot land "in
+between" your push and pop. Add `--include-untracked` to move untracked files
+out too. Because it never runs `git stash pop|drop|clear`, it does not trip
+the `stash-scope` ask that would stall a headless sweep — whereas raw
+`git stash pop` from a worktree still asks, correctly, and always will.
+
 This does **not** apply to the `check-main-clean.sh --quarantine` recovery
 flow below (§"If it exits 3…") — that flow's use of `git stash` operates on
 the **main checkout**, is single-writer by construction (only one agent's

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -113,6 +113,16 @@ writes your WIP as a patch file under
 `<worktree-root>/.snapshots/issue-<N>-<timestamp>.patch`, scoped to your own
 worktree, so there is no shared stack to collide on.
 
+**For a "clean baseline vs. my diff" comparison** — temporarily clearing your
+fix to re-run a lint/test baseline, then restoring it — `snapshot` is *not*
+enough (it captures a patch but does not reset the working tree). Use
+`./.loom/scripts/worktree.sh stash-push <issue-number>`, run the baseline
+check, then `./.loom/scripts/worktree.sh stash-pop <issue-number>` (#5217).
+It anchors your WIP to a **per-issue** ref (`refs/loom/stash-baseline/issue-<N>`),
+never `refs/stash`, so no concurrent builder's stash can land between your
+push and pop — and, unlike raw `git stash pop`, it does not trip the
+`stash-scope` ask that would stall a headless sweep.
+
 ## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
 
 **If a comment you're posting (fix summary, clarifying question, conflict-only

--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -735,6 +735,33 @@ prevention remains procedural, not just guard-enforced — prefer
 capture, scoped to one worktree, no shared stack) over ad-hoc `git stash`
 for WIP handling (see `defaults/roles/builder.md` / `defaults/roles/doctor.md`).
 
+**Headless baseline-diff pattern (#5217).** Because a busy repo almost always
+has two or more `.loom-managed` worktrees active, the collision ask above
+fires on nearly every occurrence of the legitimate, worktree-confined
+`git stash push && <baseline check> && git stash pop` sequence used to diff a
+clean baseline against in-progress WIP (clippy/shellcheck/test-output
+comparisons) — an unanswerable `ask` in a headless sweep with no human
+present. **The guard was deliberately NOT widened for it.** A same-chain
+"push and pop appear in one command, so allow" heuristic was considered and
+rejected: push and pop are two separate guard-approved Bash calls with an
+arbitrary-duration command running in between, so another worktree's
+concurrent `git stash push` can still land on the shared stack inside that
+window and the "pop" then restores the *wrong* entry — command shape alone
+cannot see that. Instead, `worktree.sh` gained a clean-and-restore pair that
+removes the shared-mutable-state precondition entirely:
+
+| Verb | What it does |
+|------|--------------|
+| `worktree.sh stash-push <N> [--include-untracked]` | Captures the worktree's uncommitted tracked diff with `git stash create` (which builds a stash-format commit but **never writes `refs/stash`**), anchors it under the per-issue ref `refs/loom/stash-baseline/issue-<N>`, then resets that one worktree to a clean `HEAD` baseline. With `--include-untracked`, untracked files (Loom runtime markers excluded) move to a per-issue holding directory instead. |
+| `worktree.sh stash-pop <N>` | Re-applies exactly what `stash-push <N>` captured from that same per-issue ref / holding directory, then clears them. Refuses loudly — **without discarding the captured baseline** — if nothing is pending or if re-applying conflicts. |
+
+Each issue gets its **own** ref rather than a slot on a shared stack, so no
+other worktree's stash operation can interleave, and neither verb's command
+text contains a raw `git stash pop|drop|clear` — so both are
+guard-transparent, not a guard exemption. Raw `git stash pop`/`drop`/`clear`
+stays exactly as gated as before, in the main checkout and in a linked
+worktree alike.
+
 **Examples**:
 
 ```bash
@@ -743,13 +770,21 @@ git stash pop
 git stash drop stash@{1}
 git stash clear
 
-# In a linked worktree (.loom/worktrees/issue-N) — allowed, no ask:
+# In a linked worktree (.loom/worktrees/issue-N) — allowed only while it is
+# the ONLY managed worktree; asks once a second one exists (#4821):
 cd .loom/worktrees/issue-42 && git stash pop
 
 # Never gated, in either location — these cannot remove a stash entry:
 git stash push -m "wip"
 git stash apply
 git stash list
+
+# Headless clean-baseline-vs-my-diff comparison — never gated, because
+# neither verb touches refs/stash (#5217):
+./.loom/scripts/worktree.sh stash-push 42
+cargo clippy --message-format=short > /tmp/baseline.txt   # clean-tree baseline
+./.loom/scripts/worktree.sh stash-pop 42
+cargo clippy --message-format=short > /tmp/with-wip.txt   # then diff the two
 
 # Opt out for a whole repo:
 #   .loom/config.json  ->  { "guards": { "stashScope": false } }

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -3406,6 +3406,24 @@ fi
 # `<main>/.loom/worktrees/`, we ask too — a single active worktree has no one
 # else's stash entry to collide with, so it stays ungated.
 #
+# NOTE (#5217): this fires correctly, per the design above, for a legitimate
+# `git stash push && <baseline check> && git stash pop` pattern too — used to
+# diff a clean baseline against WIP (clippy/shellcheck/test-output
+# comparisons) — since in this repo's typical worktree count that pattern is
+# gated on nearly every occurrence, with no human to answer in headless mode.
+# A same-chain heuristic ("push and pop appear in the same command, so
+# allow") was considered and REJECTED during #5217's curation: push and pop
+# are two separate guard-approved Bash calls with an arbitrary-duration
+# command running between them, so another worktree's concurrent `git stash
+# push` can still land on the SHARED stack during that window, and a same-
+# chain "pop" then restores the WRONG entry — a same-chain heuristic alone
+# cannot see that. The fix is `worktree.sh stash-push`/`stash-pop`
+# (`.loom/scripts/worktree.sh`), which never touch `refs/stash` — WIP is
+# anchored to a PER-ISSUE ref instead, so there is no shared stack left to
+# collide on. This ask (and the main-checkout ask above) stay exactly as
+# strict as before for any RAW `git stash pop/drop/clear` — the new commands
+# are a guard-transparent replacement path, not a guard exemption.
+#
 # Gated by stash_scope_guard_enabled() (guards.stashScope /
 # LOOM_GUARD_STASH_SCOPE, default on), invoked LAZILY only after the pattern
 # already matched, mirroring every other cold-path toggle in this file.
@@ -3446,7 +3464,7 @@ if echo "$COMMAND_ASK_SCAN" | grep -qE '(^|[;&|(]|[[:space:]])git[[:space:]]+sta
         fi
 
         if [[ "$_stash_worktree_count" -ge 2 ]]; then
-            ask "Command requires confirmation: $COMMAND (git stash pop/drop/clear from a linked worktree can destroy ANOTHER builder's WIP — refs/stash is a single stack SHARED across every linked worktree of this repo, not per-worktree, and $_stash_worktree_count managed worktrees are currently active. Use './.loom/scripts/worktree.sh snapshot <issue-number>' instead of git stash for ad-hoc WIP; set guards.stashScope:false / LOOM_GUARD_STASH_SCOPE=0 to disable this ask)" "stash-scope:worktree-collision"
+            ask "Command requires confirmation: $COMMAND (git stash pop/drop/clear from a linked worktree can destroy ANOTHER builder's WIP — refs/stash is a single stack SHARED across every linked worktree of this repo, not per-worktree, and $_stash_worktree_count managed worktrees are currently active. Use './.loom/scripts/worktree.sh snapshot <issue-number>' instead of git stash for ad-hoc WIP, or './.loom/scripts/worktree.sh stash-push <issue-number>' + 'stash-pop <issue-number>' for a clean-baseline-vs-diff comparison — neither touches the shared refs/stash stack, so neither needs this ask; set guards.stashScope:false / LOOM_GUARD_STASH_SCOPE=0 to disable this ask)" "stash-scope:worktree-collision"
         fi
     elif [[ "$_stash_effective_cwd" != "$CWD" ]]; then
         # A `cd <dir>` prefix resolved to a target that does not exist or is

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -118,6 +118,7 @@ test-worktree-root-override.sh
 test-worktree-sentinel-reinvoke.sh
 test-worktree-sentinel.sh
 test-worktree-snapshot.sh
+test-worktree-stash-baseline.sh
 
 # tests/hooks/ (repo root) — Claude-path guard suites, wired since #4769.
 tests/hooks/test-guard-destructive-dispatcher.sh

--- a/defaults/scripts/tests/test-worktree-stash-baseline.sh
+++ b/defaults/scripts/tests/test-worktree-stash-baseline.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# test-worktree-stash-baseline.sh - Tests for the `worktree.sh stash-push
+# <N>` / `worktree.sh stash-pop <N>` verb pair (#5217)
+#
+# Verifies the worktree-scoped, per-issue clean-baseline stash:
+#   1. stash-push captures tracked-file changes and resets the worktree to a
+#      clean baseline WITHOUT touching `git stash` (stash list identical
+#      before/after — unlike raw `git stash push`, which IS gated by
+#      guard-destructive-generic.sh's stash-scope:worktree-collision ask).
+#   2. stash-pop restores exactly what stash-push captured (tracked diff).
+#   3. --include-untracked moves untracked files out on push and restores
+#      them on pop; the default omits them.
+#   4. A clean worktree still succeeds (no-op push, nothing to reset).
+#   5. A second stash-push before pop refuses (no data loss / no silent
+#      overwrite of a pending baseline).
+#   6. stash-pop with nothing pending fails cleanly, without side effects.
+#   7. stash-push / stash-pop on a non-existent worktree fail cleanly.
+#   8. --json emits a single parseable document for both verbs.
+#   9. Loom runtime markers are never swept into the untracked holding dir.
+#  10. The per-issue ref (refs/loom/stash-baseline/issue-<N>) is created by
+#      push and cleared by pop — never left dangling on a clean round trip.
+#  11. Another worktree's `git stash push` landing BETWEEN a stash-push and
+#      its stash-pop cannot corrupt the restore (the #5217 race), and does
+#      not consume that worktree's shared-stack entry either.
+#  12. Contrast fixture: the raw `git stash push`/`pop` pattern DOES lose to
+#      the identical interleaving — which is why the guard's ask on raw
+#      stash pop/drop/clear must stay exactly as strict as before.
+#  13. The full `stash-push && <check> && stash-pop` chain exits 0 even when
+#      the worktree was already clean (a pop with nothing captured is a
+#      no-op, not an error, so the chain cannot break mid-sweep).
+#
+# Follows the throwaway-repo harness pattern in test-worktree-snapshot.sh: a
+# bare origin remote + a working repo, with worktree.sh + its lib/ helpers
+# copied into a temp tree, then the script driven directly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+
+WORKTREE_SH="$SCRIPTS_DIR/worktree.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+# --- Throwaway repo setup ---------------------------------------------------
+TMP=$(mktemp -d /tmp/loom-stash-baseline-test.XXXXXX)
+trap 'rm -rf "$TMP"; cd "$REPO_ROOT" 2>/dev/null || true' EXIT
+
+git init -q -b main "$TMP/origin.git" --bare
+git init -q -b main "$TMP/repo"
+cd "$TMP/repo"
+git config user.email t@t
+git config user.name t
+echo "tracked file" > tracked.txt
+git add tracked.txt
+git commit --allow-empty -q -m init
+git remote add origin "$TMP/origin.git"
+git push -q origin main
+
+mkdir -p .loom/scripts/lib
+cp "$WORKTREE_SH" .loom/scripts/worktree.sh
+if [[ -d "$SCRIPTS_DIR/lib" ]]; then
+    cp -R "$SCRIPTS_DIR"/lib/* .loom/scripts/lib/ 2>/dev/null || true
+fi
+chmod +x .loom/scripts/worktree.sh
+
+REPO="$TMP/repo"
+
+# Helper: create a fresh managed worktree for an issue number.
+make_worktree() {
+    local n="$1"
+    cd "$REPO"
+    ./.loom/scripts/worktree.sh "$n" >/dev/null 2>&1
+}
+
+# --- Test 1: stash-push resets to a clean baseline without touching git stash
+echo "Test 1: stash-push captures tracked changes, resets to clean baseline, never touches git stash"
+make_worktree 301
+cd "$REPO"
+echo "modified content" >> ".loom/worktrees/issue-301/tracked.txt"
+stash_before="$(git stash list)"
+if ./.loom/scripts/worktree.sh stash-push 301 >/tmp/sbp-out1.$$ 2>&1; then
+    pass "stash-push exited 0 for a dirty worktree"
+else
+    fail "stash-push exited non-zero (see /tmp/sbp-out1.$$)"
+fi
+stash_after="$(git stash list)"
+if [[ "$stash_before" == "$stash_after" ]]; then
+    pass "git stash list is unchanged by stash-push"
+else
+    fail "git stash list changed — stash-push touched the shared stash"
+fi
+if [[ "$(cat ".loom/worktrees/issue-301/tracked.txt")" == "tracked file" ]]; then
+    pass "worktree reset to the clean HEAD baseline after stash-push"
+else
+    fail "worktree was NOT reset to a clean baseline after stash-push"
+fi
+if git -C ".loom/worktrees/issue-301" rev-parse --verify --quiet refs/loom/stash-baseline/issue-301 >/dev/null 2>&1; then
+    pass "per-issue baseline ref was created (refs/loom/stash-baseline/issue-301)"
+else
+    fail "no per-issue baseline ref was created"
+fi
+
+# --- Test 2: stash-pop restores exactly what stash-push captured -----------
+echo ""
+echo "Test 2: stash-pop restores the captured tracked diff and clears the ref"
+if ./.loom/scripts/worktree.sh stash-pop 301 >/tmp/sbp-out2.$$ 2>&1; then
+    pass "stash-pop exited 0"
+else
+    fail "stash-pop exited non-zero (see /tmp/sbp-out2.$$)"
+fi
+if grep -q "modified content" ".loom/worktrees/issue-301/tracked.txt"; then
+    pass "stash-pop restored the captured tracked-file diff"
+else
+    fail "stash-pop did NOT restore the captured diff"
+fi
+if ! git -C ".loom/worktrees/issue-301" rev-parse --verify --quiet refs/loom/stash-baseline/issue-301 >/dev/null 2>&1; then
+    pass "per-issue baseline ref was cleared by stash-pop"
+else
+    fail "per-issue baseline ref was left dangling after stash-pop"
+fi
+
+# --- Test 3: --include-untracked round-trips untracked files ---------------
+echo ""
+echo "Test 3: --include-untracked moves untracked files out on push, restores them on pop"
+make_worktree 302
+cd "$REPO"
+echo "brand new file" > ".loom/worktrees/issue-302/untracked.txt"
+if ./.loom/scripts/worktree.sh stash-push 302 --include-untracked >/tmp/sbp-out3a.$$ 2>&1; then
+    pass "stash-push --include-untracked exited 0"
+else
+    fail "stash-push --include-untracked exited non-zero (see /tmp/sbp-out3a.$$)"
+fi
+if [[ ! -e ".loom/worktrees/issue-302/untracked.txt" ]]; then
+    pass "untracked file was moved out of the worktree by stash-push --include-untracked"
+else
+    fail "untracked file was NOT moved out of the worktree"
+fi
+if ./.loom/scripts/worktree.sh stash-pop 302 >/tmp/sbp-out3b.$$ 2>&1; then
+    pass "stash-pop exited 0"
+else
+    fail "stash-pop exited non-zero (see /tmp/sbp-out3b.$$)"
+fi
+if [[ -f ".loom/worktrees/issue-302/untracked.txt" ]] && grep -q "brand new file" ".loom/worktrees/issue-302/untracked.txt"; then
+    pass "stash-pop restored the untracked file with its original content"
+else
+    fail "stash-pop did NOT restore the untracked file"
+fi
+if git -C ".loom/worktrees/issue-302" status --porcelain -- untracked.txt | grep -q '^??'; then
+    pass "restored file remains untracked (not staged) after stash-pop"
+else
+    fail "restored file was left staged/tracked after stash-pop"
+fi
+
+echo ""
+echo "Test 3b: without --include-untracked, an untracked file is left alone by stash-push"
+make_worktree 303
+cd "$REPO"
+echo "should stay put" > ".loom/worktrees/issue-303/plain-untracked.txt"
+./.loom/scripts/worktree.sh stash-push 303 >/tmp/sbp-out3c.$$ 2>&1 || true
+if [[ -f ".loom/worktrees/issue-303/plain-untracked.txt" ]]; then
+    pass "default stash-push (no --include-untracked) leaves untracked files in place"
+else
+    fail "default stash-push unexpectedly moved an untracked file"
+fi
+./.loom/scripts/worktree.sh stash-pop 303 >/tmp/sbp-out3d.$$ 2>&1 || true
+
+# --- Test 4: a clean worktree still succeeds (no-op) ------------------------
+echo ""
+echo "Test 4: a clean worktree still succeeds as a no-op"
+make_worktree 304
+cd "$REPO"
+if ./.loom/scripts/worktree.sh stash-push 304 >/tmp/sbp-out4.$$ 2>&1; then
+    pass "stash-push exited 0 for a clean worktree"
+else
+    fail "stash-push exited non-zero for a clean worktree (see /tmp/sbp-out4.$$)"
+fi
+if ! git -C ".loom/worktrees/issue-304" rev-parse --verify --quiet refs/loom/stash-baseline/issue-304 >/dev/null 2>&1; then
+    pass "no baseline ref created for a worktree with nothing to push"
+else
+    fail "a baseline ref was created despite no changes to push"
+fi
+
+# --- Test 5: a second stash-push before pop refuses -------------------------
+echo ""
+echo "Test 5: stash-push refuses when a pending push already exists for the issue"
+make_worktree 305
+cd "$REPO"
+echo "first change" >> ".loom/worktrees/issue-305/tracked.txt"
+./.loom/scripts/worktree.sh stash-push 305 >/tmp/sbp-out5a.$$ 2>&1
+echo "second change" >> ".loom/worktrees/issue-305/tracked.txt"
+if ./.loom/scripts/worktree.sh stash-push 305 >/tmp/sbp-out5b.$$ 2>&1; then
+    fail "stash-push succeeded despite a pending push already existing (data-loss risk)"
+else
+    pass "stash-push refused a second push while one is already pending"
+fi
+if grep -q "second change" ".loom/worktrees/issue-305/tracked.txt"; then
+    pass "the second (uncaptured) change was left in place, not silently discarded"
+else
+    fail "the second change was lost by the refused stash-push"
+fi
+# Clean up: restore file to a poppable state before continuing.
+git -C ".loom/worktrees/issue-305" checkout -- tracked.txt
+./.loom/scripts/worktree.sh stash-pop 305 >/tmp/sbp-out5c.$$ 2>&1 || true
+
+# --- Test 6: stash-pop with nothing pending fails cleanly -------------------
+echo ""
+echo "Test 6: stash-pop refuses cleanly when nothing is pending"
+make_worktree 306
+cd "$REPO"
+if ./.loom/scripts/worktree.sh stash-pop 306 >/tmp/sbp-out6.$$ 2>&1; then
+    fail "stash-pop succeeded despite nothing being pending"
+else
+    pass "stash-pop exited non-zero when nothing is pending"
+fi
+
+# --- Test 7: stash-push / stash-pop on a non-existent worktree fail cleanly -
+echo ""
+echo "Test 7: stash-push and stash-pop refuse a non-existent issue worktree"
+cd "$REPO"
+if ./.loom/scripts/worktree.sh stash-push 999999 >/tmp/sbp-out7a.$$ 2>&1; then
+    fail "stash-push succeeded for a non-existent worktree (should have failed)"
+else
+    pass "stash-push exited non-zero for a non-existent worktree"
+fi
+if ./.loom/scripts/worktree.sh stash-pop 999999 >/tmp/sbp-out7b.$$ 2>&1; then
+    fail "stash-pop succeeded for a non-existent worktree (should have failed)"
+else
+    pass "stash-pop exited non-zero for a non-existent worktree"
+fi
+
+# --- Test 8: --json emits a single parseable document -----------------------
+echo ""
+echo "Test 8: stash-push/stash-pop --json emit parseable JSON documents"
+make_worktree 307
+cd "$REPO"
+echo "json test" >> ".loom/worktrees/issue-307/tracked.txt"
+if ./.loom/scripts/worktree.sh stash-push 307 --json >/tmp/sbp-out8a.$$ 2>/tmp/sbp-err8a.$$; then
+    if grep -q '"success": true' /tmp/sbp-out8a.$$ && grep -q '"hasTrackedChanges": true' /tmp/sbp-out8a.$$ && grep -q '"ref"' /tmp/sbp-out8a.$$; then
+        pass "stash-push --json emits success=true, hasTrackedChanges=true, ref"
+    else
+        fail "stash-push --json output missing expected fields (see /tmp/sbp-out8a.$$)"
+    fi
+else
+    fail "stash-push --json exited non-zero (see /tmp/sbp-out8a.$$ /tmp/sbp-err8a.$$)"
+fi
+if ./.loom/scripts/worktree.sh stash-pop 307 --json >/tmp/sbp-out8b.$$ 2>/tmp/sbp-err8b.$$; then
+    if grep -q '"success": true' /tmp/sbp-out8b.$$ && grep -q '"restoredTracked": true' /tmp/sbp-out8b.$$; then
+        pass "stash-pop --json emits success=true, restoredTracked=true"
+    else
+        fail "stash-pop --json output missing expected fields (see /tmp/sbp-out8b.$$)"
+    fi
+else
+    fail "stash-pop --json exited non-zero (see /tmp/sbp-out8b.$$ /tmp/sbp-err8b.$$)"
+fi
+
+# --- Test 9: Loom runtime markers are never swept into the holding dir -----
+echo ""
+echo "Test 9: Loom runtime markers are never moved by --include-untracked"
+make_worktree 308
+cd "$REPO"
+touch ".loom/worktrees/issue-308/.loom-in-use" ".loom/worktrees/issue-308/.loom-checkpoint"
+echo "real wip" > ".loom/worktrees/issue-308/real-wip.txt"
+if ./.loom/scripts/worktree.sh stash-push 308 --include-untracked >/tmp/sbp-out9.$$ 2>&1; then
+    if [[ -f ".loom/worktrees/issue-308/.loom-in-use" ]] && [[ -f ".loom/worktrees/issue-308/.loom-checkpoint" ]] && [[ ! -e ".loom/worktrees/issue-308/real-wip.txt" ]]; then
+        pass "runtime markers stayed in place; real WIP file was moved out"
+    else
+        fail "runtime markers were swept, or real WIP was left behind"
+    fi
+else
+    fail "stash-push --include-untracked exited non-zero (see /tmp/sbp-out9.$$)"
+fi
+./.loom/scripts/worktree.sh stash-pop 308 >/tmp/sbp-out9b.$$ 2>&1 || true
+
+# --- Test 10: the cross-worktree race the shared stash stack exposes --------
+#
+# This is the acceptance-criteria case from #5217: "simulate another
+# worktree's stash entry landing mid-sequence". A same-chain
+# `git stash push && <cmd> && git stash pop` heuristic in the GUARD cannot
+# make that pattern safe, because push and pop are two separate calls with an
+# arbitrary-duration command in between — another worktree's `git stash push`
+# can land on the SHARED stack during that window and be popped by mistake.
+# stash-push/stash-pop are immune by construction: each issue's WIP is
+# anchored to its OWN ref, so there is no shared stack to interleave on.
+echo ""
+echo "Test 10: another worktree's git stash landing between stash-push and stash-pop cannot corrupt the restore"
+make_worktree 310
+make_worktree 311
+cd "$REPO"
+echo "wip-from-310" >> ".loom/worktrees/issue-310/tracked.txt"
+./.loom/scripts/worktree.sh stash-push 310 >/tmp/sbp-out10a.$$ 2>&1
+
+# Mid-sequence: a concurrent builder in ANOTHER worktree pushes onto the
+# shared refs/stash stack — exactly the interleaving that makes a raw
+# push/pop pair unsafe.
+echo "wip-from-311" >> ".loom/worktrees/issue-311/tracked.txt"
+git -C ".loom/worktrees/issue-311" stash push -q -m "concurrent builder 311" >/dev/null 2>&1
+shared_stack_depth_before=$(git stash list | wc -l | tr -d ' ')
+
+if ./.loom/scripts/worktree.sh stash-pop 310 >/tmp/sbp-out10b.$$ 2>&1; then
+    pass "stash-pop 310 exited 0 despite another worktree's stash entry landing mid-sequence"
+else
+    fail "stash-pop 310 failed after a concurrent cross-worktree stash push (see /tmp/sbp-out10b.$$)"
+fi
+if grep -q "wip-from-310" ".loom/worktrees/issue-310/tracked.txt" && \
+   ! grep -q "wip-from-311" ".loom/worktrees/issue-310/tracked.txt"; then
+    pass "stash-pop restored issue 310's OWN wip, not the concurrent worktree's"
+else
+    fail "stash-pop restored the WRONG worktree's wip (cross-worktree collision not prevented)"
+fi
+shared_stack_depth_after=$(git stash list | wc -l | tr -d ' ')
+if [[ "$shared_stack_depth_before" == "$shared_stack_depth_after" ]]; then
+    pass "the other worktree's shared-stack entry was left untouched by stash-pop"
+else
+    fail "stash-pop consumed an entry from the shared refs/stash stack"
+fi
+git -C ".loom/worktrees/issue-311" stash pop -q >/dev/null 2>&1 || true
+
+# --- Test 11: contrast — the raw pattern DOES lose to the same interleaving -
+#
+# Documents why the guard must keep asking on raw `git stash pop` from a
+# worktree, and why the rejected same-chain-heuristic fix would not have been
+# safe: with the identical interleaving, raw push/pop restores the OTHER
+# worktree's WIP.
+echo ""
+echo "Test 11: contrast — raw git stash push/pop loses to the same interleaving (why the guard still asks)"
+make_worktree 312
+make_worktree 313
+cd "$REPO"
+echo "raw-wip-312" >> ".loom/worktrees/issue-312/tracked.txt"
+git -C ".loom/worktrees/issue-312" stash push -q -m "builder 312" >/dev/null 2>&1
+echo "raw-wip-313" >> ".loom/worktrees/issue-313/tracked.txt"
+git -C ".loom/worktrees/issue-313" stash push -q -m "builder 313" >/dev/null 2>&1
+git -C ".loom/worktrees/issue-312" stash pop -q >/dev/null 2>&1 || true
+if grep -q "raw-wip-313" ".loom/worktrees/issue-312/tracked.txt"; then
+    pass "raw git stash pop in worktree 312 restored worktree 313's WIP (the #4821 collision, still ask-gated)"
+else
+    fail "raw stash interleaving did not reproduce as expected — revisit this fixture"
+fi
+git -C ".loom/worktrees/issue-312" checkout -q -- tracked.txt 2>/dev/null || true
+git -C ".loom/worktrees/issue-313" checkout -q -- tracked.txt 2>/dev/null || true
+git stash clear >/dev/null 2>&1 || true
+
+# --- Test 12: the full headless chain survives an already-clean worktree ----
+#
+# The intended headless usage is a single `&&` chain. If stash-pop errored
+# whenever stash-push found nothing to capture, that chain would break
+# mid-sweep on any clean worktree — reintroducing the very stall #5217 set
+# out to remove.
+echo ""
+echo "Test 12: stash-push && <baseline check> && stash-pop exits 0 on an already-clean worktree"
+make_worktree 314
+cd "$REPO"
+if ./.loom/scripts/worktree.sh stash-push 314 >/tmp/sbp-out12.$$ 2>&1 \
+    && cat ".loom/worktrees/issue-314/tracked.txt" >/dev/null \
+    && ./.loom/scripts/worktree.sh stash-pop 314 >>/tmp/sbp-out12.$$ 2>&1; then
+    pass "the full push/check/pop chain exits 0 for a clean worktree"
+else
+    fail "the push/check/pop chain broke on a clean worktree (see /tmp/sbp-out12.$$)"
+fi
+if [[ ! -e "$REPO/.loom/worktrees/.stash-baseline/issue-314" ]]; then
+    pass "no pending state left behind after a clean-worktree round trip"
+else
+    fail "stash-pop left pending state behind at .stash-baseline/issue-314"
+fi
+
+# --- Summary ----------------------------------------------------------------
+echo ""
+echo "Tests run: $TESTS_RUN, Passed: $TESTS_PASSED, Failed: $TESTS_FAILED"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1

--- a/defaults/scripts/worktree.sh
+++ b/defaults/scripts/worktree.sh
@@ -14,6 +14,13 @@
 #     # <worktree-root>/.snapshots/issue-<N>-<UTC-timestamp>.patch — WITHOUT
 #     # touching `git stash` (which is repo-global and can be clobbered by a
 #     # concurrent builder in another worktree). Replay with `git apply`.
+#   pnpm worktree stash-push <issue-number> [--include-untracked] [--json]
+#   pnpm worktree stash-pop <issue-number> [--json]
+#     # Clean-and-restore pair for a "clean baseline vs my diff" comparison
+#     # (clippy/shellcheck/test baseline diffing) — WITHOUT touching the
+#     # shared `refs/stash` stack. Anchors captured WIP to a PER-ISSUE ref
+#     # (refs/loom/stash-baseline/issue-<N>) instead, so no other worktree's
+#     # concurrent stash op can ever land "in between" push and pop (#5217).
 #   pnpm worktree --check                              # Check if currently in a worktree
 #   pnpm worktree --json <issue-number>                # Machine-readable output
 #   pnpm worktree --return-to <dir> <issue-number>     # Store return directory
@@ -779,6 +786,360 @@ snapshot_worktree_command() {
 }
 
 # --------------------------------------------------------------------------
+# Worktree-scoped clean-baseline stash (issue #5217)
+# --------------------------------------------------------------------------
+#
+# `worktree.sh stash-push <N>` / `worktree.sh stash-pop <N>` give headless
+# Builder/Doctor sweeps a genuinely safe replacement for the
+# `git stash && <baseline check> && git stash pop` pattern used to diff a
+# clean baseline against in-progress WIP (clippy/shellcheck/test-output
+# comparisons). That raw pattern is correctly gated by
+# guard-destructive-generic.sh's `stash-scope:worktree-collision` check
+# (#4821) whenever >=2 `.loom-managed` worktrees are active — which in this
+# repo is nearly always true — producing an unanswerable `ask` in headless
+# mode with no human to answer it (#5217).
+#
+# `snapshot` (above) already solves the ADJACENT "shelve my WIP as a patch"
+# case, but deliberately does not reset the working tree, so it cannot alone
+# produce a clean baseline to diff against. stash-push/stash-pop close that
+# gap WITHOUT touching `refs/stash` at all:
+#
+#   - stash-push captures the tracked diff via `git stash create` (which
+#     builds a stash-format commit object but — unlike `git stash push` —
+#     never writes to refs/stash), anchors it under a PER-ISSUE ref
+#     (refs/loom/stash-baseline/issue-<N>) so it survives gc, then resets the
+#     worktree's tracked files to HEAD (`git reset --hard HEAD`, scoped to
+#     this one worktree's own index/working tree). Untracked files
+#     (--include-untracked) are moved into a per-issue holding directory
+#     rather than folded into the stash entry.
+#   - stash-pop reads back the SAME per-issue ref / holding-directory pair
+#     and restores both, then clears them.
+#
+# Because every issue gets its OWN ref rather than a shared stack, there is
+# no window for another worktree's concurrent `git stash push` to land "in
+# between" your push and pop — the race that makes a same-chain push/pop
+# ALLOW heuristic in the GUARD itself unsafe (considered and rejected during
+# #5217's curation: push and pop are two separate guard-approved Bash calls
+# with an arbitrary-duration command running between them, so anything that
+# lands on the SHARED stack during that window can still be popped by
+# mistake by a same-chain heuristic that only checks command shape, not
+# actual stack state). Anchoring to a per-issue ref instead of the shared
+# stack removes the shared-mutable-state precondition for that race
+# entirely, rather than trying to detect it after the fact.
+#
+# Durability note: both halves of the captured state live OUTSIDE the
+# worktree — the ref in the repo's common git dir, the untracked holding
+# directory and the pending marker under `<worktree-root>/.stash-baseline/`.
+# So even if the worktree is removed while a push is pending, nothing is
+# unrecoverable: `git stash apply refs/loom/stash-baseline/issue-<N>` still
+# replays the captured diff.
+#
+# Raw `git stash pop/drop/clear` remains exactly as gated as before by
+# guard-destructive-generic.sh — stash-push/stash-pop are the sanctioned,
+# guard-transparent replacement path for THIS pattern, not a guard exemption:
+# neither literally invokes `git stash pop|drop|clear`, so the guard's
+# pattern match never sees them, and it keeps asking on every raw stash
+# pop/drop/clear exactly as it did before this issue.
+stash_push_worktree_command() {
+    local issue_number="" json=false include_untracked=false
+    local usage="Usage: pnpm worktree stash-push <issue-number> [--include-untracked] [--json]"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --include-untracked) include_untracked=true; shift ;;
+            --json)               json=true; shift ;;
+            --*)
+                print_error "Unknown flag for stash-push: $1"
+                echo ""
+                echo "$usage"
+                return 1
+                ;;
+            *)
+                if [[ -z "$issue_number" ]]; then
+                    issue_number="$1"; shift
+                else
+                    print_error "Unexpected argument: $1"
+                    return 1
+                fi
+                ;;
+        esac
+    done
+
+    if [[ -z "$issue_number" ]]; then
+        print_error "stash-push requires an issue number"
+        echo ""
+        echo "$usage"
+        return 1
+    fi
+    if ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+        print_error "Issue number must be numeric (got: '$issue_number')"
+        echo ""
+        echo "$usage"
+        return 1
+    fi
+
+    _sbp_info()    { if [[ "$json" == true ]]; then echo -e "${BLUE}ℹ $*${NC}" >&2; else print_info "$*"; fi; }
+    _sbp_success() { if [[ "$json" == true ]]; then echo -e "${GREEN}✓ $*${NC}" >&2; else print_success "$*"; fi; }
+    _sbp_json() {
+        # $1=success(bool) $2=hasTrackedChanges(bool) $3=untrackedCount $4=ref
+        [[ "$json" == true ]] || return 0
+        printf '{"success": %s, "issueNumber": %s, "hasTrackedChanges": %s, "untrackedCount": %s, "ref": "%s"}\n' \
+            "$1" "$issue_number" "$2" "$3" "$4"
+    }
+
+    local git_common repo_root
+    if ! git_common=$(git rev-parse --git-common-dir 2>/dev/null); then
+        print_error "Not inside a git repository"
+        return 1
+    fi
+    repo_root=$(cd "$(dirname "$git_common")" 2>/dev/null && pwd) || repo_root="$(pwd)"
+
+    local worktree_root_dir worktree_path
+    worktree_root_dir="$(loom_worktree_root "$repo_root")"
+    worktree_path="$worktree_root_dir/issue-$issue_number"
+
+    if [[ ! -d "$worktree_path" ]]; then
+        print_error "No worktree found at $worktree_path — nothing to stash-push"
+        _sbp_json false false 0 ""
+        return 1
+    fi
+    if ! git -C "$worktree_path" rev-parse --git-dir >/dev/null 2>&1; then
+        print_error "$worktree_path is not a git working tree"
+        _sbp_json false false 0 ""
+        return 1
+    fi
+
+    local ref="refs/loom/stash-baseline/issue-$issue_number"
+    local holding_dir="$worktree_root_dir/.stash-baseline/issue-$issue_number"
+    local manifest_path="$holding_dir/untracked.manifest"
+    # The pending marker is what makes the intended headless chain
+    # `stash-push N && <baseline check> && stash-pop N` safe when the worktree
+    # happened to be CLEAN: nothing is captured, but the marker still records
+    # that a push occurred, so the paired stash-pop can succeed as a no-op
+    # instead of exiting 1 and breaking the `&&` chain mid-sweep. Without it,
+    # "there was nothing to restore" and "you never pushed" are indistinguishable.
+    local pending_marker="$holding_dir/pending"
+
+    if git -C "$worktree_path" rev-parse --verify --quiet "$ref" >/dev/null 2>&1 || [[ -f "$manifest_path" ]] || [[ -f "$pending_marker" ]]; then
+        print_error "A pending stash-push already exists for issue $issue_number — run 'stash-pop $issue_number' first (or resolve manually: ref $ref / $holding_dir)"
+        _sbp_json false false 0 ""
+        return 1
+    fi
+
+    local stash_commit=""
+    stash_commit="$(git -C "$worktree_path" stash create 2>/dev/null || true)"
+
+    local has_tracked=false
+    if [[ -n "$stash_commit" ]]; then
+        has_tracked=true
+        if ! git -C "$worktree_path" update-ref "$ref" "$stash_commit" 2>/dev/null; then
+            print_error "Failed to anchor baseline commit under $ref"
+            _sbp_json false false 0 ""
+            return 1
+        fi
+        if ! git -C "$worktree_path" reset --hard HEAD >/dev/null 2>&1; then
+            print_error "Failed to reset $worktree_path to a clean baseline after capturing WIP — baseline preserved at $ref, nothing lost"
+            _sbp_json false true 0 "$ref"
+            return 1
+        fi
+    fi
+
+    local untracked_count=0
+    if [[ "$include_untracked" == true ]]; then
+        local untracked
+        untracked="$(git -C "$worktree_path" ls-files --others --exclude-standard 2>/dev/null | \
+            grep -vE '(^|/)\.loom-managed$|(^|/)\.loom-in-use$|(^|/)\.loom-checkpoint$|(^|/)\.no-changes-needed$' || true)"
+        if [[ -n "$untracked" ]]; then
+            if ! mkdir -p "$holding_dir/untracked" 2>/dev/null; then
+                print_error "Could not create holding directory: $holding_dir/untracked"
+                _sbp_json false "$has_tracked" 0 "$ref"
+                return 1
+            fi
+            : > "$manifest_path"
+            while IFS= read -r f; do
+                [[ -n "$f" ]] || continue
+                local dest="$holding_dir/untracked/$f"
+                mkdir -p "$(dirname "$dest")" 2>/dev/null || continue
+                if mv "$worktree_path/$f" "$dest" 2>/dev/null; then
+                    echo "$f" >> "$manifest_path"
+                    untracked_count=$((untracked_count + 1))
+                fi
+            done <<< "$untracked"
+            [[ "$untracked_count" -eq 0 ]] && { rm -f "$manifest_path" 2>/dev/null || true; }
+        fi
+    fi
+
+    # Record the push itself, whether or not anything was captured, so the
+    # paired stash-pop is always a legitimate no-op rather than an error.
+    if ! mkdir -p "$holding_dir" 2>/dev/null || ! date -u +"%Y-%m-%dT%H:%M:%SZ" > "$pending_marker" 2>/dev/null; then
+        print_error "Could not record the pending-push marker at $pending_marker"
+        _sbp_json false "$has_tracked" "$untracked_count" "$ref"
+        return 1
+    fi
+
+    if [[ "$has_tracked" == false && "$untracked_count" -eq 0 ]]; then
+        _sbp_info "No uncommitted changes to push for issue $issue_number — worktree was already clean"
+    else
+        _sbp_success "Baseline captured for issue $issue_number (tracked: $has_tracked, untracked files moved: $untracked_count)"
+    fi
+    _sbp_info "Restore with: ./.loom/scripts/worktree.sh stash-pop $issue_number"
+
+    _sbp_json true "$has_tracked" "$untracked_count" "$ref"
+    return 0
+}
+
+# See stash_push_worktree_command's comment block above for the full design
+# rationale. stash-pop is the restore half: reads back the per-issue ref
+# (tracked changes) and holding directory (untracked files) written by
+# stash-push for the SAME issue number, applies both, and clears them.
+stash_pop_worktree_command() {
+    local issue_number="" json=false
+    local usage="Usage: pnpm worktree stash-pop <issue-number> [--json]"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --json) json=true; shift ;;
+            --*)
+                print_error "Unknown flag for stash-pop: $1"
+                echo ""
+                echo "$usage"
+                return 1
+                ;;
+            *)
+                if [[ -z "$issue_number" ]]; then
+                    issue_number="$1"; shift
+                else
+                    print_error "Unexpected argument: $1"
+                    return 1
+                fi
+                ;;
+        esac
+    done
+
+    if [[ -z "$issue_number" ]]; then
+        print_error "stash-pop requires an issue number"
+        echo ""
+        echo "$usage"
+        return 1
+    fi
+    if ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+        print_error "Issue number must be numeric (got: '$issue_number')"
+        echo ""
+        echo "$usage"
+        return 1
+    fi
+
+    _sbo_info()    { if [[ "$json" == true ]]; then echo -e "${BLUE}ℹ $*${NC}" >&2; else print_info "$*"; fi; }
+    _sbo_success() { if [[ "$json" == true ]]; then echo -e "${GREEN}✓ $*${NC}" >&2; else print_success "$*"; fi; }
+    _sbo_json() {
+        # $1=success(bool) $2=restoredTracked(bool) $3=restoredUntrackedCount
+        [[ "$json" == true ]] || return 0
+        printf '{"success": %s, "issueNumber": %s, "restoredTracked": %s, "restoredUntrackedCount": %s}\n' \
+            "$1" "$issue_number" "$2" "$3"
+    }
+
+    local git_common repo_root
+    if ! git_common=$(git rev-parse --git-common-dir 2>/dev/null); then
+        print_error "Not inside a git repository"
+        return 1
+    fi
+    repo_root=$(cd "$(dirname "$git_common")" 2>/dev/null && pwd) || repo_root="$(pwd)"
+
+    local worktree_root_dir worktree_path
+    worktree_root_dir="$(loom_worktree_root "$repo_root")"
+    worktree_path="$worktree_root_dir/issue-$issue_number"
+
+    if [[ ! -d "$worktree_path" ]]; then
+        print_error "No worktree found at $worktree_path"
+        _sbo_json false false 0
+        return 1
+    fi
+    if ! git -C "$worktree_path" rev-parse --git-dir >/dev/null 2>&1; then
+        print_error "$worktree_path is not a git working tree"
+        _sbo_json false false 0
+        return 1
+    fi
+
+    local ref="refs/loom/stash-baseline/issue-$issue_number"
+    local holding_dir="$worktree_root_dir/.stash-baseline/issue-$issue_number"
+    local manifest_path="$holding_dir/untracked.manifest"
+    local pending_marker="$holding_dir/pending"
+
+    local has_tracked=false stash_commit=""
+    if git -C "$worktree_path" rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then
+        has_tracked=true
+        stash_commit="$(git -C "$worktree_path" rev-parse "$ref" 2>/dev/null || true)"
+    fi
+    local has_manifest=false
+    [[ -f "$manifest_path" ]] && has_manifest=true
+    local has_pending=false
+    [[ -f "$pending_marker" ]] && has_pending=true
+
+    # Nothing captured AND no record of a push => the caller never pushed.
+    # That is a real error. Nothing captured but a pending marker present
+    # means stash-push ran against an already-clean worktree — a legitimate
+    # no-op restore, so the `push && check && pop` chain must not break.
+    if [[ "$has_tracked" == false && "$has_manifest" == false && "$has_pending" == false ]]; then
+        print_error "Nothing to restore for issue $issue_number — run 'stash-push $issue_number' first"
+        _sbo_json false false 0
+        return 1
+    fi
+
+    if [[ "$has_tracked" == true ]]; then
+        if ! git -C "$worktree_path" stash apply "$stash_commit" >/dev/null 2>&1; then
+            print_error "Failed to apply baseline commit $stash_commit for issue $issue_number (likely conflicts with the current tree). The captured baseline is PRESERVED at $ref — resolve manually with 'git -C $worktree_path stash apply $stash_commit', then delete the ref with 'git -C $worktree_path update-ref -d $ref'."
+            _sbo_json false false 0
+            return 1
+        fi
+        git -C "$worktree_path" update-ref -d "$ref" >/dev/null 2>&1 || true
+    fi
+
+    local restored_untracked=0
+    if [[ "$has_manifest" == true ]]; then
+        local restore_failed=false
+        while IFS= read -r f; do
+            [[ -n "$f" ]] || continue
+            local src="$holding_dir/untracked/$f"
+            [[ -f "$src" ]] || continue
+            if ! mkdir -p "$(dirname "$worktree_path/$f")" 2>/dev/null; then
+                restore_failed=true
+                continue
+            fi
+            if mv "$src" "$worktree_path/$f" 2>/dev/null; then
+                restored_untracked=$((restored_untracked + 1))
+            else
+                restore_failed=true
+            fi
+        done < "$manifest_path"
+
+        if [[ "$restore_failed" == true ]]; then
+            print_error "Some untracked files for issue $issue_number could not be restored — remaining files are still under $holding_dir/untracked (manifest kept at $manifest_path for manual recovery)"
+            _sbo_json false "$has_tracked" "$restored_untracked"
+            return 1
+        fi
+
+        rm -f "$manifest_path" 2>/dev/null || true
+        rmdir "$holding_dir/untracked" 2>/dev/null || true
+    fi
+
+    # Clear the pending marker last: everything above either restored cleanly
+    # or returned early with the captured state preserved, so reaching here
+    # means the push/pop pair is complete.
+    rm -f "$pending_marker" 2>/dev/null || true
+    rmdir "$holding_dir" 2>/dev/null || true
+
+    if [[ "$has_tracked" == false && "$restored_untracked" -eq 0 ]]; then
+        _sbo_info "Nothing was captured for issue $issue_number — the worktree was already clean at stash-push time"
+        _sbo_json true false 0
+        return 0
+    fi
+
+    _sbo_success "Baseline restored for issue $issue_number (tracked: $has_tracked, untracked files restored: $restored_untracked)"
+    _sbo_json true "$has_tracked" "$restored_untracked"
+    return 0
+}
+
+# --------------------------------------------------------------------------
 # Sparse-checkout helpers
 # --------------------------------------------------------------------------
 #
@@ -922,6 +1283,9 @@ Usage:
   pnpm worktree remove <N> [--keep-branch] [--force]    Remove one managed worktree
   pnpm worktree snapshot <N> [--include-untracked] [--json]
                                                          Save uncommitted WIP as a patch file
+  pnpm worktree stash-push <N> [--include-untracked] [--json]
+                                                         Capture WIP, reset to a clean baseline
+  pnpm worktree stash-pop <N> [--json]                  Restore WIP captured by stash-push
   pnpm worktree --check                                 Check if in a worktree
   pnpm worktree --json <issue-number>                   Machine-readable JSON output
   pnpm worktree --return-to <dir> <issue-number>        Store return directory
@@ -991,6 +1355,34 @@ Examples:
 
   pnpm worktree snapshot 42 --json
     Output: {"success": true, "issueNumber": 42, "patchPath": "/path/to/.snapshots/issue-42-...patch", "hasChanges": true, "bytes": 1234}
+
+  pnpm worktree stash-push 42
+    For a "clean baseline vs my diff" comparison (clippy/shellcheck/test
+    baseline diffing, issue #5217): captures the worktree's uncommitted
+    tracked-file diff via 'git stash create' (never touches refs/stash),
+    anchors it under the PER-ISSUE ref refs/loom/stash-baseline/issue-42, and
+    resets the worktree to a clean 'git reset --hard HEAD' baseline. Unlike
+    raw 'git stash push', two builders in different worktrees can never
+    collide — each issue gets its own ref, not a shared stack — so this does
+    NOT trigger guard-destructive-generic.sh's stash-scope:worktree-collision
+    ask even with several other '.loom-managed' worktrees active.
+
+  pnpm worktree stash-push 42 --include-untracked
+    Same as above, but also moves untracked files (respecting .gitignore,
+    excluding Loom runtime markers) into a per-issue holding directory
+    instead of leaving them in the worktree.
+
+  pnpm worktree stash-pop 42
+    Restores whatever 'stash-push 42' captured (tracked diff + any moved
+    untracked files) and clears the ref / holding directory. Succeeds as a
+    no-op when the matching stash-push found an already-clean worktree, so
+    'stash-push 42 && <baseline check> && stash-pop 42' never breaks its own
+    chain. Errors loudly, WITHOUT discarding the captured baseline, if no
+    stash-push is pending at all or if re-applying conflicts with the tree.
+
+  pnpm worktree stash-push 42 --json / stash-pop 42 --json
+    Output: {"success": true, "issueNumber": 42, "hasTrackedChanges": true, "untrackedCount": 0, "ref": "refs/loom/stash-baseline/issue-42"}
+            {"success": true, "issueNumber": 42, "restoredTracked": true, "restoredUntrackedCount": 0}
 
   pnpm worktree --check
     Shows current worktree status
@@ -1111,6 +1503,21 @@ if [[ "$1" == "snapshot" ]]; then
     shift
     # Left of && so set -e does not abort on a non-zero return from the handler.
     snapshot_worktree_command "$@" && exit 0
+    exit 1
+fi
+
+# Worktree-scoped clean-baseline stash verbs (issue #5217). Dispatched HERE
+# for the same reason `snapshot`/`remove` are: `stash-push <N>` / `stash-pop
+# <N>` must not be rejected as "Issue number must be numeric".
+if [[ "$1" == "stash-push" ]]; then
+    shift
+    stash_push_worktree_command "$@" && exit 0
+    exit 1
+fi
+
+if [[ "$1" == "stash-pop" ]]; then
+    shift
+    stash_pop_worktree_command "$@" && exit 0
     exit 1
 fi
 

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -3449,6 +3449,70 @@ rm -rf "$CD_ST2_REPO"
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- Stash-stack scope: worktree-confined baseline stash via worktree.sh stash-push/stash-pop (#5217) ---${NC}"
+# =========================================================================
+#
+# #5217: a legitimate `git stash push && <baseline check> && git stash pop`
+# chain — used to diff a clean baseline against WIP (clippy/shellcheck/test
+# comparisons) — is correctly gated by stash-scope:worktree-collision
+# whenever >=2 managed worktrees are active (nearly always true in this
+# repo), producing an unanswerable `ask` in headless mode. The fix is NOT to
+# widen the guard's own ask condition (a same-chain push/pop heuristic was
+# considered and rejected — see the comment above the worktree-collision ask
+# in guard-destructive-generic.sh — because another worktree's concurrent
+# `git stash push` can still land on the SHARED stack in the window between
+# the two guard-approved Bash calls). Instead, `worktree.sh stash-push` /
+# `stash-pop` (added by #5217) never touch `refs/stash` at all — they anchor
+# WIP to a PER-ISSUE ref — so invoking them is guard-transparent: the text
+# never contains a raw `git stash pop|drop|clear`, so the pattern this block
+# scans for never matches. These tests assert BOTH halves of the fix: the
+# narrowed-safe path is genuinely available, AND raw git stash usage
+# (including a same-chain push/pop, proving the rejected heuristic was NOT
+# adopted) is exactly as gated as before.
+
+ST3_REPO=$(make_wt_repo_two_linked)
+ST3_WT1_DIR="$ST3_REPO/.loom/worktrees/issue-1"
+
+# The sanctioned replacement commands never literally invoke `git stash
+# pop|drop|clear`, so they sail through even with >=2 managed worktrees
+# active and cwd inside a linked worktree — the exact configuration that
+# asks for raw git stash above.
+assert_allow "stash-scope (#5217): worktree.sh stash-push allows from a linked worktree even with >=2 managed worktrees" \
+    "./.loom/scripts/worktree.sh stash-push 1" "$ST3_WT1_DIR"
+assert_allow "stash-scope (#5217): worktree.sh stash-pop allows from a linked worktree even with >=2 managed worktrees" \
+    "./.loom/scripts/worktree.sh stash-pop 1" "$ST3_WT1_DIR"
+assert_allow "stash-scope (#5217): chained stash-push, baseline check, stash-pop allows from a linked worktree" \
+    "./.loom/scripts/worktree.sh stash-push 1 && cat file.txt && ./.loom/scripts/worktree.sh stash-pop 1" "$ST3_WT1_DIR"
+assert_allow "stash-scope (#5217): worktree.sh stash-push --include-untracked allows from a linked worktree" \
+    "./.loom/scripts/worktree.sh stash-push 1 --include-untracked" "$ST3_WT1_DIR"
+
+# Control: raw git stash pop/drop/clear from the SAME fixture must still ask,
+# unchanged — the new commands are an addition, not a relaxation of the
+# existing worktree-collision protection.
+assert_ask "stash-scope (#5217): raw git stash pop from a linked worktree still asks with >=2 managed worktrees" \
+    "git stash pop" "$ST3_WT1_DIR"
+assert_ask "stash-scope (#5217): raw git stash drop from a linked worktree still asks with >=2 managed worktrees" \
+    "git stash drop" "$ST3_WT1_DIR"
+
+# Control: the rejected same-chain heuristic must NOT have been adopted — a
+# raw `git stash push && <cmd> && git stash pop` chain (the shape the
+# original #5217 report described) still asks exactly like a bare pop, since
+# the guard only ever sees the literal 'git stash pop' token in the chain.
+assert_ask "stash-scope (#5217): raw chained 'git stash push && ... && git stash pop' still asks (same-chain heuristic NOT adopted)" \
+    "git stash push -u && cat file.txt && git stash pop" "$ST3_WT1_DIR"
+
+# Control: the updated worktree-collision ask message documents BOTH
+# sanctioned alternatives (snapshot for ad-hoc WIP, stash-push/stash-pop for
+# a baseline-diff comparison) so a headless sweep that hits the ask can see
+# the guard-transparent path without a human needing to explain it.
+assert_ask_reason_matches "stash-scope (#5217): worktree-collision ask message documents the stash-push/stash-pop alternative" \
+    "git stash pop" "stash-push.*stash-pop" "$ST3_WT1_DIR"
+
+rm -rf "$ST3_REPO"
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- Performance check ---${NC}"
 # =========================================================================
 


### PR DESCRIPTION
## Summary

Headless Builder/Doctor sweeps that want a "clean baseline vs. my diff" comparison (clippy/shellcheck/test-output diffing) had no safe primitive. Raw `git stash push && <baseline check> && git stash pop` run from a worktree trips `guard-destructive-generic.sh`'s `stash-scope:worktree-collision` **ask** whenever two or more `.loom-managed` worktrees are active — effectively always in this repo — and there is no human to answer it, so the sweep stalls.

**The guard was deliberately NOT widened.** Per the issue's "Why the guard exists" analysis, a same-chain "push and pop appear in one command, so allow" heuristic is *not* safe: push and pop are two separate guard-approved Bash calls with an arbitrary-duration command running in between, so another worktree's concurrent `git stash push` can still land on the shared `refs/stash` stack inside that window and the "pop" then restores the **wrong** entry. Command shape alone cannot see that.

This PR takes direction **(a)**: give `worktree.sh` a genuinely safe clean-and-restore pair that removes the shared-mutable-state precondition entirely, and steer headless baseline-diff callers at it.

## Changes

**`defaults/scripts/worktree.sh`** — two new verbs:

| Verb | Behavior |
|------|----------|
| `stash-push <N> [--include-untracked] [--json]` | Captures the worktree's uncommitted tracked diff with `git stash create` (builds a stash-format commit but **never writes `refs/stash`**), anchors it under the **per-issue** ref `refs/loom/stash-baseline/issue-<N>`, then resets that one worktree to a clean `HEAD` baseline. `--include-untracked` moves untracked files to a per-issue holding directory (Loom runtime markers excluded). Refuses a second push while one is pending. |
| `stash-pop <N> [--json]` | Re-applies exactly what its own push captured, then clears the ref/holding directory. A pending marker makes "pop with nothing captured" a legitimate **no-op**, so the intended `push && check && pop` chain cannot break on an already-clean worktree. Every failure path preserves the captured baseline rather than discarding it. |

Because each issue gets its own ref rather than a slot on a shared stack, there is no window for another worktree's stash op to interleave. Both halves of the captured state (the ref in the common git dir, the holding dir + marker under `<worktree-root>/.stash-baseline/`) live **outside** the worktree, so the WIP stays recoverable even if the worktree is removed mid-sequence.

**`defaults/hooks/guard-destructive-generic.sh`** — behavior unchanged; only the `stash-scope:worktree-collision` ask *message* now names the new alternative alongside `snapshot`, plus a comment block recording why the same-chain heuristic was rejected. Raw `git stash pop|drop|clear` stays exactly as gated as before, in the main checkout and in a linked worktree alike — neither new verb's command text contains that token, so they are guard-transparent, not a guard exemption.

**Docs** — `defaults/docs/guard-hooks.md` (new "Headless baseline-diff pattern (#5217)" subsection + example; also corrected one stale adjacent example that claimed a linked-worktree `git stash pop` is unconditionally allowed, which #4821 changed), `builder.md` and `doctor.md` (steer the baseline-diff pattern at the new verbs, and note that `snapshot` alone is *not* a substitute because it never resets the working tree).

**Note on installed copies**: per `builder.md` § "NEVER run resync-installed.sh from your worktree", this PR changes only `defaults/`; propagating into `.loom/hooks|docs/` is the periodic resync chore's job.

## Acceptance Criteria Verification

- [x] **Fix direction decided with the race window accounted for** — direction (a). The race is not *detected after the fact*; its precondition (a shared stack) is removed. Test 10 lands a real `git stash push` from another worktree between a `stash-push` and its `stash-pop` and asserts the restore is unaffected; Test 11 is the contrast fixture proving the raw pattern *does* lose to that identical interleaving.
- [x] **Headless sweeps no longer stall, without weakening detection** — the replacement path is `allow` (4 new guard assertions), while the genuine main-checkout restore and genuine cross-worktree collision keep asking (all pre-existing `stash-scope` assertions still pass, plus 3 new explicit controls including "raw chained push && ... && pop still asks", proving the rejected heuristic was not adopted).
- [x] **Regression coverage in `tests/hooks/test-guard-destructive.sh`** — 8 new assertions there, plus a new 29-assertion functional suite `defaults/scripts/tests/test-worktree-stash-baseline.sh` wired into `ci-wired.txt`.
- [x] `worktree.sh snapshot` is documented as *not* a drop-in substitute (it captures a patch but never resets the tree) — corrected in `builder.md` / `doctor.md`.

## Test Plan

```
bash defaults/scripts/tests/test-worktree-stash-baseline.sh   # 29/29 pass (new suite)
bash tests/hooks/test-guard-destructive.sh                    # 687/687 pass (was 679; +8)
bash defaults/scripts/tests/test-worktree-snapshot.sh         # 15/15 pass
bash defaults/scripts/tests/test-worktree-remove.sh           # 26/26 pass
bash defaults/scripts/tests/test-worktree-sentinel.sh         # 10/10 pass
bash defaults/scripts/tests/test-worktree-json-purity.sh      # 18/18 pass
bash defaults/scripts/tests/check-ci-suite-manifest.sh        # OK — 104 suites accounted for
bash scripts/check-docs-defaults-parity.sh                    # OK
bash defaults/scripts/check-phantom-labels.sh                 # OK
bash scripts/check-agents-md-sync.sh / check-claude-md-budget.sh  # OK
find defaults/scripts -name '*.sh' | xargs shellcheck --severity=warning   # clean
```

Closes #5217
