### PR TITLE
fix(guard): count synchronous Agent/Task dispatches as completed in stop backstop

### DIFF
--- a/.loom/hooks/guard-background-subagents.sh
+++ b/.loom/hooks/guard-background-subagents.sh
@@ -248,17 +248,41 @@ def stopped_task_ids:
 #      </status>` or `<status>failed</status>` in the result text — NOT
 #      `<status>running</status>`, which is still pending) of the `agentId`
 #      recovered from the launch ack text (`agentId: <ID>`).
+#   c. Structural short-circuit (issue #5243): a dispatch with
+#      `input.run_in_background == false` is SYNCHRONOUS — the harness cannot
+#      advance the assistant's turn (let alone reach a Stop event) past a
+#      blocking tool_use until its result has actually landed, so that dispatch's
+#      FIRST and only `tool_result` is always the real, final result, never a
+#      launch ack (no separate async launch ack is structurally possible for a
+#      blocking call). For these ids ANY tool_result resolves the dispatch — the
+#      launch-ack text exclusion in (a) is skipped entirely, so a sync completion
+#      whose text incidentally contains the "Async agent launched successfully"
+#      boilerplate (e.g. shared harness ack wording) still resolves. This mirrors
+#      the `.name=="Bash" and (.input.run_in_background == true)` structural
+#      filter used by the background-Bash detector below. Only an EXPLICIT
+#      `== false` triggers this; an absent field stays on the (a)/(b) path (a
+#      plain Task with no field is already resolved by its ordinary tool_result
+#      via (a), so back-compat is unchanged).
 #
-# Deliberately does NOT treat the launch ack itself as resolution (that is the
-# exact #4389 hazard recurring on this tool) — only (a) or (b) counts. A
-# genuinely orphaned Agent dispatch (no later distinct tool_result, no terminal
-# TaskOutput poll) still blocks, the true positive this detector exists for.
+# Deliberately does NOT treat an ASYNC dispatch's launch ack as resolution (that
+# is the exact #4389 hazard recurring on this tool) — for async ids only (a) or
+# (b) counts. A genuinely orphaned async Agent dispatch (no later distinct
+# tool_result, no terminal TaskOutput poll) still blocks, the true positive this
+# detector exists for.
 UNRESOLVED_TASK_IDS=$(jq -s -r "$JQ_PRELUDE"'
   . as $t
   | (results) as $r
   | [ $t[]? | select(.type=="assistant") | .message.content[]?
       | select(.type=="tool_use" and (.name=="Task" or .name=="Agent"))
       | .id ] as $task_ids
+  # Synchronous (blocking) Task/Agent dispatch ids (issue #5243): an EXPLICIT
+  # run_in_background == false makes the call block, so its first tool_result is
+  # always the real completion — never a launch ack. Any tool_result on these
+  # ids resolves the dispatch (launch-ack text exclusion skipped for them).
+  | [ $t[]? | select(.type=="assistant") | .message.content[]?
+      | select(.type=="tool_use" and (.name=="Task" or .name=="Agent"))
+      | select(.input.run_in_background == false)
+      | .id ] as $sync_task_ids
   # TaskOutput polls: the poll tool_use id, and the agentId/task ref it names.
   | ( [ $t[]? | select(.type=="assistant") | .message.content[]?
         | select(.type=="tool_use" and .name=="TaskOutput")
@@ -289,6 +313,7 @@ UNRESOLVED_TASK_IDS=$(jq -s -r "$JQ_PRELUDE"'
             | ((.text | capture("agentId: (?<v>[A-Za-z0-9_-]+)")?).v) // empty ]
         ) as $agent_ids
       | if ($id_results | length) == 0 then $id
+        elif (($sync_task_ids | index($id)) != null) then empty
         elif ($real_completions | length) > 0 then empty
         elif ( [ $agent_ids[] | select(($polled_ok_refs | index(.)) != null) ]
                | length ) > 0 then empty

--- a/defaults/hooks/guard-background-subagents.sh
+++ b/defaults/hooks/guard-background-subagents.sh
@@ -248,17 +248,41 @@ def stopped_task_ids:
 #      </status>` or `<status>failed</status>` in the result text — NOT
 #      `<status>running</status>`, which is still pending) of the `agentId`
 #      recovered from the launch ack text (`agentId: <ID>`).
+#   c. Structural short-circuit (issue #5243): a dispatch with
+#      `input.run_in_background == false` is SYNCHRONOUS — the harness cannot
+#      advance the assistant's turn (let alone reach a Stop event) past a
+#      blocking tool_use until its result has actually landed, so that dispatch's
+#      FIRST and only `tool_result` is always the real, final result, never a
+#      launch ack (no separate async launch ack is structurally possible for a
+#      blocking call). For these ids ANY tool_result resolves the dispatch — the
+#      launch-ack text exclusion in (a) is skipped entirely, so a sync completion
+#      whose text incidentally contains the "Async agent launched successfully"
+#      boilerplate (e.g. shared harness ack wording) still resolves. This mirrors
+#      the `.name=="Bash" and (.input.run_in_background == true)` structural
+#      filter used by the background-Bash detector below. Only an EXPLICIT
+#      `== false` triggers this; an absent field stays on the (a)/(b) path (a
+#      plain Task with no field is already resolved by its ordinary tool_result
+#      via (a), so back-compat is unchanged).
 #
-# Deliberately does NOT treat the launch ack itself as resolution (that is the
-# exact #4389 hazard recurring on this tool) — only (a) or (b) counts. A
-# genuinely orphaned Agent dispatch (no later distinct tool_result, no terminal
-# TaskOutput poll) still blocks, the true positive this detector exists for.
+# Deliberately does NOT treat an ASYNC dispatch's launch ack as resolution (that
+# is the exact #4389 hazard recurring on this tool) — for async ids only (a) or
+# (b) counts. A genuinely orphaned async Agent dispatch (no later distinct
+# tool_result, no terminal TaskOutput poll) still blocks, the true positive this
+# detector exists for.
 UNRESOLVED_TASK_IDS=$(jq -s -r "$JQ_PRELUDE"'
   . as $t
   | (results) as $r
   | [ $t[]? | select(.type=="assistant") | .message.content[]?
       | select(.type=="tool_use" and (.name=="Task" or .name=="Agent"))
       | .id ] as $task_ids
+  # Synchronous (blocking) Task/Agent dispatch ids (issue #5243): an EXPLICIT
+  # run_in_background == false makes the call block, so its first tool_result is
+  # always the real completion — never a launch ack. Any tool_result on these
+  # ids resolves the dispatch (launch-ack text exclusion skipped for them).
+  | [ $t[]? | select(.type=="assistant") | .message.content[]?
+      | select(.type=="tool_use" and (.name=="Task" or .name=="Agent"))
+      | select(.input.run_in_background == false)
+      | .id ] as $sync_task_ids
   # TaskOutput polls: the poll tool_use id, and the agentId/task ref it names.
   | ( [ $t[]? | select(.type=="assistant") | .message.content[]?
         | select(.type=="tool_use" and .name=="TaskOutput")
@@ -289,6 +313,7 @@ UNRESOLVED_TASK_IDS=$(jq -s -r "$JQ_PRELUDE"'
             | ((.text | capture("agentId: (?<v>[A-Za-z0-9_-]+)")?).v) // empty ]
         ) as $agent_ids
       | if ($id_results | length) == 0 then $id
+        elif (($sync_task_ids | index($id)) != null) then empty
         elif ($real_completions | length) > 0 then empty
         elif ( [ $agent_ids[] | select(($polled_ok_refs | index(.)) != null) ]
                | length ) > 0 then empty

--- a/defaults/hooks/tests/test-guard-background-subagents.sh
+++ b/defaults/hooks/tests/test-guard-background-subagents.sh
@@ -43,6 +43,13 @@
 #     tool_result on the same id, or a non-error TERMINAL TaskOutput poll of
 #     the recovered agentId, resolves it; a <status>running</status> poll does
 #     NOT; existing Task-named fixtures continue to pass unmodified
+#   - synchronous Agent/Task dispatch resolution (#5243): a
+#     `run_in_background: false` dispatch blocks the turn, so its first and only
+#     tool_result is the real final result -- any tool_result on the id resolves
+#     it, even when the text incidentally carries "Async agent launched
+#     successfully" boilerplate; an ASYNC dispatch with only its launch ack still
+#     blocks (the short-circuit must not leak to async ids); a mixed sync/async
+#     transcript with all dispatches completed allows the stop on the first try
 #   - jq absent -> allow (fail-open)
 #   - contract: block output is valid JSON with decision=="block" and a
 #     non-empty reason; exit code is always 0
@@ -115,6 +122,32 @@ AGENT5086_ACK_POLLED='{"type":"user","message":{"role":"user","content":[{"type"
 AGENT5086_POLL_USE='{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_poll03","name":"TaskOutput","input":{"agentId":"aagent03","block":true,"timeout":600}}]}}'
 AGENT5086_POLL_RESULT_TERMINAL='{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_poll03","content":"<retrieval_status>success</retrieval_status>\n<status>completed</status>\nWork complete: opened PR #5556 for issue #3."}]}}'
 AGENT5086_POLL_RESULT_RUNNING='{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_poll03","content":"<retrieval_status>timeout</retrieval_status>\n<status>running</status>\nStill working..."}]}}'
+
+# --- synchronous Agent/Task dispatch fixtures (issue #5243) -------------------
+# A `run_in_background: false` dispatch is a STRUCTURAL guarantee: the harness
+# cannot advance the turn (or reach a Stop) past a blocking tool_use until its
+# result has landed, so the dispatch's first and only tool_result is always the
+# real, final result — never a launch ack. Any tool_result on the id resolves it.
+
+# (s5243) sync Agent whose only tool_result is the inline final result — no
+# separate launch ack — resolves.
+AGENT5243_SYNC_USE='{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_sync01","name":"Agent","input":{"prompt":"do the thing","run_in_background":false}}]}}'
+AGENT5243_SYNC_RESULT='{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_sync01","content":"Work complete: opened PR #6001 for issue #10."}]}}'
+
+# (s5243 edge) sync dispatch whose inline result text INCIDENTALLY contains the
+# "Async agent launched successfully" boilerplate (e.g. shared harness ack
+# wording) — must STILL resolve, because the launch-ack text exclusion is skipped
+# for sync ids. This is the exact false-positive #5243 was filed for.
+AGENT5243_SYNC_ACKTEXT_USE='{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_sync02","name":"Agent","input":{"prompt":"do the other thing","run_in_background":false}}]}}'
+AGENT5243_SYNC_ACKTEXT_RESULT='{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_sync02","content":"Async agent launched successfully. agentId: async99. Work complete: PR #6002 opened."}]}}'
+
+# (s5243 contrast) an ASYNC dispatch (run_in_background:true) with ONLY its launch
+# ack must STILL block — the sync short-circuit must NOT leak to async ids.
+AGENT5243_ASYNC_USE='{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_async01","name":"Agent","input":{"prompt":"async work","run_in_background":true}}]}}'
+AGENT5243_ASYNC_ACK='{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_async01","content":"Async agent launched successfully. agentId: async01. You will be notified automatically when it completes."}]}}'
+# Sync Task (back-compat tool name) with run_in_background:false and inline result.
+TASK5243_SYNC_USE='{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_sync03","name":"Task","input":{"subagent_type":"loom-builder","run_in_background":false}}]}}'
+TASK5243_SYNC_RESULT='{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_sync03","content":"Subagent completed: opened PR #6003."}]}}'
 
 # Background Bash (issue #4389 — the #4257 recurrence via run_in_background)
 # fixtures. A background dispatch gets an IMMEDIATE tool_result ack (NOT
@@ -364,6 +397,70 @@ result=$(run_hook "$T1" false)
 assert_block "(d5086) back-compat: unresolved Task-named dispatch -> still block" "$result"
 result=$(run_hook "$T2" false)
 assert_allow "(d5086) back-compat: resolved Task-named dispatch -> still allow" "$result"
+
+# --- synchronous Agent/Task dispatch resolution (issue #5243) ----------------
+# A `run_in_background: false` dispatch blocks the turn, so its first and only
+# tool_result is the real final result — never a launch ack. Any tool_result on
+# the id resolves it, even when the text incidentally carries ack boilerplate.
+
+# (s5243a) sync Agent whose only tool_result is the inline final result -> allow.
+T5243a="$TMPROOT/transcript-agent-sync.jsonl"
+write_transcript "$T5243a" "$AGENT5243_SYNC_USE" "$AGENT5243_SYNC_RESULT"
+result=$(run_hook "$T5243a" false)
+assert_allow "(s5243a) sync Agent (run_in_background:false) + inline result -> allow" "$result"
+
+# (s5243b) sync Agent whose inline result text incidentally contains the
+# "Async agent launched successfully" boilerplate -> STILL allow (the exact
+# false positive #5243 was filed for; the launch-ack exclusion is skipped here).
+T5243b="$TMPROOT/transcript-agent-sync-acktext.jsonl"
+write_transcript "$T5243b" "$AGENT5243_SYNC_ACKTEXT_USE" "$AGENT5243_SYNC_ACKTEXT_RESULT"
+result=$(run_hook "$T5243b" false)
+assert_allow "(s5243b) sync Agent whose result text contains ack boilerplate -> allow" "$result"
+
+# (s5243c) sync Task (back-compat tool name) with run_in_background:false -> allow.
+T5243c="$TMPROOT/transcript-task-sync.jsonl"
+write_transcript "$T5243c" "$TASK5243_SYNC_USE" "$TASK5243_SYNC_RESULT"
+result=$(run_hook "$T5243c" false)
+assert_allow "(s5243c) sync Task (run_in_background:false) + inline result -> allow" "$result"
+
+# (s5243d) true-positive retained: an ASYNC dispatch (run_in_background:true) with
+# ONLY its launch ack must STILL block. The sync short-circuit must not leak to
+# async ids.
+T5243d="$TMPROOT/transcript-agent-async-ack-only.jsonl"
+write_transcript "$T5243d" "$AGENT5243_ASYNC_USE" "$AGENT5243_ASYNC_ACK"
+result=$(run_hook "$T5243d" false)
+assert_block "(s5243d) async Agent (run_in_background:true) with only launch ack -> block" "$result"
+
+# (s5243e) acceptance-criterion regression fixture: mixed sync + async dispatches,
+# ALL completed -> guard allows the stop on the first try. One sync Agent (inline
+# result), one sync Task (inline result), one async Agent resolved by a later
+# distinct completion tool_result, and one async Agent resolved via a blocking
+# TaskOutput poll.
+T5243e="$TMPROOT/transcript-mixed-sync-async-all-done.jsonl"
+write_transcript "$T5243e" \
+    "$AGENT5243_SYNC_USE" "$AGENT5243_SYNC_RESULT" \
+    "$TASK5243_SYNC_USE" "$TASK5243_SYNC_RESULT" \
+    "$AGENT5086_USE_COMPLETED" "$AGENT5086_ACK_COMPLETED" "$AGENT5086_RESULT_COMPLETED" \
+    "$AGENT5086_USE_POLLED" "$AGENT5086_ACK_POLLED" "$AGENT5086_POLL_USE" "$AGENT5086_POLL_RESULT_TERMINAL"
+result=$(run_hook "$T5243e" false)
+assert_allow "(s5243e) mixed sync/async dispatches all completed -> allow first try" "$result"
+
+# (s5243f) mixed transcript with one genuinely-orphaned async dispatch amid the
+# resolved sync/async work -> STILL block exactly ONE Task/Agent (no under-count
+# from the sync short-circuit, no over-count of the resolved ones).
+T5243f="$TMPROOT/transcript-mixed-one-orphan.jsonl"
+write_transcript "$T5243f" \
+    "$AGENT5243_SYNC_USE" "$AGENT5243_SYNC_RESULT" \
+    "$TASK5243_SYNC_USE" "$TASK5243_SYNC_RESULT" \
+    "$AGENT5243_ASYNC_USE" "$AGENT5243_ASYNC_ACK"
+raw_5243f=$(run_hook "$T5243f" false)
+assert_block "(s5243f) mixed sync-done + one orphaned async -> block" "$raw_5243f"
+reason_5243f=$(echo "${raw_5243f#*|}" | jq -r '.reason // empty' 2>/dev/null || true)
+if [[ "$reason_5243f" == *"1 dispatched Task/Agent"* ]]; then
+    pass "(s5243g) mixed transcript counts exactly 1 orphaned Task/Agent"
+else
+    fail "(s5243g) mixed transcript counts exactly 1 orphaned Task/Agent (got: $reason_5243f)"
+fi
 
 # --- background Bash (run_in_background) detection (issue #4389) -----------
 


### PR DESCRIPTION
## Summary

`guard-background-subagents.sh` (Stop-hook backstop) false-positived on synchronous (`run_in_background: false`) Agent/Task dispatches. Its `UNRESOLVED_TASK_IDS` detector treated a sync dispatch's inline `tool_result` the same as an async dispatch's launch ack — requiring a second, *distinct* completion whose text does **not** match `"Async agent launched successfully"`. So a sync dispatch whose result text incidentally carried that boilerplate re-blocked the stop, burning an extra model turn per sweep in headless `claude -p` mode (the reported scenario in rjwalters/lean-genius).

## Root cause & fix

A `run_in_background: false` dispatch is a **structural** guarantee, not a heuristic one: the harness cannot advance the assistant's turn — let alone reach a `Stop` event — past a blocking `tool_use` until its result has actually landed. So that dispatch's first and only `tool_result` is *always* the real, final result, never a launch ack.

The fix special-cases `.input.run_in_background == false` in the per-id resolution branch: for those ids **any** `tool_result` resolves the dispatch, skipping the launch-ack text exclusion entirely. Only an explicit `== false` triggers this — an absent field stays on the existing branch-(a)/(b) path (a plain `Task` with no field is already resolved by its ordinary `tool_result`), so back-compat is unchanged. This mirrors the `.name=="Bash" and (.input.run_in_background == true)` structural filter already used one detector down for background Bash.

The fix is **structural, not text-shape-dependent**: it resolves sync ids without inspecting the result text at all, so it holds regardless of the exact harness wording a sync completion produces. (The curator note asked to verify the live `tool_result` shape; because the fix deliberately never reads that text for sync ids, the specific shape is not load-bearing — the edge-case fixture `s5243b` exercises the worst case where the sync result text *does* contain the async boilerplate.)

## Scope

Only the first and fourth acceptance criteria were confirmed/root-caused (sync dispatches count as completed; mixed sync/async regression fixture). The second and third (TaskStop'd background tasks; SendMessage-resume dedup) were unverified speculation carried from the original report — TaskStop'd background Bash is already covered by the existing `(t)` fixture, and no distinct SendMessage-resume gap was reproducible, so neither is addressed here per the curator's guidance not to treat them as verified requirements.

## Tests

Added to `defaults/hooks/tests/test-guard-background-subagents.sh`:
- `s5243a` sync Agent + inline result -> allow
- `s5243b` sync result text contains ack boilerplate -> allow (the exact false positive)
- `s5243c` sync Task (back-compat tool name) -> allow
- `s5243d` async dispatch with only its launch ack -> **still block** (short-circuit must not leak to async ids)
- `s5243e` mixed sync/async, all completed -> allow first try (acceptance criterion 4)
- `s5243f`/`s5243g` mixed with one orphaned async -> block exactly one

All 61 cases pass (`./defaults/hooks/tests/test-guard-background-subagents.sh`); existing #5086 / #4389 / #4696 / #5013 fixtures unchanged.

## Files
- `defaults/hooks/guard-background-subagents.sh` — canonical source
- `.loom/hooks/guard-background-subagents.sh` — installed copy, kept byte-identical
- `defaults/hooks/tests/test-guard-background-subagents.sh` — regression fixtures

Closes #5243

🤖 Generated with [Claude Code](https://claude.com/claude-code)