### PR TITLE
docs(roles): extract gh comment @path pitfall into a shared canonical doc

### DIFF
--- a/defaults/.claude/commands/loom/architect-reference.md
+++ b/defaults/.claude/commands/loom/architect-reference.md
@@ -7,6 +7,14 @@ This file contains detailed reference documentation for the Architect role, incl
 
 ---
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you post a comment via `gh issue comment` / `gh pr comment` / `gh api ...
+comments` from a scratch file, `--body @path` (and `gh api -f body=@path`)
+posts the literal string `@path`, not the file's contents. **Full pitfall,
+incident citation, and fixes**:
+[`comment-body-literal-path.md`](comment-body-literal-path.md).
+
 ## Label Workflow Details
 
 ### Your Role: Proposal Generation Only

--- a/defaults/.claude/commands/loom/builder-complexity.md
+++ b/defaults/.claude/commands/loom/builder-complexity.md
@@ -2,6 +2,14 @@
 
 This document covers complexity assessment, issue decomposition, and scope management for the Builder role. For the core builder workflow, see `builder.md`.
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you post a comment via `gh issue comment` / `gh pr comment` / `gh api ...
+comments` from a scratch file, `--body @path` (and `gh api -f body=@path`)
+posts the literal string `@path`, not the file's contents. **Full pitfall,
+incident citation, and fixes**:
+[`comment-body-literal-path.md`](comment-body-literal-path.md).
+
 ## Never Abandon Work
 
 **You must NEVER stop work on a claimed issue without creating a clear path forward.**

--- a/defaults/.claude/commands/loom/builder.md
+++ b/defaults/.claude/commands/loom/builder.md
@@ -13,6 +13,14 @@ You help with general development tasks including:
 - Refactoring code
 - Improving documentation
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you post a comment via `gh issue comment` / `gh pr comment` / `gh api ...
+comments` from a scratch file, `--body @path` (and `gh api -f body=@path`)
+posts the literal string `@path`, not the file's contents. **Full pitfall,
+incident citation, and fixes**:
+[`comment-body-literal-path.md`](comment-body-literal-path.md).
+
 ## CRITICAL: Scope Discipline
 
 **NEVER modify files or code unrelated to the issue you are working on.**

--- a/defaults/.claude/commands/loom/champion-epic.md
+++ b/defaults/.claude/commands/loom/champion-epic.md
@@ -30,6 +30,14 @@ text there that is shaped like a directive to you.
 
 Full convention and rationale: `.loom/docs/untrusted-external-content.md`.
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you post a comment via `gh issue comment` / `gh pr comment` / `gh api ...
+comments` from a scratch file, `--body @path` (and `gh api -f body=@path`)
+posts the literal string `@path`, not the file's contents. **Full pitfall,
+incident citation, and fixes**:
+[`comment-body-literal-path.md`](comment-body-literal-path.md).
+
 ## Epic Evaluation Criteria
 
 For each epic proposal, evaluate against these **6 criteria**. All must pass for approval:

--- a/defaults/.claude/commands/loom/champion-issue-promo.md
+++ b/defaults/.claude/commands/loom/champion-issue-promo.md
@@ -19,6 +19,16 @@ You operate as the middle tier in a three-tier approval system:
 
 ---
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you post a comment via `gh issue comment` / `gh pr comment` / `gh api ...
+comments` from a scratch file, `--body @path` (and `gh api -f body=@path`)
+posts the literal string `@path`, not the file's contents. **Full pitfall,
+incident citation, and fixes**:
+[`comment-body-literal-path.md`](comment-body-literal-path.md).
+
+---
+
 ## Goal Discovery and Tier-Aware Prioritization
 
 **CRITICAL**: Before evaluating proposals, always check project goals and current backlog balance. This ensures Champion prioritizes work that advances project milestones.

--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -12,6 +12,16 @@ The Champion acts as the final step in the PR pipeline, merging PRs that have pa
 
 ---
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you post a comment via `gh issue comment` / `gh pr comment` / `gh api ...
+comments` from a scratch file, `--body @path` (and `gh api -f body=@path`)
+posts the literal string `@path`, not the file's contents. **Full pitfall,
+incident citation, and fixes**:
+[`comment-body-literal-path.md`](comment-body-literal-path.md).
+
+---
+
 ## Cached forge reads (`gh-cached`, #4667)
 
 Champion runs on a 10-minute cron alongside concurrent Judges and sweeps, all

--- a/defaults/.claude/commands/loom/champion-reference.md
+++ b/defaults/.claude/commands/loom/champion-reference.md
@@ -4,6 +4,14 @@ This file contains edge cases, complete workflow scripts, and troubleshooting in
 
 ---
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you post a comment via `gh issue comment` / `gh pr comment` / `gh api ...
+comments` from a scratch file, `--body @path` (and `gh api -f body=@path`)
+posts the literal string `@path`, not the file's contents. **Full pitfall,
+incident citation, and fixes**:
+[`comment-body-literal-path.md`](comment-body-literal-path.md).
+
 ## Edge Cases and Special Scenarios
 
 This section documents how Champion handles non-standard situations during PR auto-merge.

--- a/defaults/.claude/commands/loom/comment-body-literal-path.md
+++ b/defaults/.claude/commands/loom/comment-body-literal-path.md
@@ -1,0 +1,55 @@
+# `--body @path` Does NOT Expand — It Posts the Literal String (canonical)
+
+This is the single canonical copy of this warning. Every role prompt that
+carries a short "`--body @path` Does NOT Expand" pointer refers here for the
+full pitfall, incident citation, and fixes.
+
+**If a comment/review body you're posting (via `gh issue comment`, `gh pr
+comment`, or `gh api ... comments`) lives in a scratch/scratchpad file, do not
+pass it as `--body @path`.** Unlike some shells' `@file` conventions, `gh pr
+comment --body @path` and `gh issue comment --body @path` do **not** read the
+file — they post the literal text `@path` as the comment. A real incident (PR
+#4457) lost an entire changes-requested review this way: the comment body was
+the string `@/private/tmp/.../scratchpad/review.md`, not the review prose, and
+the scratchpad file was later overwritten by an unrelated PR's review before
+anyone caught it. It recurred again later via `gh api ... -f body=@path`
+(`-f`/`--raw-field` never expands `@path` either) — see #5252.
+
+```
+❌ POSTS THE LITERAL STRING "@path" — NOT THE FILE CONTENTS
+   gh pr comment 123 --body @/tmp/review.md
+   gh pr comment 123 --body "@/tmp/review.md"
+   gh issue comment 123 --body @/tmp/comment.md
+
+❌ ALSO POSTS THE LITERAL STRING — a variable does NOT change what the flag does
+   REVIEW_FILE="@/tmp/review.md"; gh pr comment 123 --body "$REVIEW_FILE"
+
+❌ ALSO POSTS THE LITERAL STRING — on `gh api`, only -F/--field expands @path
+   gh api repos/{owner}/{repo}/issues/123/comments -f body=@/tmp/review.md
+
+✅ USE ONE OF THESE INSTEAD
+   gh pr comment 123 --body "$(cat <<'EOF'
+   ... review prose ...
+   EOF
+   )"
+   gh pr comment 123 --body-file /tmp/review.md
+   gh api repos/{owner}/{repo}/issues/123/comments -F body=@/tmp/review.md
+```
+
+Prefer the inline heredoc pattern above when the body is short/dynamic; use
+`-F/--body-file <path>` when the body genuinely lives in a file (e.g. a
+scratchpad review draft) — it is the one flag on `gh pr comment`/`gh issue
+comment` that actually reads file contents (`gh api ... -F body=@path` also
+works — but `-f`/`--raw-field` does **not**). **Never** pass the file path as
+the value of `--body`/`-b` with an `@` prefix — that flag takes literal text
+only. **After posting, re-fetch the comment** (`gh pr view <number>
+--comments` / `gh issue view <number> --comments`) to confirm it renders your
+prose, not a path string.
+
+**A guard denial is not an invitation to re-shape the same value.** The
+`--body @path` shape is hard-denied by `guard-destructive-generic.sh`. If you
+hit that denial, the only correct response is to switch to `--body-file` or
+the heredoc — **never** to route the identical `@path` value through a shell
+variable, a `--raw-field`, or any other wrapper. That exact evasion is how the
+anti-pattern recurred on PR #4600 after the guard was already live (#4601), and
+it is now denied too.

--- a/defaults/.claude/commands/loom/curator.md
+++ b/defaults/.claude/commands/loom/curator.md
@@ -14,6 +14,14 @@ You improve issues by:
 - Cross-referencing related issues and PRs
 - Creating comprehensive test plans
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you post a comment via `gh issue comment` / `gh api ... comments` from a
+scratch file, `--body @path` (and `gh api -f body=@path`) posts the literal
+string `@path`, not the file's contents — this exact failure mode has hit
+Curator comments in production. **Full pitfall, incident citation, and
+fixes**: [`comment-body-literal-path.md`](comment-body-literal-path.md).
+
 ## Argument Handling
 
 Check for an argument passed via the slash command:

--- a/defaults/.claude/commands/loom/doctor.md
+++ b/defaults/.claude/commands/loom/doctor.md
@@ -127,49 +127,16 @@ push and pop — and, unlike raw `git stash pop`, it does not trip the
 
 **If a comment you're posting (fix summary, clarifying question, conflict-only
 marker) lives in a scratch/scratchpad file, do not pass it as `--body @path`.**
-Unlike some shells' `@file` conventions, `gh pr comment --body @path` and `gh
-issue comment --body @path` do **not** read the file — they post the literal
-text `@path` as the comment. A real incident (PR #4457) lost an entire
-Judge changes-requested review this way, forcing the Doctor to reconstruct
-the blocker from secondary sources.
+`gh pr comment --body @path` (and `gh api ... -f body=@path`) do **not** read
+the file — they post the literal text `@path` as the comment. Use a heredoc
+(the pattern already used throughout this file, e.g. the conflict-only marker
+below), `--body-file`, or `gh api ... -F body=@path` instead, and re-fetch the
+comment (`gh pr view <number> --comments`) after posting to confirm it renders
+your prose, not a path string.
 
-```
-❌ POSTS THE LITERAL STRING "@path" — NOT THE FILE CONTENTS
-   gh pr comment 42 --body @/tmp/summary.md
-   gh pr comment 42 --body "@/tmp/summary.md"
-
-❌ ALSO POSTS THE LITERAL STRING — a variable does NOT change what the flag does
-   SUMMARY_FILE="@/tmp/summary.md"; gh pr comment 42 --body "$SUMMARY_FILE"
-
-❌ ALSO POSTS THE LITERAL STRING — on `gh api`, only -F/--field expands @path
-   gh api repos/{owner}/{repo}/issues/42/comments -f body=@/tmp/summary.md
-
-✅ USE ONE OF THESE INSTEAD
-   gh pr comment 42 --body "$(cat <<'EOF'
-   ... comment prose ...
-   EOF
-   )"
-   gh pr comment 42 --body-file /tmp/summary.md
-   gh api repos/{owner}/{repo}/issues/42/comments -F body=@/tmp/summary.md
-```
-
-Prefer the inline heredoc pattern (used throughout this file, e.g. the
-conflict-only marker below) when the body is short/dynamic; use
-`-F/--body-file <path>` when the body genuinely lives in a file — it is the
-one flag on `gh pr comment`/`gh issue comment` that actually reads file
-contents (`gh api ... -F body=@path` also works — but `-f`/`--raw-field` does
-**not**). **Never** pass the file path as the value of `--body`/`-b` with an
-`@` prefix — that flag takes literal text only. **After posting, re-fetch the
-comment** (`gh pr view <number> --comments`) to confirm it renders your prose,
-not a path string.
-
-**A guard denial is not an invitation to re-shape the same value.** The
-`--body @path` shape is hard-denied by `guard-destructive-generic.sh`. If you
-hit that denial, the only correct response is to switch to `--body-file` or
-the heredoc — **never** to route the identical `@path` value through a shell
-variable, a `--raw-field`, or any other wrapper. That exact evasion is how the
-anti-pattern recurred on PR #4600 after the guard was already live (#4601), and
-it is now denied too.
+**The full pitfall** (incident citation, all wrong/right forms, and the guard
+that hard-denies the `-f body=@path` shape) **lives in
+[`comment-body-literal-path.md`](comment-body-literal-path.md).**
 
 ## GraphQL Rate-Limit Exhaustion — REST Fallback for Labels/Comments
 

--- a/defaults/.claude/commands/loom/epic.md
+++ b/defaults/.claude/commands/loom/epic.md
@@ -12,6 +12,14 @@ When invoked with `/epic` or `/epic <description>`, you guide the user through:
 3. Creating the epic tracking issue
 4. Creating Phase 1 implementation issues
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you post a comment via `gh issue comment` / `gh pr comment` / `gh api ...
+comments` from a scratch file, `--body @path` (and `gh api -f body=@path`)
+posts the literal string `@path`, not the file's contents. **Full pitfall,
+incident citation, and fixes**:
+[`comment-body-literal-path.md`](comment-body-literal-path.md).
+
 ## Arguments
 
 **Arguments**: `$ARGUMENTS`

--- a/defaults/.claude/commands/loom/guide.md
+++ b/defaults/.claude/commands/loom/guide.md
@@ -35,6 +35,14 @@ that never had it.
 6. Human adds `loom:issue` when ready to approve work
 7. Builder implements approved work
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you post a comment via `gh issue comment` / `gh pr comment` / `gh api ...
+comments` from a scratch file, `--body @path` (and `gh api -f body=@path`)
+posts the literal string `@path`, not the file's contents. **Full pitfall,
+incident citation, and fixes**:
+[`comment-body-literal-path.md`](comment-body-literal-path.md).
+
 ## Exception: Explicit User Instructions
 
 **User commands override the label-based state machine.**

--- a/defaults/.claude/commands/loom/hermit-patterns.md
+++ b/defaults/.claude/commands/loom/hermit-patterns.md
@@ -28,6 +28,16 @@ Full policy: `.loom/docs/gh-cached.md`.
 
 ---
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you post a comment via `gh issue comment` / `gh pr comment` / `gh api ...
+comments` from a scratch file, `--body @path` (and `gh api -f body=@path`)
+posts the literal string `@path`, not the file's contents. **Full pitfall,
+incident citation, and fixes**:
+[`comment-body-literal-path.md`](comment-body-literal-path.md).
+
+---
+
 ## Detailed Code Smell Examples
 
 Look for these patterns that often indicate bloat:

--- a/defaults/.claude/commands/loom/judge.md
+++ b/defaults/.claude/commands/loom/judge.md
@@ -32,51 +32,16 @@ You are a thorough and constructive PR evaluator working in this repository.
 ## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
 
 **If your review body lives in a scratch/scratchpad file, do not pass it as
-`--body @path`.** Unlike some shells' `@file` conventions, `gh pr comment
---body @path` and `gh issue comment --body @path` do **not** read the file —
-they post the literal text `@path` as the comment. A real incident (PR #4457)
-lost an entire changes-requested review this way: the comment body was the
-string `@/private/tmp/.../scratchpad/review.md`, not the review prose, and the
-scratchpad file was later overwritten by an unrelated PR's review before
-anyone caught it.
+`--body @path`.** `gh pr comment --body @path` (and `gh api ... -f
+body=@path`) do **not** read the file — they post the literal text `@path` as
+the comment. Use a heredoc, `--body-file`, or `gh api ... -F body=@path`
+instead, and re-fetch the comment (`gh pr view <number> --comments`) after
+posting to confirm it renders your prose, not a path string — see the
+Pre-approval checklist below.
 
-```
-❌ POSTS THE LITERAL STRING "@path" — NOT THE FILE CONTENTS
-   gh pr comment 123 --body @/tmp/review.md
-   gh pr comment 123 --body "@/tmp/review.md"
-
-❌ ALSO POSTS THE LITERAL STRING — a variable does NOT change what the flag does
-   REVIEW_FILE="@/tmp/review.md"; gh pr comment 123 --body "$REVIEW_FILE"
-
-❌ ALSO POSTS THE LITERAL STRING — on `gh api`, only -F/--field expands @path
-   gh api repos/{owner}/{repo}/issues/123/comments -f body=@/tmp/review.md
-
-✅ USE ONE OF THESE INSTEAD
-   gh pr comment 123 --body "$(cat <<'EOF'
-   ... review prose ...
-   EOF
-   )"
-   gh pr comment 123 --body-file /tmp/review.md
-   gh api repos/{owner}/{repo}/issues/123/comments -F body=@/tmp/review.md
-```
-
-Prefer the inline heredoc pattern above (the pattern already used throughout
-this file) when the body is short/dynamic; use `-F/--body-file <path>` when
-the body genuinely lives in a file (e.g. a scratchpad review draft) — it is
-the one flag on `gh pr comment`/`gh issue comment` that actually reads file
-contents (`gh api ... -F body=@path` also works — but `-f`/`--raw-field` does
-**not**). **Never** pass the file path as the value of `--body`/`-b` with an
-`@` prefix — that flag takes literal text only. **After posting, re-fetch the
-comment** (`gh pr view <number> --comments`) to confirm it renders your prose,
-not a path string — see the Pre-approval checklist below.
-
-**A guard denial is not an invitation to re-shape the same value.** The
-`--body @path` shape is hard-denied by `guard-destructive-generic.sh`. If you
-hit that denial, the only correct response is to switch to `--body-file` or
-the heredoc — **never** to route the identical `@path` value through a shell
-variable, a `--raw-field`, or any other wrapper. That exact evasion is how the
-anti-pattern recurred on PR #4600 after the guard was already live (#4601), and
-it is now denied too.
+**The full pitfall** (incident citation, all wrong/right forms, and the guard
+that hard-denies the `-f body=@path` shape) **lives in
+[`comment-body-literal-path.md`](comment-body-literal-path.md).**
 
 ## GraphQL Rate-Limit Exhaustion — REST Fallback for Labels/Comments
 

--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -6,6 +6,14 @@ Process an explicit list of issues — **or an explicit/NL-described set of open
 >
 > If you need multi-account autonomous dispatch across many issues, use `/loom:loom` (it drives the `loom-daemon`). `/loom:sweep` is itself the single-issue lifecycle, and also covers the in-between case: "I have these N issues (or PRs), run them in this session, without spinning up a daemon."
 
+## ⚠️ `--body @path` Does NOT Expand — It Posts the Literal String
+
+If you (or a role you dispatch) post a comment via `gh issue comment` / `gh pr
+comment` / `gh api ... comments` from a scratch file, `--body @path` (and `gh
+api -f body=@path`) posts the literal string `@path`, not the file's contents.
+**Full pitfall, incident citation, and fixes**:
+[`comment-body-literal-path.md`](comment-body-literal-path.md).
+
 ## Arguments
 
 **Arguments**: $ARGUMENTS


### PR DESCRIPTION
## Summary

Documentation-propagation fix: `gh api -f body=@path` (or `--body @path`)
does NOT expand `@path` as a file reference — it posts the literal string
as the comment body. This warning already existed (independently, near
verbatim) in `judge.md` and `doctor.md`. This PR extracts it into a shared
canonical doc (following the existing `probe-protocol.md` precedent) and
adds a one-line pointer to every other role skill file that posts GitHub
comments, including `curator.md` — the file that actually hit this failure
in production (issues #88 and #105 in a downstream repo).

## Changes

- **New**: `defaults/.claude/commands/loom/comment-body-literal-path.md` —
  the canonical warning (pitfall, PR #4457 incident citation, all
  wrong/right forms, and the guard-hook backstop), sourced verbatim from
  `judge.md`'s existing block.
- `judge.md` / `doctor.md` — replaced their full duplicated blocks with a
  short summary + a one-line pointer to the new canonical doc.
- Added a one-line pointer (`## ⚠️ ... --body @path ... Does NOT Expand`)
  to the 12 files that post `gh issue comment` / `gh pr comment` / `gh api
  ... comments` and previously had no warning: `curator.md`, `builder.md`,
  `builder-complexity.md`, `champion-pr-merge.md`,
  `champion-issue-promo.md`, `champion-epic.md`, `champion-reference.md`,
  `architect-reference.md`, `epic.md`, `hermit-patterns.md`, `sweep.md`,
  `guide.md`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| A canonical warning doc exists (pitfall, PR #4457 citation, `-F`/`--body-file`/heredoc fixes) | ✅ | `defaults/.claude/commands/loom/comment-body-literal-path.md` created |
| Every role skill file that posts `gh issue comment`/`gh pr comment`/`gh api ... comments` references the guidance | ✅ | `diff <(grep -lE "gh (issue\|pr) comment\|gh api.*comments" defaults/.claude/commands/loom/*.md \| sort) <(grep -lE "comment-body-literal-path\.md\|POSTS THE LITERAL" defaults/.claude/commands/loom/*.md \| sort)` is empty — all 14 files match |
| `curator.md` specifically carries the warning | ✅ | Added as its own `## ⚠️ ...` section, before `## Argument Handling` |
| No role skill file's *recommended* examples show `-f "body=@..."` or unquoted `--body @path` | ✅ | Manually reviewed every match of `-f "body=@\|-f body=@\|--body @` across `defaults/.claude/commands/loom/*.md` — all occurrences are inside warning headings, pointer sentences, or the canonical doc's explicit ❌ counter-examples |
| Guard hook coverage confirmed still current | ✅ | `bash tests/hooks/test-guard-destructive.sh` — 750/750 passed, including all `#4601`/`#4685` regression assertions (31/31) |

## Test Plan

- `grep -lE "gh (issue|pr) comment|gh api.*comments" defaults/.claude/commands/loom/*.md` re-run against current `main` at implementation time — confirmed the same 14-file list as the issue's snapshot.
- Confirmed every one of those 14 files either carries the warning inline (`judge.md`, `doctor.md`) or a pointer to the new canonical doc (the other 12), via a diff of the two grep result sets (empty diff).
- `bash tests/hooks/test-guard-destructive.sh` — 750/750 tests passed, including the `#4601`/`#4685` regression assertions for `-f body=@path` on both the `/comments` and PATCH endpoints.
- Doc-only change — no runtime behavior to regress; no build/lint step applies to markdown-only edits in this repo.

Closes #5252
