### PR TITLE
fix(guard): mask check-duplicate.sh positional arguments in the ask-tier scan

### DIFF
--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -2155,6 +2155,114 @@ strip_literal_text() {
     }'
 }
 
+# Mask quoted POSITIONAL arguments (no preceding flag name) to a small
+# allowlist of known non-executing commands/scripts (issue #5235, the
+# ask-tier analog of the #5155/#5160 fix). strip_literal_text() above only
+# recognizes text following a named flag (--body/-m/--title/--notes/
+# --comment); it has no effect on a script whose free-text arguments are
+# purely positional, e.g. `./.loom/scripts/check-duplicate.sh "TITLE"
+# "DESCRIPTION"`. check-duplicate.sh never EXECUTES a positional argument —
+# it only reads it as dedup text — so masking a quoted argument immediately
+# following it (optionally after short flags, e.g.
+# `check-duplicate.sh --include-merged-prs "..."`) can never blind the
+# ASK_PATTERNS scan (or any other COMMAND_ASK_SCAN consumer, e.g.
+# stash-scope:main-checkout / stash-scope:worktree-collision) to a real
+# invocation. Deliberately narrow allowlist, same "deliberately narrow"
+# convention documented above strip_literal_text()'s
+# mask_flag_cat_heredocs(): a command that WRAPS the phrase and then
+# executes it — `sh -c "git stash pop"`, `bash -c '...'`, `eval "..."` — is
+# NOT in this allowlist and stays fully visible to every ASK_PATTERNS entry,
+# exactly as before.
+#
+# DELIBERATELY EXCLUDES grep/egrep/fgrep/rg, unlike guard-loom-workflow.sh's
+# mask_command_positional_args() (#5155/#5160) which this function is
+# otherwise modeled on. In THIS file, COMMAND_ASK_SCAN also feeds the SQL
+# DDL/DML check (SQL_DDL_PATTERN, below) — which, once a command is
+# disqualified from (or has opted out of) the #3687 read-only fast path,
+# intentionally scans a `grep <pattern> <file>` invocation's own quoted
+# positional pattern for a literal DDL phrase like "DROP TABLE" and denies,
+# by design (see the "Fast path security" / "Fast path off" test groups in
+# tests/hooks/test-guard-destructive.sh). Adding grep/rg to this allowlist
+# was tried and directly regressed those tests: masking grep's own quoted
+# argument blinded the full-path SQL-DDL scan to text it is specifically
+# tested to still catch. check-duplicate.sh has no such competing consumer
+# of its raw argument text anywhere in this file, so it stays the only
+# entry. Extend this allowlist only for another read-only positional-arg
+# consumer with NO conflicting raw-text scan elsewhere in this file.
+#
+# This is an intentional NEAR-DUPLICATE of guard-loom-workflow.sh's own
+# mask_command_positional_args() (issue #5155/#5160) — kept as a SEPARATE
+# function in this file, same convention as strip_literal_text() above being
+# a separate copy from that file's strip_literal_text(): the two guards'
+# decision-time masking must never be coupled, so a future fix/tuning of one
+# cannot silently change the other's behavior.
+#
+# Masks EVERY quoted argument that directly, consecutively follows the
+# command+flags (separated only by whitespace) — not just the first — so
+# multi-positional-arg scripts like check-duplicate.sh's `TITLE DESCRIPTION`
+# signature get both arguments masked. Masking stops at the first token that
+# is not a quoted string (a bare filename, `&&`, `|`, etc.), leaving anything
+# after that boundary — including a real ask-triggering invocation chained
+# onto the same line — fully visible.
+mask_ask_positional_args() {
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)
+        DQ = sprintf("%c", 34)
+        # Command-name allowlist: known non-executing commands/scripts whose
+        # positional string arguments are search/dedup text, never live shell
+        # syntax. grep/egrep/fgrep/rg are deliberately NOT here — see the
+        # SQL-DDL conflict documented in the function header comment above.
+        # Extend only when another read-only positional-arg consumer causes a
+        # real false ask AND has no competing raw-text consumer elsewhere in
+        # this file (see #5235, mirroring #5155).
+        cmdre = "(\\./\\.loom/scripts/check-duplicate\\.sh)"
+        # Zero or more short/long flags between the command name and the
+        # first quoted positional argument (e.g.
+        # `check-duplicate.sh --include-merged-prs --issue 5235`).
+        flagre = "([ \t]+-[A-Za-z0-9_-]+)*"
+        anchor = "(^|[ \t\n;&|`(])" cmdre flagre "[ \t]+"
+        buf = ""
+    }
+    { buf = buf (NR > 1 ? "\n" : "") $0 }
+    END {
+        s = buf
+        out = ""
+        while (match(s, anchor)) {
+            pre     = substr(s, 1, RSTART - 1)
+            matched = substr(s, RSTART, RLENGTH)
+            rest    = substr(s, RSTART + RLENGTH)
+            out = out pre matched
+            # Mask every consecutive quoted positional argument immediately
+            # following the anchor (whitespace-separated). Stops at the first
+            # non-quote-starting token, so anything after the argument list
+            # (a pipe, &&, an unrelated command) is left fully visible.
+            while (1) {
+                qc = substr(rest, 1, 1)
+                if (qc != DQ && qc != SQ) break
+                endpos = 0
+                for (i = 2; i <= length(rest); i++) {
+                    if (substr(rest, i, 1) == qc) { endpos = i; break }
+                }
+                if (endpos == 0) break
+                inner = substr(rest, 2, endpos - 2)
+                if (index(inner, "$(") == 0 && index(inner, "`") == 0) {
+                    gsub(/./, "X", inner)
+                }
+                out = out qc inner qc
+                rest = substr(rest, endpos + 1)
+                while (substr(rest, 1, 1) == " " || substr(rest, 1, 1) == "\t") {
+                    out = out substr(rest, 1, 1)
+                    rest = substr(rest, 2)
+                }
+            }
+            s = rest
+        }
+        out = out s
+        printf "%s", out
+    }'
+}
+
 # Helper: output a deny decision and exit
 #
 # Optional second arg is a short, STABLE rule tag (issue #3771) recorded as the
@@ -2557,12 +2665,30 @@ fi
 # false-asks. The strip only runs when a text-carrying flag is present, keeping
 # it off the hot path. Never feeds the catastrophic scan (that keeps reading the
 # raw command), so this can only NARROW an ask, never miss a hard deny.
-# =============================================================================
+#
+# POSITIONAL-ARGUMENT MASKING (#5235): strip_literal_text() above is keyed
+# ONLY on named-flag presence, so a script with a purely POSITIONAL
+# signature — e.g. `./.loom/scripts/check-duplicate.sh TITLE DESCRIPTION`
+# (no flags at all) — never triggered it, leaving its free-text TITLE/
+# DESCRIPTION arguments scanned unmasked. This is the same class of gap
+# #5155/#5160 already fixed for guard-loom-workflow.sh's gh-pr-merge-redirect
+# scan. mask_ask_positional_args() (defined above, a deliberate near-
+# duplicate of that fix, with a narrower allowlist — see its header comment
+# for why grep/rg are deliberately excluded here) masks quoted positional
+# arguments to check-duplicate.sh BEFORE the flag-keyed strip above runs, so
+# a dedup check whose prose quotes an ask-phrase (e.g. "git stash pop") as
+# inert text no longer false-asks on stash-scope:main-checkout,
+# force-op:protected, or any other ASK_PATTERNS entry. Gated on the same
+# command-name substring the awk allowlist matches, keeping it off the hot
+# path for the vast majority of commands that never invoke it.
 COMMAND_ASK_SCAN="$COMMAND_NO_COMMENT"
+if [[ "$COMMAND_NO_COMMENT" == *"check-duplicate.sh"* ]]; then
+    COMMAND_ASK_SCAN=$(mask_ask_positional_args "$COMMAND_ASK_SCAN")
+fi
 if [[ "$COMMAND_NO_COMMENT" == *"--body"* || "$COMMAND_NO_COMMENT" == *"--message"* || \
       "$COMMAND_NO_COMMENT" == *"--title"* || "$COMMAND_NO_COMMENT" == *"--notes"* || \
       "$COMMAND_NO_COMMENT" == *"--comment"* || "$COMMAND_NO_COMMENT" == *"-m"* ]]; then
-    COMMAND_ASK_SCAN=$(strip_literal_text "$COMMAND_NO_COMMENT")
+    COMMAND_ASK_SCAN=$(strip_literal_text "$COMMAND_ASK_SCAN")
 fi
 
 # =============================================================================

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -3681,6 +3681,52 @@ assert_ask_env "stash-scope: LOOM_GUARD_STASH_SCOPE=1 overrides config-off -> as
 assert_allow "stash-scope: git status alone still allowed (read-only fast path unaffected)" \
     "git status" "$ST_REPO"
 
+# --- Ask-tier positional-argument masking false-positive regressions (#5235) ----
+#
+# COMMAND_ASK_SCAN (which every ASK_PATTERNS entry, including
+# stash-scope:main-checkout, matches against) used to have NO positional-
+# argument masking at all -- strip_literal_text() is keyed only on a fixed
+# set of named flags (--body/-m/--title/--notes/--comment), so a script with
+# a purely POSITIONAL signature (no flags) never triggered it. This is the
+# same class of bug #5155/#5160 already fixed for guard-loom-workflow.sh's
+# gh-pr-merge-redirect scan; mask_ask_positional_args() (issue #5235) closes
+# the analogous gap here for check-duplicate.sh. Reuses ST_REPO (main
+# checkout cwd) so `git stash pop/drop/clear` quoted as inert prose
+# exercises the real stash-scope:main-checkout ask this bug used to
+# false-trigger.
+
+assert_allow "ask-tier (#5235): check-duplicate.sh positional TITLE/DESCRIPTION quoting 'git stash pop' as inert prose no longer asks" \
+    './.loom/scripts/check-duplicate.sh "Guard false positive: stash-scope redirect" "quotes git stash pop as inert text, not a live invocation"' "$ST_REPO"
+
+# Deliberate scope decision (see mask_ask_positional_args()'s header comment
+# in guard-destructive-generic.sh): grep/rg are NOT in this ask-tier
+# allowlist, unlike guard-loom-workflow.sh's #5155/#5160 fix -- COMMAND_ASK_SCAN
+# also feeds the SQL DDL/DML check, which intentionally still scans a grep
+# invocation's own quoted search pattern for a literal DDL phrase once off
+# the read-only fast path (see the "Fast path security"/"Fast path off" test
+# groups above). Piped to `cat` (same disqualifier the SQL-DDL fast-path
+# tests above use) so this actually reaches the ask-tier scan instead of
+# short-circuiting via the #3687 read-only fast path. So a grep search
+# quoting the ask-phrase as prose still asks here -- this is the documented,
+# deliberately narrower scope, not a miss.
+assert_ask "ask-tier (#5235): grep -n search whose pattern quotes 'git stash pop' mid-sentence still asks (grep deliberately not allowlisted, see SQL-DDL conflict)" \
+    'grep -n "this example mentions git stash pop mid-sentence" defaults/hooks/guard-destructive-generic.sh | cat' "$ST_REPO"
+
+# Regression guard: masking a matched positional span must not blind the
+# ask-tier scan to a SECOND, REAL invocation elsewhere on the same command
+# line -- masking only narrows what THIS check misses inside the matched
+# check-duplicate.sh argument, it never widens what it misses outside that
+# span.
+assert_ask_reason_matches "ask-tier (#5235): still asks on a REAL git stash pop chained after a masked check-duplicate.sh call" \
+    './.loom/scripts/check-duplicate.sh "title" "this example mentions git stash pop mid-sentence" && git stash pop' \
+    "MAIN checkout" "$ST_REPO"
+
+# Regression guard: a command NOT in the positional-arg allowlist (echo) must
+# leave the phrase fully visible -- the allowlist narrows, it never widens.
+assert_ask_reason_matches "ask-tier (#5235): still asks when phrase is quoted in an echo argument (echo not allowlisted)" \
+    'echo "this example mentions git stash pop mid-sentence" | bash' \
+    "MAIN checkout" "$ST_REPO"
+
 rm -rf "$ST_REPO" "$ST_REPO_OFF"
 
 echo ""


### PR DESCRIPTION
## Summary

`guard-destructive-generic.sh` builds `COMMAND_ASK_SCAN` — the working copy
every `ASK_PATTERNS` entry (including `stash-scope:main-checkout`,
`stash-scope:worktree-collision`, `force-op:protected`, `sql-ddl`, and
others) matches against — by redacting quoted text, but only when a named
text-carrying flag (`--body`, `-m`, `--title`, `--notes`, `--comment`) is
present in the command. Scripts with a purely **positional** signature, e.g.
`./.loom/scripts/check-duplicate.sh TITLE DESCRIPTION` (no flags at all),
never triggered that redaction, so their free-text positional arguments were
scanned unmasked — causing a false ask when the prose happened to quote a
trigger phrase like "git stash pop" as inert text (e.g. filing a bug report
*about* this very guard, or running a dedup check whose description quotes
the trigger phrase).

This is the same class of bug #5155/#5160 already fixed for
`guard-loom-workflow.sh`'s `gh-pr-merge-redirect` scan — but that fix never
covered `guard-destructive-generic.sh`'s independent ask-tier copy.

## Changes

- Added `mask_ask_positional_args()` to `defaults/hooks/guard-destructive-generic.sh`
  — a near-duplicate of `guard-loom-workflow.sh`'s `mask_command_positional_args()`
  (#5155/#5160), masking quoted positional arguments that directly follow a
  small command-name allowlist.
- Wired it into the `COMMAND_ASK_SCAN` construction, running before the
  existing flag-keyed `strip_literal_text()` pass.
- **Scope decision**: the allowlist contains only `check-duplicate.sh`, not
  `grep`/`egrep`/`fgrep`/`rg` as the issue's recommended fix suggested.
  `COMMAND_ASK_SCAN` also feeds the SQL DDL/DML check (`SQL_DDL_PATTERN`),
  which intentionally still scans a `grep <pattern> <file>` invocation's own
  quoted search pattern for a literal SQL table-drop/schema-drop/truncate
  phrase once the command is off the read-only fast path — by design, per
  the existing "Fast path security" / "Fast path off" test groups. Adding
  grep/rg to the allowlist directly regressed 5 of those tests locally;
  `check-duplicate.sh` has no such competing raw-text consumer anywhere in
  the file, so it stays the only entry. This is documented in the new
  function's header comment, with guidance to extend the allowlist only for
  a consumer with no conflicting raw-text scan elsewhere in the file.
- The installed `.loom/hooks/guard-destructive-generic.sh` copy is
  intentionally left untouched — per repo convention, propagating `defaults/`
  edits into the installed copies is the periodic `chore: resync installed
  Loom surfaces` commit's job, done from the main checkout after this PR
  merges.
- Extended `tests/hooks/test-guard-destructive.sh` with 4 new cases: the
  `check-duplicate.sh` false-positive repro (now allows), a `grep` case
  proving the deliberate scope decision (still asks, piped through `cat` to
  disqualify the read-only fast path), a "masking doesn't widen" regression
  (a real `git stash pop` chained after a masked `check-duplicate.sh` call
  still asks), and an "allowlist doesn't overreach" regression (`echo`,
  not allowlisted, still asks).

## Acceptance Criteria Verification

- [x] Ask-tier scan now masks `check-duplicate.sh`'s positional TITLE/DESCRIPTION
  arguments before matching against `ASK_PATTERNS` — verified via new test
  `ask-tier (#5235): check-duplicate.sh positional TITLE/DESCRIPTION quoting
  'git stash pop' as inert prose no longer asks`.
- [x] Masking narrows only — never widens: a real invocation chained after a
  masked argument, and a non-allowlisted command wrapping the same phrase,
  both still ask (verified by 2 new regression tests).
- [x] No regression to any existing catastrophic/ask-tier behavior, including
  the SQL-DDL fast-path-disqualified tests that motivated excluding
  `grep`/`rg` from the allowlist.
- [x] Installed `.loom/hooks/` copy left untouched (propagated by the
  periodic resync commit, not this PR).

## Test Plan

```
$ bash tests/hooks/test-guard-destructive.sh
...
=========================================
  Total:  750
  Passed: 750
  Failed: 0
=========================================
ALL TESTS PASSED
```

Also confirmed:
- `bash -n defaults/hooks/guard-destructive-generic.sh` — syntax OK
- `shellcheck -x defaults/hooks/guard-destructive-generic.sh` — no new
  warnings (5 pre-existing informational `SC2016`/`SC1003` notes, all
  outside the diff)
- `git diff --stat` scoped to exactly the two files above; no unrelated
  changes; `check-main-clean.sh` confirms the main checkout is untouched.

Closes #5235
