### PR TITLE
fix(resync): dereference symlinked source files in resync_tree's walk

### DIFF
--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -21,8 +21,16 @@
 # surface map — note the asymmetric source->target mapping):
 #   .loom/hooks/            <- defaults/hooks/            (top-level *.sh)
 #   .loom/scripts/          <- defaults/scripts/          (recursive)
-#   .loom/roles/            <- defaults/roles/            (recursive)
-#   .loom/docs/             <- defaults/docs/             (recursive; symlinks skipped)
+#   .loom/roles/            <- defaults/roles/            (recursive; SOURCE-side
+#                                                          symlinks resolved to
+#                                                          content, #5222 — all 17
+#                                                          defaults/roles/*.md are
+#                                                          symlinks to
+#                                                          .claude/commands/loom/*.md)
+#   .loom/docs/             <- defaults/docs/             (recursive; DESTINATION-side
+#                                                          symlinks skipped, e.g. this
+#                                                          dogfood repo's own
+#                                                          .loom/docs/*.md)
 #   .loom/runtimes/         <- defaults/runtimes/         (recursive; BACKFILLED if absent, #4688)
 #   .loom/bin/              <- defaults/.loom/bin/        (recursive; live consumer CLI)
 #   .claude/commands/loom/  <- defaults/.claude/commands/loom/ (recursive)
@@ -384,11 +392,15 @@ abs_file_path() {
 }
 
 # Octal permission bits of a path, or "" when unavailable (GNU stat, then BSD).
+# -L (dereference) so a symlinked source (e.g. defaults/roles/*.md -> the
+# .claude/commands/loom/*.md skillification target, #5222) reports the
+# REFERENT's mode rather than the symlink's own (typically 755/lrwxrwxrwx)
+# mode -- both GNU and BSD `stat` report the link's own bits without -L.
 file_mode() {
     local p="$1" m
-    m="$(stat -c '%a' "$p" 2>/dev/null)" || m=""
+    m="$(stat -L -c '%a' "$p" 2>/dev/null)" || m=""
     if [[ -z "$m" ]]; then
-        m="$(stat -f '%OLp' "$p" 2>/dev/null)" || m=""
+        m="$(stat -L -f '%OLp' "$p" 2>/dev/null)" || m=""
     fi
     printf '%s' "$m"
 }
@@ -573,6 +585,22 @@ apply_deferred_self_sync() {
 #                       ".claude/commands/loom", ".loom/bin").
 #   A missing src_dir is a silent no-op. Existing sync_one semantics (ignore
 #   list, symlink skip, idempotent copy, --dry-run) apply per file.
+#
+#   SOURCE-SIDE symlinks (#5222): all 17 defaults/roles/*.md files are
+#   symlinks to ../.claude/commands/loom/*.md (the skillification dedup, so
+#   the two copies of each role prompt never drift). Plain `find -type f`
+#   lstats each entry and a symlink never matches `-type f`, so those 17
+#   files silently fell out of the walk entirely -- not updated, not
+#   skipped, not counted -- and a consumer repo's installed .loom/roles/*.md
+#   (real file copies there, not symlinks) went stale forever while resync
+#   reported success. `find -L` dereferences before the type test, so a
+#   symlinked source is walked as the regular file it resolves to; `cp`
+#   (sync_one) and `cmp` both already dereference by default, so the
+#   destination gets the RESOLVED CONTENT, never a copied link. This is a
+#   source-side concern only -- the destination-side symlink guard in
+#   sync_one (`[[ -L "$dst" ]]`, protecting e.g. this dogfood repo's own
+#   .loom/roles/*.md and .loom/docs/*.md, which are themselves symlinks back
+#   into defaults/) is untouched and still runs first.
 resync_tree() {
     local src_dir="$1" dst_dir="$2" report_prefix="$3" defaults_prefix="$4"
     [[ -d "$src_dir" ]] || return 0
@@ -586,7 +614,7 @@ resync_tree() {
             continue
         fi
         sync_one "$src" "$dst_dir/$rel" "$report_prefix/$rel"
-    done < <(find "$src_dir" -type f -print0 2>/dev/null | sort -z)
+    done < <(find -L "$src_dir" -type f -print0 2>/dev/null | sort -z)
 }
 
 # ---------- canonical Repo Skills guard detection (#4041, #4894) ----------

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -16,6 +16,9 @@
 #   (j) local-only custom role -> survives untouched
 #   (k) resync-ignore pins a new-surface file -> reported "skipped"
 #   (l) symlinked install target -> skipped, not clobbered
+#   (l2) symlinked SOURCE file -> resolved to its content (not a copied link),
+#        appears in the per-file report (updated/unchanged), destination-side
+#        symlink protection (l) is unaffected (#5222)
 #   (m) recorded loom_source gone -> clear error, exit 1
 #   (n) metadata re-stamp -> loom_version/loom_commit/last_resync present after apply
 # Canonical-guard-defer (#4041, #4403, #4566):
@@ -93,6 +96,10 @@ export GIT_COMMITTER_NAME="test" GIT_COMMITTER_EMAIL="test@example.com"
 #   .loom/scripts/custom-only.sh     (repo-specific, no defaults/ counterpart)
 # Widened surfaces (#4239):
 #   defaults/roles/builder.md            -> .loom/roles/builder.md (drift)
+#   defaults/roles/symlinked-role.md     -> .loom/roles/symlinked-role.md (SOURCE
+#                                            is a symlink to a sibling file, #5222 —
+#                                            mirrors defaults/roles/*.md -> ../.claude/
+#                                            commands/loom/*.md in the real repo)
 #   defaults/docs/troubleshooting.md     -> .loom/docs/troubleshooting.md (drift)
 #   defaults/.loom/bin/loom              -> .loom/bin/loom (drift)
 #   defaults/.claude/commands/loom/x.md  -> .claude/commands/loom/x.md (drift)
@@ -125,6 +132,12 @@ make_fixture() {
     printf 'ROLE-NEW\n' > "$repo/defaults/roles/builder.md"
     printf 'ROLE-OLD\n' > "$repo/.loom/roles/builder.md"
     printf 'CUSTOM-ROLE\n' > "$repo/.loom/roles/custom-role.md"   # local-only
+
+    # #5222: a SOURCE-side symlink, mirroring the real defaults/roles/*.md ->
+    # ../.claude/commands/loom/*.md skillification layout. sync_one/resync_tree
+    # must resolve this to its target's content, never copy the link itself.
+    printf 'SYMLINK-TARGET-CONTENT\n' > "$repo/defaults/roles/_symlink-target.md"
+    ln -s "_symlink-target.md" "$repo/defaults/roles/symlinked-role.md"
 
     printf 'DOC-NEW\n' > "$repo/defaults/docs/troubleshooting.md"
     printf 'DOC-OLD\n' > "$repo/.loom/docs/troubleshooting.md"
@@ -331,6 +344,69 @@ if [[ -L "$REPO/.loom/docs/troubleshooting.md" ]]; then
     pass "(l) symlink left intact (not clobbered into a regular file)"
 else
     fail "(l) symlink was clobbered"
+fi
+
+# --- (l2) symlinked SOURCE file is resolved to content, not silently skipped -
+#
+# #5222: defaults/roles/symlinked-role.md (built by make_fixture as a symlink
+# to the sibling defaults/roles/_symlink-target.md) mirrors the real repo's
+# defaults/roles/*.md -> ../.claude/commands/loom/*.md skillification layout.
+# Before the fix, plain `find -type f` lstats each entry, a symlink never
+# matches `-type f`, so this file fell out of the walk entirely -- never
+# reported, never copied -- while the consumer's install-metadata.json still
+# got re-stamped current. The regression check: the resolved destination must
+# be a REGULAR FILE with the target's content, not a symlink, and the file
+# must show up in the per-file report.
+echo "Test group 10b: symlinked SOURCE file is resolved to content (#5222)"
+REPO="$(make_fixture)"
+DRY_OUT="$(cd "$REPO" && bash "$SCRIPT" --dry-run 2>&1)"
+RC=$?
+if [[ $RC -eq 2 ]] && grep -q "roles/symlinked-role.md" <<<"$DRY_OUT"; then
+    pass "(l2) --dry-run reports the symlinked source file, not silently omitted"
+else
+    fail "(l2) --dry-run did not report roles/symlinked-role.md (rc=$RC)"
+fi
+if [[ ! -e "$REPO/.loom/roles/symlinked-role.md" ]]; then
+    pass "(l2) --dry-run created nothing for the symlinked source file"
+else
+    fail "(l2) --dry-run unexpectedly wrote .loom/roles/symlinked-role.md"
+fi
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]]; then pass "(l2) apply exits 0"; else fail "(l2) apply exits 0 (got $RC)"; fi
+if grep -q "roles/symlinked-role.md" <<<"$OUT"; then
+    pass "(l2) apply reports the symlinked source file in the per-file output"
+else
+    fail "(l2) apply did not report roles/symlinked-role.md"
+fi
+if [[ -f "$REPO/.loom/roles/symlinked-role.md" && ! -L "$REPO/.loom/roles/symlinked-role.md" ]]; then
+    pass "(l2) destination is a REGULAR FILE (not a copied symlink)"
+else
+    fail "(l2) destination is missing or is itself a symlink"
+fi
+if [[ "$(cat "$REPO/.loom/roles/symlinked-role.md" 2>/dev/null)" == "SYMLINK-TARGET-CONTENT" ]]; then
+    pass "(l2) destination content matches the symlink's RESOLVED target"
+else
+    fail "(l2) destination content does not match the resolved target"
+fi
+# Idempotent rerun: no drift once the symlinked source has been resolved once.
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ $RC -eq 0 ]] && grep -q "Already in sync" <<<"$OUT"; then
+    pass "(l2) rerun is a clean no-op (symlinked source treated as unchanged)"
+else
+    fail "(l2) rerun was not a clean no-op (rc=$RC)"
+fi
+# The destination-side symlink protection case (l) must be completely
+# unaffected by resolving SOURCE-side symlinks.
+REPO2="$(make_fixture)"
+rm -f "$REPO2/.loom/docs/troubleshooting.md"
+ln -s "../../defaults/docs/troubleshooting.md" "$REPO2/.loom/docs/troubleshooting.md"
+(cd "$REPO2" && bash "$SCRIPT" >/dev/null 2>&1)
+if [[ -L "$REPO2/.loom/docs/troubleshooting.md" ]]; then
+    pass "(l2) destination-side symlink protection (l) still holds alongside the source-side fix"
+else
+    fail "(l2) destination-side symlink protection (l) regressed"
 fi
 
 # --- (m) recorded loom_source gone -> clear error, exit 1 --------------------


### PR DESCRIPTION
## Summary

`resync_tree()` in `defaults/scripts/resync-installed.sh` walked its source
directory with plain `find "$src_dir" -type f`, which lstats each entry — a
symlink never matches `-type f`. All 17 `defaults/roles/*.md` files are
symlinks to `../.claude/commands/loom/*.md` (the skillification dedup), so
they silently fell out of the walk entirely: not updated, not skipped, not
counted. A consumer repo's `.loom/roles/*.md` (real file copies there, not
symlinks) went stale indefinitely while resync reported success and
re-stamped `install-metadata.json` to the current version.

## Changes

- `defaults/scripts/resync-installed.sh`:
  - `resync_tree()` now walks with `find -L "$src_dir" -type f`, so a
    symlinked source is dereferenced before the type test and walked as the
    regular file it resolves to. `sync_one`'s existing `cp`/`cmp` calls
    already dereference symlinks by default, so the destination ends up with
    the **resolved content**, never a copied link.
  - `file_mode()` now uses `stat -L` (both the GNU and BSD branches) so a
    freshly-created destination (no prior installed copy) inherits the
    **referent's** permission bits, not the symlink's own (verified: BSD/macOS
    and GNU `stat` both report `755`/`lrwxrwxrwx`-style bits for the link
    itself without `-L`, vs. the target's real mode, e.g. `644`, with `-L`).
  - The **destination-side** symlink guard (`[[ -L "$dst" ]]` in `sync_one`,
    which protects this dogfood repo's own `.loom/roles/*.md` and
    `.loom/docs/*.md` — themselves symlinks back into `defaults/`) is
    untouched; this fix is source-side only.
  - Updated the header comment block describing the roles/docs surfaces to
    distinguish the source-side resolve (roles) from the destination-side
    skip (docs).

- `defaults/scripts/tests/test-resync-installed.sh`: added test group **(l2)**
  — builds a fixture with a symlinked source file
  (`defaults/roles/symlinked-role.md -> _symlink-target.md`, mirroring the
  real repo's layout) and asserts:
  - `--dry-run` reports the symlinked source in its per-file output (not
    silently omitted) and writes nothing.
  - `apply` reports it, creates a **regular file** (not a symlink) at the
    destination, with content matching the symlink's resolved target.
  - A rerun is a clean no-op (idempotent).
  - The destination-side symlink protection case (l) is unaffected by this
    change (re-verified alongside the new case).

## Acceptance Criteria Verification

- [x] `resync-installed.sh` updates `.loom/roles/*.md` in a consumer repo when
      the source files are symlinks (content copied, not the link) — verified
      by the new (l2) test group.
- [x] Symlinked source files appear in the per-file report
      (updated/unchanged), not silently omitted from the counts — verified by
      the `--dry-run` and `apply` report assertions in (l2).
- [x] Destination-side symlink protection (dogfood `.loom/docs` case) is
      unchanged — re-verified in (l2) alongside the pre-existing (l) group;
      both still pass.
- [x] `test-resync-installed.sh` gains a case with a symlinked source file —
      added as test group (l2)/"Test group 10b".

Also verified against the real dogfood tree: all 17 `defaults/roles/*.md`
symlinks resolve correctly under the new `find -L` walk (confirmed via
`stat -L` behavior on both macOS/BSD and GNU coreutils, and `cp`/`cmp`'s
default dereference-source behavior).

## Test Plan

```
bash defaults/scripts/tests/test-resync-installed.sh
# Results: 122/122 passed (was 114/114 before adding the new (l2) group)
```

Also ran `shellcheck -x` on both changed files — only pre-existing info-level
`SC2094`/`SC2012` findings unrelated to this change (verified present on
`origin/main` too).

Closes #5222