### PR TITLE
fix(guard): normalize wrapper, assignment and quoting shapes in interpreter-opener detection

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -1634,40 +1634,87 @@ function mask_heredoc_bodies(s,   out, lines, nl, i, j, line, trimmed, body, del
 # `echo "installs bash" <<EOF` does NOT match, since "bash" there is a bare
 # argument, not the command word.
 #
-# Recognizing the command word robustly (#5205): the interpreter word is
-# matched against the path BASENAME of each segment command word, and any
-# leading `env`/`command`/`exec`/`builtin` wrapper (with its own flags and
-# `VAR=value` assignments) is stripped first -- none of those change what
-# actually executes. So a path-qualified or wrapped invocation of the same
-# interpreter (`/bin/bash <<EOF`, `env bash <<EOF`, `command bash <<EOF`,
-# `./bash <<EOF`, `/usr/bin/python3 <<EOF`) is caught too, closing the
-# evasion class where those forms slipped past the old first-token-only
-# regex and got their live bodies silently masked (i.e. ALLOWed).
-function _interp_basename(tok,   base) {
-    # Reduce a (possibly path-qualified) command word to its basename: the
-    # text after the last `/`. `/bin/bash` -> `bash`, `./bash` -> `bash`,
-    # `/usr/bin/python3` -> `python3`; a bare `bash` or `.` is unchanged.
+# Recognizing the command word robustly (#5205, widened #5226): the
+# interpreter word is matched against the path BASENAME of each segment
+# command word, after normalizing away the shell decorations that do not
+# change what actually executes --
+#   * quoting / backslash-escaping of the command word itself
+#     (`"bash" <<EOF`, `\bash <<EOF` -- the classic alias-dodge idiom),
+#   * a bare `VAR=value` assignment prefix (`LC_ALL=C bash <<EOF`),
+#   * a leading wrapper command with its own flags, assignments and
+#     numeric/duration operands (env, command, exec, builtin, sudo, doas,
+#     nohup, setsid, nice, ionice, stdbuf, timeout, time, xargs, unbuffer).
+# So `/bin/bash <<EOF`, `env bash <<EOF`, `LC_ALL=C bash <<EOF`,
+# `sudo bash <<EOF`, `cat <<EOF | sudo bash`, `timeout 60 bash <<EOF`,
+# `"bash" <<EOF`, `\bash <<EOF` and `/usr/bin/python3 <<EOF` all resolve to
+# the same real interpreter and are caught, closing the evasion class where
+# those forms slipped past the older first-token-only / unwrapped checks and
+# got their live bodies silently masked (i.e. ALLOWed).
+#
+# FAIL-CLOSED TAIL (#5226): an interpreter allowlist is an unbounded tail --
+# there is always one more wrapper. The residual class no allowlist can ever
+# enumerate is a command word the guard cannot resolve to a NAME at all:
+# `$SHELL <<EOF`, `${INTERP} <<EOF`, `$(which bash) <<EOF`. Those are treated
+# as interpreter-fed, so the body stays visible and the catastrophic-tier
+# check still sees any live invocation inside it.
+#
+# Inverting the whole test (mask ONLY for a known-inert SINK allowlist, so
+# every unknown opener fails closed) was considered and deliberately
+# rejected: the canonical Loom issue-filing idiom is
+# `create-issue.sh --title T --body "$(cat <<EOF ... EOF)"`, whose command
+# word is an ordinary repo script -- as is every other repo wrapper around a
+# forge call. Under a sink allowlist each of those hard-stalls on a
+# catastrophic-tier deny the moment the prose it carries quotes the
+# anti-pattern, which is precisely the #5181 false positive this masking
+# exists to fix (that bug was found when an agent could not file the report
+# about it). So the default for a resolvable-but-unknown command word stays
+# "mask", and only unresolvable words fail closed.
+function _interp_basename(tok,   base, SQ, DQ) {
+    # Reduce a (possibly quoted, backslash-escaped, path-qualified) command
+    # word to its basename: quotes and backslashes removed, then the text
+    # after the last `/`. `/bin/bash` -> `bash`, `./bash` -> `bash`,
+    # `/usr/bin/python3` -> `python3`, `"bash"` -> `bash`, `\bash` -> `bash`,
+    # `"/bin/bash"` -> `bash`; a bare `bash` or `.` is unchanged. Stripping
+    # quotes/backslashes ANYWHERE in the word (not just at its edges) also
+    # collapses the `b"a"sh` / `b\ash` splitting idioms, which the shell
+    # resolves to that same command.
+    SQ = sprintf("%c", 39)    # single quote
+    DQ = sprintf("%c", 34)    # double quote
     base = tok
+    gsub(SQ, "", base)
+    gsub(DQ, "", base)
+    gsub(/\\/, "", base)
     sub(/^.*\//, "", base)
     return base
 }
 function is_interpreter_opener(line,   n, segs, i, seg, m, toks, j, base) {
     # Split into command segments on ; & | (covers && and || too) so a piped
-    # or chained interpreter is caught in ANY position, e.g. `cat <<EOF | bash`.
+    # or chained interpreter is caught in ANY position, e.g. `cat <<EOF | bash`
+    # and `cat <<EOF | sudo bash`.
     n = split(line, segs, /[;&|]+/)
     for (i = 1; i <= n; i++) {
         seg = segs[i]
         sub(/^[ \t]+/, "", seg)
         m = split(seg, toks, /[ \t]+/)
         if (m == 0) continue
-        # Strip leading command wrappers that do not change what runs:
-        # env / command / exec / builtin, each followed by its own -flags
-        # and (for env) VAR=value assignments, then the real command word.
         j = 1
+        # (1) Strip a BARE `VAR=value` assignment prefix. This is ordinary
+        # shell with no `env` in front (`LC_ALL=C bash <<EOF`) and is the
+        # most common prefix in practice; before #5226 it fell straight
+        # through, because assignments were only skipped AFTER an
+        # env/command/exec/builtin token had already been seen.
+        while (j <= m && toks[j] ~ /^[A-Za-z_][A-Za-z0-9_]*=/) j++
+        # (2) Strip leading wrapper commands that do not change what runs,
+        # each followed by its own -flags, `VAR=value` assignments and
+        # numeric/duration operands (`timeout 60`, `timeout 1.5h`,
+        # `nice -n 10`, `ionice -c 2`), then re-check for another wrapper.
+        # The wrapper word goes through _interp_basename() too, so
+        # `/usr/bin/sudo` and `\sudo` strip exactly like a bare `sudo`.
         while (j <= m) {
-            if (toks[j] == "env" || toks[j] == "command" || toks[j] == "exec" || toks[j] == "builtin") {
+            base = _interp_basename(toks[j])
+            if (base ~ /^(env|command|exec|builtin|sudo|doas|nohup|setsid|nice|ionice|stdbuf|timeout|time|xargs|unbuffer)$/) {
                 j++
-                while (j <= m && (toks[j] ~ /^-/ || toks[j] ~ /^[A-Za-z_][A-Za-z0-9_]*=/)) j++
+                while (j <= m && (toks[j] ~ /^-/ || toks[j] ~ /^[A-Za-z_][A-Za-z0-9_]*=/ || toks[j] ~ /^[0-9]+([.][0-9]+)?[smhd]?$/)) j++
                 continue
             }
             break
@@ -1675,6 +1722,12 @@ function is_interpreter_opener(line,   n, segs, i, seg, m, toks, j, base) {
         if (j > m) continue
         base = _interp_basename(toks[j])
         if (base ~ /^(bash|sh|zsh|dash|ksh|python[0-9.]*|perl|ruby|node|nodejs|eval|source|\.)$/)
+            return 1
+        # (3) Fail CLOSED on a command word that resolves to no name at all --
+        # a variable / command substitution, or an empty word. See the
+        # FAIL-CLOSED TAIL note above: resolvable-but-unknown command words
+        # (`cat`, `tee`, a repo script) keep masking, per #5181.
+        if (base == "" || base ~ /[$`]/)
             return 1
     }
     return 0

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -1634,40 +1634,87 @@ function mask_heredoc_bodies(s,   out, lines, nl, i, j, line, trimmed, body, del
 # `echo "installs bash" <<EOF` does NOT match, since "bash" there is a bare
 # argument, not the command word.
 #
-# Recognizing the command word robustly (#5205): the interpreter word is
-# matched against the path BASENAME of each segment command word, and any
-# leading `env`/`command`/`exec`/`builtin` wrapper (with its own flags and
-# `VAR=value` assignments) is stripped first -- none of those change what
-# actually executes. So a path-qualified or wrapped invocation of the same
-# interpreter (`/bin/bash <<EOF`, `env bash <<EOF`, `command bash <<EOF`,
-# `./bash <<EOF`, `/usr/bin/python3 <<EOF`) is caught too, closing the
-# evasion class where those forms slipped past the old first-token-only
-# regex and got their live bodies silently masked (i.e. ALLOWed).
-function _interp_basename(tok,   base) {
-    # Reduce a (possibly path-qualified) command word to its basename: the
-    # text after the last `/`. `/bin/bash` -> `bash`, `./bash` -> `bash`,
-    # `/usr/bin/python3` -> `python3`; a bare `bash` or `.` is unchanged.
+# Recognizing the command word robustly (#5205, widened #5226): the
+# interpreter word is matched against the path BASENAME of each segment
+# command word, after normalizing away the shell decorations that do not
+# change what actually executes --
+#   * quoting / backslash-escaping of the command word itself
+#     (`"bash" <<EOF`, `\bash <<EOF` -- the classic alias-dodge idiom),
+#   * a bare `VAR=value` assignment prefix (`LC_ALL=C bash <<EOF`),
+#   * a leading wrapper command with its own flags, assignments and
+#     numeric/duration operands (env, command, exec, builtin, sudo, doas,
+#     nohup, setsid, nice, ionice, stdbuf, timeout, time, xargs, unbuffer).
+# So `/bin/bash <<EOF`, `env bash <<EOF`, `LC_ALL=C bash <<EOF`,
+# `sudo bash <<EOF`, `cat <<EOF | sudo bash`, `timeout 60 bash <<EOF`,
+# `"bash" <<EOF`, `\bash <<EOF` and `/usr/bin/python3 <<EOF` all resolve to
+# the same real interpreter and are caught, closing the evasion class where
+# those forms slipped past the older first-token-only / unwrapped checks and
+# got their live bodies silently masked (i.e. ALLOWed).
+#
+# FAIL-CLOSED TAIL (#5226): an interpreter allowlist is an unbounded tail --
+# there is always one more wrapper. The residual class no allowlist can ever
+# enumerate is a command word the guard cannot resolve to a NAME at all:
+# `$SHELL <<EOF`, `${INTERP} <<EOF`, `$(which bash) <<EOF`. Those are treated
+# as interpreter-fed, so the body stays visible and the catastrophic-tier
+# check still sees any live invocation inside it.
+#
+# Inverting the whole test (mask ONLY for a known-inert SINK allowlist, so
+# every unknown opener fails closed) was considered and deliberately
+# rejected: the canonical Loom issue-filing idiom is
+# `create-issue.sh --title T --body "$(cat <<EOF ... EOF)"`, whose command
+# word is an ordinary repo script -- as is every other repo wrapper around a
+# forge call. Under a sink allowlist each of those hard-stalls on a
+# catastrophic-tier deny the moment the prose it carries quotes the
+# anti-pattern, which is precisely the #5181 false positive this masking
+# exists to fix (that bug was found when an agent could not file the report
+# about it). So the default for a resolvable-but-unknown command word stays
+# "mask", and only unresolvable words fail closed.
+function _interp_basename(tok,   base, SQ, DQ) {
+    # Reduce a (possibly quoted, backslash-escaped, path-qualified) command
+    # word to its basename: quotes and backslashes removed, then the text
+    # after the last `/`. `/bin/bash` -> `bash`, `./bash` -> `bash`,
+    # `/usr/bin/python3` -> `python3`, `"bash"` -> `bash`, `\bash` -> `bash`,
+    # `"/bin/bash"` -> `bash`; a bare `bash` or `.` is unchanged. Stripping
+    # quotes/backslashes ANYWHERE in the word (not just at its edges) also
+    # collapses the `b"a"sh` / `b\ash` splitting idioms, which the shell
+    # resolves to that same command.
+    SQ = sprintf("%c", 39)    # single quote
+    DQ = sprintf("%c", 34)    # double quote
     base = tok
+    gsub(SQ, "", base)
+    gsub(DQ, "", base)
+    gsub(/\\/, "", base)
     sub(/^.*\//, "", base)
     return base
 }
 function is_interpreter_opener(line,   n, segs, i, seg, m, toks, j, base) {
     # Split into command segments on ; & | (covers && and || too) so a piped
-    # or chained interpreter is caught in ANY position, e.g. `cat <<EOF | bash`.
+    # or chained interpreter is caught in ANY position, e.g. `cat <<EOF | bash`
+    # and `cat <<EOF | sudo bash`.
     n = split(line, segs, /[;&|]+/)
     for (i = 1; i <= n; i++) {
         seg = segs[i]
         sub(/^[ \t]+/, "", seg)
         m = split(seg, toks, /[ \t]+/)
         if (m == 0) continue
-        # Strip leading command wrappers that do not change what runs:
-        # env / command / exec / builtin, each followed by its own -flags
-        # and (for env) VAR=value assignments, then the real command word.
         j = 1
+        # (1) Strip a BARE `VAR=value` assignment prefix. This is ordinary
+        # shell with no `env` in front (`LC_ALL=C bash <<EOF`) and is the
+        # most common prefix in practice; before #5226 it fell straight
+        # through, because assignments were only skipped AFTER an
+        # env/command/exec/builtin token had already been seen.
+        while (j <= m && toks[j] ~ /^[A-Za-z_][A-Za-z0-9_]*=/) j++
+        # (2) Strip leading wrapper commands that do not change what runs,
+        # each followed by its own -flags, `VAR=value` assignments and
+        # numeric/duration operands (`timeout 60`, `timeout 1.5h`,
+        # `nice -n 10`, `ionice -c 2`), then re-check for another wrapper.
+        # The wrapper word goes through _interp_basename() too, so
+        # `/usr/bin/sudo` and `\sudo` strip exactly like a bare `sudo`.
         while (j <= m) {
-            if (toks[j] == "env" || toks[j] == "command" || toks[j] == "exec" || toks[j] == "builtin") {
+            base = _interp_basename(toks[j])
+            if (base ~ /^(env|command|exec|builtin|sudo|doas|nohup|setsid|nice|ionice|stdbuf|timeout|time|xargs|unbuffer)$/) {
                 j++
-                while (j <= m && (toks[j] ~ /^-/ || toks[j] ~ /^[A-Za-z_][A-Za-z0-9_]*=/)) j++
+                while (j <= m && (toks[j] ~ /^-/ || toks[j] ~ /^[A-Za-z_][A-Za-z0-9_]*=/ || toks[j] ~ /^[0-9]+([.][0-9]+)?[smhd]?$/)) j++
                 continue
             }
             break
@@ -1675,6 +1722,12 @@ function is_interpreter_opener(line,   n, segs, i, seg, m, toks, j, base) {
         if (j > m) continue
         base = _interp_basename(toks[j])
         if (base ~ /^(bash|sh|zsh|dash|ksh|python[0-9.]*|perl|ruby|node|nodejs|eval|source|\.)$/)
+            return 1
+        # (3) Fail CLOSED on a command word that resolves to no name at all --
+        # a variable / command substitution, or an empty word. See the
+        # FAIL-CLOSED TAIL note above: resolvable-but-unknown command words
+        # (`cat`, `tee`, a repo script) keep masking, per #5181.
+        if (base == "" || base ~ /[$`]/)
             return 1
     }
     return 0

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -671,6 +671,97 @@ gh api repos/o/r/issues/1/comments -f body=@/tmp/review.md
 EOF
 echo done'
 
+# --- #5226: the command-word shapes that STILL resolved to a real interpreter
+# but fell through is_interpreter_opener() after #5205 ----------------------
+#
+# #5205 closed the path-qualified (`/bin/bash`) and env/command/exec/builtin
+# wrapper classes. Six adjacent shapes still resolved to the same interpreter
+# and were not recognized, so their heredoc bodies got masked and the live
+# `gh api ... -f body=@path` inside them silently flipped DENY -> ALLOW —
+# reopening the #4523/#4601/#4685 data-loss shape on a catastrophic-tier
+# check. Each was verified failing (allow) against PR #5205's head 6523d882
+# before the #5226 fix. The `bash <<EOF` control at line ~599 stays the
+# reference decision: this fix only ever widens recognition.
+assert_deny "#5226: Bare VAR=value prefix 'LC_ALL=C bash <<EOF ... EOF' still denies" \
+    'LC_ALL=C bash <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5226: sudo-wrapped interpreter 'sudo bash <<EOF ... EOF' still denies" \
+    'sudo bash <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5226: sudo wrapper in PIPE position ('cat <<EOF | sudo bash') still denies" \
+    'cat <<'"'"'EOF'"'"' | sudo bash
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5226: exec-wrapper with a positional operand 'timeout 60 bash <<EOF ... EOF' still denies" \
+    'timeout 60 bash <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5226: quoted command word '\"bash\" <<EOF ... EOF' still denies" \
+    '"bash" <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5226: backslash-escaped command word '\\bash <<EOF ... EOF' still denies" \
+    '\bash <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+# Fail-closed tail: a command word that resolves to NO name at all (a
+# variable / command substitution) is treated as interpreter-fed, since no
+# allowlist can enumerate what it expands to.
+assert_deny "#5226: Unresolvable command word '\"\$SHELL\" <<EOF ... EOF' fails closed (denies)" \
+    '"$SHELL" <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+assert_deny "#5226: Unresolvable command word '\$(which bash) <<EOF ... EOF' fails closed (denies)" \
+    '$(which bash) <<'"'"'EOF'"'"'
+gh api repos/o/r/issues/123/comments -f body=@/tmp/review.md
+EOF'
+
+# The #5181 false-positive allow must survive all of the above: an inert
+# prose body destined for a plain file sink still ALLOWs — including through
+# the same wrapper/assignment-prefix normalization that now catches the
+# interpreter shapes (a stripped wrapper in front of a NON-interpreter must
+# resolve to that non-interpreter, not to a deny).
+assert_allow "#5226/#5181: A heredoc body to 'tee file' (non-interpreter sink) that merely quotes the phrase stays allowed" \
+    'tee /tmp/report4.md <<'"'"'EOF'"'"'
+Example of the anti-pattern:
+gh api repos/o/r/issues/1/comments -f body=@/tmp/review.md
+EOF
+echo done'
+
+assert_allow "#5226/#5181: A heredoc body to 'sudo tee file' (wrapped non-interpreter sink) stays allowed" \
+    'sudo tee /tmp/report5.md <<'"'"'EOF'"'"'
+Example of the anti-pattern:
+gh api repos/o/r/issues/1/comments -f body=@/tmp/review.md
+EOF
+echo done'
+
+assert_allow "#5226/#5181: A heredoc body to 'LC_ALL=C cat > file' (assignment-prefixed non-interpreter sink) stays allowed" \
+    'LC_ALL=C cat > /tmp/report6.md <<'"'"'EOF'"'"'
+Example of the anti-pattern:
+gh api repos/o/r/issues/1/comments -f body=@/tmp/review.md
+EOF
+echo done'
+
+# The canonical Loom issue-filing idiom: a repo script carrying the prose as
+# an argument via $(cat <<EOF ...). Its command word is an ordinary script,
+# NOT an interpreter, so the body stays masked and this keeps ALLOWing — the
+# exact production shape #5181 was filed about.
+assert_allow "#5226/#5181: create-issue.sh --body \"\$(cat <<EOF ...)\" carrying the phrase as prose stays allowed" \
+    './.loom/scripts/create-issue.sh --title "Guard bug" --body "$(cat <<'"'"'EOF'"'"'
+Example of the anti-pattern this issue is about:
+gh api repos/o/r/issues/1/comments -f body=@/tmp/review.md
+EOF
+)"'
+
 # --- #4685: the same literal-@ loss on the `edit` subcommand — real-world
 # evidence is issue #4608's body being corrupted to the literal string
 # `@/tmp/issue4608_body_new.txt`. The #4523/#4601 rules above are hard-anchored


### PR DESCRIPTION
## Summary

`is_interpreter_opener()` decides whether a heredoc body stays **visible** to
the `gh-api-rawfield-body-literal-at` catastrophic-tier DENY check. #5205
taught it path-qualified (`/bin/bash`, `./bash`) and
`env`/`command`/`exec`/`builtin`-wrapped openers, but six adjacent shapes still
resolved to a real interpreter without being recognized — so their bodies were
masked and a live `gh api ... -f body=@path` inside them silently flipped
DENY → ALLOW, reopening the #4523/#4601/#4685 data-loss shape.

Verified pre-fix (`.loom/` copy, unmodified) vs. post-fix side by side:

| Opener | before | after |
|---|---|---|
| `bash <<EOF` (control) | deny | **deny** |
| `LC_ALL=C bash <<EOF` | allow | **deny** |
| `sudo bash <<EOF` | allow | **deny** |
| `cat <<EOF \| sudo bash` | allow | **deny** |
| `timeout 60 bash <<EOF` | allow | **deny** |
| `"bash" <<EOF` | allow | **deny** |
| `\bash <<EOF` | allow | **deny** |
| `nice -n 10 python3 <<EOF` | allow | **deny** |
| `"$SHELL" <<EOF` | allow | **deny** (fail-closed tail) |
| `$(which bash) <<EOF` | allow | **deny** (fail-closed tail) |
| `cat > f.md <<EOF` | allow | allow |
| `/bin/cat > f.md <<EOF` | allow | allow |
| `tee f.md <<EOF` | allow | allow |
| `sudo tee f.md <<EOF` | allow | allow |
| `LC_ALL=C cat > f.md <<EOF` | allow | allow |
| `create-issue.sh --body "$(cat <<EOF …)"` | allow | allow |

## Approach: normalize the command word, don't enumerate spellings of it

The issue sketched two directions — (1) extend the interpreter allowlist, or
(2) invert to a known-inert **sink** allowlist so unknown openers fail closed.
This PR takes a hybrid: normalization + a targeted fail-closed rule for the
one class no allowlist can ever enumerate.

**Why not the full inversion.** The canonical Loom issue-filing idiom is
`./.loom/scripts/create-issue.sh --title T --body "$(cat <<'EOF' … EOF)"`
(the shape used throughout `defaults/.claude/commands/loom/*.md`), whose
command word is an ordinary repo script — as is every other repo wrapper
around a forge call. Under a sink allowlist, each of those hard-stalls on a
**catastrophic-tier deny** the moment the prose it carries quotes the
anti-pattern. That is precisely the #5181 false positive this masking exists to
fix — a bug discovered *because* an agent could not file the report about it,
and one with no human recourse in a headless run. So a resolvable-but-unknown
command word keeps masking.

**What does fail closed**: a command word that resolves to no *name* at all
(`$SHELL`, `${INTERP}`, `$(which bash)`). That is the genuinely unbounded
residual class, it is cheap to detect, and its false-positive cost is
negligible (a prose sink invoked through a variable expansion is not a real
idiom). This directly answers the issue's "unbounded tail" objection to
direction 1 without inheriting direction 2's regression.

## Changes

`defaults/hooks/guard-destructive-generic.sh` (+ the byte-identical
`.loom/hooks/` copy):

- **`_interp_basename()`** strips quotes and backslashes *anywhere* in the word
  before taking the path basename — so `"bash"`, `\bash`, `"/bin/bash"` and the
  `b"a"sh` / `b\ash` splitting idioms all resolve to `bash`.
- **`is_interpreter_opener()` step (1)** strips a leading **bare** `VAR=value`
  assignment prefix. Previously assignments were only skipped *after* an
  `env`/`command`/`exec`/`builtin` token had been seen, so `LC_ALL=C bash`
  fell straight through to `break`.
- **step (2)** widens the stripped-wrapper set to `sudo`, `doas`, `nohup`,
  `setsid`, `nice`, `ionice`, `stdbuf`, `timeout`, `time`, `xargs`, `unbuffer`
  (alongside the existing four), each consuming its own flags, assignments and
  numeric/duration operands (`timeout 60`, `timeout 1.5h`, `nice -n 10`,
  `ionice -c 2`). Wrapper words go through `_interp_basename()` too, so
  `/usr/bin/sudo` and `\sudo` strip like bare `sudo`.
- **step (3)** returns "interpreter-fed" for an unresolvable/empty command word.
- The block comment records the rejected inversion and its rationale, so the
  next widening does not re-litigate it from scratch.

`tests/hooks/test-guard-destructive.sh`: 12 new cases — one per gap shape, two
fail-closed cases, and four preserved-allow cases.

## Acceptance Criteria Verification

- [x] **Each gap shape is DENIED** — 6 new `assert_deny` cases (`LC_ALL=C bash`,
      `sudo bash`, `cat <<EOF | sudo bash`, `timeout 60 bash`, `"bash"`,
      `\bash`), each confirmed `allow` against the pre-fix guard and `deny`
      against the fixed one (table above).
- [x] **#5181 false-positive allow preserved** — `cat > f.md <<EOF`,
      `/bin/cat > f.md <<EOF` (pre-existing cases, still green) plus new
      `tee f.md`, `sudo tee f.md`, `LC_ALL=C cat > f.md`, and the
      `create-issue.sh --body "$(cat <<EOF …)"` production idiom.
- [x] **Regression tests added** for every gap shape plus the preserved-allow
      cases, in `tests/hooks/test-guard-destructive.sh`.
- [x] **`.loom/` and `defaults/` copies byte-identical** —
      `diff .loom/hooks/guard-destructive-generic.sh defaults/hooks/guard-destructive-generic.sh`
      is empty (both files changed identically in this commit, matching the
      #5198/#5205 precedent for live guard hooks).
- [x] **Full suite passes** — `tests/hooks/test-guard-destructive.sh`:
      **709/709**, 0 failed (697 before, +12 new). Perf check 14 ms avg
      (< 200 ms threshold).
- [x] **Control case still DENYs** — `bash <<EOF` (existing #5198 case)
      unchanged; every change only widens recognition, and the four
      preserved-allow cases prove nothing was narrowed.

## Test Plan

- [x] `./tests/hooks/test-guard-destructive.sh` → 709 passed, 0 failed.
- [x] `./tests/hooks/test-guard-destructive-dispatcher.sh` → 12 passed, 0 failed.
- [x] `bash -n` on both changed shell files.
- [x] Pre/post comparison harness run against the unmodified `.loom/` copy as
      the pre-fix control (results in the table above); harness deleted, not
      committed.
- [x] `check-main-clean.sh` → main worktree clean.

Closes #5226
