### PR TITLE
fix(worktree-root): fall back loudly when the resolved override root is unreadable

### DIFF
--- a/defaults/scripts/lib/worktree-root.sh
+++ b/defaults/scripts/lib/worktree-root.sh
@@ -59,6 +59,14 @@ _LOOM_WORKTREE_ROOT_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 # shellcheck source=./config-resolver.sh
 source "$_LOOM_WORKTREE_ROOT_LIB_DIR/config-resolver.sh"
 
+# _loom_root_unreadable <dir> — true if the path exists (stat succeeds) but
+# readdir fails (e.g. macOS TCC removable-volumes denial: stat/df keep
+# succeeding while `ls`/readdir returns EPERM). A `-d` check alone cannot
+# detect this state.
+_loom_root_unreadable() {
+    [[ -d "$1" ]] && ! command ls "$1" >/dev/null 2>&1
+}
+
 # loom_worktree_root <repo_root>
 #
 # Echoes the absolute worktree base directory. `repo_root` must be an absolute
@@ -69,7 +77,13 @@ loom_worktree_root() {
     # 1. Env var override — highest priority.
     if [[ -n "${LOOM_WORKTREE_ROOT:-}" ]]; then
         if [[ "$LOOM_WORKTREE_ROOT" == /* ]]; then
-            echo "${LOOM_WORKTREE_ROOT%/}/$(basename "$repo_root")"
+            local env_target="${LOOM_WORKTREE_ROOT%/}/$(basename "$repo_root")"
+            if _loom_root_unreadable "$env_target"; then
+                echo "loom_worktree_root: LOOM_WORKTREE_ROOT target exists but is unreadable (readdir failed, e.g. macOS TCC removable-volumes denial): '$env_target'; falling back to default" >&2
+                echo "$repo_root/.loom/worktrees"
+                return 0
+            fi
+            echo "$env_target"
             return 0
         fi
         echo "loom_worktree_root: LOOM_WORKTREE_ROOT must be an absolute path (got: '$LOOM_WORKTREE_ROOT'); falling back to default" >&2
@@ -84,7 +98,13 @@ loom_worktree_root() {
     cfg_root=$(loom_config_get "$repo_root" "worktree.root" "")
     if [[ -n "$cfg_root" ]]; then
         if [[ "$cfg_root" == /* ]]; then
-            echo "${cfg_root%/}/$(basename "$repo_root")"
+            local cfg_target="${cfg_root%/}/$(basename "$repo_root")"
+            if _loom_root_unreadable "$cfg_target"; then
+                echo "loom_worktree_root: worktree.root target exists but is unreadable (readdir failed, e.g. macOS TCC removable-volumes denial): '$cfg_target'; falling back to default" >&2
+                echo "$repo_root/.loom/worktrees"
+                return 0
+            fi
+            echo "$cfg_target"
             return 0
         fi
         echo "loom_worktree_root: worktree.root in the resolved config must be an absolute path (got: '$cfg_root'); falling back to default" >&2

--- a/defaults/scripts/tests/test-worktree-root-override.sh
+++ b/defaults/scripts/tests/test-worktree-root-override.sh
@@ -22,6 +22,11 @@
 #      worktree root override (locks stay in the main repo).
 #   7. loom_worktree_root() unit behavior: relative override is rejected with a
 #      warning and falls back to the default.
+#   8. loom_worktree_root() unit behavior: a resolved override target that
+#      exists but is unreadable (chmod 000 — stat succeeds, readdir fails,
+#      e.g. macOS TCC removable-volumes EPERM) warns loudly and falls back to
+#      the default, for both the env-var and config-key branches. A
+#      nonexistent target still passes through unchanged (#5237).
 #
 # Pattern follows test-worktree-sentinel.sh / test-worktree-nested-symlinks.sh:
 # throwaway bare origin + repo in a mktemp dir, copy worktree.sh + lib/, run.
@@ -255,6 +260,53 @@ printf '{ "worktree": { "root": "also/relative" } }\n' > "$CFGREPO/.loom/config.
 r=$(loom_worktree_root "$CFGREPO" 2>/dev/null)
 assert_eq "$r" "$CFGREPO/.loom/worktrees" "relative config override falls back to default path"
 rm -rf "$CFGREPO"
+
+# --- Test 8: env-var override target unreadable (readdir EPERM) → falls back ---
+echo ""
+echo "Test 8: env-var override target exists but is unreadable (readdir EPERM) -> falls back"
+unset LOOM_WORKTREE_ROOT
+UNREADABLE_ENV_BASE=$(mktemp -d /tmp/loom-unread-env.XXXXXX)
+UNREADABLE_ENV_REPO_ROOT="/tmp/loom-unread-env-repo/reporoot"
+UNREADABLE_ENV_TARGET="$UNREADABLE_ENV_BASE/$(basename "$UNREADABLE_ENV_REPO_ROOT")"
+mkdir -p "$UNREADABLE_ENV_TARGET"
+chmod 000 "$UNREADABLE_ENV_TARGET"
+r=$(LOOM_WORKTREE_ROOT="$UNREADABLE_ENV_BASE" loom_worktree_root "$UNREADABLE_ENV_REPO_ROOT" 2>/dev/null)
+assert_eq "$r" "$UNREADABLE_ENV_REPO_ROOT/.loom/worktrees" "unreadable env-override target falls back to default path"
+if LOOM_WORKTREE_ROOT="$UNREADABLE_ENV_BASE" loom_worktree_root "$UNREADABLE_ENV_REPO_ROOT" 2>&1 >/dev/null | grep -q "unreadable"; then
+    pass "unreadable env-override target emits a stderr warning"
+else
+    fail "unreadable env-override target did not warn"
+fi
+chmod 755 "$UNREADABLE_ENV_TARGET"
+rm -rf "$UNREADABLE_ENV_BASE"
+
+# Sanity: a NONEXISTENT env-override target still passes through unchanged
+# (callers mkdir -p it later) — the readdir probe must not fire on a target
+# that simply doesn't exist yet.
+NONEXISTENT_ENV_BASE="/tmp/loom-nonexistent-env-base.$$"
+r=$(LOOM_WORKTREE_ROOT="$NONEXISTENT_ENV_BASE" loom_worktree_root "$UNREADABLE_ENV_REPO_ROOT" 2>/dev/null)
+assert_eq "$r" "$NONEXISTENT_ENV_BASE/$(basename "$UNREADABLE_ENV_REPO_ROOT")" "nonexistent env-override target still passes through unchanged"
+
+# --- Test 9: config-key override target unreadable (readdir EPERM) → falls back ---
+echo ""
+echo "Test 9: config-key override target exists but is unreadable (readdir EPERM) -> falls back"
+unset LOOM_WORKTREE_ROOT
+UNREADABLE_CFG_BASE=$(mktemp -d /tmp/loom-unread-cfg.XXXXXX)
+CFGREPO2=$(mktemp -d /tmp/loom-unread-cfgrepo.XXXXXX)
+mkdir -p "$CFGREPO2/.loom"
+printf '{ "worktree": { "root": "%s" } }\n' "$UNREADABLE_CFG_BASE" > "$CFGREPO2/.loom/config.json"
+UNREADABLE_CFG_TARGET="$UNREADABLE_CFG_BASE/$(basename "$CFGREPO2")"
+mkdir -p "$UNREADABLE_CFG_TARGET"
+chmod 000 "$UNREADABLE_CFG_TARGET"
+r=$(loom_worktree_root "$CFGREPO2" 2>/dev/null)
+assert_eq "$r" "$CFGREPO2/.loom/worktrees" "unreadable config-override target falls back to default path"
+if loom_worktree_root "$CFGREPO2" 2>&1 >/dev/null | grep -q "unreadable"; then
+    pass "unreadable config-override target emits a stderr warning"
+else
+    fail "unreadable config-override target did not warn"
+fi
+chmod 755 "$UNREADABLE_CFG_TARGET"
+rm -rf "$UNREADABLE_CFG_BASE" "$CFGREPO2"
 
 # --- Summary ---
 echo ""


### PR DESCRIPTION
## Summary

Adds a readdir-based unreadable-root probe to `loom_worktree_root()` so a
resolved override root that exists but has lost read access (macOS TCC
removable-volumes denial: `stat`/`-d`/`df` keep succeeding while `ls`/readdir
returns EPERM) fails loudly with a stderr warning and falls back to the
default `$repo_root/.loom/worktrees`, instead of handing callers a dead path
that only surfaces as a mid-session failure once something tries to `cd`/write
into it.

## Changes

- `defaults/scripts/lib/worktree-root.sh`: add `_loom_root_unreadable <dir>`
  (`[[ -d "$1" ]] && ! command ls "$1" >/dev/null 2>&1`) and call it on the
  **resolved, repo-namespaced** override path (not the override base dir,
  which false-positives on search-only mode-711 parents) in both the
  `LOOM_WORKTREE_ROOT` env-var branch and the `worktree.root` config-key
  branch, right before each branch's `echo`. On a true result, warn on stderr
  and fall through to the default path. The no-override default branch
  (`$repo_root/.loom/worktrees`) is untouched, and a nonexistent override
  root still passes through unchanged (`_loom_root_unreadable` returns false
  when `-d` fails, matching existing pass-through behavior since callers
  `mkdir -p` the parent later).
- `defaults/scripts/tests/test-worktree-root-override.sh`: add Test 8
  (env-var branch) and Test 9 (config-key branch) exercising a `chmod 000`
  resolved override target, asserting both the fallback path and the stderr
  warning, plus a nonexistent-target sanity check that confirms pass-through
  is unaffected.

Ported from a local divergence (rjwalters/lean-genius PR #43646) discovered
after a lean-genius fleet host lost read access to its external worktree
volume mid-session via a cached TCC denial; this brings the fix upstream into
the lock-stepped `defaults/scripts/lib/worktree-root.sh` (v0.10.6, #3530/#3538)
so the next Loom install bump doesn't silently revert it, and applies the
downstream review refinement of probing only the resolved subdir instead of
the override base dir.

## Acceptance Criteria Verification

- [x] `defaults/scripts/lib/worktree-root.sh` falls back loudly (stderr
      warning) when the resolved override root exists but readdir fails, in
      both env-var and config branches — verified by Test 8/Test 9.
- [x] Nonexistent override roots still pass through unchanged; default branch
      byte-for-byte unchanged — verified by the nonexistent-target sanity
      check in Test 8 and by Test 1/Test 7 (untouched default-branch logic).
- [x] Test coverage via chmod-000 dirs in the helper's test suite — Test 8
      (env-var branch) and Test 9 (config-key branch), run as a non-root user
      (`rwalters`, uid 501) so the permission check is real.

## Test Plan

- [x] `shellcheck defaults/scripts/lib/worktree-root.sh
      defaults/scripts/tests/test-worktree-root-override.sh` — clean.
- [x] `bash defaults/scripts/tests/test-worktree-root-override.sh` — 23/23
      passing (18 pre-existing + 5 new: readdir-unreadable fallback + warning
      for both branches, and one nonexistent-target sanity check).
- [x] `bash defaults/scripts/tests/test-disk-headroom.sh` — 42/42 passing
      (unaffected, sources the same lib file for an unrelated helper).
- [x] Edge case: nonexistent override root still passes through unchanged.
- [x] Edge case: default branch (no override set) byte-for-byte unchanged.

Closes #5237