### PR TITLE
fix(guard): require structural anchor for Part of/Contributes to declarations in merge-pr.sh

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -528,11 +528,42 @@ _check_no_open_stacked_children
 PARTIAL_OPEN_BEFORE_MERGE=""
 PARTIAL_CONFLICT_ISSUES=""
 
+# Strips Markdown fenced code blocks (``` ... ```) from stdin, one line at a
+# time: a fence-open/-close toggle drops everything between the fences
+# (inclusive of the fence markers themselves). Used so a `Part of #N` shown as
+# example/quoted text inside a fenced block reads as documentation, never a
+# live declaration (#5234).
+_strip_fenced_code_blocks() {
+  awk '
+    /^[[:space:]]*```/ { infence = !infence; next }
+    !infence { print }
+  '
+}
+
 # Issue numbers referenced with a NON-closing partial-increment keyword
-# (`Part of #N` / `Contributes to #N`, case-insensitive), one per line, deduped.
+# (`Part of #N` / `Contributes to #N`, case-insensitive) as a DECLARATION, one
+# per line, deduped.
+#
+# "Declaration" is deliberately narrower than "appears anywhere in the body"
+# (#5234): a bare `grep` over the whole text also matched a mid-sentence,
+# backticked, conditional mention like "...say so and I will switch the
+# reference to `Part of #4574`" — prose describing a hypothetical, not a
+# declared intent — and treated it as authoritative, reopening a correctly
+# closed issue. To count as a declaration here the keyword must be
+# line-leading, optionally preceded by a list marker (`-`/`*`/`+`/numbered
+# `1.`/blockquote `>`) and/or whitespace — matching the actual shape this
+# convention produces (a one-line `Part of #123` / `Contributes to #456`
+# trailer, per builder-pr.md), not prose that merely references the pattern.
+#
+# Fenced code blocks are stripped first, then inline code spans (`` `...` ``)
+# are blanked so a backticked mention cannot itself satisfy the line-leading
+# anchor (the #5234 repro used backticks specifically to mark the reference as
+# hypothetical, not live).
 _partial_increment_refs() {
   { printf '%s\n' "$1" \
-      | grep -oiE '(Part of|Contributes to)[[:space:]]+#[0-9]+' \
+      | _strip_fenced_code_blocks \
+      | sed -E 's/`[^`]*`//g' \
+      | grep -oiE '^[[:space:]]*([-*+>]|[0-9]+\.)?[[:space:]]*(Part of|Contributes to)[[:space:]]+#[0-9]+' \
       | grep -oE '[0-9]+' \
       | sort -un; } || true
 }
@@ -565,6 +596,23 @@ _body_closing_refs() {
 _closing_ref_snippets() {
   { printf '%s\n' "$1" \
       | grep -oiE "\\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\\b[[:space:]]+#$2\\b" \
+      | sort -u | tr '\n' '|' | sed 's/|$//; s/|/", "/g'; } || true
+}
+
+# The literal declaration text (`Part of #N` / `Contributes to #N`) that
+# _partial_increment_refs read as authoritative for issue $2 inside text $1,
+# rendered the same way _closing_ref_snippets renders the closing-keyword side
+# (`snippet", "snippet`) — so the pre-merge warning can show an operator BOTH
+# sides of the conflict and judge for themselves whether the declaration was
+# real (AC #4, #5234). Runs the identical fenced-block/inline-code-span
+# stripping as _partial_increment_refs so the quoted snippet always matches
+# what was actually matched, never a code-block artifact.
+_partial_increment_ref_snippets() {
+  { printf '%s\n' "$1" \
+      | _strip_fenced_code_blocks \
+      | sed -E 's/`[^`]*`//g' \
+      | grep -oiE "^[[:space:]]*([-*+>]|[0-9]+\\.)?[[:space:]]*(Part of|Contributes to)[[:space:]]+#$2\\b" \
+      | sed -E 's/^[[:space:]]+//' \
       | sort -u | tr '\n' '|' | sed 's/|$//; s/|/", "/g'; } || true
 }
 
@@ -647,23 +695,28 @@ _check_partial_increment_close_conflict() {
     fi
     PARTIAL_CONFLICT_ISSUES="${PARTIAL_CONFLICT_ISSUES:+$PARTIAL_CONFLICT_ISSUES }$issue_num"
 
-    local body_offending commit_offending dr=""
+    local body_offending commit_offending partial_offending dr=""
     # Match _check_no_open_stacked_children's dry-run contract: report the
     # would-be outcome without claiming a merge is happening.
     [[ "${DRY_RUN:-false}" == "true" ]] && dr="[dry-run] "
     body_offending="$(_closing_ref_snippets "$pr_body" "$issue_num")"
     commit_offending="$(_closing_ref_snippets "$commit_messages" "$issue_num")"
+    # The declaration text itself (AC #4, #5234) — quoted alongside the closing
+    # keyword below so an operator can see both sides and judge for themselves
+    # whether the declaration was a real trailer or, e.g., prose that happened
+    # to survive the structural anchor.
+    partial_offending="$(_partial_increment_ref_snippets "$pr_body" "$issue_num")"
 
     # Name the source, because the operator remedy differs per source: edit the
     # PR body, reword/amend a commit, or unlink a Development-sidebar reference.
     if [[ -n "$body_offending" ]]; then
-      warning "${dr}Partial-increment conflict (#4569): PR #$PR_NUMBER declares a NON-closing \`Part of\`/\`Contributes to\` reference to #$issue_num, but its body ALSO carries a closing reference to #$issue_num (\"$body_offending\") — GitHub honors a closing keyword ANYWHERE in the body, so merging this PR WILL close #$issue_num against the declared intent."
+      warning "${dr}Partial-increment conflict (#4569): PR #$PR_NUMBER declares a NON-closing \`Part of\`/\`Contributes to\` reference to #$issue_num (\"$partial_offending\"), but its body ALSO carries a closing reference to #$issue_num (\"$body_offending\") — GitHub honors a closing keyword ANYWHERE in the body, so merging this PR WILL close #$issue_num against the declared intent."
       warning "  ${dr}merge-pr.sh would reopen #$issue_num immediately after the merge. To avoid the close/reopen flicker entirely, edit the PR body so no closing keyword is immediately followed by \`#$issue_num\` (e.g. write \`close the issue\` or \`close issue #$issue_num\` instead of \`close #$issue_num\`), then re-run this merge."
     elif [[ -n "$commit_offending" ]]; then
-      warning "${dr}Partial-increment conflict (#4595): PR #$PR_NUMBER declares a NON-closing \`Part of\`/\`Contributes to\` reference to #$issue_num, but a closing keyword in a commit message of this PR references #$issue_num (\"$commit_offending\") — this merge squashes without overriding the commit message, so GitHub composes the squash message from these commits and merging WILL close #$issue_num against the declared intent."
+      warning "${dr}Partial-increment conflict (#4595): PR #$PR_NUMBER declares a NON-closing \`Part of\`/\`Contributes to\` reference to #$issue_num (\"$partial_offending\"), but a closing keyword in a commit message of this PR references #$issue_num (\"$commit_offending\") — this merge squashes without overriding the commit message, so GitHub composes the squash message from these commits and merging WILL close #$issue_num against the declared intent."
       warning "  ${dr}merge-pr.sh would reopen #$issue_num immediately after the merge. To avoid the close/reopen flicker entirely, reword the offending commit message (\`git commit --amend\` / \`git rebase -i\` + force-push) so no closing keyword is immediately followed by \`#$issue_num\`, then re-run this merge."
     else
-      warning "${dr}Partial-increment conflict (#4569): PR #$PR_NUMBER declares a NON-closing \`Part of\`/\`Contributes to\` reference to #$issue_num, but GitHub reports #$issue_num as a closing target of this PR (no closing keyword found in the body or commit messages — most likely a Development-sidebar link), so merging this PR WILL close #$issue_num against the declared intent."
+      warning "${dr}Partial-increment conflict (#4569): PR #$PR_NUMBER declares a NON-closing \`Part of\`/\`Contributes to\` reference to #$issue_num (\"$partial_offending\"), but GitHub reports #$issue_num as a closing target of this PR (no closing keyword found in the body or commit messages — most likely a Development-sidebar link), so merging this PR WILL close #$issue_num against the declared intent."
       warning "  ${dr}merge-pr.sh would reopen #$issue_num immediately after the merge. To avoid the close/reopen flicker entirely, unlink #$issue_num from this PR's Development sidebar, then re-run this merge."
     fi
   done <<< "$partial_refs"

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -559,12 +559,21 @@ _strip_fenced_code_blocks() {
 # are blanked so a backticked mention cannot itself satisfy the line-leading
 # anchor (the #5234 repro used backticks specifically to mark the reference as
 # hypothetical, not live).
+#
+# The second stage extracts `#N` tokens FIRST and only then strips the `#`.
+# Scanning the whole matched span for any digit run would also pick up the
+# numbered-list marker's own ordinal (`3. Part of #789` -> `3` and `789`),
+# which is exactly the false-positive-reopen class this guard exists to
+# prevent: a body carrying both `3. Part of #789` and a genuine `Closes #3`
+# would see #3 registered as a declared partial increment AND a closing
+# reference, and get reopened right after a correct close.
 _partial_increment_refs() {
   { printf '%s\n' "$1" \
       | _strip_fenced_code_blocks \
       | sed -E 's/`[^`]*`//g' \
       | grep -oiE '^[[:space:]]*([-*+>]|[0-9]+\.)?[[:space:]]*(Part of|Contributes to)[[:space:]]+#[0-9]+' \
-      | grep -oE '[0-9]+' \
+      | grep -oE '#[0-9]+' \
+      | tr -d '#' \
       | sort -un; } || true
 }
 

--- a/defaults/scripts/tests/test-merge-pr-partial-increment.sh
+++ b/defaults/scripts/tests/test-merge-pr-partial-increment.sh
@@ -127,8 +127,9 @@ source "$HELPERS_DIR/lib/forge-helpers.sh"
 
 # --- Extract the functions under test from merge-pr.sh and source them ---
 # Two spans, each bounded by an anchor line that is NOT part of the span:
-#   1. `_partial_increment_refs() {` .. `_check_partial_increment_close_conflict
-#      || true` — the #4569 pre-merge guard and its two pure-text ref extractors.
+#   1. `_strip_fenced_code_blocks() {` .. `_check_partial_increment_close_conflict
+#      || true` — the #4569 pre-merge guard, its pure-text ref extractors, and
+#      the #5234 code-span/fence-stripping helper the extractors depend on.
 #      Stopping at the INVOCATION line keeps the top-level call out of the
 #      sourced file (we drive the guard explicitly from the tests).
 #   2. `_reset_one_partial_issue() {` .. `# Handle auto-merge mode` — the
@@ -138,17 +139,17 @@ source "$HELPERS_DIR/lib/forge-helpers.sh"
 FUNCS_FILE="$(mktemp)"
 trap 'rm -rf "$FUNCS_FILE" "$STUB_DIR" 2>/dev/null || true' EXIT
 awk '
-  /^_partial_increment_refs\(\) \{/                     { capture=1 }
+  /^_strip_fenced_code_blocks\(\) \{/                    { capture=1 }
   /^_check_partial_increment_close_conflict \|\| true/   { capture=0 }
   /^_reset_one_partial_issue\(\) \{/                    { capture=1 }
   /^# Handle auto-merge mode/                           { capture=0 }
   capture { print }
 ' "$MERGE_PR_SRC" > "$FUNCS_FILE"
 
-for _fn in _partial_increment_refs _closing_refs_stdin _body_closing_refs \
-           _closing_ref_snippets _pr_commit_messages \
-           _check_partial_increment_close_conflict _reset_one_partial_issue \
-           _reset_partial_increment_labels; do
+for _fn in _strip_fenced_code_blocks _partial_increment_refs _closing_refs_stdin \
+           _body_closing_refs _closing_ref_snippets _partial_increment_ref_snippets \
+           _pr_commit_messages _check_partial_increment_close_conflict \
+           _reset_one_partial_issue _reset_partial_increment_labels; do
     if ! grep -q "^${_fn}() {" "$FUNCS_FILE"; then
         echo -e "${RED}FATAL${NC}: could not extract $_fn from $MERGE_PR_SRC" >&2
         exit 2
@@ -250,6 +251,9 @@ cat > "$STUB_DIR/issue-888.json" <<'EOF'
 EOF
 cat > "$STUB_DIR/issue-321.json" <<'EOF'
 {"state":"open","pull_request":{"url":"x"},"labels":[{"name":"loom:building"}]}
+EOF
+cat > "$STUB_DIR/issue-4574.json" <<'EOF'
+{"state":"open","labels":[{"name":"loom:building"}]}
 EOF
 
 # Canned `pulls/<N>/commits` payload: one JSON commit object per message given.
@@ -394,6 +398,82 @@ assert_eq "" "$(_body_closing_refs 'close issue #123')" \
   "'close issue #123' is NOT a closing reference (keyword not adjacent to #N)"
 assert_eq "1234" "$(_body_closing_refs 'Closes #1234')" \
   "Full number is extracted (no #123 prefix confusion)"
+
+echo ""
+echo "Testing _partial_increment_refs prose/code-span guarding (#5234)..."
+
+# PA1: the exact #5234 incident shape — a mid-sentence, backticked, conditional
+# mention of `Part of #4574` inside a paragraph addressed to the Judge, plus
+# the real, declared `Closes #4574` elsewhere in the body. The backticked
+# mention is prose describing a hypothetical ("if you would rather... I will
+# switch the reference to"), not a declaration, and must NOT be read as one.
+incident_body='Summary of the fix.
+
+Judge: if you would rather this stay open until #4580 lands, say so and I will switch the reference to `Part of #4574`.
+
+More detail about the change.
+
+Closes #4574'
+assert_eq "" "$(_partial_increment_refs "$incident_body")" \
+  "#5234 incident: backticked, mid-sentence 'Part of #4574' is NOT read as a declaration"
+
+reset_log
+PR_JSON="$(jq -n --arg body "$incident_body" '{body: $body}')"
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "" "$PARTIAL_CONFLICT_ISSUES" \
+  "#5234 incident: no conflict recorded — the real 'Closes #4574' stands unopposed"
+assert_eq "" "$PARTIAL_OPEN_BEFORE_MERGE" \
+  "#5234 incident: #4574 is not tracked as a partial-increment ref at all (no declaration found)"
+
+# PA2: companion — a genuine, line-leading `Part of #4574` trailer (its own
+# line, no backticks) still triggers the existing partial-increment path, and
+# a conflicting closing reference elsewhere in the body is still detected. Also
+# verifies AC #4: the warning quotes the matched declaration text.
+genuine_body='Summary of the fix.
+
+Part of #4574
+
+Closes #4574'
+assert_eq "4574" "$(_partial_increment_refs "$genuine_body")" \
+  "Companion: genuine line-leading 'Part of #4574' IS read as a declaration"
+
+reset_log
+PR_JSON="$(jq -n --arg body "$genuine_body" '{body: $body}')"
+run_capturing_stderr _check_partial_increment_close_conflict
+genuine_err="$(read_stderr)"
+assert_eq "4574" "$PARTIAL_CONFLICT_ISSUES" \
+  "Companion: genuine 'Part of #4574' + 'Closes #4574' -> conflict recorded (existing path still fires)"
+assert_contains "$genuine_err" '("Part of #4574")' \
+  "Companion: warning quotes the matched declaration text with context (AC #4)"
+assert_contains "$genuine_err" 'Closes #4574' \
+  "Companion: warning also quotes the offending closing-keyword text"
+
+# PA3: `Part of #123` shown inside a FENCED code block (not just inline
+# backticks) is also excluded — a documentation example, not a live
+# declaration.
+fenced_body='Example usage of the convention:
+
+```
+Part of #123
+```
+
+Closes #123'
+assert_eq "" "$(_partial_increment_refs "$fenced_body")" \
+  "Fenced code block: 'Part of #123' inside a triple-backtick fence is NOT a declaration"
+
+# PA4: mid-sentence prose (no backticks at all) referencing the pattern is
+# still excluded by the line-leading anchor alone.
+prose_body='This work is part of #123, a larger initiative that will continue after this PR.'
+assert_eq "" "$(_partial_increment_refs "$prose_body")" \
+  "Mid-sentence prose 'part of #123' (no backticks) is NOT a declaration (line-leading anchor)"
+
+# PA5: a list-marker-prefixed declaration still counts (AC: "optionally after
+# list-marker/whitespace").
+list_body='Changes in this increment:
+
+- Part of #123'
+assert_eq "123" "$(_partial_increment_refs "$list_body")" \
+  "List-marker prefix: '- Part of #123' still counts as a declaration"
 
 echo ""
 echo "Testing _check_partial_increment_close_conflict (pre-merge guard)..."
@@ -686,6 +766,12 @@ assert_contains "$src" 'repos/$REPO_NWO/pulls/$PR_NUMBER/commits' \
   "merge-pr.sh reads the PR's commit messages for closing keywords (#4595)"
 assert_contains "$src" '--paginate' \
   "merge-pr.sh paginates the commits fetch (>30-commit PRs are not truncated)"
+assert_contains "$src" '_strip_fenced_code_blocks' \
+  "merge-pr.sh strips fenced code blocks before matching a partial-increment declaration (#5234)"
+assert_contains "$src" "sed -E 's/\`[^\`]*\`//g'" \
+  "merge-pr.sh blanks inline code spans before matching a partial-increment declaration (#5234)"
+assert_contains "$src" '_partial_increment_ref_snippets' \
+  "merge-pr.sh quotes the matched partial-increment declaration text in the pre-merge warning (#5234 AC #4)"
 
 # --- Summary ---
 echo ""

--- a/defaults/scripts/tests/test-merge-pr-partial-increment.sh
+++ b/defaults/scripts/tests/test-merge-pr-partial-increment.sh
@@ -255,6 +255,14 @@ EOF
 cat > "$STUB_DIR/issue-4574.json" <<'EOF'
 {"state":"open","labels":[{"name":"loom:building"}]}
 EOF
+# PA6 fixtures: a numbered-list declaration `3. Part of #789` whose marker
+# ordinal (3) collides with a genuine `Closes #3` elsewhere in the same body.
+cat > "$STUB_DIR/issue-3.json" <<'EOF'
+{"state":"open","labels":[{"name":"loom:building"}]}
+EOF
+cat > "$STUB_DIR/issue-789.json" <<'EOF'
+{"state":"open","labels":[{"name":"loom:building"}]}
+EOF
 
 # Canned `pulls/<N>/commits` payload: one JSON commit object per message given.
 # Written in the GitHub REST shape the script reads (.[].commit.message).
@@ -474,6 +482,38 @@ list_body='Changes in this increment:
 - Part of #123'
 assert_eq "123" "$(_partial_increment_refs "$list_body")" \
   "List-marker prefix: '- Part of #123' still counts as a declaration"
+
+# PA6: a NUMBERED list marker carries its own digits, which the second-stage
+# extraction must not mistake for an issue number. PA5 only covers a dash
+# marker (no digits to leak), so this case is what caught the regression: with
+# a naive `grep -oE '[0-9]+'` over the whole matched span, `3. Part of #789`
+# yielded BOTH `3` and `789`. Paired with a genuine `Closes #3` elsewhere in
+# the body, that spuriously registers #3 as a declared partial increment AND a
+# closing reference — the exact false-positive-reopen shape #5234 exists to
+# eliminate, reintroduced through the list-marker support itself.
+numbered_body='Changes in this increment:
+
+3. Part of #789
+
+Closes #3'
+assert_eq "789" "$(_partial_increment_refs "$numbered_body")" \
+  "Numbered list marker: '3. Part of #789' yields ONLY 789 — the marker ordinal 3 does not leak"
+
+reset_log
+PR_JSON="$(jq -n --arg body "$numbered_body" '{body: $body}')"
+_check_partial_increment_close_conflict 2>/dev/null
+assert_eq "" "$PARTIAL_CONFLICT_ISSUES" \
+  "Numbered list marker: no conflict — 'Closes #3' stands, #3 is not a partial-increment ref"
+assert_eq "789" "$PARTIAL_OPEN_BEFORE_MERGE" \
+  "Numbered list marker: only the real declaration target (#789) is tracked as open before the merge"
+
+# PA7: blockquote marker (`>`), the other marker branch the regex claims to
+# support and that no test previously exercised.
+quoted_body='Context from the epic:
+
+> Part of #456'
+assert_eq "456" "$(_partial_increment_refs "$quoted_body")" \
+  "Blockquote marker: '> Part of #456' still counts as a declaration"
 
 echo ""
 echo "Testing _check_partial_increment_close_conflict (pre-merge guard)..."


### PR DESCRIPTION
## Summary

`_partial_increment_refs()` in `defaults/scripts/merge-pr.sh` used to match `Part of #N` / `Contributes to #N` anywhere in a PR body — including mid-sentence prose inside backticks that merely *described* switching to that reference, not a declared one. That false positive caused `merge-pr.sh` to treat a correctly-declared `Closes #N` as conflicting with a non-existent partial-increment intent, and reopen an issue that had just been correctly closed (issue #4574 in `rjwalters/kicad-tools`, via PR #4581).

## Changes

- Added `_strip_fenced_code_blocks()`: strips fenced (```` ``` ````) code blocks from the PR body before matching.
- `_partial_increment_refs()` now also blanks inline code spans (`` `...` ``) and requires the `Part of` / `Contributes to` keyword to be **line-leading** (optionally after a list marker `-`/`*`/`+`/numbered/`>`) to count as a declaration — mirroring the structural-anchor idea already used in `_closing_refs_stdin`'s `\b` word-boundary guarding.
- Added `_partial_increment_ref_snippets()`, modeled on the existing `_closing_ref_snippets()` helper, and used it to quote the matched declaration text in the pre-merge conflict warning — so an operator can see both sides of a conflict (declaration text + closing-keyword text) before the merge proceeds.
- When the tightened match finds no genuine declaration (e.g. the backticked/conditional prose case), `_check_partial_increment_close_conflict` naturally early-returns with no partial refs found, so no conflict is reported and a legitimate `Closes #N` stands unopposed — no new logic was needed for this beyond the tightened extractor.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| `_partial_increment_refs()` ignores matches inside inline code spans and fenced code blocks | ✅ | New tests PA1 (inline backticks) and PA3 (fenced block) assert empty output |
| A `Part of`/`Contributes to` reference is only authoritative when line-leading (declaration), not mid-sentence prose | ✅ | New tests PA1, PA4 (non-backticked mid-sentence prose) assert empty output; PA2, PA5 (line-leading / list-marker) assert the ref is still captured |
| Body with BOTH a closing reference and a non-surviving non-closing reference → no conflict, close stands | ✅ | PA1 end-to-end: `_check_partial_increment_close_conflict` records empty `PARTIAL_CONFLICT_ISSUES` and empty `PARTIAL_OPEN_BEFORE_MERGE` for the incident-shaped body |
| Pre-merge conflict warning quotes matched text with context | ✅ | `_partial_increment_ref_snippets()` added and wired into all three warning branches; PA2 asserts the warning contains `("Part of #4574")` |
| Regression test: backticked/conditional `Part of #N` + `Closes #N` merges/stays closed; companion genuine line-leading `Part of #N` still triggers the conflict path | ✅ | PA1 / PA2 in `test-merge-pr-partial-increment.sh` |

## Test Plan

Ran the existing regression suite (extended in place, not a new file) with the fix applied:

```
./defaults/scripts/tests/test-merge-pr-partial-increment.sh
```

Result: `89/89 passed, 0 failed` (79 pre-existing + 10 new PA1–PA5 assertions, all passing; no pre-existing case needed changes since every existing `Part of`/`Contributes to` fixture in the suite was already on its own line).

Also verified with `bash -n` and `shellcheck --severity=warning` on both changed files (clean).

Closes #5234