### PR TITLE
fix(judge,curator): separate observed evidence from inferred root cause in filed issues

### DIFF
--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -849,7 +849,19 @@ $CURRENT
 ## Curator Enhancement
 
 ### Problem Statement
-[Clear explanation of the problem and why it matters]
+[Clear explanation of the problem and why it matters — what was actually
+observed: quoted output, a reproducible command, the exact diff/log line.
+Keep this to what is measured, not guessed.]
+
+### Suspected Cause (unverified)
+[Only include this section if the original issue or your own reading implies
+a root-cause hypothesis. State it as something to test, not a finding — e.g.
+"Likely caused by X; needs verification by instrumenting Y" — never state a
+guessed mechanism as settled fact. If you cite a numeric bound (a timeout, a
+budget, a clearance/threshold), name its source (a rule's configured value, a
+net-class override, a manufacturer floor, a config default) rather than a
+bare literal. Omit this section entirely if the issue is pure observed
+behavior with no inferred mechanism attached.]
 
 ### Acceptance Criteria
 - [ ] Specific, testable criterion 1
@@ -878,6 +890,21 @@ gh issue comment 310 --body "📝 **Curator**: Enhanced issue description with i
 **Important:**
 - Always preserve the original issue text
 - Add clear section headers to show what you added
+- **Separate observed from inferred, the same way Judge-filed follow-ups
+  must** (see `judge.md` "Observed vs. inferred"): a Curator's own read of the
+  code is evidence of *that* something is wrong, not proof of *why*. Never
+  write a guessed mechanism under a bare `### Root Cause` heading — use
+  `### Suspected Cause (unverified)` and phrase it as a hypothesis, so a
+  downstream Builder knows it is licensed to refute it with measurement. This
+  applies to any issue where you add root-cause content, not just the
+  Process-Improvement Issues covered above — a Curator's framing carries the
+  same authority (and the same risk of being wrong) whether the issue is
+  about agent behavior or an ordinary bug/feature.
+- An explicit, measured refutation of the suspected cause is a complete,
+  successful outcome for the Builder to close the issue with — not a failure
+  to deliver a fix. Say so when you enhance an issue that carries an
+  unverified cause, so the Builder isn't pushed to force a fix onto a
+  mechanism that measurement rules out.
 - Leave a comment noting you amended the description
 - This creates a single source of truth for Workers
 

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -1808,6 +1808,41 @@ When you identify issues during evaluation, take concrete action - never leave c
 - Test coverage gaps (existing tests pass but could be more comprehensive)
 - Non-critical bugs (workarounds exist, low impact)
 
+**Observed vs. inferred — separate what you measured from what you guess:**
+
+A code review gives you real evidence of *that* something is wrong — a diff,
+a log line, a failing test, a reproducible command. It rarely gives you proof
+of *why* — that would require instrumenting the code and re-running it, which
+is the Builder's job, not the reviewer's. Filing the two with the same
+rhetorical weight (e.g. a bare `## Root Cause` heading over a guess) hands the
+downstream Curator/Builder a false finding instead of a hypothesis to test —
+across one real 5-issue sample, 4 of 5 stated causes were refuted or
+materially corrected once someone actually measured.
+
+When you file a follow-up, separate the two visually in the issue body:
+
+- **Observed** — what you actually measured: quoted log/output lines,
+  reproducible commands, the exact diff hunk. State this under a heading like
+  `## Observed` or `## Symptom`.
+- **Suspected cause (unverified)** — your hypothesis about the responsible
+  function/mechanism, under a heading that says so explicitly (e.g. `##
+  Suspected cause (unverified)`), never `## Root Cause`. Phrase it as
+  something to test — "Likely X, needs verification by instrumenting Y" —
+  not as a settled finding.
+- **Numeric bounds need a named source.** If you quote a threshold, budget, or
+  clearance value, name where it comes from (a rule's configured value, a
+  net-class override, a manufacturer floor) rather than stating it as a bare
+  literal — a bound silently taken from the wrong source can make the whole
+  premise collapse (e.g. citing a fab-floor clearance when the board's own
+  net class overrides it).
+- **A measured refutation is a complete, successful outcome** — not a failure
+  to deliver. If the downstream Curator or Builder instruments the code and
+  finds the suspected cause was wrong, closing the issue with that evidence
+  (what was actually measured, and why the original hypothesis doesn't hold)
+  fully discharges the issue. Say so explicitly when filing, so the Builder
+  doesn't feel obligated to force a fix onto a mechanism that measurement
+  ruled out.
+
 **Example workflow:**
 ```bash
 # Judge finds minor documentation issue during evaluation
@@ -1848,6 +1883,14 @@ During code evaluation, you may discover bugs or issues that aren't related to t
 3. Document: What the problem is, how to reproduce it, potential impact
 4. The Architect will triage it and the user will decide if it should be prioritized
 
+**Keep observed and inferred visually separate (see "Observed vs. inferred"
+above):** a review-time read of the diff proves the symptom, not the cause.
+Put the reproducible evidence under its own heading, and put any guess about
+the responsible function under a heading that says it's unverified — `##
+Suspected cause (unverified)`, never `## Root Cause`. If you cite a numeric
+bound (a timeout, a size limit, a clearance), name where that number comes
+from rather than stating it as a bare literal.
+
 **Example:**
 ```bash
 # Create unlabeled issue - Architect will triage it
@@ -1869,9 +1912,14 @@ While evaluating PR #45, I noticed that terminal output becomes corrupted when t
 - **Frequency**: Low (uncommon directory names)
 - **Workaround**: Rename directory to avoid special chars
 
-## Root Cause
+## Suspected cause (unverified)
 
-Likely in `src/lib/terminal-manager.ts:142` - path not properly escaped before passing to tmux
+Possibly `src/lib/terminal-manager.ts:142` - path may not be escaped before
+being passed to tmux. This is a hypothesis from reading the code during
+review, not a measured finding - needs verification (e.g. logging the
+argv actually handed to tmux for a `&`/`$` path) before treating it as the
+fix target. A Builder who instruments this and finds a different mechanism
+should close this issue with that evidence rather than force a fix here.
 
 Discovered while evaluating PR #45
 EOF


### PR DESCRIPTION
## Summary

Judge-filed follow-up issues stated an inferred root cause with the same rhetorical weight as an observed symptom — across a real 5-issue sample, 4 of 5 stated causes were refuted or materially corrected once someone actually measured. This PR updates guidance and the **example templates themselves** (not just surrounding prose) in the two canonical role files:

- `defaults/.claude/commands/loom/judge.md` (`defaults/roles/judge.md` symlinks to it):
  - "Creating Follow-up Issues" (~L1803): new "Observed vs. inferred" guidance — separate measured evidence from a hypothesis about the responsible function, require a `## Suspected cause (unverified)` heading (never `## Root Cause`), require numeric bounds to name their source, and treat a measured refutation as a complete, successful Builder outcome rather than a failed fix.
  - "Raising Concerns" (~L1841): same guidance, plus the EXAMPLE TEMPLATE itself is fixed — the bare `## Root Cause` heading with unhedged text ("Likely in `src/lib/terminal-manager.ts:142` - path not properly escaped...") now reads `## Suspected cause (unverified)` with explicitly hedged wording and a note on what would refute it.
- `defaults/.claude/commands/loom/curator.md` (`defaults/roles/curator.md` symlinks to it):
  - The "Curator Enhancement" body template (~L849) gets an optional `### Suspected Cause (unverified)` section (distinct from `### Problem Statement`, which is now scoped to observed content), plus an "Important" bullet extending the same observed/inferred discipline to any ordinary bug/feature issue enhancement a Curator writes — not just the existing Process-Improvement Issues section, which only covered issues about agent behavior.

No production/runtime code paths are touched — this is prose/template-only in two role-definition markdown files.

## Verification

```
grep -n '## Root Cause\|## Root cause' defaults/.claude/commands/loom/judge.md
grep -n '### Root Cause\|### Root cause\|## Root Cause\|## Root cause' defaults/.claude/commands/loom/curator.md
```

All remaining hits are prose explicitly warning against the bare-heading anti-pattern (e.g. "never `## Root Cause`") — no example/template in either file contains an unhedged `## Root Cause` / `### Root Cause` heading anymore.

## Test plan

- [x] Manual re-read of judge.md's "Raising Concerns" example end-to-end — the heading and its content now read as an explicit hypothesis, not a stated finding.
- [x] Grep-based verification (above) confirms zero bare/unhedged `## Root Cause` occurrences remain in either file's example templates.
- N/A automated tests — these are prompt/guidance markdown files with no test harness (per the issue's own Test Plan note).

Closes #5246