### PR TITLE
fix(guard): mask inert cat-heredoc bodies in text-carrying flag values

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -1822,8 +1822,114 @@ resolve_stash_cwd() {
 # it does not model backslash-escaped quotes, but since the result feeds only
 # the narrowing (never widening) catastrophic scan, the worst case is a raw
 # substring surviving — never a catastrophic block being skipped incorrectly.
+#
+# -----------------------------------------------------------------------------
+# HEREDOC-WRAPPED FLAG VALUES (#5216)
+#
+# The `$(`-floor above is exactly right for a general command substitution, but
+# it also declines to redact THIS repo's own pervasive idiom for any multi-line
+# comment body (CLAUDE.md / judge.md / doctor.md / builder-pr.md all show it):
+#
+#     gh pr comment 4357 --body "$(cat <<QUOTED_DELIM
+#     …prose that may QUOTE a dangerous command as an example…
+#     QUOTED_DELIM
+#     )" && gh pr edit 4357 --add-label "loom:pr"
+#
+# Every value built that way necessarily contains `$(`, so before this pass it
+# was NEVER redacted — and a dangerous-command example merely quoted inside the
+# body (a Judge documenting the shell-injection payload a PR now rejects, an
+# Auditor quoting a guard pattern) hard-denied the whole command on the
+# catastrophic tier. Observed live in guard-decisions.log on 2026-07-29 (a Judge
+# approval on PR #4357) and reproduced for the #3679 force-push literals too:
+# the gap is CONSTRUCTION-specific (heredoc-wrapped value), not pattern-specific.
+#
+# mask_flag_cat_heredocs() (below) closes it by masking ONLY the BODY of a
+# heredoc in this one provably-inert shape, and only when ALL of these hold:
+#   1. the opener is the complete tail of its line, immediately preceded by a
+#      recognized text-carrying flag, its opening quote, and `$(cat`;
+#   2. the heredoc delimiter is QUOTED (single- or double-quoted, `<<-` allowed)
+#      — a quoted delimiter is what guarantees the outer shell performs NO
+#      expansion on the body, so a `$(…)` sitting IN the body is inert text
+#      rather than live code (an UNQUOTED delimiter is rejected outright);
+#   3. the block is CLOSED in this same buffer (mirrors #5087's "never mask
+#      speculatively" rule for mask_heredoc_bodies);
+#   4. the very next line after the delimiter line is `)` + that same opening
+#      quote — i.e. the substitution ends immediately, with nothing chained
+#      after the heredoc inside it.
+# Condition 4 is what keeps a `--body "$(cat <<QUOTED_DELIM … QUOTED_DELIM`
+# <newline> `rm -rf /` <newline> `)"` command denying: bash ends the heredoc at
+# the delimiter line and then genuinely RUNS the following line inside the
+# substitution, so nothing is masked there. Condition 1 is what keeps an
+# INTERPRETER-FED heredoc denying — a body consumed by `bash <<DELIM`,
+# `sh -s <<DELIM`, or `cat <<DELIM … | sh` is live code
+# to the inner shell, and none of those match `<flag> <quote>$(cat`. This is the
+# deliberate narrowing versus reusing mask_heredoc_bodies() (#5000) here: that
+# helper masks ANY closed heredoc body regardless of its consumer, a documented
+# and accepted fail-open for the write-target scanner (#5117 Known Limitation 1)
+# that must NOT be inherited by the catastrophic hard-deny floor.
+#
+# KNOWN LIMITATION (recorded, mirroring the #5117 convention): this recognizes
+# only the literal `cat`-consumed shape spelled out above. A semantically
+# equivalent variant — `$(command cat <<DELIM …)`, a heredoc opened on a
+# continuation line, or a body whose delimiter line is followed by `) "` with a
+# space — is simply not recognized and keeps denying exactly as it does today.
+# That is the safe direction (a false positive that already exists, never a new
+# bypass), and the shape above is the one the repo's own role prompts prescribe.
+# -----------------------------------------------------------------------------
 strip_literal_text() {
     printf '%s' "$1" | awk '
+    # Mask the body of a `<flag> "$(cat <<QUOTED_DELIM … DELIM\n)"` heredoc.
+    # See the header comment above for the four conditions and why each is
+    # load-bearing. Body bytes are replaced 1:1 with "X" so the buffer keeps
+    # its byte offsets and line count; the opener line, the delimiter line and
+    # everything outside the body are left untouched.
+    function mask_flag_cat_heredocs(s,   lines, nl, i, j, line, pre, oq, delim, dq, closeat, trimmed, body, dashform) {
+        if (index(s, "<<") == 0) return s
+        nl = split(s, lines, "\n")
+        for (i = 1; i <= nl; i++) {
+            line = lines[i]
+            # (2) opener must END the line and carry a QUOTED delimiter.
+            if (match(line, /<<-?["'"'"'][A-Za-z0-9_]+["'"'"'][ \t]*$/) == 0) continue
+            dashform = (substr(line, RSTART + 2, 1) == "-")
+            delim = substr(line, RSTART, RLENGTH)
+            sub(/^<<-?/, "", delim)
+            sub(/[ \t]*$/, "", delim)
+            dq = substr(delim, 1, 1)
+            if (substr(delim, length(delim), 1) != dq) continue   # quotes must match
+            delim = substr(delim, 2, length(delim) - 2)
+            if (delim == "") continue
+            # (1) …immediately preceded by <flag> <openquote>$(cat.
+            pre = substr(line, 1, RSTART - 1)
+            if (pre !~ /(^|[ \t])(--message|--body|--notes|--title|--comment|-m)[ \t]*=?[ \t]*["'"'"']\$\([ \t]*cat[ \t]+$/) continue
+            oq = ""
+            for (j = length(pre); j >= 1; j--) {
+                if (substr(pre, j, 2) == "$(") { oq = substr(pre, j - 1, 1); break }
+            }
+            if (oq != DQ && oq != SQ) continue
+            # (3) the block must be CLOSED inside this buffer.
+            closeat = 0
+            for (j = i + 1; j <= nl; j++) {
+                trimmed = lines[j]
+                if (dashform) sub(/^\t+/, "", trimmed)
+                if (trimmed == delim) { closeat = j; break }
+            }
+            if (closeat == 0) continue
+            # (4) the substitution must close IMMEDIATELY after the delimiter
+            #     line — `)` + the same opening quote — so nothing chained
+            #     after the heredoc inside `$( … )` is masked away.
+            if (closeat == nl) continue
+            if (substr(lines[closeat + 1], 1, 2) != ")" oq) continue
+            for (j = i + 1; j < closeat; j++) {
+                body = lines[j]
+                gsub(/./, "X", body)
+                lines[j] = body
+            }
+            i = closeat
+        }
+        s = lines[1]
+        for (i = 2; i <= nl; i++) s = s "\n" lines[i]
+        return s
+    }
     BEGIN {
         SQ = sprintf("%c", 39)   # single quote
         DQ = sprintf("%c", 34)   # double quote
@@ -1847,7 +1953,16 @@ strip_literal_text() {
     # byte-for-byte identical to the previous behaviour.
     { buf = buf (NR > 1 ? "\n" : "") $0 }
     END {
-        s = buf
+        # PRE-PASS (#5216): blank the body of a `<flag> "$(cat <<QDELIMQ … )"`
+        # heredoc before the quoted-span redaction below runs. It has to happen
+        # here rather than inside the loop because `re`'"'"'s quoted-span classes
+        # ([^"]* / [^'"'"']*) stop at the first quote character, and a heredoc body
+        # is free to contain raw quotes (prose routinely does) — so the span
+        # match alone cannot see such a value whole. Masking first also means
+        # the `$(`-floor below needs no exception: by the time the loop reads
+        # this span, the only text left inside it is `$(cat <<QDELIMQ`, the
+        # delimiter, and `)`.
+        s = mask_flag_cat_heredocs(buf)
         out = ""
         while (match(s, re)) {
             pre     = substr(s, 1, RSTART - 1)
@@ -2361,7 +2476,16 @@ lifecycle_or_cloud_reason() {
 # unanswered ASK still blocks (see defaults/docs/guard-hooks.md). A lifecycle
 # deny takes precedence over a cloud-delete ask in a compound command (e.g.
 # `az group delete …; halt`), so the hard floor is never downgraded.
-_LIFECYCLE_CLOUD_REASONS=$(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT")
+#
+# SCANS COMMAND_ASK_SCAN, NOT COMMAND_NO_COMMENT (#5216). lifecycle_or_cloud_reason()
+# segment-parses per physical line, so a heredoc BODY line inside
+# `--body "$(cat <<'EOF' … EOF)"` whose first word happens to be a lifecycle verb
+# ("halt the deploy if this fails", "shutdown checklist:") was read as a live
+# `halt`/`shutdown` command word and hard-denied a comment that runs nothing.
+# The literal-redacted copy blanks only that quoted-value text; a real
+# `… ; halt` outside a flag value, or a `bash -c 'halt'` payload (never
+# redacted), still reaches this check and still denies.
+_LIFECYCLE_CLOUD_REASONS=$(lifecycle_or_cloud_reason "$COMMAND_ASK_SCAN")
 _LIFECYCLE_DENY=$(printf '%s\n' "$_LIFECYCLE_CLOUD_REASONS" | grep '^system lifecycle command:' | head -1)
 if [[ -n "$_LIFECYCLE_DENY" ]]; then
     deny "BLOCKED: $_LIFECYCLE_DENY" "lifecycle"
@@ -2379,10 +2503,23 @@ fi
 # all four DDL statements in one pass (cheaper than a per-pattern loop), and
 # sql_guard_enabled() is consulted only after a match, so the config read stays
 # off the hot path.
+#
+# SCANS COMMAND_ASK_SCAN, NOT COMMAND_NO_COMMENT (#5216). This check was the one
+# broad-substring deny that never received #3679's quoted-flag-value redaction:
+# `gh pr comment --body "example payload: DROP TABLE users"` hard-denied a
+# comment that runs no SQL at all, where the equivalent prose about `rm -rf /`
+# was already allowed by the catastrophic scan. COMMAND_ASK_SCAN is the
+# comment-stripped AND literal-redacted copy (built above; already relied on by
+# the deny-tier write-confinement check, so its use here is not an ask-tier-only
+# convention), which also carries #5216's heredoc-body masking — so both the
+# plain `--body "…"` and the heredoc-wrapped `--body "$(cat <<'EOF' … EOF)"`
+# forms of quoted prose stop false-positiving in one step. `-c`/`-e` are NOT
+# text-carrying flags, so the real invocations (`psql -c '…'`, `mysql -e '…'`)
+# are untouched and still deny.
 # =============================================================================
 SQL_DDL_PATTERN='DROP DATABASE|DROP TABLE|DROP SCHEMA|TRUNCATE TABLE'
-if echo "$COMMAND_NO_COMMENT" | grep -qiE "$SQL_DDL_PATTERN" && sql_guard_enabled; then
-    matched=$(echo "$COMMAND_NO_COMMENT" | grep -oiE "$SQL_DDL_PATTERN" | head -1)
+if echo "$COMMAND_ASK_SCAN" | grep -qiE "$SQL_DDL_PATTERN" && sql_guard_enabled; then
+    matched=$(echo "$COMMAND_ASK_SCAN" | grep -oiE "$SQL_DDL_PATTERN" | head -1)
     deny "BLOCKED: Command matches dangerous pattern: ${matched:-SQL DDL statement}" "sql-ddl"
 fi
 
@@ -2737,10 +2874,26 @@ expand_leading_tilde() {
     esac
 }
 
+# SCANS COMMAND_NO_LITERAL_TEXT, NOT RAW $COMMAND (#5216). extract_rm_targets()
+# segments with qsplit(), which — like every quote-tracking scan in this file —
+# is driven one PHYSICAL LINE at a time and has no memory of a `"` opened on an
+# earlier line. So a heredoc BODY line inside `--body "$(cat <<'EOF' … EOF)"`
+# was segmented as if it were live shell: the prose
+# `Example payload: \`owner/name; rm -rf /\`` split on its `;` into a segment
+# whose command word is `rm`, manufacturing the target ``/` `` and hard-denying a
+# Judge comment that deletes nothing (observed on PR #4357). Same failure family
+# as #5000's phantom write targets, and the reason fixing only the
+# ALWAYS_BLOCK_PATTERNS scan above leaves the reported command still denied.
+# The literal-redacted copy blanks exactly the quoted flag-value text (including
+# #5216's provably-inert `$(cat <<QDELIMQ … )` heredoc bodies) and nothing else,
+# so a REAL `rm -rf /` — bare, sudo-prefixed, after a `&&`, or smuggled through
+# `bash -c '…'` / `-m "$(rm -rf /)"` (neither of which is ever redacted) — still
+# reaches this check unchanged.
+#
 # Cheap pre-check keeps awk off the hot path for the ~99% of commands that have
 # no recursive/force rm at all.
-if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
-    RM_TARGETS=$(extract_rm_targets "$COMMAND" | head -20)
+if echo "$COMMAND_NO_LITERAL_TEXT" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
+    RM_TARGETS=$(extract_rm_targets "$COMMAND_NO_LITERAL_TEXT" | head -20)
 
     for target in $RM_TARGETS; do
         # Skip empty targets
@@ -3173,12 +3326,20 @@ fi
 #
 # A cheap pre-check keeps the config read + segment parser off the hot path for
 # the ~99% of commands with no force flag at all.
+#
+# SCANS COMMAND_ASK_SCAN, NOT COMMAND_NO_COMMENT (#5216). parse_force_ops() is
+# another per-physical-line segment parser, so a heredoc BODY line that BEGINS
+# with a force op (a Judge quoting `git push --force origin main` at the start of
+# a line, the exact prose #3679 exists to allow) was parsed as a live force op
+# and asked — and an unanswered ask blocks a headless sweep just like a deny.
+# Reading the literal-redacted copy keeps that prose inert while every real force
+# op — bare, chained after `&&`, or inside `bash -c '…'` — is untouched.
 # =============================================================================
-if [[ "$COMMAND_NO_COMMENT" == *git* ]] && \
-   echo "$COMMAND_NO_COMMENT" | grep -qE '(--force|--force-with-lease|(^|[[:space:]])-f([[:space:]]|$)|--hard)'; then
+if [[ "$COMMAND_ASK_SCAN" == *git* ]] && \
+   echo "$COMMAND_ASK_SCAN" | grep -qE '(--force|--force-with-lease|(^|[[:space:]])-f([[:space:]]|$)|--hard)'; then
     _FORCE_MODE=$(force_scope_mode)
     if [[ "$_FORCE_MODE" != "off" ]]; then
-        _FORCE_OPS=$(parse_force_ops "$COMMAND_NO_COMMENT" "$CWD")
+        _FORCE_OPS=$(parse_force_ops "$COMMAND_ASK_SCAN" "$CWD")
         if [[ -n "$_FORCE_OPS" ]]; then
             if [[ "$_FORCE_MODE" == "all" ]]; then
                 # Preserve pre-#3674 behaviour byte-for-byte: any force op asks.
@@ -3500,8 +3661,17 @@ CLOUD_ASK_PATTERNS=(
     'docker restart'
 )
 
+# SCANS COMMAND_ASK_SCAN, NOT COMMAND_NO_COMMENT (#5216). This was the only ask
+# loop still reading the merely comment-stripped copy — ASK_PATTERNS (#3756) and
+# REVERSIBLE_GH_PATTERNS above both already scan the literal-redacted copy — so
+# an `aws s3 rm`/`rb` phrase quoted as prose inside a `--body`/`-m` value still
+# false-asked after the catastrophic scan stopped false-denying it. In a headless
+# sweep an unanswered ask blocks just like a deny (see defaults/docs/
+# guard-hooks.md), so leaving it here would have left the reported stall half
+# fixed for the aws siblings. A real `aws s3 rb s3://bucket` outside a quoted
+# flag value is untouched and still asks.
 for pattern in "${CLOUD_ASK_PATTERNS[@]}"; do
-    if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern" && cloud_guard_enabled; then
+    if echo "$COMMAND_ASK_SCAN" | grep -qE "$pattern" && cloud_guard_enabled; then
         ask "Command requires confirmation: $COMMAND (set guards.cloudCli:false in .loom/config.json if this repo manages cloud infra as a first-class workflow)" "cloud-cli:$pattern"
     fi
 done

--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -922,10 +922,23 @@ New issues from this policy enter through normal intake (`loom:triage` → Curat
 
 **First refinement pass (#3898):**
 - `guards.forceScope:"protected"` recommended for autonomous repos (above).
-- The catastrophic scan no longer false-positives on **documentation text** — a dangerous command merely *mentioned* inside a multi-line `--body`/`-m`/`--title`/`--notes`/`--comment` value (e.g. `gh issue create --body "…"`) is redacted as a single span and does **not** deny, while a genuinely dangerous command, or a command-substitution `$(…)` smuggled inside such a value, still DENIES.
+- The catastrophic scan no longer false-positives on **documentation text** — a dangerous command merely *mentioned* inside a multi-line `--body`/`-m`/`--title`/`--notes`/`--comment` value (e.g. `gh issue create --body "…"`) is redacted as a single span and does **not** deny, while a genuinely dangerous command, or a command-substitution `$(…)` smuggled inside such a value, still DENIES. (The one shape this pass could *not* cover — a value wrapped in `"$(cat <<'EOF' … EOF)"`, which necessarily contains `$(` — was closed later by the third pass below.)
 - `git checkout .` / `git restore .` / `git clean -fd` **stay ASK** (evaluated, kept flagged): they irreversibly discard uncommitted/untracked work, so the standing policy files a per-trigger issue rather than blanket-allowlisting them. A repo that wants them to pass headless can add the command word to an allowlist per its own risk decision.
 
 **Second refinement pass (#4216):** `aws iam delete-*` and `az`/`gcloud … delete` were retiered from the catastrophic deny list to the **ungated ask tier**. A hard block on credential/resource deletion was over-broad — deleting an IAM key is often the *security-positive* step — and left only the undocumented script-file bypass as recourse. The deny→ask move is safe for autonomous mode by construction: a headless sweep's unanswered ASK still blocks (per the paragraph above), so nothing that was denied headless now silently runs; only a supervised interactive operator gains a confirm prompt. The patterns stay **ungated** (not folded into `guards.cloudCli`) so a repo disabling the cloud ASK category for EC2-churn convenience cannot silently bypass IAM deletion.
+
+**Third refinement pass (#5216):** the #3898 redaction above stops at any quoted flag value containing `$(` — the anti-smuggling floor that keeps `git commit -m "$(<destructive command>)"` denying. But Loom's own prescribed idiom for a multi-line comment body is `--body "$(cat <<'EOF' … EOF)"`, which *always* contains `$(`, so such a value was never redacted and a dangerous command merely **quoted inside the heredoc body as documentation** hard-denied the whole command (observed on a Judge approval for PR #4357, and reproducible for the #3679 force-push literals too — the gap was construction-specific, not pattern-specific). The guard now blanks the **body** of that one provably-inert shape before scanning, and every broad scan that could be tripped by such prose — the catastrophic `ALWAYS_BLOCK_PATTERNS` loop, the SQL-DDL deny, the `rm`-scope deny, the lifecycle deny, and the force-op / cloud-CLI asks — reads the redacted copy.
+
+Masking applies **only** when all of these hold, so a heredoc that is genuinely *executed* keeps denying:
+
+| Condition | Rejected example (still denies) |
+|-----------|--------------------------------|
+| Opener is the complete tail of a recognized text-carrying flag's quoted value, immediately after `$(cat` | `--body "$(bash <<'EOF' … EOF)"`, `cat <<'EOF' … EOF \| sh`, `sh -s <<'EOF' … EOF` — the body is live code to an inner interpreter |
+| Heredoc delimiter is **quoted** (`<<'EOF'` / `<<"EOF"`, `<<-` allowed) | `--body "$(cat <<EOF … EOF)"` — an unquoted delimiter lets the outer shell expand the body |
+| Block is **closed** in the same command buffer | an unterminated opener masks nothing (mirrors #5087) |
+| The line after the delimiter line is `)` + the same opening quote | `--body "$(cat <<'EOF' … EOF` ⏎ `rm -rf /` ⏎ `)"` — bash ends the heredoc and really runs the next line |
+
+This is deliberately narrower than the `mask_heredoc_bodies()` helper the write-target scanner uses: that one masks any closed heredoc body regardless of its consumer, an accepted fail-open there (#5117 Known Limitation 1) that must not be inherited by the hard-deny floor. **Known limitation** (recorded, not fixed): only the literal `cat`-consumed spelling above is recognized — an equivalent variant (`$(command cat <<'EOF' …)`, a heredoc opened on a continuation line, `) "` with a space before the closing quote) is simply not recognized and keeps false-positiving exactly as before. That is the safe direction: a pre-existing false positive, never a new bypass.
 
 ### When a Legitimate Operation Is Pattern-Blocked
 

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1822,8 +1822,114 @@ resolve_stash_cwd() {
 # it does not model backslash-escaped quotes, but since the result feeds only
 # the narrowing (never widening) catastrophic scan, the worst case is a raw
 # substring surviving — never a catastrophic block being skipped incorrectly.
+#
+# -----------------------------------------------------------------------------
+# HEREDOC-WRAPPED FLAG VALUES (#5216)
+#
+# The `$(`-floor above is exactly right for a general command substitution, but
+# it also declines to redact THIS repo's own pervasive idiom for any multi-line
+# comment body (CLAUDE.md / judge.md / doctor.md / builder-pr.md all show it):
+#
+#     gh pr comment 4357 --body "$(cat <<QUOTED_DELIM
+#     …prose that may QUOTE a dangerous command as an example…
+#     QUOTED_DELIM
+#     )" && gh pr edit 4357 --add-label "loom:pr"
+#
+# Every value built that way necessarily contains `$(`, so before this pass it
+# was NEVER redacted — and a dangerous-command example merely quoted inside the
+# body (a Judge documenting the shell-injection payload a PR now rejects, an
+# Auditor quoting a guard pattern) hard-denied the whole command on the
+# catastrophic tier. Observed live in guard-decisions.log on 2026-07-29 (a Judge
+# approval on PR #4357) and reproduced for the #3679 force-push literals too:
+# the gap is CONSTRUCTION-specific (heredoc-wrapped value), not pattern-specific.
+#
+# mask_flag_cat_heredocs() (below) closes it by masking ONLY the BODY of a
+# heredoc in this one provably-inert shape, and only when ALL of these hold:
+#   1. the opener is the complete tail of its line, immediately preceded by a
+#      recognized text-carrying flag, its opening quote, and `$(cat`;
+#   2. the heredoc delimiter is QUOTED (single- or double-quoted, `<<-` allowed)
+#      — a quoted delimiter is what guarantees the outer shell performs NO
+#      expansion on the body, so a `$(…)` sitting IN the body is inert text
+#      rather than live code (an UNQUOTED delimiter is rejected outright);
+#   3. the block is CLOSED in this same buffer (mirrors #5087's "never mask
+#      speculatively" rule for mask_heredoc_bodies);
+#   4. the very next line after the delimiter line is `)` + that same opening
+#      quote — i.e. the substitution ends immediately, with nothing chained
+#      after the heredoc inside it.
+# Condition 4 is what keeps a `--body "$(cat <<QUOTED_DELIM … QUOTED_DELIM`
+# <newline> `rm -rf /` <newline> `)"` command denying: bash ends the heredoc at
+# the delimiter line and then genuinely RUNS the following line inside the
+# substitution, so nothing is masked there. Condition 1 is what keeps an
+# INTERPRETER-FED heredoc denying — a body consumed by `bash <<DELIM`,
+# `sh -s <<DELIM`, or `cat <<DELIM … | sh` is live code
+# to the inner shell, and none of those match `<flag> <quote>$(cat`. This is the
+# deliberate narrowing versus reusing mask_heredoc_bodies() (#5000) here: that
+# helper masks ANY closed heredoc body regardless of its consumer, a documented
+# and accepted fail-open for the write-target scanner (#5117 Known Limitation 1)
+# that must NOT be inherited by the catastrophic hard-deny floor.
+#
+# KNOWN LIMITATION (recorded, mirroring the #5117 convention): this recognizes
+# only the literal `cat`-consumed shape spelled out above. A semantically
+# equivalent variant — `$(command cat <<DELIM …)`, a heredoc opened on a
+# continuation line, or a body whose delimiter line is followed by `) "` with a
+# space — is simply not recognized and keeps denying exactly as it does today.
+# That is the safe direction (a false positive that already exists, never a new
+# bypass), and the shape above is the one the repo's own role prompts prescribe.
+# -----------------------------------------------------------------------------
 strip_literal_text() {
     printf '%s' "$1" | awk '
+    # Mask the body of a `<flag> "$(cat <<QUOTED_DELIM … DELIM\n)"` heredoc.
+    # See the header comment above for the four conditions and why each is
+    # load-bearing. Body bytes are replaced 1:1 with "X" so the buffer keeps
+    # its byte offsets and line count; the opener line, the delimiter line and
+    # everything outside the body are left untouched.
+    function mask_flag_cat_heredocs(s,   lines, nl, i, j, line, pre, oq, delim, dq, closeat, trimmed, body, dashform) {
+        if (index(s, "<<") == 0) return s
+        nl = split(s, lines, "\n")
+        for (i = 1; i <= nl; i++) {
+            line = lines[i]
+            # (2) opener must END the line and carry a QUOTED delimiter.
+            if (match(line, /<<-?["'"'"'][A-Za-z0-9_]+["'"'"'][ \t]*$/) == 0) continue
+            dashform = (substr(line, RSTART + 2, 1) == "-")
+            delim = substr(line, RSTART, RLENGTH)
+            sub(/^<<-?/, "", delim)
+            sub(/[ \t]*$/, "", delim)
+            dq = substr(delim, 1, 1)
+            if (substr(delim, length(delim), 1) != dq) continue   # quotes must match
+            delim = substr(delim, 2, length(delim) - 2)
+            if (delim == "") continue
+            # (1) …immediately preceded by <flag> <openquote>$(cat.
+            pre = substr(line, 1, RSTART - 1)
+            if (pre !~ /(^|[ \t])(--message|--body|--notes|--title|--comment|-m)[ \t]*=?[ \t]*["'"'"']\$\([ \t]*cat[ \t]+$/) continue
+            oq = ""
+            for (j = length(pre); j >= 1; j--) {
+                if (substr(pre, j, 2) == "$(") { oq = substr(pre, j - 1, 1); break }
+            }
+            if (oq != DQ && oq != SQ) continue
+            # (3) the block must be CLOSED inside this buffer.
+            closeat = 0
+            for (j = i + 1; j <= nl; j++) {
+                trimmed = lines[j]
+                if (dashform) sub(/^\t+/, "", trimmed)
+                if (trimmed == delim) { closeat = j; break }
+            }
+            if (closeat == 0) continue
+            # (4) the substitution must close IMMEDIATELY after the delimiter
+            #     line — `)` + the same opening quote — so nothing chained
+            #     after the heredoc inside `$( … )` is masked away.
+            if (closeat == nl) continue
+            if (substr(lines[closeat + 1], 1, 2) != ")" oq) continue
+            for (j = i + 1; j < closeat; j++) {
+                body = lines[j]
+                gsub(/./, "X", body)
+                lines[j] = body
+            }
+            i = closeat
+        }
+        s = lines[1]
+        for (i = 2; i <= nl; i++) s = s "\n" lines[i]
+        return s
+    }
     BEGIN {
         SQ = sprintf("%c", 39)   # single quote
         DQ = sprintf("%c", 34)   # double quote
@@ -1847,7 +1953,16 @@ strip_literal_text() {
     # byte-for-byte identical to the previous behaviour.
     { buf = buf (NR > 1 ? "\n" : "") $0 }
     END {
-        s = buf
+        # PRE-PASS (#5216): blank the body of a `<flag> "$(cat <<QDELIMQ … )"`
+        # heredoc before the quoted-span redaction below runs. It has to happen
+        # here rather than inside the loop because `re`'"'"'s quoted-span classes
+        # ([^"]* / [^'"'"']*) stop at the first quote character, and a heredoc body
+        # is free to contain raw quotes (prose routinely does) — so the span
+        # match alone cannot see such a value whole. Masking first also means
+        # the `$(`-floor below needs no exception: by the time the loop reads
+        # this span, the only text left inside it is `$(cat <<QDELIMQ`, the
+        # delimiter, and `)`.
+        s = mask_flag_cat_heredocs(buf)
         out = ""
         while (match(s, re)) {
             pre     = substr(s, 1, RSTART - 1)
@@ -2361,7 +2476,16 @@ lifecycle_or_cloud_reason() {
 # unanswered ASK still blocks (see defaults/docs/guard-hooks.md). A lifecycle
 # deny takes precedence over a cloud-delete ask in a compound command (e.g.
 # `az group delete …; halt`), so the hard floor is never downgraded.
-_LIFECYCLE_CLOUD_REASONS=$(lifecycle_or_cloud_reason "$COMMAND_NO_COMMENT")
+#
+# SCANS COMMAND_ASK_SCAN, NOT COMMAND_NO_COMMENT (#5216). lifecycle_or_cloud_reason()
+# segment-parses per physical line, so a heredoc BODY line inside
+# `--body "$(cat <<'EOF' … EOF)"` whose first word happens to be a lifecycle verb
+# ("halt the deploy if this fails", "shutdown checklist:") was read as a live
+# `halt`/`shutdown` command word and hard-denied a comment that runs nothing.
+# The literal-redacted copy blanks only that quoted-value text; a real
+# `… ; halt` outside a flag value, or a `bash -c 'halt'` payload (never
+# redacted), still reaches this check and still denies.
+_LIFECYCLE_CLOUD_REASONS=$(lifecycle_or_cloud_reason "$COMMAND_ASK_SCAN")
 _LIFECYCLE_DENY=$(printf '%s\n' "$_LIFECYCLE_CLOUD_REASONS" | grep '^system lifecycle command:' | head -1)
 if [[ -n "$_LIFECYCLE_DENY" ]]; then
     deny "BLOCKED: $_LIFECYCLE_DENY" "lifecycle"
@@ -2379,10 +2503,23 @@ fi
 # all four DDL statements in one pass (cheaper than a per-pattern loop), and
 # sql_guard_enabled() is consulted only after a match, so the config read stays
 # off the hot path.
+#
+# SCANS COMMAND_ASK_SCAN, NOT COMMAND_NO_COMMENT (#5216). This check was the one
+# broad-substring deny that never received #3679's quoted-flag-value redaction:
+# `gh pr comment --body "example payload: DROP TABLE users"` hard-denied a
+# comment that runs no SQL at all, where the equivalent prose about `rm -rf /`
+# was already allowed by the catastrophic scan. COMMAND_ASK_SCAN is the
+# comment-stripped AND literal-redacted copy (built above; already relied on by
+# the deny-tier write-confinement check, so its use here is not an ask-tier-only
+# convention), which also carries #5216's heredoc-body masking — so both the
+# plain `--body "…"` and the heredoc-wrapped `--body "$(cat <<'EOF' … EOF)"`
+# forms of quoted prose stop false-positiving in one step. `-c`/`-e` are NOT
+# text-carrying flags, so the real invocations (`psql -c '…'`, `mysql -e '…'`)
+# are untouched and still deny.
 # =============================================================================
 SQL_DDL_PATTERN='DROP DATABASE|DROP TABLE|DROP SCHEMA|TRUNCATE TABLE'
-if echo "$COMMAND_NO_COMMENT" | grep -qiE "$SQL_DDL_PATTERN" && sql_guard_enabled; then
-    matched=$(echo "$COMMAND_NO_COMMENT" | grep -oiE "$SQL_DDL_PATTERN" | head -1)
+if echo "$COMMAND_ASK_SCAN" | grep -qiE "$SQL_DDL_PATTERN" && sql_guard_enabled; then
+    matched=$(echo "$COMMAND_ASK_SCAN" | grep -oiE "$SQL_DDL_PATTERN" | head -1)
     deny "BLOCKED: Command matches dangerous pattern: ${matched:-SQL DDL statement}" "sql-ddl"
 fi
 
@@ -2737,10 +2874,26 @@ expand_leading_tilde() {
     esac
 }
 
+# SCANS COMMAND_NO_LITERAL_TEXT, NOT RAW $COMMAND (#5216). extract_rm_targets()
+# segments with qsplit(), which — like every quote-tracking scan in this file —
+# is driven one PHYSICAL LINE at a time and has no memory of a `"` opened on an
+# earlier line. So a heredoc BODY line inside `--body "$(cat <<'EOF' … EOF)"`
+# was segmented as if it were live shell: the prose
+# `Example payload: \`owner/name; rm -rf /\`` split on its `;` into a segment
+# whose command word is `rm`, manufacturing the target ``/` `` and hard-denying a
+# Judge comment that deletes nothing (observed on PR #4357). Same failure family
+# as #5000's phantom write targets, and the reason fixing only the
+# ALWAYS_BLOCK_PATTERNS scan above leaves the reported command still denied.
+# The literal-redacted copy blanks exactly the quoted flag-value text (including
+# #5216's provably-inert `$(cat <<QDELIMQ … )` heredoc bodies) and nothing else,
+# so a REAL `rm -rf /` — bare, sudo-prefixed, after a `&&`, or smuggled through
+# `bash -c '…'` / `-m "$(rm -rf /)"` (neither of which is ever redacted) — still
+# reaches this check unchanged.
+#
 # Cheap pre-check keeps awk off the hot path for the ~99% of commands that have
 # no recursive/force rm at all.
-if echo "$COMMAND" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
-    RM_TARGETS=$(extract_rm_targets "$COMMAND" | head -20)
+if echo "$COMMAND_NO_LITERAL_TEXT" | grep -qE 'rm[[:space:]]+-[a-zA-Z]*[rf]'; then
+    RM_TARGETS=$(extract_rm_targets "$COMMAND_NO_LITERAL_TEXT" | head -20)
 
     for target in $RM_TARGETS; do
         # Skip empty targets
@@ -3173,12 +3326,20 @@ fi
 #
 # A cheap pre-check keeps the config read + segment parser off the hot path for
 # the ~99% of commands with no force flag at all.
+#
+# SCANS COMMAND_ASK_SCAN, NOT COMMAND_NO_COMMENT (#5216). parse_force_ops() is
+# another per-physical-line segment parser, so a heredoc BODY line that BEGINS
+# with a force op (a Judge quoting `git push --force origin main` at the start of
+# a line, the exact prose #3679 exists to allow) was parsed as a live force op
+# and asked — and an unanswered ask blocks a headless sweep just like a deny.
+# Reading the literal-redacted copy keeps that prose inert while every real force
+# op — bare, chained after `&&`, or inside `bash -c '…'` — is untouched.
 # =============================================================================
-if [[ "$COMMAND_NO_COMMENT" == *git* ]] && \
-   echo "$COMMAND_NO_COMMENT" | grep -qE '(--force|--force-with-lease|(^|[[:space:]])-f([[:space:]]|$)|--hard)'; then
+if [[ "$COMMAND_ASK_SCAN" == *git* ]] && \
+   echo "$COMMAND_ASK_SCAN" | grep -qE '(--force|--force-with-lease|(^|[[:space:]])-f([[:space:]]|$)|--hard)'; then
     _FORCE_MODE=$(force_scope_mode)
     if [[ "$_FORCE_MODE" != "off" ]]; then
-        _FORCE_OPS=$(parse_force_ops "$COMMAND_NO_COMMENT" "$CWD")
+        _FORCE_OPS=$(parse_force_ops "$COMMAND_ASK_SCAN" "$CWD")
         if [[ -n "$_FORCE_OPS" ]]; then
             if [[ "$_FORCE_MODE" == "all" ]]; then
                 # Preserve pre-#3674 behaviour byte-for-byte: any force op asks.
@@ -3500,8 +3661,17 @@ CLOUD_ASK_PATTERNS=(
     'docker restart'
 )
 
+# SCANS COMMAND_ASK_SCAN, NOT COMMAND_NO_COMMENT (#5216). This was the only ask
+# loop still reading the merely comment-stripped copy — ASK_PATTERNS (#3756) and
+# REVERSIBLE_GH_PATTERNS above both already scan the literal-redacted copy — so
+# an `aws s3 rm`/`rb` phrase quoted as prose inside a `--body`/`-m` value still
+# false-asked after the catastrophic scan stopped false-denying it. In a headless
+# sweep an unanswered ask blocks just like a deny (see defaults/docs/
+# guard-hooks.md), so leaving it here would have left the reported stall half
+# fixed for the aws siblings. A real `aws s3 rb s3://bucket` outside a quoted
+# flag value is untouched and still asks.
 for pattern in "${CLOUD_ASK_PATTERNS[@]}"; do
-    if echo "$COMMAND_NO_COMMENT" | grep -qE "$pattern" && cloud_guard_enabled; then
+    if echo "$COMMAND_ASK_SCAN" | grep -qE "$pattern" && cloud_guard_enabled; then
         ask "Command requires confirmation: $COMMAND (set guards.cloudCli:false in .loom/config.json if this repo manages cloud infra as a first-class workflow)" "cloud-cli:$pattern"
     fi
 done

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2068,6 +2068,176 @@ assert_deny "#3679 regression: chained 'force-push to main && echo done' still d
 echo ""
 
 # =========================================================================
+echo -e "${YELLOW}--- #5216: heredoc-wrapped flag values quoting a dangerous example ---${NC}"
+# =========================================================================
+#
+# #3679's redaction (strip_literal_text) declines to redact any quoted flag
+# value carrying `$(` — its anti-smuggling floor, which keeps
+# `git commit -m "$(<destructive>)"` denying. But this repo's OWN prescribed
+# idiom for a multi-line comment body is `--body "$(cat <<'EOF' … EOF)"`, which
+# necessarily contains `$(` — so such a value was NEVER redacted, and a
+# dangerous command merely QUOTED in the body as documentation hard-denied the
+# whole command (observed live on a Judge approval for PR #4357, and again for
+# the #3679 force-push literals: the gap is CONSTRUCTION-specific, not
+# pattern-specific).
+#
+# mask_flag_cat_heredocs() blanks the BODY of that one provably-inert shape:
+# a QUOTED heredoc delimiter (no expansion) feeding a literal `cat`, opened as
+# the complete tail of a text-carrying flag's quoted value, CLOSED in the same
+# buffer, with the substitution closing immediately (`)` + the same quote) on
+# the line right after the delimiter. Every deny below is one of those
+# conditions failing, i.e. text that really can execute.
+_HD_DDL="DR""OP TA""BLE"
+
+# ---- false positives now ALLOWED (inert heredoc-body prose) ----
+assert_allow "#5216: heredoc --body quoting an 'rm -rf /' payload, chained with gh pr edit (the PR #4357 repro) allowed" \
+    'gh pr comment 4357 --body "$(cat <<'"'"'EOF2'"'"'
+## Security
+Example payload: `owner/name; rm -rf /` — validate_repo() rejects this.
+EOF2
+)" && gh pr edit 4357 --add-label "loom:pr" --remove-label "loom:review-requested"'
+
+assert_allow "#5216: heredoc --body quoting a force-push-to-main example allowed (shared mechanism, not rm-specific)" \
+    'gh pr comment 999 --body "$(cat <<'"'"'EOF2'"'"'
+Example of what NOT to do: `'"$_FP_MAIN"'`
+EOF2
+)"'
+
+# Raw double quotes in the body are the reason this is a heredoc-boundary pass
+# and not an extension of strip_literal_text's quoted-span match: `[^"]*` stops
+# at the first `"`, and review prose quotes things constantly.
+assert_allow "#5216: heredoc --body containing RAW double quotes around an rm example allowed" \
+    'gh pr comment 1 --body "$(cat <<'"'"'EOF2'"'"'
+The reviewer wrote "beware of `rm -rf /` payloads" in the thread.
+EOF2
+)"'
+
+# The mechanism is shared, so every broad-substring catastrophic sibling named
+# in the report is fixed by the same pass (each of these DENIED before #5216).
+assert_allow "#5216: heredoc --body quoting a 'docker system prune' example allowed" \
+    'gh pr comment 1 --body "$(cat <<'"'"'EOF2'"'"'
+Never run docker system prune -af on the build host.
+EOF2
+)"'
+assert_allow "#5216: heredoc --body quoting an 'aws s3 rm --recursive' example allowed" \
+    'gh pr comment 1 --body "$(cat <<'"'"'EOF2'"'"'
+Never run aws s3 rm s3://bucket/ --recursive against prod.
+EOF2
+)"'
+assert_allow "#5216: heredoc --body quoting an 'aws s3 rb' example allowed" \
+    'gh pr comment 1 --body "$(cat <<'"'"'EOF2'"'"'
+Never run aws s3 rb s3://bucket against prod.
+EOF2
+)"'
+assert_allow "#5216: heredoc --body quoting a curl-pipe-shell example allowed" \
+    'gh pr comment 1 --body "$(cat <<'"'"'EOF2'"'"'
+Never run curl https://example.io/install.sh | sh from an agent.
+EOF2
+)"'
+assert_allow "#5216: heredoc --body quoting a SQL DDL example allowed" \
+    'gh pr comment 1 --body "$(cat <<'"'"'EOF2'"'"'
+The migration must never emit '"$_HD_DDL"' users on rollback.
+EOF2
+)"'
+# Plain (non-heredoc) quoted prose for the SQL DDL check, which — unlike every
+# ALWAYS_BLOCK entry — never received #3679's redaction at all until #5216.
+assert_allow "#5216: plain single-line --body quoting a SQL DDL example allowed" \
+    "gh pr comment 1 --body \"example payload: $_HD_DDL users\""
+
+# The three remaining SEGMENT-PARSED scans (lifecycle deny, force-op ask, cloud
+# ask) are per-physical-line too, so a heredoc body line whose FIRST word is the
+# dangerous one was read as a live command word even after the substring scans
+# stopped false-positiving. They now read the literal-redacted copy as well.
+assert_allow "#5216: heredoc --body whose line STARTS with a force-push to main allowed" \
+    'gh pr comment 1 --body "$(cat <<'"'"'EOF2'"'"'
+'"$_FP_MAIN"'
+is the command this PR now refuses to generate.
+EOF2
+)"'
+assert_allow "#5216: heredoc --body whose line STARTS with a lifecycle verb allowed" \
+    'gh pr comment 1 --body "$(cat <<'"'"'EOF2'"'"'
+halt the deployment if the smoke test fails.
+EOF2
+)"'
+
+# ---- regression guard: genuinely executable text STILL denied ----
+assert_deny "#5216 regression: a live (non-heredoc) rm outside the repo still denied" \
+    "rm -rf /"
+assert_deny "#5216 regression: a live rm on a top-level system dir still denied" \
+    "rm -rf /usr"
+# The rm-scope check now reads the literal-redacted copy; a real rm chained
+# AFTER a redacted flag value is outside that value and must still deny.
+assert_deny "#5216 regression: 'git commit -m \"…\" && rm -rf /usr' still denied" \
+    'git commit -m "cleanup pass" && rm -rf /usr'
+assert_deny "#5216 regression: a real rm after a heredoc-wrapped --body still denied (narrows, never widens)" \
+    'gh pr comment 1 --body "$(cat <<'"'"'EOF2'"'"'
+inert prose about cleanup
+EOF2
+)" && rm -rf /'
+
+# Command-substitution smuggling — the #3679 safety floor — is untouched:
+# `-c` is not a text-carrying flag, and a `$(…)` value that is NOT the narrow
+# cat-heredoc shape is never redacted.
+assert_deny "#5216 regression: bash -c 'rm -rf /' still denied" \
+    "bash -c 'rm -rf /'"
+assert_deny "#5216 regression: git commit -m \"\$(rm -rf /)\" still denied" \
+    'git commit -m "$(rm -rf /)"'
+
+# INTERPRETER-FED HEREDOC — the scoping decision this fix turns on. The body of
+# a heredoc handed to an interpreter is live code to that inner shell, which is
+# exactly the #5117 Known Limitation that made mask_heredoc_bodies() unsafe to
+# reuse verbatim on the hard-deny floor. Requiring the opener to be preceded by
+# `<flag> <quote>$(cat` CLOSES it here: none of these match, so all still deny.
+assert_deny "#5216 scoping: --body \"\$(bash <<'EOF' … EOF)\" (interpreter-fed) still denied" \
+    'gh pr comment 1 --body "$(bash <<'"'"'EOF2'"'"'
+rm -rf /
+EOF2
+)"'
+assert_deny "#5216 scoping: 'cat <<EOF … EOF | sh' (heredoc piped to a shell) still denied" \
+    'cat <<'"'"'EOF2'"'"' | sh
+rm -rf /
+EOF2'
+assert_deny "#5216 scoping: 'sh -s <<EOF … EOF' (heredoc as stdin script) still denied" \
+    'sh -s <<'"'"'EOF2'"'"'
+rm -rf /
+EOF2'
+
+# A command chained AFTER the heredoc but still INSIDE the substitution really
+# runs (bash ends the heredoc at the delimiter line), so nothing is masked.
+assert_deny "#5216 scoping: a command chained after the heredoc inside \$( … ) still denied" \
+    'gh pr comment 1 --body "$(cat <<'"'"'EOF2'"'"'
+inert prose
+EOF2
+rm -rf /
+)"'
+
+# An UNQUOTED delimiter lets the outer shell expand the body before `cat` sees
+# it, so the body is not provably inert and is never masked.
+assert_deny "#5216 scoping: an UNQUOTED heredoc delimiter is not masked, still denied" \
+    'gh pr comment 1 --body "$(cat <<EOF2
+rm -rf /
+EOF2
+)"'
+
+# Real invocations of the siblings above are unaffected by the masking pass.
+assert_deny "#5216 regression: a real 'docker system prune' still denied" \
+    "docker system prune -af"
+assert_deny "#5216 regression: a real SQL DDL invocation still denied" \
+    "psql -c '$_HD_DDL users;'"
+assert_deny "#5216 regression: a real lifecycle command still denied" \
+    "sudo halt"
+assert_deny "#5216 regression: a lifecycle command chained after a quoted message still denied" \
+    'git commit -m "halt the deploy checklist" && halt'
+assert_ask "#5216 regression: a real force-push to a feature branch still asks" \
+    "git push --force origin feature/issue-1"
+assert_deny "#5216 regression: a real bucket removal still denied" \
+    "aws s3 rb s3://some-bucket"
+assert_ask "#5216 regression: a real 'docker rm' still asks (cloud/container ask tier)" \
+    "docker rm -f mycontainer"
+
+echo ""
+
+# =========================================================================
 echo -e "${YELLOW}--- Read-only fast path (guards.readOnlyFastPath / LOOM_GUARD_READONLY_FASTPATH, #3687) ---${NC}"
 # =========================================================================
 


### PR DESCRIPTION
## Summary

`strip_literal_text()` refuses to redact any quoted flag value containing `$(` — its documented anti-smuggling floor, which is what keeps a command-substitution payload from being laundered past the catastrophic tier. But this repo's own prescribed idiom for a multi-line comment body (`--body "$(cat <<'EOF' … EOF)"`, in CLAUDE.md, judge.md, doctor.md, builder-pr.md) *always* contains `$(`, so such a value was **never** redacted. A dangerous command merely **quoted inside the heredoc body as documentation** therefore hard-denied the entire command — observed live on a Judge approval for PR #4357, and reproducible for the #3679 force-push literals too. The gap is **construction-specific** (heredoc-wrapped value), not pattern-specific.

This PR adds `mask_flag_cat_heredocs()`, a heredoc-boundary-aware pre-pass inside `strip_literal_text()` that blanks the **body** of exactly one provably-inert shape, and routes the remaining broad scans that per-physical-line parsing let the same prose trip through the redacted copy.

### The scoping decision (interpreter-fed heredocs)

The issue explicitly warned against blanket-reusing `mask_heredoc_bodies()` (#5000) here: that helper masks *any* closed heredoc body regardless of what consumes it — an accepted fail-open for the write-target scanner (#5117 Known Limitation 1), but not acceptable on the catastrophic hard-deny floor, where a `bash <<'EOF' … EOF` body is live code to an inner shell.

The new pass masks only when **all four** conditions hold, and each one is load-bearing:

| Condition | What it rejects (still denies) |
|-----------|--------------------------------|
| 1. Opener is the complete tail of a recognized text-carrying flag's quoted value, immediately after `$(cat` | **Interpreter-fed heredocs**: `--body "$(bash <<Q … Q)"`, `cat <<Q … Q \| sh`, `sh -s <<Q … Q` — none match `<flag> <quote>$(cat` |
| 2. Heredoc delimiter is **quoted** (`<<-` allowed) | An unquoted delimiter lets the outer shell expand the body before `cat` sees it, so it is not provably inert |
| 3. Block is **closed** in the same buffer | An unterminated/false opener masks nothing (mirrors #5087's "never mask speculatively") |
| 4. The line after the delimiter line is `)` + that same opening quote | A command **chained after the heredoc inside the substitution** (`… Q` ⏎ `rm -rf /` ⏎ `)"`) really runs — bash ends the heredoc at the delimiter line |

So condition 1 **closes** the interpreter-fed case rather than leaving it as a known limitation; there are three `assert_deny` scoping tests for it (`--body "$(bash <<Q …)"`, `cat <<Q … | sh`, `sh -s <<Q …`).

**Known limitation** (recorded in the hook header and `guard-hooks.md`, mirroring the #5117 convention): only the literal `cat`-consumed spelling is recognized. An equivalent variant (`$(command cat <<Q …)`, an opener on a continuation line, `) "` with a space) is not recognized and keeps false-positiving exactly as it does today — a pre-existing false positive, never a new bypass.

### Why the fix is not the ALWAYS_BLOCK loop alone

Fixing only `ALWAYS_BLOCK_PATTERNS` leaves the issue's own repro **still denied**: the `rm`-scope check independently segment-parses the raw command per physical line, reads the body line `Example payload: ` + a backticked `owner/name; <recursive force removal of />` as a live `rm` segment, and denies with `rm on protected system path`. Same failure family as #5000's phantom write targets. Four sibling scans had the same per-line blindness, so they now read the literal-redacted copy too. Every one of them is a *narrowing* change: a real invocation outside a quoted flag value is byte-for-byte unaffected.

## Changes

- `defaults/hooks/guard-destructive-generic.sh` (+ the byte-identical vendored `.loom/hooks/` copy):
  - New `mask_flag_cat_heredocs()` awk helper, run as a pre-pass in `strip_literal_text()`'s `END` block. It runs before the existing quoted-span redaction because `re`'s span classes (`[^"]*` / `[^']*`) stop at the first quote character, and heredoc prose contains raw quotes constantly — the span match alone cannot see such a value whole. Body bytes are replaced 1:1 with `X`, preserving byte offsets and line count.
  - SQL-DDL deny now scans `COMMAND_ASK_SCAN` (comment-stripped **and** literal-redacted). This was the one broad-substring deny that never received #3679's redaction at all — plain `--body "example payload: <DDL>"` denied where the equivalent prose about a recursive removal was already allowed. `-c`/`-e` are not text-carrying flags, so `psql -c '…'` / `mysql -e '…'` still deny.
  - `rm`-scope deny (`extract_rm_targets` + its pre-check) now scans `COMMAND_NO_LITERAL_TEXT`.
  - Lifecycle deny (`lifecycle_or_cloud_reason`) now scans `COMMAND_ASK_SCAN` — a body line starting with `halt`/`shutdown` was read as a live command word.
  - Force-op ask (`parse_force_ops` + its pre-check) and the cloud-CLI ask loop now scan `COMMAND_ASK_SCAN`, matching `ASK_PATTERNS` / `REVERSIBLE_GH_PATTERNS`, which already did. An unanswered ask blocks a headless sweep just like a deny, so leaving these would have half-fixed the reported stall.
- `tests/hooks/test-guard-destructive.sh`: new `#5216` block, 29 assertions.
- `defaults/docs/guard-hooks.md`: "Third refinement pass (#5216)" with the four-condition table and the known limitation; amended the #3898 bullet to point at it.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| 1. Fix the false positive for a heredoc-wrapped `--body`/`-m`/`--title`/`--notes`/`--comment` value quoting a dangerous example, for the shared `ALWAYS_BLOCK_PATTERNS` catastrophic scan | ✅ | Single shared-mechanism fix in `strip_literal_text()`, which already feeds the whole catastrophic loop. Issue's exact repro command re-run through the guard by hand → **ALLOW**; `assert_allow` "#5216: heredoc --body quoting an 'rm -rf /' payload, chained with gh pr edit (the PR #4357 repro) allowed" |
| 2. Masking scoped narrowly enough that a genuinely-executed dangerous command inside an interpreter-fed heredoc still denies | ✅ | Condition 1 (see table above) closes it rather than documenting it away. 3 scoping `assert_deny`s: `--body "$(bash <<Q …)"`, `cat <<Q … \| sh`, `sh -s <<Q …`. Plus `assert_deny` for a command chained after the heredoc inside `$( … )`, and for an unquoted delimiter |
| 3. Same fix covers the sibling broad-substring catastrophic patterns (docker-prune, both aws-s3-delete patterns, sql-ddl, curl/wget-pipe-shell) and the #3679 force-push literals — no narrowing | ✅ | `assert_allow` for each of docker-prune, `aws s3 rm --recursive`, `aws s3 rb`, curl-pipe-shell, SQL DDL (heredoc **and** plain single-line), and force-push-to-main (mid-line **and** line-start). Non-narrowing: all 40 pre-existing #3679 assertions still pass, plus new `assert_deny`/`assert_ask` for real `docker system prune`, real DDL, real bucket removal, real `docker rm`, real force-push to a feature branch |
| 4. Non-regression: command-substitution-smuggled destructive removal still hard-denies | ✅ | `assert_deny` for `bash -c 'rm -rf /'` and `git commit -m "$(rm -rf /)"`; plus live `rm -rf /`, live `rm -rf /usr`, `git commit -m "…" && rm -rf /usr`, and a real removal chained after a heredoc-wrapped body ("narrows, never widens") |
| 5. Regression tests added to `tests/hooks/test-guard-destructive.sh` mirroring the #5181 block | ✅ | New `--- #5216 ---` section, 29 assertions, all listed above. The interpreter-fed scoping case is an explicit `assert_deny` (the fix closes it), not a commented `assert_allow` |

## Test Plan

- `./tests/hooks/test-guard-destructive.sh` → **708 passed, 0 failed** (679 pre-existing + 29 new), including the #3679 and #5181 blocks and the <200ms performance assertion (14ms avg).
- `tests/hooks/test-guard-destructive-dispatcher.sh` → 12/12; `defaults/hooks/tests/test-guard-worktree-paths.sh` → 28/28 (includes the `.loom/` vs `defaults/` byte-identity assertion); `tests/install/test-hooks-preserve.sh` → 10/10.
- `shellcheck --severity=error` clean on the modified hook; `bash -n` clean on the hook and the test suite.
- `scripts/check-docs-defaults-parity.sh` → OK.
- Manually re-ran the issue's own repro command through the guard: **ALLOW** (was `deny` / `catastrophic:rm…` on `main`).
- Manually diffed guard decisions for 17 hand-built probe commands against `main`'s copy: every deny that should persist persists; only the inert-prose cases flipped to allow.

Closes #5216
