### PR TITLE
fix(tests): neutralize PATH resolution in safehoused-service missing-binary test

### DIFF
--- a/defaults/scripts/tests/test-safehoused-service.sh
+++ b/defaults/scripts/tests/test-safehoused-service.sh
@@ -140,7 +140,7 @@ assert_contains "$unit_u" "ExecStart=$FAKE_BIN" "--unit is accepted and the unit
 # ============================================================================
 # placeholder fallback when no binary is found (still exits 0, valid preview)
 # ============================================================================
-ph_out="$(env -u SAFEHOUSED_BIN bash "$SVC_SCRIPT" --print-unit 2>/dev/null; echo "rc=$?")"
+ph_out="$(env -u SAFEHOUSED_BIN PATH="$(mktemp -d)" "$BASH" "$SVC_SCRIPT" --print-unit 2>/dev/null; echo "rc=$?")"
 assert_contains "$ph_out" "ExecStart=/path/to/safehoused" "missing-binary preview falls back to a placeholder ExecStart"
 assert_contains "$ph_out" "rc=0" "missing-binary preview still exits 0 (no side effects)"
 

--- a/defaults/scripts/tests/test-safehoused-service.sh
+++ b/defaults/scripts/tests/test-safehoused-service.sh
@@ -140,7 +140,7 @@ assert_contains "$unit_u" "ExecStart=$FAKE_BIN" "--unit is accepted and the unit
 # ============================================================================
 # placeholder fallback when no binary is found (still exits 0, valid preview)
 # ============================================================================
-ph_out="$(env -u SAFEHOUSED_BIN PATH="$(mktemp -d)" "$BASH" "$SVC_SCRIPT" --print-unit 2>/dev/null; echo "rc=$?")"
+ph_out="$(env -u SAFEHOUSED_BIN HOME="$(mktemp -d)" PATH="$(mktemp -d)" "$BASH" "$SVC_SCRIPT" --print-unit 2>/dev/null; echo "rc=$?")"
 assert_contains "$ph_out" "ExecStart=/path/to/safehoused" "missing-binary preview falls back to a placeholder ExecStart"
 assert_contains "$ph_out" "rc=0" "missing-binary preview still exits 0 (no side effects)"
 


### PR DESCRIPTION
## Summary

`test-safehoused-service.sh`'s "missing-binary preview falls back to a
placeholder ExecStart" test case only unset `SAFEHOUSED_BIN` before invoking
`safehoused-service.sh --print-unit`, but the script's binary-resolution
order (`locate_safehoused_bin()`) is a 3-step fallback chain:
`SAFEHOUSED_BIN` env -> `command -v safehoused` on `PATH` ->
`~/.cargo/bin/safehoused`. On any host where a real `safehoused` binary is
already resolvable via `PATH` (e.g. a fleet-provisioned host with it
installed at `~/.local/bin/safehoused`) or at `~/.cargo/bin/safehoused`, the
test failed because the script rendered a real `ExecStart=<resolved path>`
instead of the expected placeholder `ExecStart=/path/to/safehoused`. Same
class of non-hermetic-test bug as #4881/#5157.

## Changes

- In the `ph_out=...` invocation (`defaults/scripts/tests/test-safehoused-service.sh`),
  also set `PATH` and `HOME` to freshly created, separate empty scratch
  directories (`mktemp -d` each) for the duration of that one subshell, so
  neither `command -v safehoused` (PATH) nor `~/.cargo/bin/safehoused` (HOME)
  can resolve anything regardless of what's actually installed on the host
  running the test. Two independent scratch dirs are used since `HOME` and a
  `PATH` entry serve unrelated purposes.
- Invoke the interpreter via `"$BASH"` (bash's own absolute path, set by bash
  itself) instead of the bare `bash` command name — `env`'s `PATH` override
  also governs `env`'s own lookup of the command it execs, so overriding
  `PATH` while still saying plain `bash` would make `env` itself fail to find
  the `bash` binary (rc=127). Using `$BASH` sidesteps that by never doing a
  PATH-based lookup for the interpreter itself.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Fix neutralizes `command -v safehoused` PATH resolution for the missing-binary test | done | `PATH="$(mktemp -d)"` on the one invocation |
| Fix neutralizes `~/.cargo/bin/safehoused` HOME resolution for the missing-binary test | done | separate `HOME="$(mktemp -d)"` on the same invocation |
| `bash defaults/scripts/tests/test-safehoused-service.sh` passes all tests | done | `Tests run: 25, passed: 25, failed: 0` |
| Fix restores hermeticity against ambient PATH state (not just passes on this host by luck) | done | Created a dummy executable named `safehoused` in a scratch temp dir, prepended it to `PATH`, re-ran the full suite: still `Tests run: 25, passed: 25, failed: 0`. Scratch dir removed afterward. |
| No other test case in the file modified | done | single-line diff, scoped to the one invocation |

## Test Plan

```
$ bash defaults/scripts/tests/test-safehoused-service.sh
...
Tests run: 25, passed: 25, failed: 0
```

Also verified with a hostile `PATH` (dummy `safehoused` executable
prepended) to confirm the fix actually restores hermeticity against the
regression the issue reports — same result, 25/25 passed, then the scratch
dummy binary was removed.

Closes #5248