### PR TITLE
feat(champion): detect dependency cycles with a bounded cross-repo walk

### DIFF
--- a/defaults/.claude/commands/loom/champion-issue-promo.md
+++ b/defaults/.claude/commands/loom/champion-issue-promo.md
@@ -162,7 +162,65 @@ For each proposal issue (`loom:curated`, `loom:architect`, `loom:hermit`, or `lo
 ### 2. Technical Feasibility
 - [ ] Solution approach is technically sound
 - [ ] No obvious blockers or dependencies
+- [ ] Declared blockers are *resolvable* — not a dependency cycle (see "Dependency-cycle gate" below)
 - [ ] Fits within existing architecture
+
+#### Dependency-cycle gate (#5213)
+
+The "no obvious blockers or dependencies" check above is **single-hop and
+same-repo**: it looks at the `Blocked by`/`Depends on`/`Requires` references in
+this issue's body and asks whether each is closed. That is blind to a *cycle* —
+this issue waits on #B, and #B (or something #B waits on, possibly in another
+repo) waits back on this issue. Such an issue can never become promotable by
+waiting, and every future Champion pass re-derives the same conclusion.
+
+**Run the gate only when the proposal actually declares a blocker** — an issue
+whose body has no `(Blocked by|Depends on|Requires)` reference costs nothing:
+
+```bash
+ISSUE_NUMBER=<number>
+
+# Cheap trigger: does this proposal declare any dependency at all? Same
+# vocabulary as everywhere else (#4508), widened to cross-repo/URL refs.
+DECLARES_DEP=$("$GH_READ" issue view "$ISSUE_NUMBER" --json body --jq '.body' \
+  | grep -cE '(Blocked by|Depends on|Requires)[*_:[:space:]]*(([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[0-9]+|https?://[^[:space:]),]+/issues/[0-9]+)')
+
+if [ "$DECLARES_DEP" -gt 0 ]; then
+  CYCLE_RC=0
+  ./.loom/scripts/detect-dependency-cycle.sh --issue "$ISSUE_NUMBER" --report || CYCLE_RC=$?
+  if [ "$CYCLE_RC" -eq 1 ]; then
+    # Criterion 2 FAILS. The script has already posted one comment naming every
+    # node in the cycle and added loom:operator-only. Do NOT promote, do NOT
+    # post a separate NEEDS REVISION verdict — a cycle is not something the
+    # proposal's author can fix by revising this issue's text, and
+    # loom:operator-only already excludes it from every future pass.
+    echo "#$ISSUE_NUMBER is in a dependency cycle — routed to loom:operator-only, skipping promotion"
+  fi
+fi
+```
+
+The detector is bounded by construction (default 4 hops, 25 fetched issues, 500
+edges; cached reads; `SEARCH_TRUNCATED:` printed whenever a bound fires so
+`NO_CYCLE` is never read as proof) and its comment is idempotent on the cycle's
+node set, so a cycle that survives several passes is surfaced exactly once. Full
+rationale, marker vocabulary and the bounded-cost table live in
+`champion-pr-merge.md` → "Dependency-cycle detection (#5213)"; both call sites
+run the same script, so there is one walk implementation to keep correct.
+
+**It also runs at most once per issue, without needing its own skip.** Adding
+`loom:operator-only` removes the issue from every future promotion pass —
+`champion.md`'s candidate queries already exclude that label, and "When NOT to
+Promote" below restates it — so the pass that finds a cycle is the last pass that
+walks it. Nothing here needs to be added to the body-hash idempotency machinery
+in "Idempotency check": that marker answers "has the proposal been revised", a
+question a cycle is indifferent to.
+
+**If an "Epic-aware blocker sub-check" is present under this criterion** (it
+resolves blockers whose epic has in substance already shipped), run it **first**
+and let this gate see only the blockers that survive it. A blocker the epic check
+clears is *resolvable*, not a deadlock, and reporting it as a cycle would put a
+human in front of an issue that needed no human. The two are independent
+mechanisms with independent markers — neither reads the other's state.
 
 ### 3. Implementation Clarity
 - [ ] Enough detail for a Builder to start work

--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -899,6 +899,26 @@ for blocked in $BLOCKED_ISSUES; do
     fi
   done
 
+  # "Still blocked" is only a valid conclusion if waiting can ever end. Run the
+  # bounded, cross-repo cycle detector on exactly this branch (#5213) — see
+  # "Dependency-cycle detection" below for why it is gated here and nowhere else.
+  if [ "$ALL_RESOLVED" = false ]; then
+    # Second gate, before the walk: a cycle already surfaced on this issue is a
+    # human's to break, and re-walking it every pass buys nothing. One cached
+    # label read (backlog observation, not arbitration) replaces up to
+    # --max-nodes forge reads. Cached("$GH_READ") — see "Cached forge reads".
+    ALREADY_ROUTED=$("$GH_READ" issue view "$blocked" --json labels \
+      --jq '[.labels[].name] | index("loom:operator-only") // empty')
+
+    if [ -z "$ALREADY_ROUTED" ]; then
+      CYCLE_RC=0
+      ./.loom/scripts/detect-dependency-cycle.sh --issue "$blocked" --report || CYCLE_RC=$?
+      if [ "$CYCLE_RC" -eq 1 ]; then
+        echo "  Dependency CYCLE on #$blocked — surfaced and routed to loom:operator-only; not re-deriving 'still blocked'"
+      fi
+    fi
+  fi
+
   if [ "$ALL_RESOLVED" = true ]; then
     echo "  All dependencies resolved - unblocking #$blocked"
     gh issue edit "$blocked" --remove-label "loom:blocked" --add-label "loom:issue"
@@ -911,6 +931,50 @@ All dependencies are now resolved. This issue is ready for implementation.
   fi
 done
 ```
+
+#### Dependency-cycle detection (#5213)
+
+**Why this exists.** Everything above is **single-hop and same-repo**: it asks "is
+the issue named in `Blocked by: #N` closed yet?". That question has no reachable
+answer when the declared dependencies form a **cycle** — A waits on B, B waits on
+A — so the loop above re-derives `Still blocked` on every pass, forever, and
+nothing in either issue's text makes the cycle visible. The incident that motivated
+this ran for weeks across two repos (an epic in one repo blocking a dependent in
+another, whose own output the epic's last remaining phase needed) and was only
+found by an operator walking 15 child issues by hand.
+
+**`./.loom/scripts/detect-dependency-cycle.sh --issue <N> [--repo <owner/repo>]`**
+closes that gap. It walks the same `(Blocked by|Depends on|Requires)` vocabulary
+this file already parses — but **N hops instead of one**, and **across repos**,
+following `owner/repo#N` and issue-URL references as well as bare `#N`. Exit codes
+mirror `check-duplicate.sh`: **0** = no cycle within the bounds, **1** = cycle
+detected, **2** = error. Read the marker lines on stdout (`CYCLE_PATH:`,
+`CYCLE_NODES:`, `CYCLE_FINGERPRINT:`, `SEARCH_TRUNCATED:`, `UNREADABLE:`) rather
+than re-deriving anything yourself.
+
+| Property | How the script guarantees it |
+|---|---|
+| **Bounded cost** | Hard caps on hops (`--max-depth`, default 4), distinct issues fetched (`--max-nodes`, default 25) and edges examined (`--max-steps`, default 500); each issue is fetched at most once per run; reads go through `gh-cached`. A bound that fires prints `SEARCH_TRUNCATED:` so `NO_CYCLE` is never mistaken for proof. |
+| **Not on every pass** | Two gates precede it. (1) It is invoked **only** on the `ALL_RESOLVED=false` branch above — i.e. only once the cheap single-hop check has already concluded "still blocked", so an issue that unblocks normally never pays for a walk. (2) An issue already carrying `loom:operator-only` is skipped outright — the cycle was surfaced on an earlier pass and a human owns it, so one cached label read replaces the whole walk from then on. |
+| **Surfaced, not silent** | `--report` posts **one** comment naming every node in the cycle and adds `loom:operator-only`. Breaking a cycle means deciding which declared edge is wrong or which side ships a partial first — a human decision Champion is not entitled to make. |
+| **Idempotent** | The comment carries `<!-- champion:dep-cycle:<fingerprint> -->`, fingerprinted on the cycle's **node set** (sorted), so the same cycle discovered from either side collapses to one identity and is commented once; a genuinely different cycle still gets its own comment. Same marker-and-skip shape as `champion-issue-promo.md`'s body-hash idempotency. |
+| **Fail-safe** | A `CLOSED` node ends that branch of the walk (a resolved edge cannot deadlock anyone), an unreadable cross-repo issue is reported as `UNREADABLE:` rather than crashing, and without `--report` the script is strictly read-only. |
+
+Do **not** remove `loom:blocked` when a cycle is found — the issue genuinely is
+blocked. The change is that a human now owns it (`loom:operator-only`) instead of
+Champion re-deriving the same dead conclusion on the next pass.
+
+**A cycle is not the same finding as a completed-but-unpromoted epic.** If an
+"Epic-Aware Blocker Check" section is present in `champion-common.md`, run it
+**first** and let the cycle detector see only what survives it: a blocker whose
+epic has in substance already shipped is a *resolvable* edge that the epic check
+clears on its own, and reporting it as a deadlock would put a human in front of an
+issue that needed no human. The two checks answer different questions — "has this
+blocker actually finished?" versus "can this blocker ever finish?" — and the
+detector is the fallback for the second, which only arises once the first has said
+no. They share no state and no marker (`champion:epic-block:*` vs.
+`champion:dep-cycle:*`), so either can land, be edited, or be removed without
+touching the other.
 
 ### Step 5.5: Create Follow-on Issues
 

--- a/defaults/scripts/detect-dependency-cycle.sh
+++ b/defaults/scripts/detect-dependency-cycle.sh
@@ -1,0 +1,477 @@
+#!/usr/bin/env bash
+# detect-dependency-cycle.sh - Bounded, cross-repo dependency-cycle detection
+# for Champion's blocking evaluation (issue #5213).
+#
+# THE FAILURE MODE THIS EXISTS FOR
+#
+# Champion's unblock evaluation (champion-pr-merge.md "Step 5: Unblock
+# Dependent Issues") and its promotion feasibility check are both SINGLE-HOP
+# and SAME-REPO: they read a blocked issue's `Blocked by`/`Depends on`/
+# `Requires` references and ask "is #N closed yet?". That question has no
+# answer when the dependency graph contains a cycle -- A waits on B, B waits
+# on A -- so every pass re-derives "still blocked", forever, and nothing in
+# either issue's text makes the cycle visible. A real fleet deadlock of
+# exactly this shape (an epic in one repo blocking a dependent issue in
+# another, whose own remaining phase depended on that dependent's output) was
+# found only by an operator manually walking 15 child issues.
+#
+# This script walks the declared dependency edges from one issue, BOUNDED in
+# depth / fetched nodes / examined edges, following `owner/repo#N` and issue-URL
+# references ACROSS repos, and reports a cycle if the walk ever re-enters a node
+# already on the current path. With --report it additionally surfaces the cycle
+# on the issue (one idempotent comment naming every node in the cycle) and routes
+# the issue to `loom:operator-only`, because breaking a cycle is a human decision
+# (which declared edge is wrong, or which side ships a partial first) that no
+# automated pass is entitled to make.
+#
+# Usage:
+#   detect-dependency-cycle.sh --issue <N> [--repo <owner/repo>] [options]
+#
+# Examples:
+#   detect-dependency-cycle.sh --issue 56
+#   detect-dependency-cycle.sh --issue 391 --repo 2AMLogic/klayout-tools
+#   detect-dependency-cycle.sh --issue 56 --report          # comment + operator-only
+#
+# Options:
+#   --issue <N>        Issue number to start the walk from (required).
+#   --repo <nwo>       owner/repo of --issue (default: the current repo's origin).
+#   --max-depth <D>    Max hops from the root = longest detectable cycle
+#                       (default: 4, $LOOM_DEPCYCLE_MAX_DEPTH).
+#   --max-nodes <M>    Max DISTINCT issues fetched from the forge (default: 25,
+#                       $LOOM_DEPCYCLE_MAX_NODES).
+#   --max-steps <S>    Max dependency edges examined (default: 500,
+#                       $LOOM_DEPCYCLE_MAX_STEPS).
+#   --report           On a cycle, post an idempotent comment on --issue naming
+#                       every node in the cycle and add `loom:operator-only`.
+#                       Without this flag the script is strictly read-only.
+#   --no-cache         Read via plain `gh` instead of the `gh-cached` wrapper.
+#   --help,-h          Show this help.
+#
+# Output (stdout, marker lines -- parseable by the Champion prose):
+#   Cycle found:
+#     CYCLE_DETECTED
+#     CYCLE_PATH: owner/a#1 -> owner/b#2 -> owner/a#1
+#     CYCLE_NODES: owner/a#1 owner/b#2
+#     CYCLE_FINGERPRINT: <16 hex>
+#   No cycle:
+#     NO_CYCLE
+#     SCANNED: <distinct issues fetched>
+#   Partial-coverage markers (either case; informational, never a match):
+#     SEARCH_TRUNCATED: depth|nodes|steps ...   -- a bound stopped the walk, so
+#                                                  "NO_CYCLE" means "no cycle
+#                                                  within the bounds", not "none"
+#     UNREADABLE: owner/repo#N ...              -- not visible to this token
+#   --report only:
+#     REPORTED: <issue>            -- comment posted + loom:operator-only added
+#     ALREADY_REPORTED: <issue>    -- this exact cycle was already surfaced
+#
+# Exit codes (mirrors check-duplicate.sh's convention):
+#   0 - No cycle found within the bounds
+#   1 - Dependency cycle detected
+#   2 - Error (bad arguments, root issue unreadable, missing jq)
+#
+# BOUNDED COST. Every knob above is a hard stop, and the walk is additionally
+# memoized: each distinct issue is fetched at most once per invocation, and a
+# subtree that completed without hitting the depth bound is never re-walked.
+# Reads default to the `gh-cached` wrapper (30s TTL), so a Champion pass that
+# checks several blocked issues in a row shares one set of responses. Callers
+# should still invoke this only when the cheap single-hop check has already
+# concluded "still blocked" -- that is the trigger condition, not every pass.
+#
+# FALSE-POSITIVE POSTURE. The edge parser deliberately reuses the repo's existing
+# two-stage dependency-phrase parse (#4508) rather than inventing a stricter
+# second one, and that parse is line-scoped: every reference on a line that
+# declares a dependency phrase is treated as an edge, so "Blocked by #2. See also
+# #99." yields both. That is over-inclusive by design -- under-parsing here would
+# miss a real deadlock, while over-parsing at worst routes one issue to a human
+# with the full path spelled out. A false positive is bounded and reversible: one
+# comment, one label, no state machine advanced, `loom:blocked` left untouched.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---- output helpers ----
+if [[ -t 2 ]]; then
+    RED='\033[0;31m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+else
+    RED=''; YELLOW=''; BLUE=''; NC=''
+fi
+err()  { echo -e "${RED}ERROR: $1${NC}" >&2; }
+warn() { echo -e "${YELLOW}WARNING: $1${NC}" >&2; }
+info() { echo -e "${BLUE}i $1${NC}" >&2; }
+
+show_help() {
+    sed -n '2,72p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# ---- defaults ----
+ISSUE=""
+REPO_NWO=""
+MAX_DEPTH="${LOOM_DEPCYCLE_MAX_DEPTH:-4}"
+MAX_NODES="${LOOM_DEPCYCLE_MAX_NODES:-25}"
+MAX_STEPS="${LOOM_DEPCYCLE_MAX_STEPS:-500}"
+DO_REPORT=0
+NO_CACHE=0
+
+# ---- dependency-reference parser (reused vocabulary, extracted by tests) ----
+#
+# REUSES the exact dependency-phrase vocabulary established in guide.md's
+# `parse_dependencies` and shared by champion-pr-merge.md's unblock loop
+# (`(Blocked by|Depends on|Requires)[*_:[:space:]]*#N`, tolerant of markdown
+# emphasis/colon between the phrase and the ref, #4508). It does NOT introduce
+# a second divergent parser; it only widens the REFERENCE half so a cross-repo
+# edge is followable:
+#
+#   #391                                          -> same repo as the citing issue
+#   2AMLogic/klayout-tools#391                    -> explicit owner/repo
+#   https://github.com/2AMLogic/marketing/issues/56 -> issue URL
+#
+# Two-stage, exactly like every other reuser: stage 1 selects lines declaring a
+# dependency phrase, stage 2 extracts EVERY reference on those lines (not just
+# the first), so comma-separated lists are captured in full. Emits normalized
+# `owner/repo#N` nodes, deduplicated.
+parse_dependency_refs() {
+    local body="$1" default_repo="$2"
+    printf '%s\n' "$body" \
+        | grep -E '(Blocked by|Depends on|Requires)[*_:[:space:]]*(([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[0-9]+|https?://[^[:space:]),]+/issues/[0-9]+)' \
+        | grep -oE '([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#[0-9]+|https?://[^[:space:]),]+/issues/[0-9]+' \
+        | while IFS= read -r ref; do
+            case "$ref" in
+                http*)
+                    # https://<host>/<owner>/<repo>/issues/<N>
+                    local num="${ref##*/}"
+                    local rest="${ref%/issues/*}"   # https://<host>/<owner>/<repo>
+                    rest="${rest#*://}"             # <host>/<owner>/<repo>
+                    rest="${rest#*/}"               # <owner>/<repo>
+                    [[ "$rest" == */* ]] && printf '%s#%s\n' "$rest" "$num"
+                    ;;
+                '#'*)
+                    printf '%s#%s\n' "$default_repo" "${ref#\#}"
+                    ;;
+                *)
+                    printf '%s\n' "$ref"
+                    ;;
+            esac
+        done \
+        | sort -u
+}
+
+# ---- small set helpers (space-separated strings; no bash-4 assoc arrays) ----
+# True (0) if $1 appears as a whole word in the space-separated list $2.
+_in_set() {
+    local needle="$1" haystack=" $2 "
+    [[ "$haystack" == *" $needle "* ]]
+}
+
+# Portable sha256 (sha256sum on Linux, shasum on macOS) - same fallback shape
+# the rest of the repo's scripts and the Champion prose use.
+_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then sha256sum
+    elif command -v shasum >/dev/null 2>&1; then shasum -a 256
+    else cksum; fi
+}
+
+# Filesystem-safe cache key for an `owner/repo#N` node.
+_node_key() {
+    printf '%s' "$1" | tr '/#' '__'
+}
+
+# ---- forge reads (memoized, bounded) ----
+FETCH_COUNT=0
+UNREADABLE_NODES=""
+TRUNCATED=""
+# Monotonic tally of every event that left part of the graph unexplored (a bound
+# stopped the walk, or a node was unreadable). The memoization guard in _walk
+# snapshots it around a subtree to decide whether that subtree was complete.
+INCOMPLETE_COUNT=0
+
+_note_truncated() {
+    _in_set "$1" "$TRUNCATED" || TRUNCATED="$TRUNCATED $1"
+    INCOMPLETE_COUNT=$((INCOMPLETE_COUNT + 1))
+}
+
+# Populate $CACHE_DIR/<key> with "STATE\n<body>" for a node. Returns 0 when the
+# node is readable (or already cached), 1 when it is not (unreadable, or the
+# fetch budget is spent). Each distinct node costs at most one forge read.
+_fetch_node() {
+    local node="$1"
+    local key f
+    key="$(_node_key "$node")"
+    f="$CACHE_DIR/$key"
+    [[ -f "$f" ]] && return 0
+    [[ -f "$f.miss" ]] && return 1
+
+    if [[ "$FETCH_COUNT" -ge "$MAX_NODES" ]]; then
+        _note_truncated "nodes"
+        return 1
+    fi
+    FETCH_COUNT=$((FETCH_COUNT + 1))
+
+    local repo="${node%#*}" num="${node##*#}" json
+    json="$("$GH_READ" issue view "$num" --repo "$repo" --json state,body 2>/dev/null)" || json=""
+    if [[ -z "$json" ]]; then
+        : > "$f.miss"
+        _in_set "$node" "$UNREADABLE_NODES" || UNREADABLE_NODES="$UNREADABLE_NODES $node"
+        INCOMPLETE_COUNT=$((INCOMPLETE_COUNT + 1))
+        return 1
+    fi
+    # `printf '%s\n' "$VAR" | jq`, never `echo "$VAR" | jq` (#5094): zsh's echo
+    # reinterprets backslash escapes and corrupts captured `gh --json` payloads.
+    {
+        printf '%s\n' "$json" | jq -r '.state // "UNKNOWN"'
+        printf '%s\n' "$json" | jq -r '.body // ""'
+    } > "$f"
+    return 0
+}
+
+_node_state() { head -n 1 "$CACHE_DIR/$(_node_key "$1")" 2>/dev/null; }
+_node_body()  { tail -n +2 "$CACHE_DIR/$(_node_key "$1")" 2>/dev/null; }
+
+# ---- the walk ----
+EXPLORED=""       # nodes whose subtree completed without hitting the depth bound
+STEP_COUNT=0
+CYCLE_NODES_PATH=""   # space-separated cycle, first node repeated at the end
+
+# Given the node already on the path and the current path, emit the cycle
+# segment: from the first occurrence of $1 through the end of the path, with
+# $1 repeated to close the loop.
+_cycle_segment() {
+    local ref="$1" path="$2" out="" started=0 n
+    for n in $path; do
+        [[ "$started" -eq 0 && "$n" == "$ref" ]] && started=1
+        [[ "$started" -eq 1 ]] && out="$out $n"
+    done
+    printf '%s %s\n' "${out# }" "$ref"
+}
+
+# Depth-first walk from $1 (already fetched). $3 is the space-separated path of
+# nodes from the root through $1 inclusive.
+# Returns 1 as soon as a cycle is found (setting CYCLE_NODES_PATH), else 0.
+_walk() {
+    local node="$1" depth="$2" path="$3"
+
+    local body ref
+    body="$(_node_body "$node")"
+
+    for ref in $(parse_dependency_refs "$body" "${node%#*}"); do
+        if [[ "$STEP_COUNT" -ge "$MAX_STEPS" ]]; then
+            _note_truncated "steps"
+            return 0
+        fi
+        STEP_COUNT=$((STEP_COUNT + 1))
+
+        # A body naming its own number is never a dependency on itself.
+        [[ "$ref" == "$node" ]] && continue
+
+        # Re-entering a node already on this path IS the cycle.
+        if _in_set "$ref" "$path"; then
+            CYCLE_NODES_PATH="$(_cycle_segment "$ref" "$path")"
+            return 1
+        fi
+
+        # Already fully explored under an unbounded subtree - nothing new below.
+        _in_set "$ref" "$EXPLORED" && continue
+
+        # The depth bound is enforced HERE, before the fetch, not on entry to the
+        # recursive call: a node we will never expand has a body we will never
+        # parse, so fetching it would spend a forge read for nothing -- and the
+        # frontier is the widest layer of the walk, so that waste is the single
+        # largest avoidable cost. Detection power is unchanged: the back-edge
+        # test above has already run against this ref, so a cycle that closes
+        # exactly at the bound is still found. MAX_DEPTH is therefore the length
+        # of the longest cycle this walk can detect.
+        if [[ "$((depth + 1))" -ge "$MAX_DEPTH" ]]; then
+            _note_truncated "depth"
+            continue
+        fi
+
+        _fetch_node "$ref" || continue
+
+        # A CLOSED dependency is a resolved edge, not a live blocker: it cannot
+        # participate in a deadlock, and following it would report historical
+        # cycles that no longer hold anyone up.
+        [[ "$(_node_state "$ref")" == "OPEN" ]] || continue
+
+        local incomplete_before="$INCOMPLETE_COUNT"
+
+        if ! _walk "$ref" "$((depth + 1))" "$path $ref"; then
+            return 1
+        fi
+
+        # Memoize only when this subtree was explored COMPLETELY. A subtree cut
+        # short by the depth bound (or by an unreadable/unfetchable node) may
+        # still hold a cycle reachable from a shallower path, so recording it as
+        # explored there would under-report.
+        if [[ "$INCOMPLETE_COUNT" -eq "$incomplete_before" ]]; then
+            _in_set "$ref" "$EXPLORED" || EXPLORED="$EXPLORED $ref"
+        fi
+    done
+    return 0
+}
+
+# ---- reporting (--report only) ----
+# Comment once per distinct cycle (fingerprinted by the cycle's node SET, so the
+# same cycle discovered from either side collapses to one marker) and route the
+# issue to loom:operator-only. Mirrors champion-issue-promo.md's marker-and-skip
+# idempotency: an unchanged cycle is never re-commented, a genuinely different
+# cycle always is.
+_report_cycle() {
+    local node="$1" pretty="$2" nodes="$3" fingerprint="$4"
+    local repo="${node%#*}" num="${node##*#}"
+    local marker="<!-- champion:dep-cycle:$fingerprint -->"
+
+    if gh issue view "$num" --repo "$repo" --json comments \
+        --jq '.comments[].body' 2>/dev/null | grep -qF "$marker"; then
+        echo "ALREADY_REPORTED: $node"
+        return 0
+    fi
+
+    local body
+    body="$(cat <<EOF
+**Dependency cycle detected** - this issue cannot be unblocked by waiting.
+
+The declared \`Blocked by\` / \`Depends on\` / \`Requires\` references form a closed loop:
+
+\`\`\`
+$pretty
+\`\`\`
+
+Every issue on that path is OPEN, and each one's progress is declared to depend on
+the next, so the loop can never resolve itself: each side re-derives "still blocked"
+on every pass, indefinitely. This is the deadlock shape that previously had to be
+found by hand.
+
+Breaking a cycle is a human decision - which declared dependency edge is wrong, or
+which side ships a partial increment first - so Champion is routing this to
+\`loom:operator-only\` instead of re-deriving the same conclusion forever.
+
+**Cycle members**: $nodes
+
+---
+*Automated by Champion role (detect-dependency-cycle.sh)*
+$marker
+EOF
+)"
+
+    if ! gh issue comment "$num" --repo "$repo" --body "$body" >/dev/null 2>&1; then
+        warn "could not comment on $node"
+        return 1
+    fi
+    if ! gh issue edit "$num" --repo "$repo" --add-label "loom:operator-only" >/dev/null 2>&1; then
+        warn "could not add loom:operator-only to $node"
+    fi
+    echo "REPORTED: $node"
+    return 0
+}
+
+# ---- repo resolution ----
+_resolve_repo() {
+    local url
+    url="$(git remote get-url origin 2>/dev/null || true)"
+    if [[ -n "$url" ]]; then
+        url="${url%.git}"
+        url="$(printf '%s' "$url" | sed -E 's#^.*[:/]([^/]+/[^/]+)$#\1#')"
+        if [[ "$url" == */* ]]; then
+            printf '%s\n' "$url"
+            return 0
+        fi
+    fi
+    gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null
+}
+
+# ---- main ----
+main() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --issue)     ISSUE="${2:-}"; shift 2 ;;
+            --repo)      REPO_NWO="${2:-}"; shift 2 ;;
+            --max-depth) MAX_DEPTH="${2:-}"; shift 2 ;;
+            --max-nodes) MAX_NODES="${2:-}"; shift 2 ;;
+            --max-steps) MAX_STEPS="${2:-}"; shift 2 ;;
+            --report)    DO_REPORT=1; shift ;;
+            --no-cache)  NO_CACHE=1; shift ;;
+            --help|-h)   show_help; exit 0 ;;
+            *)           err "Unexpected argument: $1"; show_help >&2; exit 2 ;;
+        esac
+    done
+
+    if [[ -z "$ISSUE" ]]; then
+        err "Usage: detect-dependency-cycle.sh --issue <N> [--repo <owner/repo>]"
+        exit 2
+    fi
+    if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+        err "--issue must be a number (got: $ISSUE)"
+        exit 2
+    fi
+    if ! command -v jq >/dev/null 2>&1; then
+        err "jq is required"
+        exit 2
+    fi
+
+    # Reads go through the gh-cached wrapper when it is available and working -
+    # this is backlog analysis, not merge-gate arbitration, and a shared 30s TTL
+    # keeps a multi-issue Champion pass to one set of responses.
+    GH_READ="gh"
+    if [[ "$NO_CACHE" -eq 0 ]]; then
+        local ghc="$SCRIPT_DIR/gh-cached"
+        if [[ -x "$ghc" ]] && "$ghc" --version >/dev/null 2>&1; then GH_READ="$ghc"; fi
+    fi
+
+    if [[ -z "$REPO_NWO" ]]; then
+        REPO_NWO="$(_resolve_repo)"
+    fi
+    if [[ -z "$REPO_NWO" ]]; then
+        err "could not determine the repo - pass --repo <owner/repo>"
+        exit 2
+    fi
+
+    CACHE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/loom-depcycle.XXXXXX")" || {
+        err "could not create a scratch directory"
+        exit 2
+    }
+    trap 'rm -rf "$CACHE_DIR"' EXIT
+
+    local root="$REPO_NWO#$ISSUE"
+    if ! _fetch_node "$root"; then
+        err "could not read $root"
+        exit 2
+    fi
+
+    local rc=0
+    _walk "$root" 0 "$root" || rc=1
+
+    if [[ "$rc" -eq 1 ]]; then
+        local pretty nodes fingerprint
+        pretty="$(printf '%s' "$CYCLE_NODES_PATH" | sed 's/ / -> /g')"
+        # Fingerprint the cycle's node SET (sorted, deduplicated) so the same
+        # cycle collapses to one identity no matter which member it was found
+        # from - and so a genuine change in membership yields a new identity.
+        # shellcheck disable=SC2086  # intentional word splitting: space-separated node list
+        nodes="$(printf '%s\n' $CYCLE_NODES_PATH | sort -u | tr '\n' ' ')"
+        nodes="${nodes% }"
+        fingerprint="$(printf '%s' "$nodes" | _sha256 | awk '{print substr($1, 1, 16)}')"
+
+        echo "CYCLE_DETECTED"
+        echo "CYCLE_PATH: $pretty"
+        echo "CYCLE_NODES: $nodes"
+        echo "CYCLE_FINGERPRINT: $fingerprint"
+        [[ -n "$UNREADABLE_NODES" ]] && echo "UNREADABLE:$UNREADABLE_NODES"
+
+        if [[ "$DO_REPORT" -eq 1 ]]; then
+            _report_cycle "$root" "$pretty" "$nodes" "$fingerprint"
+        fi
+        exit 1
+    fi
+
+    echo "NO_CYCLE"
+    echo "SCANNED: $FETCH_COUNT"
+    [[ -n "$TRUNCATED" ]] && echo "SEARCH_TRUNCATED:$TRUNCATED"
+    [[ -n "$UNREADABLE_NODES" ]] && echo "UNREADABLE:$UNREADABLE_NODES"
+    exit 0
+}
+
+# Only run main when executed directly (not when sourced by tests).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -44,6 +44,7 @@ test-config-resolver.sh
 test-config-tiers-cli-migration.sh
 test-default-branch.sh
 test-dependency-parse.sh
+test-detect-dependency-cycle.sh
 test-disk-headroom.sh
 test-fleet-check.sh
 test-fleet-send.sh

--- a/defaults/scripts/tests/test-detect-dependency-cycle.sh
+++ b/defaults/scripts/tests/test-detect-dependency-cycle.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# test-detect-dependency-cycle.sh - Tests for detect-dependency-cycle.sh
+# (issue #5213), Champion's bounded cross-repo dependency-cycle detector.
+#
+# Champion's blocking evaluation was single-hop and same-repo: it asked "is the
+# issue named in `Blocked by: #N` closed yet?" and re-derived "still blocked"
+# forever when the answer could never become yes because the dependency graph
+# contained a cycle. The motivating incident was cross-repo (an epic in one repo
+# blocking a dependent in another, whose own remaining phase fed that epic's last
+# phase) and was found only by an operator walking the graph by hand.
+#
+# This suite is hybrid, mirroring test-dependency-parse.sh's strategy:
+#
+#   1. `parse_dependency_refs` / `_cycle_segment` / `_in_set` are real,
+#      sourceable functions (the script guards its main on `BASH_SOURCE == $0`),
+#      so they are tested directly - no duplicated mirror to drift.
+#   2. The walk, the bounds, the reporting and the exit codes are exercised
+#      black-box, by stubbing `gh` on PATH (the same approach as
+#      test-check-duplicate.sh) and running the real script as a subprocess.
+#   3. The two Champion prose call sites are pinned with literal
+#      `assert_doc_contains` checks, so wiring the detector out of
+#      champion-pr-merge.md / champion-issue-promo.md fails here.
+#
+# Hermetic: no network, no live forge, no tokens. Every read goes to the stub.
+#
+# Usage:
+#   ./.loom/scripts/tests/test-detect-dependency-cycle.sh
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)"
+DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
+DDC="$SCRIPTS_DIR/detect-dependency-cycle.sh"
+CHAMPION_MERGE_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-pr-merge.md"
+CHAMPION_PROMO_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-issue-promo.md"
+
+# Source the script for its pure helpers BEFORE defining our own colors - the
+# script's own `[[ -t 2 ]]` block defines RED/YELLOW/BLUE/NC, so sourcing first
+# (and setting ours last) keeps this file's output colors consistent.
+# shellcheck source=/dev/null
+source "$DDC"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" == *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected to contain: '$needle'"
+        echo "    Actual: '$haystack'"
+    fi
+}
+
+assert_not_contains() {
+    local haystack="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$haystack" != *"$needle"* ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected NOT to contain: '$needle'"
+        echo "    Actual: '$haystack'"
+    fi
+}
+
+assert_doc_contains() {
+    local file="$1" needle="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if grep -qF -- "$needle" "$file"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg (missing literal in $file: $needle)"
+    fi
+}
+
+# =====================================================================
+# Unit tests: the real sourced helpers
+# =====================================================================
+
+echo "--- parse_dependency_refs: shared phrase vocabulary (#4508) preserved ---"
+
+out="$(parse_dependency_refs '**Blocked by:** #1 (reason), #3 (reason)' 'o/r')"
+assert_eq $'o/r#1\no/r#3' "$out" "bold+colon comma-list captures ALL refs, normalized to the citing repo"
+
+out="$(parse_dependency_refs 'Blocked by #7' 'o/r')"
+assert_eq "o/r#7" "$out" "plain Blocked by #N"
+
+out="$(parse_dependency_refs '_Depends on_ #5' 'o/r')"
+assert_eq "o/r#5" "$out" "italic-wrapped phrase"
+
+out="$(parse_dependency_refs 'Requires #9' 'o/r')"
+assert_eq "o/r#9" "$out" "plain Requires #N"
+
+out="$(parse_dependency_refs 'Mentions #9 in passing' 'o/r')"
+assert_eq "" "$out" "a bare #N with no dependency phrase is NOT an edge"
+
+echo
+echo "--- parse_dependency_refs: cross-repo reference forms ---"
+
+out="$(parse_dependency_refs 'Blocked by 2AMLogic/klayout-tools#391' 'o/r')"
+assert_eq "2AMLogic/klayout-tools#391" "$out" "explicit owner/repo#N keeps its own repo"
+
+out="$(parse_dependency_refs 'Depends on https://github.com/2AMLogic/marketing/issues/56' 'o/r')"
+assert_eq "2AMLogic/marketing#56" "$out" "issue URL normalizes to owner/repo#N"
+
+out="$(parse_dependency_refs '**Blocked by:** #7 and 2AMLogic/x#8' 'o/r')"
+assert_eq $'2AMLogic/x#8\no/r#7' "$out" "same-repo and cross-repo refs on one line both captured"
+
+echo
+echo "--- _cycle_segment: reports the loop, not the whole path ---"
+
+assert_eq "o/r#1 o/r#2 o/r#1" "$(_cycle_segment 'o/r#1' 'o/r#1 o/r#2')" \
+    "2-cycle through the root"
+assert_eq "o/r#2 o/r#3 o/r#2" "$(_cycle_segment 'o/r#2' 'o/r#1 o/r#2 o/r#3')" \
+    "cycle NOT through the root trims the leading approach path"
+
+# =====================================================================
+# Black-box tests: stub `gh` on PATH, run the real script
+# =====================================================================
+
+STUB_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ddc-test.XXXXXX")"
+cleanup() { rm -rf "$STUB_DIR"; }
+trap cleanup EXIT
+
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+# Minimal `gh` stub: serves issue fixtures from files named issue-<owner>_<repo>_<N>.json
+STUB_DIR="$(cd "$(dirname "$0")" && pwd)"
+printf '%s\n' "$*" >> "$STUB_DIR/calls.log"
+
+[[ "${1:-}" == "--version" ]] && { echo "gh version 0.0.0 (stub)"; exit 0; }
+[[ "${1:-}" != "issue" ]] && { echo "stub gh: unhandled args: $*" >&2; exit 3; }
+
+action="$2"; num="$3"; shift 3
+repo=""; jqexpr=""; bodyarg=""; label=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)       repo="$2"; shift 2 ;;
+    --json)       shift 2 ;;
+    --jq|-q)      jqexpr="$2"; shift 2 ;;
+    --body)       bodyarg="$2"; shift 2 ;;
+    --add-label)  label="$2"; shift 2 ;;
+    *)            shift ;;
+  esac
+done
+
+key="$(printf '%s' "$repo#$num" | tr '/#' '__')"
+f="$STUB_DIR/issue-$key.json"
+
+case "$action" in
+  view)
+    [[ -f "$f" ]] || { echo "gh: issue not found" >&2; exit 1; }
+    if [[ -n "$jqexpr" ]]; then jq -r "$jqexpr" < "$f"; else cat "$f"; fi
+    ;;
+  comment)
+    [[ -f "$f" ]] || { echo "gh: issue not found" >&2; exit 1; }
+    printf '%s\n' "$bodyarg" >> "$STUB_DIR/comments-$key.log"
+    tmp="$(mktemp)"
+    jq --arg b "$bodyarg" '.comments += [{"body":$b}]' "$f" > "$tmp" && mv "$tmp" "$f"
+    ;;
+  edit)
+    [[ -f "$f" ]] || { echo "gh: issue not found" >&2; exit 1; }
+    printf '%s\n' "$label" >> "$STUB_DIR/labels-$key.log"
+    ;;
+  *)
+    echo "stub gh: unhandled issue action: $action" >&2; exit 3 ;;
+esac
+STUB
+chmod +x "$STUB_DIR/gh"
+
+export PATH="$STUB_DIR:$PATH"
+export GH_CACHE_DISABLE=1
+
+# fixture <owner/repo#N> <STATE> <body>
+fixture() {
+    local node="$1" state="$2" body="$3"
+    local key
+    key="$(printf '%s' "$node" | tr '/#' '__')"
+    jq -n --arg s "$state" --arg b "$body" \
+        '{state:$s, body:$b, comments:[]}' > "$STUB_DIR/issue-$key.json"
+}
+
+reset_state() {
+    rm -f "$STUB_DIR"/issue-*.json "$STUB_DIR"/comments-*.log \
+          "$STUB_DIR"/labels-*.log "$STUB_DIR/calls.log"
+}
+
+# run_ddc <args...> -> sets OUT / RC
+run_ddc() {
+    OUT="$("$DDC" --no-cache "$@" 2>"$STUB_DIR/stderr.log")"
+    RC=$?
+}
+
+echo
+echo "--- direct 2-cycle (same repo) ---"
+reset_state
+fixture 'o/r#1' OPEN 'Blocked by #2'
+fixture 'o/r#2' OPEN 'Blocked by #1'
+run_ddc --issue 1 --repo o/r
+assert_eq "1" "$RC" "exit 1 on a detected cycle"
+assert_contains "$OUT" "CYCLE_DETECTED" "CYCLE_DETECTED marker present"
+assert_contains "$OUT" "CYCLE_PATH: o/r#1 -> o/r#2 -> o/r#1" "cycle path names both sides and closes the loop"
+assert_contains "$OUT" "CYCLE_NODES: o/r#1 o/r#2" "cycle node set listed"
+
+echo
+echo "--- 3-hop cycle (A -> B -> C -> A) ---"
+reset_state
+fixture 'o/r#1' OPEN 'Depends on #2'
+fixture 'o/r#2' OPEN 'Depends on #3'
+fixture 'o/r#3' OPEN 'Depends on #1'
+run_ddc --issue 1 --repo o/r
+assert_eq "1" "$RC" "exit 1 on a 3-hop cycle"
+assert_contains "$OUT" "CYCLE_PATH: o/r#1 -> o/r#2 -> o/r#3 -> o/r#1" "3-hop path reported in order"
+
+echo
+echo "--- cycle that does not pass through the root ---"
+reset_state
+fixture 'o/r#1' OPEN 'Depends on #2'
+fixture 'o/r#2' OPEN 'Depends on #3'
+fixture 'o/r#3' OPEN 'Depends on #2'
+run_ddc --issue 1 --repo o/r
+assert_eq "1" "$RC" "exit 1 - a cycle downstream of the root still deadlocks the root"
+assert_contains "$OUT" "CYCLE_PATH: o/r#2 -> o/r#3 -> o/r#2" "reports the loop itself, not the approach path"
+
+echo
+echo "--- cross-repo cycle (the motivating incident's shape) ---"
+reset_state
+fixture '2AMLogic/marketing#56' OPEN 'Blocked by 2AMLogic/klayout-tools#391 (epic must land first)'
+fixture '2AMLogic/klayout-tools#391' OPEN 'Phase 8 Depends on https://github.com/2AMLogic/marketing/issues/56 canary output'
+run_ddc --issue 56 --repo 2AMLogic/marketing
+assert_eq "1" "$RC" "exit 1 on a cycle spanning two repos"
+assert_contains "$OUT" "CYCLE_PATH: 2AMLogic/marketing#56 -> 2AMLogic/klayout-tools#391 -> 2AMLogic/marketing#56" \
+    "cross-repo path names both repos"
+
+echo
+echo "--- cycle fingerprint is identical from either side of the cycle ---"
+reset_state
+fixture 'o/a#1' OPEN 'Blocked by o/b#2'
+fixture 'o/b#2' OPEN 'Blocked by o/a#1'
+run_ddc --issue 1 --repo o/a
+FP_A="$(printf '%s\n' "$OUT" | sed -n 's/^CYCLE_FINGERPRINT: //p')"
+run_ddc --issue 2 --repo o/b
+FP_B="$(printf '%s\n' "$OUT" | sed -n 's/^CYCLE_FINGERPRINT: //p')"
+assert_eq "$FP_A" "$FP_B" "same cycle discovered from either member yields one identity"
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -n "$FP_A" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: fingerprint is non-empty"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: fingerprint is non-empty"
+fi
+
+echo
+echo "--- non-cyclic chain within the depth bound is NOT reported ---"
+reset_state
+fixture 'o/r#1' OPEN 'Blocked by #2'
+fixture 'o/r#2' OPEN 'Blocked by #3'
+fixture 'o/r#3' OPEN 'Blocked by #4'
+fixture 'o/r#4' OPEN 'No dependencies here.'
+run_ddc --issue 1 --repo o/r
+assert_eq "0" "$RC" "exit 0 on an ordinary deep chain (no false positive)"
+assert_contains "$OUT" "NO_CYCLE" "NO_CYCLE marker present"
+assert_contains "$OUT" "SCANNED: 4" "all four chain nodes were fetched exactly once"
+assert_not_contains "$OUT" "SEARCH_TRUNCATED" "a chain that fits the bound is not marked truncated"
+
+echo
+echo "--- depth bound stops the walk and says so ---"
+reset_state
+fixture 'o/r#1' OPEN 'Blocked by #2'
+fixture 'o/r#2' OPEN 'Blocked by #3'
+fixture 'o/r#3' OPEN 'Blocked by #4'
+fixture 'o/r#4' OPEN 'Blocked by #5'
+fixture 'o/r#5' OPEN 'Blocked by #6'
+fixture 'o/r#6' OPEN 'Blocked by #1'
+run_ddc --issue 1 --repo o/r --max-depth 2
+assert_eq "0" "$RC" "exit 0 when the (real) cycle lies beyond the depth bound"
+assert_contains "$OUT" "SEARCH_TRUNCATED: depth" "truncation is surfaced, so NO_CYCLE is not read as proof"
+assert_contains "$OUT" "SCANNED: 2" "depth bound caps forge reads at root + (max-depth - 1) expandable nodes"
+assert_not_contains "$(cat "$STUB_DIR/calls.log")" "issue view 3 " \
+    "the frontier node beyond the bound is never fetched (a body we would never parse)"
+
+echo
+echo "--- a cycle closing exactly AT the depth bound is still detected ---"
+reset_state
+fixture 'o/r#1' OPEN 'Blocked by #2'
+fixture 'o/r#2' OPEN 'Blocked by #1'
+run_ddc --issue 1 --repo o/r --max-depth 2
+assert_eq "1" "$RC" "skipping the frontier FETCH does not skip the frontier back-edge CHECK"
+assert_contains "$OUT" "CYCLE_PATH: o/r#1 -> o/r#2 -> o/r#1" "max-depth N still detects an N-node cycle"
+
+echo
+echo "--- node bound caps forge reads ---"
+reset_state
+fixture 'o/r#1' OPEN 'Blocked by #2'
+fixture 'o/r#2' OPEN 'Blocked by #3'
+fixture 'o/r#3' OPEN 'Blocked by #4'
+fixture 'o/r#4' OPEN 'Blocked by #5'
+fixture 'o/r#5' OPEN 'No dependencies here.'
+run_ddc --issue 1 --repo o/r --max-nodes 3
+assert_eq "0" "$RC" "exit 0 when the node budget is spent without finding a cycle"
+assert_contains "$OUT" "SEARCH_TRUNCATED: nodes" "node-budget truncation is surfaced"
+assert_contains "$OUT" "SCANNED: 3" "never fetches more than --max-nodes issues"
+
+echo
+echo "--- a CLOSED dependency is a resolved edge, not a live blocker ---"
+reset_state
+fixture 'o/r#1' OPEN 'Blocked by #2'
+fixture 'o/r#2' CLOSED 'Blocked by #1'
+run_ddc --issue 1 --repo o/r
+assert_eq "0" "$RC" "a loop through a CLOSED issue is not a live deadlock"
+assert_contains "$OUT" "NO_CYCLE" "closed edge terminates the walk"
+
+echo
+echo "--- self-reference is not a cycle ---"
+reset_state
+fixture 'o/r#1' OPEN 'Blocked by #1 (typo, refers to itself)'
+run_ddc --issue 1 --repo o/r
+assert_eq "0" "$RC" "a body naming its own number is not a dependency on itself"
+
+echo
+echo "--- an unreadable cross-repo node degrades, it does not crash ---"
+reset_state
+fixture 'o/r#1' OPEN 'Blocked by private/repo#9'
+run_ddc --issue 1 --repo o/r
+assert_eq "0" "$RC" "exit 0 when a referenced issue is not visible to this token"
+assert_contains "$OUT" "UNREADABLE: private/repo#9" "unreadable node is surfaced as partial coverage"
+
+echo
+echo "--- --report: surfaces the cycle and routes to loom:operator-only ---"
+reset_state
+fixture '2AMLogic/marketing#56' OPEN 'Blocked by 2AMLogic/klayout-tools#391'
+fixture '2AMLogic/klayout-tools#391' OPEN 'Depends on 2AMLogic/marketing#56'
+run_ddc --issue 56 --repo 2AMLogic/marketing --report
+assert_eq "1" "$RC" "--report still exits 1 on a cycle"
+assert_contains "$OUT" "REPORTED: 2AMLogic/marketing#56" "REPORTED marker emitted"
+COMMENT="$(cat "$STUB_DIR/comments-2AMLogic_marketing_56.log" 2>/dev/null || true)"
+assert_contains "$COMMENT" "Dependency cycle detected" "comment states the cycle explicitly"
+assert_contains "$COMMENT" "2AMLogic/marketing#56" "comment names this side of the cycle"
+assert_contains "$COMMENT" "2AMLogic/klayout-tools#391" "comment names the OTHER side of the cycle"
+assert_contains "$COMMENT" "champion:dep-cycle:" "comment carries the idempotency marker"
+LABELS="$(cat "$STUB_DIR/labels-2AMLogic_marketing_56.log" 2>/dev/null || true)"
+assert_contains "$LABELS" "loom:operator-only" "routes to loom:operator-only"
+
+echo
+echo "--- --report is idempotent: the same cycle is surfaced once ---"
+run_ddc --issue 56 --repo 2AMLogic/marketing --report
+assert_eq "1" "$RC" "second pass still reports the cycle to its caller"
+assert_contains "$OUT" "ALREADY_REPORTED: 2AMLogic/marketing#56" "second pass skips the comment"
+COMMENT_COUNT="$(jq '.comments | length' "$STUB_DIR/issue-2AMLogic_marketing_56.json")"
+assert_eq "1" "$COMMENT_COUNT" "exactly one comment posted across two passes"
+
+echo
+echo "--- default (no --report) is strictly read-only ---"
+reset_state
+fixture 'o/r#1' OPEN 'Blocked by #2'
+fixture 'o/r#2' OPEN 'Blocked by #1'
+run_ddc --issue 1 --repo o/r
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! ls "$STUB_DIR"/comments-*.log "$STUB_DIR"/labels-*.log >/dev/null 2>&1; then
+    TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: no comment and no label without --report"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: no comment and no label without --report"
+fi
+
+echo
+echo "--- argument validation ---"
+reset_state
+run_ddc --repo o/r
+assert_eq "2" "$RC" "missing --issue exits 2"
+run_ddc --issue notanumber --repo o/r
+assert_eq "2" "$RC" "non-numeric --issue exits 2"
+run_ddc --issue 404 --repo o/r
+assert_eq "2" "$RC" "unreadable ROOT issue exits 2 (no answer at all)"
+
+echo
+echo "--- Doc pins: the Champion prose actually calls the detector ---"
+
+# The needles below are LITERAL prose fragments, quoted exactly as they appear in
+# the .md files - the single quotes are load-bearing, not an expansion mistake.
+# shellcheck disable=SC2016
+{
+    assert_doc_contains "$CHAMPION_MERGE_MD" "detect-dependency-cycle.sh" \
+        "champion-pr-merge.md's unblock evaluation invokes the detector"
+    assert_doc_contains "$CHAMPION_MERGE_MD" "--report" \
+        "champion-pr-merge.md uses --report so a detected cycle is surfaced, not just logged"
+    assert_doc_contains "$CHAMPION_MERGE_MD" 'if [ "$ALL_RESOLVED" = false ]; then' \
+        "the walk is gated on the 'still blocked' branch, not run on every pass"
+    assert_doc_contains "$CHAMPION_MERGE_MD" '"$GH_READ" issue view "$blocked" --json labels' \
+        "an already-surfaced cycle (loom:operator-only) short-circuits the walk with one cached read"
+    assert_doc_contains "$CHAMPION_PROMO_MD" "detect-dependency-cycle.sh" \
+        "champion-issue-promo.md's Technical Feasibility check invokes the detector"
+    assert_doc_contains "$CHAMPION_PROMO_MD" 'if [ "$DECLARES_DEP" -gt 0 ]; then' \
+        "promotion runs the walk only when the proposal declares a dependency at all"
+}
+
+echo
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+[[ $TESTS_FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Champion's blocking evaluation was **single-hop and same-repo** in both places it
runs: `champion-pr-merge.md` → "Step 5: Unblock Dependent Issues" and
`champion-issue-promo.md` → Technical Feasibility criterion 2. Each reads a
`Blocked by` / `Depends on` / `Requires` reference and asks *"is #N closed yet?"* —
a question with no reachable answer when the declared edges form a **cycle**. Both
sides then re-derive "still blocked" forever, and nothing in either issue's text
makes the loop visible. The motivating incident spanned two repos and was found
only by an operator walking 15 child issues by hand.

This adds a dedicated, bounded, cross-repo cycle detector (curator's recommended
option B) and wires it into both call sites.

## Changes

- **New `defaults/scripts/detect-dependency-cycle.sh`** — depth-first walk over the
  repo's existing dependency-phrase vocabulary (#4508), widened on the *reference*
  side only so `owner/repo#N` and issue-URL edges are followable across repos.
  Exit codes mirror `check-duplicate.sh` (0 no cycle / 1 cycle / 2 error); stdout
  carries `CYCLE_PATH:`, `CYCLE_NODES:`, `CYCLE_FINGERPRINT:`, `SEARCH_TRUNCATED:`,
  `UNREADABLE:` markers so callers parse rather than re-derive.
- **`--report`** posts one comment naming every node in the cycle and adds
  `loom:operator-only`, keyed by `<!-- champion:dep-cycle:<fingerprint> -->`
  fingerprinted on the cycle's **node set** (so the same cycle found from either
  side collapses to one identity). Without `--report` the script is strictly
  read-only.
- **`champion-pr-merge.md`** — invokes the detector on exactly the
  `ALL_RESOLVED=false` branch, behind a cheap `loom:operator-only` label check, plus
  a "Dependency-cycle detection (#5213)" section with the bounded-cost table and an
  explicit statement that `loom:blocked` is *not* removed on a cycle.
- **`champion-issue-promo.md`** — a "Dependency-cycle gate" under criterion 2,
  triggered only when the proposal declares a dependency reference at all.
- **`defaults/scripts/tests/test-detect-dependency-cycle.sh`** (60 assertions) +
  `ci-wired.txt` entry.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| A cycle (E cites "Blocked by: I" and I — or one of I's own blockers — is a prerequisite for E) is detected before/during Champion's blocking evaluation instead of deadlocking silently | ✅ | Suite covers a direct 2-cycle, a 3-hop `A→B→C→A`, and a cycle *downstream* of the root (`1→2→3→2`) that reports the loop itself rather than the approach path. Wired into both evaluation sites; doc-pin assertions fail if either call site is removed |
| Detection works across repos | ✅ | Test reproduces the incident shape (`2AMLogic/marketing#56` ↔ `2AMLogic/klayout-tools#391`) via both an `owner/repo#N` and a `https://…/issues/N` reference. Also verified **live** against the real forge: `detect-dependency-cycle.sh --issue 5211 --repo rjwalters/loom` walked from this repo into `2AMLogic/klayout-tools` (`SCANNED: 3`, `NO_CYCLE`, ~3.4s) |
| On a cycle, Champion surfaces it explicitly (comment naming both sides) and routes to `loom:operator-only` rather than re-deriving "still blocked" forever | ✅ | `--report` test asserts the comment contains both `2AMLogic/marketing#56` and `2AMLogic/klayout-tools#391` plus the marker, and that `loom:operator-only` was applied; a second pass emits `ALREADY_REPORTED:` and the fixture ends with exactly **1** comment. Prose states `loom:blocked` stays |
| Bounded cost — no unbounded/expensive walk on every Champion pass | ✅ | Three hard caps (`--max-depth` 4, `--max-nodes` 25, `--max-steps` 500), one fetch per distinct node, memoization of only *completely* explored subtrees, `gh-cached` reads, and the depth bound enforced **before** the fetch so the widest frontier layer costs nothing (test asserts the out-of-bounds node is never fetched). Trigger-gated at both call sites: merge only on `ALL_RESOLVED=false` and only when `loom:operator-only` is absent; promotion only when a dependency reference exists. Any bound that fires prints `SEARCH_TRUNCATED:` so `NO_CYCLE` is never read as proof |

## Test Plan

- `defaults/scripts/tests/test-detect-dependency-cycle.sh` — **60/60 passed**,
  hermetic (a `gh` stub on `PATH`; no network, forge, or tokens). Covers: the
  sourced parser/helpers directly; 2-hop / 3-hop / off-root / cross-repo cycles;
  fingerprint stability from either member; a deep non-cyclic chain (no false
  positive); the depth bound and the node bound (including that a cycle closing
  *exactly at* the bound is still detected); `CLOSED` edges as resolved, not
  deadlocked; self-reference; an unreadable cross-repo node degrading to
  `UNREADABLE:`; `--report` idempotency; read-only default; argument validation;
  and doc pins on both Champion call sites.
- Regression suites that pin the same prose: `test-dependency-parse.sh` 22/22,
  `test-champion-critical-file-check.sh` 9/9,
  `test-forge-helpers-rate-limit-fallback.sh` 65/65.
- `check-ci-suite-manifest.sh` OK (104 suites accounted for),
  `check-docs-defaults-parity.sh` OK, `check-agents-md-sync.sh` OK.
- `shellcheck` clean at `--severity=style` on both new scripts (CI lints at
  `--severity=warning`).
- Live read-only smoke tests against `rjwalters/loom` (#4933, #4993, #4702, #5211):
  no false positives — notably #4993's `"Blocked by: Apple org enrollment. Blocks:
  … #4990"` line correctly yields **no** edge, since the phrase is not followed by a
  reference.

## Notes for review

- **Composition with #5211 / PR #5220 (open, not merged).** That PR adds an
  epic-aware blocker check to `champion-common.md` and inserts into the *same*
  region of `champion-issue-promo.md` criterion 2, so a textual conflict is
  expected for whichever merges second. This PR does not call or duplicate its
  helpers (they do not exist on `main`); instead both new sections state
  defensively that the epic check runs **first** and the cycle detector sees only
  what survives it — the two answer different questions ("has this blocker
  finished?" vs "can this blocker ever finish?") and share no state and no marker
  (`champion:epic-block:*` vs `champion:dep-cycle:*`).
- **False-positive posture** (documented in the script header): the edge parser
  reuses the repo's existing line-scoped two-stage parse rather than inventing a
  stricter second one, so it is deliberately over-inclusive. Under-parsing would
  miss a real deadlock; over-parsing at worst routes one issue to a human with the
  full path spelled out, leaving `loom:blocked` and every state machine untouched.

Closes #5213
