### PR TITLE
fix(guard): exclude heredoc redirection tokens from tee/cp/mv/sed write-target scan

### DIFF
--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -2862,6 +2862,24 @@ extract_write_targets() {
             if (toks[1] == "tee") {
                 for (j = 2; j <= m; j++) {
                     if (toks[j] == "" || toks[j] ~ /^-/) continue
+                    # Heredoc/herestring redirection (attached or quoted
+                    # delimiter, or the bare double-angle-bracket / dashed
+                    # form, plus the triple-angle-bracket herestring) is a
+                    # REDIRECTION OPERATOR feeding the tee commands stdin,
+                    # never a write-target argument -- but it is still just
+                    # another whitespace-bounded non-flag token to this
+                    # scanner, so without this exclusion the delimiter (or the
+                    # operator itself, in the space-separated bare spelling)
+                    # was misread as an extra file target and resolved against
+                    # curcwd, producing a bogus "<repo>/<<EOF" write that the
+                    # worktree-isolation check below then falsely denied
+                    # (#5232). A BARE operator token (exactly the two- or
+                    # three-char form with no attached delimiter) also
+                    # consumes the following delimiter word.
+                    if (toks[j] ~ /^<<-?/) {
+                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        continue
+                    }
                     print curcwd SEP toks[j]
                 }
             } else if (toks[1] == "sed") {
@@ -2872,6 +2890,14 @@ extract_write_targets() {
                     if (toks[j] ~ /^-i/) has_i = 1
                     if (toks[j] ~ /^-/) continue
                     if (toks[j] == "") continue
+                    # Same heredoc/herestring exclusion as the `tee` branch
+                    # above (#5232) -- a trailing `sed -i ... file <<EOF` must
+                    # not misread the redirection operator/delimiter as an
+                    # extra file operand.
+                    if (toks[j] ~ /^<<-?/) {
+                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        continue
+                    }
                     nf++
                     nfargs[nf] = toks[j]
                 }
@@ -2884,6 +2910,15 @@ extract_write_targets() {
                 for (j = 2; j <= m; j++) {
                     if (toks[j] ~ /^-/) continue
                     if (toks[j] == "") continue
+                    # Same heredoc/herestring exclusion as the `tee` branch
+                    # above (#5232) -- without it a trailing `<<EOF` after the
+                    # real cp/mv operands was misread as the LAST non-flag
+                    # token (the field this branch treats as the destination),
+                    # so it would win over the real destination entirely.
+                    if (toks[j] ~ /^<<-?/) {
+                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        continue
+                    }
                     nf++
                     nfargs[nf] = toks[j]
                 }

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -3464,11 +3464,15 @@ extract_write_targets() {
                     # was misread as an extra file target and resolved against
                     # curcwd, producing a bogus "<repo>/<<EOF" write that the
                     # worktree-isolation check below then falsely denied
-                    # (#5232). A BARE operator token (exactly the two- or
-                    # three-char form with no attached delimiter) also
-                    # consumes the following delimiter word.
+                    # (#5232). A BARE operator token (`<<`, `<<-`, `<<<` with
+                    # no attached delimiter/content) also consumes the ONE
+                    # following word -- the heredoc delimiter, or the
+                    # herestring content. Consuming exactly one word is
+                    # shell-accurate for both: a herestring takes a single
+                    # word, so in `tee f <<< a b` the `b` really IS a tee
+                    # operand and must still be scanned.
                     if (toks[j] ~ /^<<-?/) {
-                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        if (toks[j] == "<<" || toks[j] == "<<-" || toks[j] == "<<<") j++
                         continue
                     }
                     print curcwd SEP resolve_var(toks[j])
@@ -3482,11 +3486,12 @@ extract_write_targets() {
                     if (toks[j] ~ /^-/) continue
                     if (toks[j] == "") continue
                     # Same heredoc/herestring exclusion as the `tee` branch
-                    # above (#5232) -- a trailing `sed -i ... file <<EOF` must
-                    # not misread the redirection operator/delimiter as an
+                    # above (#5232) -- a trailing `sed -i ... file <<EOF` (or
+                    # `... <<< word`) must not misread the redirection
+                    # operator, its delimiter, or the herestring content as an
                     # extra file operand.
                     if (toks[j] ~ /^<<-?/) {
-                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        if (toks[j] == "<<" || toks[j] == "<<-" || toks[j] == "<<<") j++
                         continue
                     }
                     nf++
@@ -3502,12 +3507,13 @@ extract_write_targets() {
                     if (toks[j] ~ /^-/) continue
                     if (toks[j] == "") continue
                     # Same heredoc/herestring exclusion as the `tee` branch
-                    # above (#5232) -- without it a trailing `<<EOF` after the
-                    # real cp/mv operands was misread as the LAST non-flag
-                    # token (the field this branch treats as the destination),
-                    # so it would win over the real destination entirely.
+                    # above (#5232) -- without it a trailing `<<EOF` (or
+                    # `<<< word`) after the real cp/mv operands was misread as
+                    # the LAST non-flag token (the field this branch treats as
+                    # the destination), so it would win over the real
+                    # destination entirely.
                     if (toks[j] ~ /^<<-?/) {
-                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        if (toks[j] == "<<" || toks[j] == "<<-" || toks[j] == "<<<") j++
                         continue
                     }
                     nf++

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -2873,11 +2873,15 @@ extract_write_targets() {
                     # was misread as an extra file target and resolved against
                     # curcwd, producing a bogus "<repo>/<<EOF" write that the
                     # worktree-isolation check below then falsely denied
-                    # (#5232). A BARE operator token (exactly the two- or
-                    # three-char form with no attached delimiter) also
-                    # consumes the following delimiter word.
+                    # (#5232). A BARE operator token (`<<`, `<<-`, `<<<` with
+                    # no attached delimiter/content) also consumes the ONE
+                    # following word -- the heredoc delimiter, or the
+                    # herestring content. Consuming exactly one word is
+                    # shell-accurate for both: a herestring takes a single
+                    # word, so in `tee f <<< a b` the `b` really IS a tee
+                    # operand and must still be scanned.
                     if (toks[j] ~ /^<<-?/) {
-                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        if (toks[j] == "<<" || toks[j] == "<<-" || toks[j] == "<<<") j++
                         continue
                     }
                     print curcwd SEP toks[j]
@@ -2891,11 +2895,12 @@ extract_write_targets() {
                     if (toks[j] ~ /^-/) continue
                     if (toks[j] == "") continue
                     # Same heredoc/herestring exclusion as the `tee` branch
-                    # above (#5232) -- a trailing `sed -i ... file <<EOF` must
-                    # not misread the redirection operator/delimiter as an
+                    # above (#5232) -- a trailing `sed -i ... file <<EOF` (or
+                    # `... <<< word`) must not misread the redirection
+                    # operator, its delimiter, or the herestring content as an
                     # extra file operand.
                     if (toks[j] ~ /^<<-?/) {
-                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        if (toks[j] == "<<" || toks[j] == "<<-" || toks[j] == "<<<") j++
                         continue
                     }
                     nf++
@@ -2911,12 +2916,13 @@ extract_write_targets() {
                     if (toks[j] ~ /^-/) continue
                     if (toks[j] == "") continue
                     # Same heredoc/herestring exclusion as the `tee` branch
-                    # above (#5232) -- without it a trailing `<<EOF` after the
-                    # real cp/mv operands was misread as the LAST non-flag
-                    # token (the field this branch treats as the destination),
-                    # so it would win over the real destination entirely.
+                    # above (#5232) -- without it a trailing `<<EOF` (or
+                    # `<<< word`) after the real cp/mv operands was misread as
+                    # the LAST non-flag token (the field this branch treats as
+                    # the destination), so it would win over the real
+                    # destination entirely.
                     if (toks[j] ~ /^<<-?/) {
-                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        if (toks[j] == "<<" || toks[j] == "<<-" || toks[j] == "<<<") j++
                         continue
                     }
                     nf++

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -3453,6 +3453,24 @@ extract_write_targets() {
             if (toks[1] == "tee") {
                 for (j = 2; j <= m; j++) {
                     if (toks[j] == "" || toks[j] ~ /^-/) continue
+                    # Heredoc/herestring redirection (attached or quoted
+                    # delimiter, or the bare double-angle-bracket / dashed
+                    # form, plus the triple-angle-bracket herestring) is a
+                    # REDIRECTION OPERATOR feeding the tee commands stdin,
+                    # never a write-target argument -- but it is still just
+                    # another whitespace-bounded non-flag token to this
+                    # scanner, so without this exclusion the delimiter (or the
+                    # operator itself, in the space-separated bare spelling)
+                    # was misread as an extra file target and resolved against
+                    # curcwd, producing a bogus "<repo>/<<EOF" write that the
+                    # worktree-isolation check below then falsely denied
+                    # (#5232). A BARE operator token (exactly the two- or
+                    # three-char form with no attached delimiter) also
+                    # consumes the following delimiter word.
+                    if (toks[j] ~ /^<<-?/) {
+                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        continue
+                    }
                     print curcwd SEP resolve_var(toks[j])
                 }
             } else if (toks[1] == "sed") {
@@ -3463,6 +3481,14 @@ extract_write_targets() {
                     if (toks[j] ~ /^-i/) has_i = 1
                     if (toks[j] ~ /^-/) continue
                     if (toks[j] == "") continue
+                    # Same heredoc/herestring exclusion as the `tee` branch
+                    # above (#5232) -- a trailing `sed -i ... file <<EOF` must
+                    # not misread the redirection operator/delimiter as an
+                    # extra file operand.
+                    if (toks[j] ~ /^<<-?/) {
+                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        continue
+                    }
                     nf++
                     nfargs[nf] = toks[j]
                 }
@@ -3475,6 +3501,15 @@ extract_write_targets() {
                 for (j = 2; j <= m; j++) {
                     if (toks[j] ~ /^-/) continue
                     if (toks[j] == "") continue
+                    # Same heredoc/herestring exclusion as the `tee` branch
+                    # above (#5232) -- without it a trailing `<<EOF` after the
+                    # real cp/mv operands was misread as the LAST non-flag
+                    # token (the field this branch treats as the destination),
+                    # so it would win over the real destination entirely.
+                    if (toks[j] ~ /^<<-?/) {
+                        if (toks[j] == "<<" || toks[j] == "<<-") j++
+                        continue
+                    }
                     nf++
                     nfargs[nf] = toks[j]
                 }

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -3212,6 +3212,33 @@ some text
 EOF
 echo done" "$WT_REPO"
 
+# --- #5232 (herestring half): a `<<<` HERESTRING is the same defect class as
+# the heredoc forms above, but it fails one step later. `<<<` is excluded from
+# the target list by the same operator test, so the OPERATOR itself no longer
+# becomes a phantom target -- but a BARE `<<<` is followed by its content WORD
+# (real data, e.g. `tee f <<< hello` / `tee f <<< "some text"`), and unless that
+# word is consumed too it falls through and is misread as an extra write
+# target, resolving into $WT_REPO exactly like the heredoc delimiter did.
+# Consuming exactly ONE following word is shell-accurate: bash's herestring
+# takes a single word, so in `tee f <<< some text` the `text` really IS a tee
+# operand (and is deliberately still scanned as such below).
+assert_allow "write-confinement (#5232): tee to /tmp with a bare '<<< word' herestring is not misread as a second write target" \
+    "tee /tmp/loom-test-$$-hs1.md <<< hello" "$WT_REPO"
+assert_allow "write-confinement (#5232): tee to /tmp with a bare '<<< \"quoted content\"' herestring is not misread as a second write target" \
+    "tee /tmp/loom-test-$$-hs2.md <<< \"some text\"" "$WT_REPO"
+assert_allow "write-confinement (#5232): tee to /tmp with an ATTACHED '<<<word' herestring is not misread as a second write target" \
+    "tee /tmp/loom-test-$$-hs3.md <<<hello" "$WT_REPO"
+assert_allow "write-confinement (#5232): cp with a trailing bare '<<< word' herestring is not misread as the destination" \
+    "cp /tmp/a.sh /tmp/loom-test-$$-hs4.sh <<< hello" "$WT_REPO"
+assert_allow "write-confinement (#5232): sed -i on a /tmp path with a trailing '<<< word' herestring is not misread as an extra file operand" \
+    "sed -i 's/a/b/' /tmp/loom-test-$$-hs5.sh <<< hello" "$WT_REPO"
+# The genuine confinement DENY must still fire with a herestring present, and
+# consuming the herestring word must not swallow a REAL trailing operand.
+assert_deny "write-confinement (#5232): tee into the main checkout with a trailing herestring still denies (real target, not the herestring word)" \
+    "tee $WT_REPO/defaults/hooks/f3.sh <<< hello" "$WT_REPO"
+assert_deny "write-confinement (#5232): a real tee operand AFTER a bare '<<< word' herestring is still scanned (only ONE word is consumed)" \
+    "tee /tmp/loom-test-$$-hs6.md <<< hello $WT_REPO/defaults/hooks/f4.sh" "$WT_REPO"
+
 # No managed worktree anywhere -> fail open (allow).
 WT_REPO_NOWT=$(make_wt_repo)
 rm -rf "$WT_REPO_NOWT/.loom/worktrees"

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -3055,6 +3055,33 @@ some text
 EOF
 echo done" "$WT_REPO"
 
+# --- #5232 (herestring half): a `<<<` HERESTRING is the same defect class as
+# the heredoc forms above, but it fails one step later. `<<<` is excluded from
+# the target list by the same operator test, so the OPERATOR itself no longer
+# becomes a phantom target -- but a BARE `<<<` is followed by its content WORD
+# (real data, e.g. `tee f <<< hello` / `tee f <<< "some text"`), and unless that
+# word is consumed too it falls through and is misread as an extra write
+# target, resolving into $WT_REPO exactly like the heredoc delimiter did.
+# Consuming exactly ONE following word is shell-accurate: bash's herestring
+# takes a single word, so in `tee f <<< some text` the `text` really IS a tee
+# operand (and is deliberately still scanned as such below).
+assert_allow "write-confinement (#5232): tee to /tmp with a bare '<<< word' herestring is not misread as a second write target" \
+    "tee /tmp/loom-test-$$-hs1.md <<< hello" "$WT_REPO"
+assert_allow "write-confinement (#5232): tee to /tmp with a bare '<<< \"quoted content\"' herestring is not misread as a second write target" \
+    "tee /tmp/loom-test-$$-hs2.md <<< \"some text\"" "$WT_REPO"
+assert_allow "write-confinement (#5232): tee to /tmp with an ATTACHED '<<<word' herestring is not misread as a second write target" \
+    "tee /tmp/loom-test-$$-hs3.md <<<hello" "$WT_REPO"
+assert_allow "write-confinement (#5232): cp with a trailing bare '<<< word' herestring is not misread as the destination" \
+    "cp /tmp/a.sh /tmp/loom-test-$$-hs4.sh <<< hello" "$WT_REPO"
+assert_allow "write-confinement (#5232): sed -i on a /tmp path with a trailing '<<< word' herestring is not misread as an extra file operand" \
+    "sed -i 's/a/b/' /tmp/loom-test-$$-hs5.sh <<< hello" "$WT_REPO"
+# The genuine confinement DENY must still fire with a herestring present, and
+# consuming the herestring word must not swallow a REAL trailing operand.
+assert_deny "write-confinement (#5232): tee into the main checkout with a trailing herestring still denies (real target, not the herestring word)" \
+    "tee $WT_REPO/defaults/hooks/f3.sh <<< hello" "$WT_REPO"
+assert_deny "write-confinement (#5232): a real tee operand AFTER a bare '<<< word' herestring is still scanned (only ONE word is consumed)" \
+    "tee /tmp/loom-test-$$-hs6.md <<< hello $WT_REPO/defaults/hooks/f4.sh" "$WT_REPO"
+
 # No managed worktree anywhere -> fail open (allow).
 WT_REPO_NOWT=$(make_wt_repo)
 rm -rf "$WT_REPO_NOWT/.loom/worktrees"

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -3167,6 +3167,51 @@ assert_allow "write-confinement: echo > target in /tmp allows" \
 assert_allow "write-confinement: cd <worktree> && echo > relative target allows" \
     "cd $WT_DIR && echo x > f.sh" "$WT_REPO"
 
+# --- #5232: a heredoc redirection operator/delimiter trailing a real tee/cp/mv
+# (or sed -i) write target must never be misread as an ADDITIONAL write
+# target. Unlike the #5226/#5181 tee-heredoc assertions above (which run
+# against the default REPO_ROOT cwd and so only exercise this precondition
+# when the ambient primary checkout happens to have a sibling managed
+# worktree -- the normal but not guaranteed state of this repo's own primary
+# clone), these use the hermetic make_wt_repo() fixture so the "a managed
+# worktree exists elsewhere" precondition is deterministic in ANY checkout,
+# including a fresh clone or CI runner with zero sibling worktrees. Before the
+# #5232 fix, the phantom "<repo>/<<EOF" (or "<repo>/<<" + "<repo>/EOF" for the
+# bare space-separated form) target resolved into $WT_REPO -- the protected
+# main checkout -- and triggered a false DENY even though the real target
+# (under /tmp, unprotected) was entirely fine on its own.
+assert_allow "write-confinement (#5232): tee to /tmp with a trailing quoted heredoc delimiter <<'EOF' is not misread as a second write target" \
+    "tee /tmp/loom-test-$$-report1.md <<'EOF'
+some text
+EOF
+echo done" "$WT_REPO"
+assert_allow "write-confinement (#5232): sudo tee to /tmp with a trailing quoted heredoc delimiter <<'EOF' is not misread as a second write target" \
+    "sudo tee /tmp/loom-test-$$-report2.md <<'EOF'
+some text
+EOF
+echo done" "$WT_REPO"
+assert_allow "write-confinement (#5232): tee to /tmp with a bare space-separated '<< EOF' heredoc operator is not misread as two extra write targets" \
+    "tee /tmp/loom-test-$$-report3.md << EOF
+some text
+EOF
+echo done" "$WT_REPO"
+assert_allow "write-confinement (#5232): cp with a trailing bare '<< EOF' heredoc operator+delimiter is not misread as the destination" \
+    "cp /tmp/a.sh /tmp/loom-test-$$-copy.sh << EOF
+irrelevant
+EOF" "$WT_REPO"
+assert_allow "write-confinement (#5232): sed -i on a /tmp path with a trailing <<EOF heredoc is not misread as an extra file operand" \
+    "sed -i 's/a/b/' /tmp/loom-test-$$-sed.sh <<EOF
+ignored
+EOF" "$WT_REPO"
+# The real-target-in-main-checkout DENY must still fire when a heredoc is
+# ALSO present -- the exclusion must narrow false positives, not weaken the
+# genuine confinement check.
+assert_deny "write-confinement (#5232): tee into the main checkout with a trailing heredoc still denies (real target, not the heredoc token)" \
+    "tee $WT_REPO/defaults/hooks/f2.sh <<'EOF'
+some text
+EOF
+echo done" "$WT_REPO"
+
 # No managed worktree anywhere -> fail open (allow).
 WT_REPO_NOWT=$(make_wt_repo)
 rm -rf "$WT_REPO_NOWT/.loom/worktrees"

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -3239,6 +3239,33 @@ assert_deny "write-confinement (#5232): tee into the main checkout with a traili
 assert_deny "write-confinement (#5232): a real tee operand AFTER a bare '<<< word' herestring is still scanned (only ONE word is consumed)" \
     "tee /tmp/loom-test-$$-hs6.md <<< hello $WT_REPO/defaults/hooks/f4.sh" "$WT_REPO"
 
+# --- #5232 x #4914 composition: the heredoc/herestring exclusion above and
+# main's same-command `$VAR` redirect resolution (#4914) touch the SAME three
+# loops and were developed in parallel, so neither PR's suite covers them
+# TOGETHER. These assertions pin the composed behavior: the exclusion must not
+# shadow resolve_var() (a `$VAR` target that resolves INTO the main checkout
+# must still DENY even when a heredoc/herestring shares the command), and
+# resolve_var() must not resurrect the phantom target the exclusion removes (a
+# `$VAR` target resolving to an unprotected path must now ALLOW -- pre-#5232 it
+# false-DENIED on the heredoc token, not on the variable). Also pins that
+# consuming the ONE herestring content word never swallows a real `$VAR`
+# operand that follows it, and that #4914's cat-heredoc BODY exemption still
+# holds with the new exclusion in place.
+assert_deny "write-confinement (#5232 x #4914): \$VAR tee target resolving into the main checkout still denies with a trailing herestring" \
+    "F=$WT_REPO/defaults/hooks/x1.sh; tee \$F <<< hello" "$WT_REPO"
+assert_deny "write-confinement (#5232 x #4914): \$VAR tee target resolving into the main checkout still denies with a trailing heredoc" \
+    "F=$WT_REPO/defaults/hooks/x2.sh; tee \$F <<EOF
+text
+EOF" "$WT_REPO"
+assert_allow "write-confinement (#5232 x #4914): \$VAR tee target resolving to /tmp allows with a trailing herestring (phantom heredoc target gone)" \
+    "F=/tmp/loom-test-$$-var1.sh; tee \$F <<< hello" "$WT_REPO"
+assert_deny "write-confinement (#5232 x #4914): a \$VAR operand AFTER a bare '<<< word' herestring is still resolved and scanned" \
+    "F=$WT_REPO/defaults/hooks/x3.sh; tee /tmp/loom-test-$$-var2.md <<< hello \$F" "$WT_REPO"
+assert_allow "write-confinement (#5232 x #4914): a cat-heredoc BODY naming a main-checkout tee target stays exempt with the new exclusion in place" \
+    "cat > /tmp/loom-test-$$-body.md <<'EOF'
+tee $WT_REPO/defaults/hooks/x4.sh
+EOF" "$WT_REPO"
+
 # No managed worktree anywhere -> fail open (allow).
 WT_REPO_NOWT=$(make_wt_repo)
 rm -rf "$WT_REPO_NOWT/.loom/worktrees"

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -3010,6 +3010,51 @@ assert_allow "write-confinement: echo > target in /tmp allows" \
 assert_allow "write-confinement: cd <worktree> && echo > relative target allows" \
     "cd $WT_DIR && echo x > f.sh" "$WT_REPO"
 
+# --- #5232: a heredoc redirection operator/delimiter trailing a real tee/cp/mv
+# (or sed -i) write target must never be misread as an ADDITIONAL write
+# target. Unlike the #5226/#5181 tee-heredoc assertions above (which run
+# against the default REPO_ROOT cwd and so only exercise this precondition
+# when the ambient primary checkout happens to have a sibling managed
+# worktree -- the normal but not guaranteed state of this repo's own primary
+# clone), these use the hermetic make_wt_repo() fixture so the "a managed
+# worktree exists elsewhere" precondition is deterministic in ANY checkout,
+# including a fresh clone or CI runner with zero sibling worktrees. Before the
+# #5232 fix, the phantom "<repo>/<<EOF" (or "<repo>/<<" + "<repo>/EOF" for the
+# bare space-separated form) target resolved into $WT_REPO -- the protected
+# main checkout -- and triggered a false DENY even though the real target
+# (under /tmp, unprotected) was entirely fine on its own.
+assert_allow "write-confinement (#5232): tee to /tmp with a trailing quoted heredoc delimiter <<'EOF' is not misread as a second write target" \
+    "tee /tmp/loom-test-$$-report1.md <<'EOF'
+some text
+EOF
+echo done" "$WT_REPO"
+assert_allow "write-confinement (#5232): sudo tee to /tmp with a trailing quoted heredoc delimiter <<'EOF' is not misread as a second write target" \
+    "sudo tee /tmp/loom-test-$$-report2.md <<'EOF'
+some text
+EOF
+echo done" "$WT_REPO"
+assert_allow "write-confinement (#5232): tee to /tmp with a bare space-separated '<< EOF' heredoc operator is not misread as two extra write targets" \
+    "tee /tmp/loom-test-$$-report3.md << EOF
+some text
+EOF
+echo done" "$WT_REPO"
+assert_allow "write-confinement (#5232): cp with a trailing bare '<< EOF' heredoc operator+delimiter is not misread as the destination" \
+    "cp /tmp/a.sh /tmp/loom-test-$$-copy.sh << EOF
+irrelevant
+EOF" "$WT_REPO"
+assert_allow "write-confinement (#5232): sed -i on a /tmp path with a trailing <<EOF heredoc is not misread as an extra file operand" \
+    "sed -i 's/a/b/' /tmp/loom-test-$$-sed.sh <<EOF
+ignored
+EOF" "$WT_REPO"
+# The real-target-in-main-checkout DENY must still fire when a heredoc is
+# ALSO present -- the exclusion must narrow false positives, not weaken the
+# genuine confinement check.
+assert_deny "write-confinement (#5232): tee into the main checkout with a trailing heredoc still denies (real target, not the heredoc token)" \
+    "tee $WT_REPO/defaults/hooks/f2.sh <<'EOF'
+some text
+EOF
+echo done" "$WT_REPO"
+
 # No managed worktree anywhere -> fail open (allow).
 WT_REPO_NOWT=$(make_wt_repo)
 rm -rf "$WT_REPO_NOWT/.loom/worktrees"


### PR DESCRIPTION
## Summary
Fixes a false `DENY` in the worktree-isolation guard: `extract_write_targets()`'s `tee`, `sed -i`, and `cp`/`mv` branches in `defaults/hooks/guard-destructive-generic.sh` treated a trailing heredoc/herestring redirection operator (`<<EOF`, `<<-EOF`, `<<'EOF'`, the bare space-separated `<< EOF` form, and the `<<<` herestring) as an extra write-target candidate. That bogus target resolved against `curcwd` and tripped the worktree-isolation confinement check, so the extremely common `tee <file> <<'EOF' ... EOF` idiom (and `sudo tee` variant) falsely denied whenever the repo had a sibling Loom-managed worktree — the normal steady state for this repo's own primary clone.

## Changes
- `defaults/hooks/guard-destructive-generic.sh`: in the `tee`, `sed -i`, and `cp`/`mv` branches of `extract_write_targets()`, exclude any token that is (or starts with) a heredoc/herestring redirection operator from the write-target candidate list. A **bare** operator token — `<<`, `<<-`, **or `<<<`**, with the delimiter/content word on its own token — additionally consumes the ONE following word, so neither the operator, nor the heredoc delimiter, nor the herestring content is misread as a target.
  - Consuming exactly one word is shell-accurate for both forms: bash's herestring takes a single word, so in `tee f <<< a b` the `b` really *is* a `tee` operand and is deliberately still scanned (covered by a dedicated deny assertion).
- `tests/hooks/test-guard-destructive.sh`: added 13 hermetic regression tests (using the existing `make_wt_repo()` fixture, independent of whether the ambient checkout happens to have a sibling managed worktree) — 6 covering `tee`, `sudo tee`, `cp`, and `sed -i` with trailing heredoc operators, and 7 covering the `<<<` herestring forms (bare, quoted-content, attached) plus two control denies (a real main-checkout target with a trailing herestring, and a real operand *after* a consumed herestring word).

## Judge follow-up (herestring half — addressed)
The first revision's comments claimed `<<<` coverage but only half-delivered it: `/^<<-?/` matched a `<<<` token (so the operator itself was excluded), but the `j++` that consumes the following word only fired for `<<` / `<<-`. For a herestring that following word is real content, so it fell through and became a *different* phantom target — the same false DENY, one token over:

```
CMD='tee /tmp/loom-test-report.md <<< hello'
origin/main       -> DENY citing target '<repo>/<<<'
first revision    -> DENY citing target '<repo>/hello'
this revision     -> ALLOW (empty output, exit 0)
```

`<<<` is now included in the bare-operator test at **all three** exclusion sites, with regression coverage.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| Reproduce the bug first (confirm DENY) | ✅ | Ran the issue's exact repro command against pre-fix code from this repo's primary clone (which has sibling managed worktrees) — confirmed `DENY` citing `<repo>/<<EOF`; likewise `DENY` citing `<repo>/<<<` for the herestring form |
| Apply fix | ✅ | See Changes above |
| Re-run repro (confirm ALLOW) | ✅ | Both repro commands against the fixed guard now return empty output (ALLOW) |
| `bash tests/hooks/test-guard-destructive.sh` passes 746/746 (or more) | ✅ | `Total: 759  Passed: 759  Failed: 0` (746 original + 13 new #5232 regression tests) |
| Add regression test coverage if not already adequate | ✅ | Added 13 hermetic tests (`make_wt_repo()`-based) so the "sibling worktree present" precondition is deterministic in any checkout. Each new "should ALLOW" test was verified to fail (DENY) against the code that lacks the corresponding fix — the 4 bare-`<<<` allow cases fail at 755/759 against the pre-herestring-fix revision and pass at 759/759 after |
| Run broader hook test suite for regressions | ✅ | `tests/hooks/test-guard-destructive-dispatcher.sh`: 12/12 passed. `shellcheck` on both changed files shows no new findings vs. the pre-change baseline (info-level-only, pre-existing) |

## Test Plan
```
$ bash tests/hooks/test-guard-destructive.sh
...
=========================================
  Total:  759
  Passed: 759
  Failed: 0
=========================================
ALL TESTS PASSED

$ bash tests/hooks/test-guard-destructive-dispatcher.sh
=========================================
Results: 12 passed, 0 failed
=========================================
```

Closes #5232
