### PR TITLE
fix(gitignore): stop stripping a pre-existing .loom/config.json ignore rule

### DIFF
--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -359,10 +359,28 @@ pub fn update_gitignore(workspace_path: &Path) -> Result<(), String> {
     // exactly, so line-vector edits are byte-preserving for untouched regions.
     let mut lines: Vec<String> = contents.split('\n').map(str::to_string).collect();
 
-    // Remove legacy over-broad patterns that block config.json from being
-    // tracked (older installs and /imagine used `.loom/*.json`), plus the
-    // negation that was paired with that glob.
-    let legacy_overbroad = [".loom/*.json", ".loom/config.json", "!.loom/roles/*.json"];
+    // Remove legacy over-broad patterns that would shadow *any* installed
+    // `.loom/*.json` file (older installs and /imagine used `.loom/*.json`),
+    // plus the negation that was paired with that glob. These are genuinely
+    // dangerous — they block files this installer never asked the user to
+    // ignore (`.loom/install-metadata.json`, `.loom/config/skill-routes.json`,
+    // …) — so they are always removed regardless of who wrote them.
+    //
+    // #5242: `.loom/config.json` itself is deliberately NOT in this list.
+    // It used to be here (see the historical note below), on the theory that
+    // any occurrence was a leftover from the pre-#2278 bug where `.loom/config.json`
+    // was gitignored by mistake, blocking the merge-aware tracked-config design
+    // (#3598) from working. That theory stopped holding once fleet hosts started
+    // adding this exact line *on purpose*: `.loom/config.json` is committed
+    // team config by default, but a host that keeps genuinely host-local runtime
+    // state there (e.g. a `worktree.root` override) has a legitimate reason to
+    // gitignore it — and this installer never adds that rule itself (it is not
+    // in EPHEMERAL_PATTERNS), so per the "never remove ignore rules we didn't
+    // add" rule it must not strip it either. Removing it here fought that
+    // documented, intentional divergence on every subsequent install/update
+    // (rjwalters/lean-genius#43683). A single scoped `.loom/config.json` line
+    // does not shadow any other installed file, so leaving it alone is safe.
+    let legacy_overbroad = [".loom/*.json", "!.loom/roles/*.json"];
     lines.retain(|line| !legacy_overbroad.contains(&line.trim()));
 
     let begin = lines
@@ -869,7 +887,7 @@ mod tests {
     }
 
     #[test]
-    fn removes_legacy_broad_json_pattern() {
+    fn removes_legacy_broad_json_pattern_but_preserves_config_json_rule() {
         let tmp = TempDir::new().unwrap();
         let gitignore = tmp.path().join(".gitignore");
 
@@ -884,18 +902,25 @@ mod tests {
 
         let contents = fs::read_to_string(&gitignore).unwrap();
 
-        // Legacy patterns must be removed
+        // The genuinely over-broad patterns (which would shadow *any* installed
+        // `.loom/*.json` file, not just config.json) must still be removed.
         assert!(
             !contents.contains(".loom/*.json"),
             "Legacy .loom/*.json pattern should have been removed"
         );
         assert!(
-            !contents.contains(".loom/config.json"),
-            "Legacy .loom/config.json pattern should have been removed"
-        );
-        assert!(
             !contents.contains("!.loom/roles/*.json"),
             "Legacy negation pattern should have been removed"
+        );
+
+        // #5242: a narrowly-scoped `.loom/config.json` ignore rule must survive.
+        // This installer never adds this line itself (it is not in
+        // EPHEMERAL_PATTERNS), so it must not remove it either — some hosts add
+        // it deliberately to keep host-local runtime state (e.g. worktree.root
+        // overrides) out of a shared repo's tracked config.
+        assert!(
+            contents.contains(".loom/config.json"),
+            "A pre-existing, narrowly-scoped .loom/config.json ignore rule must be preserved"
         );
 
         // Specific ephemeral patterns should be added instead
@@ -904,6 +929,34 @@ mod tests {
         assert!(contents.contains(".loom/worktrees/"));
 
         // Non-Loom content preserved
+        assert!(contents.contains("node_modules/"));
+    }
+
+    #[test]
+    fn preserves_standalone_config_json_ignore_rule_across_repeated_updates() {
+        // #5242 regression: a repo that deliberately keeps `.loom/config.json`
+        // gitignored (documented host-local runtime state, e.g. a fleet host's
+        // `worktree.root` override) must not have that rule stripped again on
+        // every subsequent `update_gitignore` run (install/update/resync).
+        let tmp = TempDir::new().unwrap();
+        let gitignore = tmp.path().join(".gitignore");
+
+        fs::write(
+            &gitignore,
+            "node_modules/\n\n# Host-local divergence: worktree.root is per-machine\n.loom/config.json\n",
+        )
+        .unwrap();
+
+        update_gitignore(tmp.path()).unwrap();
+        update_gitignore(tmp.path()).unwrap();
+
+        let contents = fs::read_to_string(&gitignore).unwrap();
+
+        assert!(
+            contents.contains(".loom/config.json"),
+            "a standalone, user-added .loom/config.json ignore rule must survive repeated \
+             update_gitignore runs, got: {contents}"
+        );
         assert!(contents.contains("node_modules/"));
     }
 

--- a/scripts/test-installer.sh
+++ b/scripts/test-installer.sh
@@ -2573,6 +2573,57 @@ fi
 echo ""
 
 
+# Test: reinstall preserves a pre-existing, user-added `.loom/config.json`
+# .gitignore rule (#5242). A fleet host that keeps host-local runtime state
+# (e.g. a `worktree.root` override) in `.loom/config.json` may deliberately
+# gitignore that single, narrowly-scoped file even though Loom's default
+# design commits it for team sharing. `update_gitignore`'s legacy migration
+# (which strips genuinely over-broad `.loom/*.json`-style patterns left by
+# very old installs) must not sweep up that narrow, intentional rule too —
+# it never added the rule itself, so it must not remove it either. This
+# exercises the REAL `loom-daemon init` gitignore reconciliation
+# (`loom-daemon::init::post_init::update_gitignore`), the same code path
+# `install.sh` and `resync-installed.sh update-gitignore` both call.
+echo "Test: reinstall preserves a pre-existing .loom/config.json gitignore rule (#5242)"
+DAEMON_BIN_5242="$LOOM_ROOT/target/release/loom-daemon"
+if [[ ! -x "$DAEMON_BIN_5242" ]]; then
+  warn "Skipping Test #5242 — loom-daemon release binary not built at $DAEMON_BIN_5242"
+else
+  GITIGNORE_CONFIG_REPO="$TEST_DIR/gitignore-config-json-test"
+  create_temp_repo "$GITIGNORE_CONFIG_REPO"
+
+  # Seed a documented, host-local divergence: the operator deliberately
+  # gitignores `.loom/config.json` (mirrors rjwalters/lean-genius#43683).
+  cat > "$GITIGNORE_CONFIG_REPO/.gitignore" <<'GI5242_EOF'
+node_modules/
+
+# Host-local divergence: worktree.root is per-machine, not team-shared.
+.loom/config.json
+GI5242_EOF
+
+  if "$DAEMON_BIN_5242" init --force --defaults "$LOOM_ROOT/defaults" "$GITIGNORE_CONFIG_REPO" >/dev/null 2>&1; then
+    GI_5242="$GITIGNORE_CONFIG_REPO/.gitignore"
+
+    if grep -qxF '.loom/config.json' "$GI_5242"; then
+      pass "pre-existing .loom/config.json ignore rule survived loom-daemon init (#5242)"
+    else
+      fail ".loom/config.json ignore rule was stripped by loom-daemon init (#5242 regression)"
+    fi
+
+    # Re-running (as a resync/reinstall would) must not strip it either.
+    "$DAEMON_BIN_5242" init --force --defaults "$LOOM_ROOT/defaults" "$GITIGNORE_CONFIG_REPO" >/dev/null 2>&1 || true
+    if grep -qxF '.loom/config.json' "$GI_5242"; then
+      pass ".loom/config.json ignore rule survives a second loom-daemon init (#5242)"
+    else
+      fail ".loom/config.json ignore rule was stripped on a second run (#5242 regression)"
+    fi
+  else
+    fail "loom-daemon init failed against consumer repo with a pre-existing .gitignore (#5242)"
+  fi
+fi
+echo ""
+
+
 # ==========================================================================
 # Dogfood commands scoped-symlink (issue #3682)
 # ==========================================================================


### PR DESCRIPTION
## Summary
The installer's `.gitignore` reconciliation (`loom-daemon::init::post_init::update_gitignore`, invoked by both `install.sh`/`install-loom.sh` and `loom-daemon update-gitignore` / `resync-installed.sh`) unconditionally stripped a literal `.loom/config.json` line from a target's `.gitignore` on every run. That behavior dates to #2278 ("stop gitignoring .loom/config.json so it stays tracked across reinstalls"), which assumed any such line was a leftover from an old bug where `.loom/config.json` was accidentally gitignored, blocking the merge-aware tracked-config design (#3598).

That assumption breaks for fleet hosts that *intentionally* gitignore `.loom/config.json` to keep host-local runtime state (e.g. `worktree.root = "/Volumes/Stripe"`) out of a shared repo's tracked config — the installer never adds that ignore rule itself (it's not in `EPHEMERAL_PATTERNS`), so it shouldn't remove it either. Observed 2026-08-04 updating a 0.12.0 install to 0.18.0 in `rjwalters/lean-genius`: the re-added, documented divergence (`rjwalters/lean-genius#43683`) got stripped again on the very next installer run.

## Changes
- `loom-daemon/src/init/post_init.rs`: removed `.loom/config.json` from the `legacy_overbroad` auto-strip list in `update_gitignore`. The genuinely dangerous patterns — `.loom/*.json` and its paired `!.loom/roles/*.json` negation, which shadow *other* installed `.loom/*.json` files (`install-metadata.json`, `config/skill-routes.json`, …) — are still always removed. A single, narrowly-scoped `.loom/config.json` line doesn't shadow anything else, so it's safe to leave alone.
- Updated the existing Rust unit test (`removes_legacy_broad_json_pattern` → `removes_legacy_broad_json_pattern_but_preserves_config_json_rule`) to assert the new behavior, and added a new regression test (`preserves_standalone_config_json_ignore_rule_across_repeated_updates`) covering the exact "re-added after being stripped, stripped again" thrash scenario from the issue.
- Added a shell-level integration test to `scripts/test-installer.sh` that exercises the *real* `loom-daemon init` binary (matching the existing `Test 65` pattern for `.loom/config.json` content merging) against a repo with a pre-existing, documented `.loom/config.json` ignore rule, asserting it survives both a first and a repeated `init --force` run.

I did not pursue the issue's second, optional acceptance criterion (shipping a default config under a different filename, e.g. `config.default.json`) — the source-side template already lives at a different path/name (`defaults/config.json`, merged into the target's `.loom/config.json`), so renaming further wouldn't change the actual point of contention (whether the *target's* `.loom/config.json` stays trackable-by-default vs. host-overridable). The primary fix (not stripping an existing ignore rule) resolves the reported bug directly.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Installer preserves an existing `.loom/config.json` ignore rule in the target's .gitignore (or never removes ignore rules it didn't add) | ✅ | `.loom/config.json` removed from `legacy_overbroad`; new Rust tests + new shell integration test against the real `loom-daemon init` binary all confirm the rule survives repeated runs |
| Ship a default config under a different name so config.json stays ignorable (optional) | Not pursued | See rationale above — not a clean fit given the existing `defaults/config.json` → `.loom/config.json` merge design; the primary fix already resolves the reported symptom |

## Test Plan
- `cargo test --package loom-daemon --lib init::post_init` — 27/27 passed, including the two new/updated tests.
- `cargo clippy --package loom-daemon --lib -- -D warnings` — clean.
- `cargo fmt --package loom-daemon -- --check` — clean.
- `bash scripts/test-installer.sh` (full suite, including the new `#5242` test block) — 178/179 passed; the 1 pre-existing failure (`test-loom-dispatcher.sh`, launchd-supervision env-var harvesting) reproduces identically on `main` without this change and is unrelated to `.gitignore`/`config.json` reconciliation.

Closes #5242