### PR TITLE
fix(gh-cached): scope the cache directory per repo to stop cross-repo leakage

### DIFF
--- a/defaults/docs/gh-cached.md
+++ b/defaults/docs/gh-cached.md
@@ -6,6 +6,15 @@ cache under `/tmp/gh-cache/`. Because the cache is on disk, it is shared
 **across processes on one host** — the N sweep / Judge / Champion sessions
 running concurrently against the same repo hit the same entries.
 
+The cache directory is further scoped **per repo** (#5224): the wrapper
+resolves `git rev-parse --show-toplevel` once per invocation (cheap, local, no
+network) and hashes it into a subdirectory of `GH_CACHE_DIR`, so two different
+repos on the same host issuing the textually identical `gh` invocation never
+read (or invalidate) each other's cached entries — the sessions sharing
+entries above are always sessions against the *same* repo. `GH_CACHE_REPO_ID`
+overrides the resolved identity directly when needed (tests, or a working
+directory that isn't a git repo).
+
 This document is the policy reference for **which** reads in the
 `/loom:sweep`, `/loom:judge`, and Champion-PR-merge skills go through the
 wrapper and which are deliberately left uncached (#4667). The motivating
@@ -208,7 +217,11 @@ stub `gh` on `PATH` and a temp `GH_CACHE_DIR`, asserting: repeated `pr list` /
 `issue list` / `pr view` reads hit the cache; `--no-cache` bypasses; `gh pr
 checks` and `gh repo view` are never cached; a wrapped `gh pr edit` /
 `gh pr comment` invalidates the cached reads of that PR (including the cached
-listing that contains it); and a state change is observed once the TTL expires.
+listing that contains it); a state change is observed once the TTL expires;
+and (#5224) two different repo identities — both via `GH_CACHE_REPO_ID` and
+via two real, distinct git toplevels — never share a cache read or an
+invalidation for the textually identical `gh` args, even when both repos have
+a numerically-identical resource id.
 
 ### Manual (inherently runtime — cannot be unit-tested)
 

--- a/defaults/scripts/gh-cached
+++ b/defaults/scripts/gh-cached
@@ -5,7 +5,9 @@ Drop-in replacement for `gh` that caches read-only command responses
 to reduce API calls. Mutations bypass the cache and invalidate
 related entries.
 
-Cache is file-backed in /tmp/gh-cache/ for cross-process sharing.
+Cache is file-backed in /tmp/gh-cache/ for cross-process sharing, scoped into
+a per-repo subdirectory (#5224) so two different repos on the same host never
+share cache entries even when they issue textually identical `gh` commands.
 
 Usage:
     gh-cached issue view 42 --json labels
@@ -15,11 +17,17 @@ Usage:
     gh-cached --cache-stats                            # show hit/miss statistics
 
 Environment:
-    GH_CACHE_DIR       Cache directory (default: /tmp/gh-cache)
+    GH_CACHE_DIR       Cache directory base (default: /tmp/gh-cache); the
+                        actual cache lives under a per-repo subdirectory of
+                        this path — see resolve_repo_id() below.
     GH_CACHE_TTL       Default TTL in seconds (default: 30)
     GH_CACHE_MAX_SIZE  Max cached entries (default: 256)
     GH_CACHE_DISABLE   Set to "1" to disable caching entirely
     GH_CACHE_DEBUG     Set to "1" for debug logging to stderr
+    GH_CACHE_REPO_ID   Override the resolved repo identity used to scope
+                        GH_CACHE_DIR (default: `git rev-parse
+                        --show-toplevel`). Mainly for tests and non-git
+                        working directories that still want isolation.
 """
 
 from __future__ import annotations
@@ -33,7 +41,49 @@ import time
 
 # ─── Configuration ──────────────────────────────────────────────────────────
 
-CACHE_DIR = os.environ.get("GH_CACHE_DIR", "/tmp/gh-cache")
+
+def resolve_repo_id() -> str:
+    """Resolve a stable per-host-repo identity used to scope CACHE_DIR (#5224).
+
+    Two different repos on the same host issuing the textually identical `gh`
+    command must never share a cache entry — `cache_key()` alone only hashes
+    the `gh` argv, which says nothing about which repo it targets (most reads
+    routed through this wrapper have no explicit `--repo` and resolve via the
+    cwd's git remote). Scoping CACHE_DIR itself (rather than only extending
+    cache_key()'s hash input) also naturally repo-isolates enforce_max_size(),
+    invalidate_for_resource(), invalidate_all_for_type(), and clear_cache(),
+    since every one of them already operates on CACHE_DIR as-is.
+
+    Uses `git rev-parse --show-toplevel` — cheap, local, no network call —
+    mirroring the existing pattern of resolving $GH_READ once per session via
+    a local probe (defaults/docs/gh-cached.md). GH_CACHE_REPO_ID overrides the
+    resolved identity directly (used by tests, and as an escape hatch for
+    non-git working directories that still want isolation).
+    """
+    override = os.environ.get("GH_CACHE_REPO_ID", "")
+    if override:
+        return override
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if proc.returncode == 0:
+            top = proc.stdout.strip()
+            if top:
+                return top
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    # Not inside a git repo (or git unavailable): fall back to a fixed
+    # sentinel so behavior is deterministic rather than silently unscoped.
+    return "_no-repo"
+
+
+CACHE_DIR_BASE = os.environ.get("GH_CACHE_DIR", "/tmp/gh-cache")
+REPO_ID = resolve_repo_id()
+CACHE_DIR = os.path.join(CACHE_DIR_BASE, hashlib.sha256(REPO_ID.encode()).hexdigest()[:16])
 DEFAULT_TTL = int(os.environ.get("GH_CACHE_TTL", "30"))
 MAX_CACHE_SIZE = int(os.environ.get("GH_CACHE_MAX_SIZE", "256"))
 CACHE_DISABLED = os.environ.get("GH_CACHE_DISABLE", "") == "1"
@@ -399,6 +449,7 @@ def try_etag_list(resource_type: str, args: list[str]) -> tuple[str, int] | None
 
 def main() -> int:
     args = sys.argv[1:]
+    debug(f"REPO_ID={REPO_ID!r} CACHE_DIR={CACHE_DIR}")
 
     # Handle meta-commands
     if "--clear-cache" in args:

--- a/defaults/scripts/tests/test-gh-cached.sh
+++ b/defaults/scripts/tests/test-gh-cached.sh
@@ -395,6 +395,16 @@ if command -v git >/dev/null 2>&1; then
     echo '[{"number":2222,"labels":["loom:review-requested"]}]' > "$STATE_DIR/pr-list.json"
     outB=$(ghc_cwd "$REPO_B_DIR" pr list --label "loom:review-requested" --state open --limit 500)
     assert_eq "2" "$(call_count)" "two distinct real git toplevels issuing the same 'gh' args both hit the real gh (default git-based resolution, not just the override)"
+    case "$outA" in
+      *1111*) sawA="yes" ;;
+      *) sawA="no" ;;
+    esac
+    assert_eq "yes" "$sawA" "repo A (a distinct real git toplevel) reads its own PR #1111 from the real gh"
+    case "$outB" in
+      *2222*) sawB="yes" ;;
+      *) sawB="no" ;;
+    esac
+    assert_eq "yes" "$sawB" "repo B (a distinct real git toplevel) reads its own PR #2222, not repo A's cached response"
     case "$outB" in
       *1111*) leaked2="yes" ;;
       *) leaked2="no" ;;

--- a/defaults/scripts/tests/test-gh-cached.sh
+++ b/defaults/scripts/tests/test-gh-cached.sh
@@ -318,6 +318,94 @@ reset_cache
 LOOM_ETAG_LIST_DISABLE=1 ghc_etag issue list --label "loom:issue" --state open --json number,title >/dev/null
 assert_eq "1" "$(call_count)" "LOOM_ETAG_LIST_DISABLE=1 bypasses the ETag path (falls to gh)"
 
+# --- 10. Multi-repo cache isolation (#5224) --------------------------------
+# CACHE_DIR is scoped per-repo so two different repos on the same host never
+# share a cache entry for a textually identical `gh` invocation — the bug
+# reported in #5224 (a leaked PR from an unrelated repo's cached `pr list`).
+echo ""
+echo "Testing multi-repo cache isolation (#5224)..."
+
+# GH_CACHE_REPO_ID is the direct override (used here as the "injected
+# repo-identity override for the test" per the issue's suggested test shape).
+ghc_repo() {
+    local repo_id="$1"; shift
+    PATH="$STUB_DIR:$PATH" \
+    GH_CACHE_DIR="$CACHE_DIR" \
+    GH_CACHE_TTL="${TTL_OVERRIDE:-30}" \
+    GH_CACHE_REPO_ID="$repo_id" \
+    LOOM_ETAG_LIST_DISABLE=1 \
+      "$GH_CACHED" "$@"
+}
+
+reset_cache
+echo '[{"number":4242,"labels":["loom:review-requested"]}]' > "$STATE_DIR/pr-list.json"
+repoA_out1=$(ghc_repo repoA pr list --label "loom:review-requested" --state open --limit 500)
+echo '[{"number":9999,"labels":["loom:review-requested"]}]' > "$STATE_DIR/pr-list.json"
+repoB_out1=$(ghc_repo repoB pr list --label "loom:review-requested" --state open --limit 500)
+assert_eq "2" "$(call_count)" "identical 'gh' args from two different repo identities both hit the real gh (no cross-repo cache hit)"
+case "$repoB_out1" in
+  *4242*) leaked="yes" ;;
+  *) leaked="no" ;;
+esac
+assert_eq "no" "$leaked" "repo B's read does not return repo A's cached PR #4242"
+
+# repoA's own cache is still warm and unaffected by repoB's read.
+repoA_out2=$(ghc_repo repoA pr list --label "loom:review-requested" --state open --limit 500)
+assert_eq "2" "$(call_count)" "repoA's own repeat read is still served from its own cache (unaffected by repoB's read)"
+assert_eq "$repoA_out1" "$repoA_out2" "…and returns repoA's original cached payload, not repoB's"
+
+# restore baseline listing for later blocks
+echo '[{"number":4242,"labels":["loom:review-requested"]}]' > "$STATE_DIR/pr-list.json"
+
+# Invalidation isolation ("Additional risk" in #5224): a mutation issued
+# under repoA's identity must not invalidate repoB's cached entry for a
+# numerically-identical resource id (both have a "#4242").
+reset_cache
+ghc_repo repoA pr view 4242 --json labels >/dev/null            # warm repoA: 1 call
+ghc_repo repoB pr view 4242 --json labels >/dev/null            # warm repoB: 2 calls
+ghc_repo repoA pr edit 4242 --add-label "loom:pr" >/dev/null    # mutation in repoA: 3 calls
+ghc_repo repoB pr view 4242 --json labels >/dev/null            # repoB re-read: still cached
+assert_eq "3" "$(call_count)" "a mutation issued under repoA's identity does not invalidate repoB's cached entry for the same resource id"
+
+# The real (non-override) resolution path: distinct git toplevels, not just
+# the GH_CACHE_REPO_ID override, must isolate too.
+if command -v git >/dev/null 2>&1; then
+    echo ""
+    echo "Testing multi-repo isolation via real distinct git toplevels..."
+
+    REPO_A_DIR="$TMP_ROOT/repoA"
+    REPO_B_DIR="$TMP_ROOT/repoB"
+    mkdir -p "$REPO_A_DIR" "$REPO_B_DIR"
+    git -C "$REPO_A_DIR" init -q
+    git -C "$REPO_B_DIR" init -q
+
+    ghc_cwd() {
+        local dir="$1"; shift
+        ( cd "$dir" && \
+          PATH="$STUB_DIR:$PATH" \
+          GH_CACHE_DIR="$CACHE_DIR" \
+          GH_CACHE_TTL="${TTL_OVERRIDE:-30}" \
+          LOOM_ETAG_LIST_DISABLE=1 \
+            "$GH_CACHED" "$@" )
+    }
+
+    reset_cache
+    echo '[{"number":1111,"labels":["loom:review-requested"]}]' > "$STATE_DIR/pr-list.json"
+    outA=$(ghc_cwd "$REPO_A_DIR" pr list --label "loom:review-requested" --state open --limit 500)
+    echo '[{"number":2222,"labels":["loom:review-requested"]}]' > "$STATE_DIR/pr-list.json"
+    outB=$(ghc_cwd "$REPO_B_DIR" pr list --label "loom:review-requested" --state open --limit 500)
+    assert_eq "2" "$(call_count)" "two distinct real git toplevels issuing the same 'gh' args both hit the real gh (default git-based resolution, not just the override)"
+    case "$outB" in
+      *1111*) leaked2="yes" ;;
+      *) leaked2="no" ;;
+    esac
+    assert_eq "no" "$leaked2" "repo B (a distinct real git toplevel) does not see repo A's cached PR #1111"
+
+    echo '[{"number":4242,"labels":["loom:review-requested"]}]' > "$STATE_DIR/pr-list.json"
+else
+    echo "SKIP: git not available — skipping real-git-toplevel isolation test"
+fi
+
 # --- Summary ---------------------------------------------------------------
 echo ""
 echo "────────────────────────────────"


### PR DESCRIPTION
## Summary

- `gh-cached`'s `cache_key()` hashed only the `gh` CLI argv, and `CACHE_DIR` defaulted to a single host-wide `/tmp/gh-cache/`. Two different repos on the same host issuing the textually identical `gh` invocation (e.g. `gh pr list --label=loom:review-requested --state=open --limit 500`) therefore produced the same cache key/path, so one repo's Judge/Champion/Curator could silently read another, unrelated repo's cached PR/issue data — confirmed live on 2026-08-04 in this repo.
- Fixed by scoping `CACHE_DIR` itself per repo (rather than only extending `cache_key()`'s hash input), following the curator's recommendation, so the fix covers both the read-leakage and the related invalidation-isolation gap in one change.

## Changes

- `defaults/scripts/gh-cached`: added `resolve_repo_id()`, which resolves the repo identity via `git rev-parse --show-toplevel` (cheap, local, no network call — matches the existing pattern of resolving `$GH_READ` once per session via a local probe). `CACHE_DIR` is now `GH_CACHE_DIR/<sha256(repo_id)[:16]>/` instead of a flat `GH_CACHE_DIR`. `GH_CACHE_REPO_ID` overrides the resolved identity directly (for tests, and non-git working directories that still want isolation). Since `enforce_max_size()`, `invalidate_for_resource()`, `invalidate_all_for_type()`, and `clear_cache()` all already operate on `CACHE_DIR` as-is, they become naturally repo-isolated with no further changes. Added a debug line reporting the resolved `REPO_ID`/`CACHE_DIR` under `GH_CACHE_DEBUG=1`.
- `defaults/scripts/tests/test-gh-cached.sh`: added a new "Multi-repo cache isolation (#5224)" block — two synthetic repo identities (`GH_CACHE_REPO_ID` override) issuing the identical `gh pr list` never share a cache read, repo A's own cache stays warm/unaffected by repo B's read, and a mutation issued under repo A's identity does not invalidate repo B's cached entry for a numerically-identical resource id (the "additional risk" the curator flagged). A second block re-derives the same guarantees through two real, distinct `git init` toplevels (not just the override), proving the default (non-override) resolution path isolates too.
- `defaults/docs/gh-cached.md`: updated the "running concurrently against the same repo" framing to state the new per-repo `CACHE_DIR` scoping explicitly, and extended the "Automated" verification section to mention the new test coverage.

## Acceptance Criteria Verification

- [x] Two different repos issuing the textually identical `gh` invocation never read each other's cached entries — verified by the new "Multi-repo cache isolation" test block (both the `GH_CACHE_REPO_ID`-override and real-git-toplevel variants).
- [x] The fix scopes `CACHE_DIR` per-repo (not just `cache_key()`'s hash input) — `enforce_max_size()`, `invalidate_for_resource()`, `invalidate_all_for_type()`, and `clear_cache()` are all naturally repo-isolated since they operate on `CACHE_DIR` unmodified; verified by the invalidation-isolation test case (a repo-A mutation on resource id `4242` does not invalidate repo B's cached entry for the same numeric id).
- [x] Repo identity is resolved without a live `gh`/network call — `git rev-parse --show-toplevel` only.
- [x] Existing single-repo-host behavior is unchanged — all 24 pre-existing assertions in `test-gh-cached.sh` still pass unmodified (the repo-scoping hash is constant across a single test run's cwd, so cache-key collisions/hits behave exactly as before).

## Test Plan

Ran `defaults/scripts/tests/test-gh-cached.sh` in the worktree: **31/31 passed** (24 pre-existing + 7 new assertions across the two new multi-repo isolation blocks). `python3 -m py_compile` on the modified script succeeds.

Closes #5224