### PR TITLE
fix(test): unset ambient LOOM_ROLE in test-spawn-codex.sh's run_preflight

### DIFF
--- a/defaults/scripts/tests/test-spawn-codex.sh
+++ b/defaults/scripts/tests/test-spawn-codex.sh
@@ -942,7 +942,7 @@ run_preflight() {
     shift 2
     local rc=0
     PREFLIGHT_OUT="$(env -u LOOM_CODEX_HOME -u LOOM_CODEX_PROFILE -u LOOM_CODEX_SANDBOX \
-        -u LOOM_CODEX_NETWORK -u LOOM_MODEL -u LOOM_EFFORT -u LOOM_CODEX_MODEL \
+        -u LOOM_CODEX_NETWORK -u LOOM_MODEL -u LOOM_EFFORT -u LOOM_CODEX_MODEL -u LOOM_ROLE \
         LOOM_SWEEP_NICE=0 LOOM_CODEX_NO_EXEC=1 LOOM_SPAWN_NO_EXPORT=1 \
         "$@" bash "$SPAWN_CODEX" -p "hi" 2>&1)" || rc=$?
     assert_eq "$expected" "$rc" "$desc"


### PR DESCRIPTION
## Summary

`defaults/scripts/tests/test-spawn-codex.sh`'s `run_preflight()` helper unset several env vars (`LOOM_CODEX_HOME`, `LOOM_CODEX_PROFILE`, `LOOM_CODEX_SANDBOX`, `LOOM_CODEX_NETWORK`, `LOOM_MODEL`, `LOOM_EFFORT`, `LOOM_CODEX_MODEL`) before invoking `spawn-codex.sh`, but not `LOOM_ROLE`. Every real Loom agent session (Builder, Auditor, Doctor, etc. — set by `spawn-claude.sh` / the daemon) exports `LOOM_ROLE` ambiently, so the "no LOOM_ROLE + unprovisioned profile -> proceeds" test case leaked that ambient value through the `env` call and asserted a false `role=unset` audit line. This passed in CI only because GitHub Actions runners don't export `LOOM_ROLE`, but failed whenever the suite was run from inside a real Loom agent session.

## Fix

Add `-u LOOM_ROLE` to the `env -u ...` list in `run_preflight()`, matching the existing pattern for the other ambient vars.

## Test plan

- [x] Reproduced the bug: with `LOOM_ROLE=auditor` exported ambiently, the pre-fix test showed the exact failure described in the issue ("the audit line reports an unset role"), asserting `role=unset` but getting the leaked ambient value instead.
- [x] After the fix, rerunning with `LOOM_ROLE` still exported ambiently no longer fails that assertion.
- [x] `bash -n` and `shellcheck --severity=warning` clean on the modified file.
- [x] Confirmed (by toggling the fix on/off in place) that the only remaining 2 failures observed when running the suite from inside this issue's worktree ("builder + ready managed hook -> proceeds", "audit line reports hooks=ready") are pre-existing and unrelated to this change — they reproduce identically with the unmodified upstream test file, and are caused by the known bridge-path resolution divergence between a worktree's own `.loom/hooks/guard-codex-bridge.sh` copy and the `defaults/` copy (referenced in the test's own comments, issue #4787), not by `LOOM_ROLE` handling.

Closes #5245