### PR TITLE
fix(daemon): release the claim lock/label/peer-claim when spawn_child fails

### DIFF
--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -3004,15 +3004,28 @@ fn handle_request(
                 },
                 Err(e) => match e.downcast::<crate::runtime_admission::RuntimeRejection>() {
                     Ok(rejection) => Response::RuntimeRejected(rejection),
-                    Err(e) => Response::Error {
-                        // #5210: `{e:#}` (anyhow's alternate Display) walks the
-                        // full `.context()` chain instead of printing only the
-                        // outermost context, so a specific inner failure (e.g.
-                        // `resolve_spawn_bin`'s "spawn-worker.sh not found under
-                        // ...") reaches the MCP client instead of being
-                        // silently collapsed into "failed to spawn sweep child".
-                        message: format!("dispatch_sweep failed: {e:#}"),
-                    },
+                    Err(e) => {
+                        // Issue #5236: the pre-dispatch `log::info!` above only
+                        // ever logs the *attempt*, never the failure — until
+                        // now, the daemon's own log had no record of why a
+                        // dispatch failed at all, only the caller's response
+                        // did (#5210/#5218 fixed the caller-facing half). Log
+                        // the same full error chain at WARN so an operator
+                        // reading `loom-daemon`'s log (not just the MCP/CLI
+                        // response) can diagnose a dispatch failure without
+                        // reproducing it.
+                        log::warn!("dispatch_sweep: {kind:?} failed: {e:#}");
+                        Response::Error {
+                            // #5210: `{e:#}` (anyhow's alternate Display) walks
+                            // the full `.context()` chain instead of printing
+                            // only the outermost context, so a specific inner
+                            // failure (e.g. `resolve_spawn_bin`'s
+                            // "spawn-worker.sh not found under ...") reaches
+                            // the MCP client instead of being silently
+                            // collapsed into "failed to spawn sweep child".
+                            message: format!("dispatch_sweep failed: {e:#}"),
+                        }
+                    }
                 },
             }
         }

--- a/loom-daemon/src/live_claim.rs
+++ b/loom-daemon/src/live_claim.rs
@@ -226,15 +226,38 @@ pub fn pid_is_live_claim_for(pid: u32, issue: u32) -> bool {
 /// `is_live` is injected so tests can drive both verdicts without spawning
 /// processes. Fail-open: a missing lock dir, unreadable or unparseable
 /// `owner.json`, or a dead/zombie owner all resolve to `None`.
+///
+/// `own_untracked_pid` (Issue #5236) excludes one specific false-positive:
+/// `SweepRegistry::acquire_lock` stamps `owner_pid` with the *dispatching
+/// daemon's own pid* as a provisional placeholder — it is rewritten to the
+/// spawned child's real pid by `record_child_pid_in_lock` (#3808) once the
+/// child exists. When `spawn_child` fails before that rewrite runs (or ran
+/// historically, pre-#5236, and the caller's own cleanup didn't reach it),
+/// the placeholder is left behind with `owner_pid` == a pid that is, by
+/// construction, still alive: this daemon itself. A bare liveness/argv check
+/// cannot distinguish that from a real claim on non-Linux hosts (no
+/// `/proc/<pid>/cmdline` to read, so [`pid_is_live_claim_for`] falls back to
+/// bare liveness and reports "confirmed live" — the daemon's own pid is
+/// always alive while it's asking the question). Passing
+/// `Some(std::process::id())` here — but ONLY when the caller has already
+/// confirmed no tracked child/registry entry corresponds to this lock — lets
+/// leg 1 recognize that specific placeholder shape and refuse to count it as
+/// evidence, regardless of what `is_live` would otherwise say. `None` (the
+/// default for every non-registry caller, which has no child bookkeeping to
+/// consult) preserves the pre-#5236 behavior exactly.
 #[must_use]
 pub fn live_lock_owner_in(
     locks_dir: &Path,
     issue: u32,
     is_live: &dyn Fn(u32) -> bool,
+    own_untracked_pid: Option<u32>,
 ) -> Option<LiveClaimEvidence> {
     let owner_path = locks_dir.join(format!("issue-{issue}")).join("owner.json");
     let raw = std::fs::read_to_string(&owner_path).ok()?;
     let owner: LockOwnerView = serde_json::from_str(&raw).ok()?;
+    if own_untracked_pid == Some(owner.owner_pid) {
+        return None;
+    }
     if !is_live(owner.owner_pid) {
         return None;
     }
@@ -400,11 +423,33 @@ pub fn live_sweep_process_in(_workspace_root: &Path, _issue: u32) -> Option<Live
 /// Read-only and short-circuiting: leg 1 (a `read_to_string`) and leg 2 (one
 /// small JSON file) run before the `/proc` scan, so the common
 /// nothing-is-claimed case costs two file reads plus a bounded directory walk.
+///
+/// Plain wrapper around [`probe_excluding`] with `own_untracked_pid: None` —
+/// the shape every caller without registry bookkeeping needs (the orphan
+/// reaper, claim reconciliation).
 #[must_use]
 pub fn probe(
     workspace_root: &Path,
     journal_path: Option<&Path>,
     issue: u32,
+) -> Option<LiveClaimEvidence> {
+    probe_excluding(workspace_root, journal_path, issue, None)
+}
+
+/// [`probe`], with one additional exclusion (Issue #5236): a claim-lock
+/// owner whose pid equals `own_untracked_pid` is never treated as evidence,
+/// no matter what leg 1's liveness check would otherwise conclude. See
+/// [`live_lock_owner_in`]'s doc for why this exists — it lets
+/// [`crate::sweep_registry::SweepRegistry::live_claim_evidence`] pass its own
+/// pid once it has confirmed, via its own bookkeeping (`self.entries`), that
+/// no tracked sweep corresponds to the lock. Every other caller passes
+/// `None` via [`probe`] and is unaffected.
+#[must_use]
+pub fn probe_excluding(
+    workspace_root: &Path,
+    journal_path: Option<&Path>,
+    issue: u32,
+    own_untracked_pid: Option<u32>,
 ) -> Option<LiveClaimEvidence> {
     // Both bookkeeping legs verify the recorded PID's argv where the platform
     // allows it ([`pid_is_live_claim_for`]), so a *stale* record whose PID has
@@ -412,7 +457,7 @@ pub fn probe(
     let is_live: &dyn Fn(u32) -> bool = &|pid| pid_is_live_claim_for(pid, issue);
 
     let locks_dir = workspace_root.join(".loom").join("locks");
-    if let Some(evidence) = live_lock_owner_in(&locks_dir, issue, is_live) {
+    if let Some(evidence) = live_lock_owner_in(&locks_dir, issue, is_live, own_untracked_pid) {
         return Some(evidence);
     }
 
@@ -526,7 +571,7 @@ mod tests {
     fn live_lock_owner_reports_a_live_pid() {
         let dir = tempdir().unwrap();
         write_lock(dir.path(), 4275, 4242, "sweep-issue-4275-1");
-        let evidence = live_lock_owner_in(dir.path(), 4275, &|_| true).unwrap();
+        let evidence = live_lock_owner_in(dir.path(), 4275, &|_| true, None).unwrap();
         assert_eq!(
             evidence,
             LiveClaimEvidence::ClaimLock {
@@ -543,26 +588,45 @@ mod tests {
         // claim. `acquire_lock` refuses on existence; this probe must not.
         let dir = tempdir().unwrap();
         write_lock(dir.path(), 4275, 4242, "sweep-issue-4275-1");
-        assert!(live_lock_owner_in(dir.path(), 4275, &|_| false).is_none());
+        assert!(live_lock_owner_in(dir.path(), 4275, &|_| false, None).is_none());
     }
 
     #[test]
     fn live_lock_owner_fails_open_on_missing_and_corrupt_owner() {
         let dir = tempdir().unwrap();
         // Missing entirely.
-        assert!(live_lock_owner_in(dir.path(), 4275, &|_| true).is_none());
+        assert!(live_lock_owner_in(dir.path(), 4275, &|_| true, None).is_none());
         // Present but unparseable.
         let lock = dir.path().join("issue-4275");
         std::fs::create_dir_all(&lock).unwrap();
         std::fs::write(lock.join("owner.json"), "not json").unwrap();
-        assert!(live_lock_owner_in(dir.path(), 4275, &|_| true).is_none());
+        assert!(live_lock_owner_in(dir.path(), 4275, &|_| true, None).is_none());
     }
 
     #[test]
     fn live_lock_owner_is_scoped_to_the_requested_issue() {
         let dir = tempdir().unwrap();
         write_lock(dir.path(), 4275, 4242, "sweep-issue-4275-1");
-        assert!(live_lock_owner_in(dir.path(), 4276, &|_| true).is_none());
+        assert!(live_lock_owner_in(dir.path(), 4276, &|_| true, None).is_none());
+    }
+
+    /// AC (Issue #5236): a lock whose `owner_pid` is the querying daemon's own
+    /// pid — the provisional placeholder `acquire_lock` writes before a child
+    /// exists — must NOT count as confirmed-live evidence when the caller has
+    /// already confirmed no tracked child corresponds to it. `is_live` alone
+    /// would say yes (the daemon calling this IS alive); `own_untracked_pid`
+    /// overrides that, regardless of platform argv-reading support.
+    #[test]
+    fn live_lock_owner_excludes_own_untracked_pid_even_when_live() {
+        let dir = tempdir().unwrap();
+        let own = std::process::id();
+        write_lock(dir.path(), 4275, own, "sweep-issue-4275-leaked");
+        assert!(live_lock_owner_in(dir.path(), 4275, &|_| true, Some(own)).is_none());
+        // A DIFFERENT pid is unaffected by the exclusion, even with the same
+        // `own_untracked_pid` filter in play — it only ever matches on exact
+        // pid equality.
+        write_lock(dir.path(), 4276, 4242, "sweep-issue-4276-real");
+        assert!(live_lock_owner_in(dir.path(), 4276, &|_| true, Some(own)).is_some());
     }
 
     // ---- leg 2: machine-level journal ------------------------------------
@@ -674,6 +738,31 @@ mod tests {
         let journal = dir.path().join("sweeps.json");
         let evidence = probe(dir.path(), Some(&journal), 4275).unwrap();
         assert!(matches!(evidence, LiveClaimEvidence::ClaimLock { .. }));
+    }
+
+    /// AC (Issue #5236): `probe_excluding` must not report a leaked
+    /// provisional lock (`owner_pid` == the querying daemon's own pid, no
+    /// tracked child) as a confirmed-live claim — cross-platform, unlike the
+    /// argv-based exclusion below which only fires on Linux. This is the
+    /// exact shape `dispatch_inner` used to leave behind before #5236's
+    /// cleanup fix: `acquire_lock`'s placeholder, never rewritten because
+    /// `spawn_child` failed first.
+    #[test]
+    fn probe_excluding_ignores_a_leaked_provisional_lock_owned_by_self() {
+        let dir = tempdir().unwrap();
+        let locks = dir.path().join(".loom").join("locks");
+        let own = std::process::id();
+        write_lock(&locks, 4275, own, "sweep-issue-4275-leaked");
+        let journal_path = dir.path().join("sweeps.json");
+        assert!(probe_excluding(dir.path(), Some(&journal_path), 4275, Some(own)).is_none());
+        // A genuinely live claim (a distinct, real sweep process) must still
+        // be refused by `probe_excluding` with the SAME exclusion in play —
+        // the fix must not weaken the guard for real duplicates. The
+        // exclusion only ever matches on exact pid equality, so a different
+        // issue's genuinely-live sweep is unaffected.
+        let sweep = FakeSweep::spawn(4276);
+        write_lock(&locks, 4276, sweep.pid(), "sweep-issue-4276-live");
+        assert!(probe_excluding(dir.path(), Some(&journal_path), 4276, Some(own)).is_some());
     }
 
     #[test]

--- a/loom-daemon/src/sweep_registry/dispatch.rs
+++ b/loom-daemon/src/sweep_registry/dispatch.rs
@@ -1092,17 +1092,47 @@ impl SweepRegistry {
         // stagger (the default outside production / in tests) is a no-op.
         self.apply_dispatch_stagger();
         let log_path = self.compute_log_path(issue_number);
-        let (child, token_name, runtime, immediate_preflight_death) = self
-            .spawn_child(
-                issue_number,
-                &log_path,
-                &sweep_id,
-                model,
-                effort,
-                depends_on,
-                runtime_admission.as_ref(),
-            )
-            .context("failed to spawn sweep child")?;
+        let (child, token_name, runtime, immediate_preflight_death) = match self.spawn_child(
+            issue_number,
+            &log_path,
+            &sweep_id,
+            model,
+            effort,
+            depends_on,
+            runtime_admission.as_ref(),
+        ) {
+            Ok(spawned) => spawned,
+            Err(e) => {
+                // Issue #5236: `spawn_child` can fail for reasons that have
+                // nothing to do with the issue itself (e.g. a registered
+                // workspace whose `.loom/scripts/` is missing
+                // `spawn-worker.sh` — `resolve_spawn_bin` errors before any
+                // process is ever spawned). Unlike the #4689 branch below,
+                // this is a synchronous `Err`, not a synchronously-observed
+                // dead child — but the side effects already applied above
+                // (claim lock, peer-claim advertisement, label flip) are
+                // identical, and leaving them in place is exactly what wedges
+                // every retry: the leaked lock's `owner_pid` is this daemon's
+                // own (still-alive) pid, which the #4556 live-claim guard
+                // then reads as a confirmed-live claim forever (until an
+                // operator manually removes the lock dir). Unwind the same
+                // three side effects the #4689 branch reverts, so a second
+                // dispatch attempt starts from a clean slate instead of a
+                // permanent wedge.
+                log::warn!(
+                    "sweep_registry: issue #{issue_number} sweep_id={sweep_id} failed to spawn \
+                     — reverting the claim lock, label, and peer-claim advertisement instead of \
+                     leaking them (#5236): {e:#}"
+                );
+                if !self.config.skip_label_flip {
+                    let _ = self.restore_label_to_ready(issue_number);
+                    self.note_label_flip(issue_number); // #4485 flap detection
+                }
+                self.publish_peer_claim(peer_claims::ClaimKind::Retract, issue_number);
+                let _ = self.release_lock_owned(issue_number, &sweep_id);
+                return Err(e.context("failed to spawn sweep child"));
+            }
+        };
 
         // Issue #4689: the child already died — synchronously observed,
         // before this dispatch call has returned — from `spawn-claude.sh`'s
@@ -2601,6 +2631,90 @@ mod tests {
             "the claim lock must be released on the synchronous failure path"
         );
         assert!(reg.children.is_empty(), "no child handle should be retained for a dead child");
+    }
+
+    /// AC (#5236): when `spawn_child` itself returns `Err` — e.g. a
+    /// registered workspace whose `spawn_bin` resolves to a nonexistent
+    /// file, so `Command::spawn()` fails at the OS level before any child
+    /// ever exists — `dispatch_inner` must unwind the same side effects the
+    /// #4689 branch above reverts: the claim lock, the `loom:building`
+    /// label flip, and (implicitly, since nothing was ever advertised
+    /// without a peer-claim publisher configured in this fixture) the
+    /// peer-claim advertisement. Without this, the leaked lock's
+    /// `owner_pid` is this daemon's own (permanently alive, from its own
+    /// point of view) pid, which the #4556 live-claim guard misreads as a
+    /// confirmed-live claim on every retry — the exact wedge this issue
+    /// reports.
+    #[test]
+    #[serial]
+    fn dispatch_reverts_claim_lock_and_label_when_spawn_child_itself_fails() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::remove_var("LOOM_REPO");
+        let (mut reg, gh_log) = spawn_bin_missing_registry(ws);
+
+        let err = reg
+            .dispatch(&SweepKind::Issue(5236), None, None, None, None)
+            .expect_err("a spawn_child Err must fail dispatch, not Ok");
+        assert!(err.to_string().contains("failed to spawn sweep child"), "got: {err}");
+
+        let calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            calls.contains("issue edit 5236 --remove-label loom:issue --add-label loom:building"),
+            "the claim WAS taken (label flip happens before spawn_child) — got: {calls:?}"
+        );
+        assert!(
+            calls.contains("issue edit 5236 --remove-label loom:building --add-label loom:issue"),
+            "…and must be REVERTED when spawn_child fails — got: {calls:?}"
+        );
+
+        assert!(
+            running_issue_sweep_id(&reg, 5236).is_none(),
+            "a failed dispatch must not leave a Running entry behind"
+        );
+        assert!(
+            !ws.join(".loom/locks/issue-5236").exists(),
+            "the claim lock must be released when spawn_child fails, not leaked (#5236)"
+        );
+        assert!(
+            reg.children.is_empty(),
+            "no child handle exists — spawn_child never got that far"
+        );
+    }
+
+    /// The full repro from this issue's Test Plan: dispatch twice against a
+    /// workspace whose `spawn_bin` never resolves to anything runnable. The
+    /// first dispatch fails and — per the AC above — cleans up fully; the
+    /// second dispatch must reach the SAME `spawn_child` failure again, NOT
+    /// be refused by the #4556 live-claim guard reading a leaked lock whose
+    /// `owner_pid` is this daemon's own (still-alive) pid as a confirmed-live
+    /// claim.
+    #[test]
+    #[serial]
+    fn second_dispatch_after_spawn_child_failure_is_not_refused_by_the_live_claim_guard() {
+        let tmp = tempdir().unwrap();
+        let ws = tmp.path();
+        std::env::remove_var("LOOM_REPO");
+        let (mut reg, _gh_log) = spawn_bin_missing_registry(ws);
+
+        let first = reg
+            .dispatch(&SweepKind::Issue(5236), None, None, None, None)
+            .expect_err("first dispatch must fail — spawn_bin does not exist");
+        assert!(
+            first.downcast_ref::<LiveClaimDispatchError>().is_none(),
+            "the FIRST dispatch must fail on the spawn error itself, not a live-claim refusal \
+             (there is nothing to collide with yet) — got: {first}"
+        );
+
+        let second = reg
+            .dispatch(&SweepKind::Issue(5236), None, None, None, None)
+            .expect_err("second dispatch must also fail — spawn_bin still does not exist");
+        assert!(
+            second.downcast_ref::<LiveClaimDispatchError>().is_none(),
+            "the SECOND dispatch must reach the same spawn_child failure again, not be wedged \
+             behind a #4556 live-claim refusal from the first attempt's leaked lock — got: {second}"
+        );
+        assert!(second.to_string().contains("failed to spawn sweep child"), "got: {second}");
     }
 
     /// Edge case (#4689): a child that DID log a token selection before

--- a/loom-daemon/src/sweep_registry/locks.rs
+++ b/loom-daemon/src/sweep_registry/locks.rs
@@ -204,10 +204,7 @@ impl SweepRegistry {
                 // crashed, not "unregistered" — do not report it as alive.
                 continue;
             }
-            let already_registered = self.entries.values().any(|info| {
-                !info.state.is_terminal() && matches!(info.kind, SweepKind::Issue(i) if i == issue)
-            });
-            if !already_registered {
+            if !self.has_tracked_sweep_for(issue) {
                 result.push((issue, owner.owner_pid));
             }
         }
@@ -528,16 +525,43 @@ impl SweepRegistry {
     /// Read-only: unlike [`release_lock_owned`](Self::release_lock_owned) it
     /// never touches the filesystem, so it is safe to consult *before* a
     /// release, a label revert, or a re-dispatch. Delegates to
-    /// [`crate::live_claim::probe`], scoped to this registry's workspace root
-    /// and its configured journal path (tests point that at a tempdir, so the
-    /// probe never reads the real `~/.loom/sweeps.json`).
+    /// [`crate::live_claim::probe_excluding`], scoped to this registry's
+    /// workspace root and its configured journal path (tests point that at a
+    /// tempdir, so the probe never reads the real `~/.loom/sweeps.json`).
+    ///
+    /// Issue #5236: passes this daemon's own pid as the exclusion whenever
+    /// this registry has no tracked (non-terminal) entry for `issue` — the
+    /// only way a lock's `owner_pid` can legitimately equal `std::process::id()`
+    /// is `acquire_lock`'s provisional placeholder before the spawned child's
+    /// real pid is recorded (`record_child_pid_in_lock`, #3808). If that
+    /// rewrite never ran and this registry also has no tracked entry for the
+    /// issue, the lock is stale by construction — a leaked placeholder from a
+    /// `spawn_child` failure, not a confirmed-live claim — so the daemon's own
+    /// (necessarily still-alive) pid must not count as evidence against
+    /// itself. A registry that DOES have a tracked entry for the issue keeps
+    /// the exclusion off, so an actual in-flight dispatch's transient
+    /// pre-rewrite window is never misread as stale.
     #[must_use]
     pub fn live_claim_evidence(&self, issue: u32) -> Option<crate::live_claim::LiveClaimEvidence> {
-        crate::live_claim::probe(
+        let own_untracked_pid = (!self.has_tracked_sweep_for(issue)).then_some(std::process::id());
+        crate::live_claim::probe_excluding(
             &self.config.workspace_root,
             self.config.journal_path.as_deref(),
             issue,
+            own_untracked_pid,
         )
+    }
+
+    /// Whether this registry has a non-terminal (`Pending`/`Running`) entry
+    /// tracking a sweep for `issue` — shared by [`Self::live_claim_evidence`]
+    /// (#5236) and [`Self::unregistered_locked_issues`] (#4214), both of
+    /// which need the same "does our own bookkeeping know about this issue"
+    /// question.
+    #[must_use]
+    fn has_tracked_sweep_for(&self, issue: u32) -> bool {
+        self.entries.values().any(|info| {
+            !info.state.is_terminal() && matches!(info.kind, SweepKind::Issue(i) if i == issue)
+        })
     }
 
     // ------------------------------------------------------------------------

--- a/loom-daemon/src/sweep_registry/test_support.rs
+++ b/loom-daemon/src/sweep_registry/test_support.rs
@@ -622,6 +622,57 @@ pub(crate) fn token_selection_failure_registry(ws: &Path) -> (SweepRegistry, Pat
     (SweepRegistry::new(config), gh_log)
 }
 
+// --- spawn_child hard failure (Issue #5236) ---
+
+/// Install a fake `gh` (identical contract to
+/// [`token_selection_failure_registry`] — every dispatch-path guard probe
+/// answers "open, not a PR, no park label, no open linked PR") and point
+/// `spawn_bin` at a file that does not exist, so `spawn_child`'s
+/// `resolve_spawn_bin()` resolves the override (an explicit override is
+/// trusted verbatim, unlike the installed/defaults fallback probes) but
+/// `Command::spawn()` then fails at the OS level (`ENOENT`) — the exact
+/// repro this issue's Test Plan calls for: "point a registered workspace's
+/// spawn-bin resolution at a nonexistent file... and dispatch twice".
+///
+/// Unlike [`token_selection_failure_registry`] (a child that starts, then
+/// dies immediately) this never spawns a process at all — `dispatch_inner`'s
+/// `spawn_child` call itself returns `Err`, exercising the earlier failure
+/// path this issue's AC #1 covers.
+pub(crate) fn spawn_bin_missing_registry(ws: &Path) -> (SweepRegistry, PathBuf) {
+    let gh_log = ws.join("gh-invocations.log");
+    let fake_gh = ws.join("fake-gh.sh");
+    let script = format!(
+        "#!/usr/bin/env bash\n\
+             printf '%s\\n' \"$*\" >> \"{log}\"\n\
+             if [[ \"$1\" == \"api\" && \"$2\" == repos/* ]]; then\n\
+             printf '%s\\n' '{{\"state\":\"open\",\"is_pr\":false}}'\n\
+             exit 0\n\
+             fi\n\
+             if [[ \"$1\" == \"repo\" && \"$2\" == \"view\" ]]; then\n\
+             printf 'rjwalters/loom\\n'\n\
+             exit 0\n\
+             fi\n\
+             exit 0\n",
+        log = gh_log.display(),
+    );
+    std::fs::write(&fake_gh, &script).unwrap();
+    let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&fake_gh, perms).unwrap();
+    if let Ok(f) = std::fs::File::open(&fake_gh) {
+        let _ = f.sync_all();
+    }
+    touch_sweep_command(ws);
+
+    let mut config = SweepRegistryConfig::new(ws.to_path_buf());
+    // Deliberately nonexistent — never written to disk.
+    config.spawn_bin = Some(ws.join(".loom/scripts/does-not-exist-spawn-worker.sh"));
+    config.gh_bin = Some(fake_gh);
+    config.skip_label_flip = false; // exercise the real flip + revert path
+    config.journal_path = Some(ws.join("test-sweeps-journal.json"));
+    (SweepRegistry::new(config), gh_log)
+}
+
 // ------------------------------------------------------------------------
 // Account-exhaustion attribution at insta-crash time (Issue #4122)
 // ------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`dispatch_inner` acquires the claim lock and flips the `loom:issue` ->
`loom:building` label *before* `spawn_child` runs. When `spawn_child` itself
returns `Err` (e.g. a registered workspace whose `.loom/scripts/` is missing
`spawn-worker.sh`, so `resolve_spawn_bin` fails before any process is ever
spawned), those side effects were left in place. The leaked lock's
`owner_pid` is the daemon's own (permanently alive, from its own point of
view) pid, which the `#4556` live-claim guard then reads as a confirmed-live
claim on every retry — a permanent wedge until an operator manually removes
the lock dir. This PR fixes the leak and closes the guard's blind spot that
made it permanent, and adds the daemon-log-side half of the error-surfacing
gap (the caller-facing half was already fixed by `#5218`/`#5210`).

## Changes

- `loom-daemon/src/sweep_registry/dispatch.rs`: on a `spawn_child` `Err`,
  `dispatch_inner` now reverts the label flip (if `!skip_label_flip`),
  retracts the peer-claim advertisement, and releases the claim lock —
  mirroring the existing `#4689` immediate-preflight-death cleanup branch
  just below it — before returning the error with its original context.
- `loom-daemon/src/live_claim.rs`: `live_lock_owner_in` (leg 1 of the
  `#4556` live-claim probe) gains an `own_untracked_pid: Option<u32>`
  parameter — a lock whose `owner_pid` equals it is never treated as
  evidence, regardless of what the liveness/argv check would otherwise
  conclude. `probe` is now a thin wrapper over a new `probe_excluding`
  that threads this through; every existing caller (`probe`, unchanged
  signature) is unaffected.
- `loom-daemon/src/sweep_registry/locks.rs`: `live_claim_evidence` (the
  evidence backing the dispatch-time `#4556` guard) now passes
  `Some(std::process::id())` as the exclusion whenever this registry has no
  tracked (non-terminal) entry for the issue — the only way a lock's
  `owner_pid` can legitimately equal the daemon's own pid is
  `acquire_lock`'s provisional placeholder before
  `record_child_pid_in_lock` (`#3808`) rewrites it to the real child pid.
  Extracted a shared `has_tracked_sweep_for` helper (also now used by the
  pre-existing `unregistered_locked_issues`).
- `loom-daemon/src/ipc.rs`: `dispatch_sweep`'s `Err` arm now `log::warn!`s
  the full error chain (`{e:#}`) before constructing the `Response::Error`,
  so a dispatch failure is visible in the daemon's own log, not only in the
  MCP/CLI response.
- `loom-daemon/src/sweep_registry/test_support.rs`: adds
  `spawn_bin_missing_registry`, a fixture mirroring
  `token_selection_failure_registry` but pointing `spawn_bin` at a
  nonexistent file so `spawn_child` itself returns `Err` (rather than
  spawning a child that then dies).

## Acceptance Criteria Verification

- [x] `dispatch_inner` releases the claim lock, reverts the label flip (if
      `!skip_label_flip`), and retracts the peer-claim advertisement when
      `spawn_child` returns `Err` — mirroring the `#4689` cleanup branch.
      Verified by `dispatch_reverts_claim_lock_and_label_when_spawn_child_itself_fails`.
- [x] The live-claim guard (`live_claim::probe` leg 1) does not treat a lock
      whose `owner_pid` is the daemon's own pid with no corresponding
      tracked entry as a confirmed-live claim. Verified by
      `live_lock_owner_excludes_own_untracked_pid_even_when_live` and
      `probe_excluding_ignores_a_leaked_provisional_lock_owned_by_self`.
- [x] `dispatch_sweep`'s `Err` arm in `ipc.rs` now logs the full error chain
      at WARN. (The response-surfacing half was already done by `#5218`/`#5210`,
      verified still intact by the existing
      `test_dispatch_sweep_registered_workspace_missing_spawn_bin_surfaces_inner_error`.)
- [x] Repro test: `second_dispatch_after_spawn_child_failure_is_not_refused_by_the_live_claim_guard`
      dispatches twice against a workspace whose `spawn_bin` resolves to a
      nonexistent file — the second dispatch reaches the same `spawn_child`
      failure again instead of being refused by the `#4556` guard.

## Test Plan

- `cargo test --lib` in `loom-daemon/`: 3373 passed, 1 pre-existing
  unrelated failure (`daemon_install_state::tests::launchctl_pid_falls_back_to_gui_uid_then_user_uid_when_no_override`
  — fails because this host has a real `loom-daemon` running under
  `gui/501/com.rjwalters.loom-daemon`, an environment-dependent probe of
  the live launchd state; untouched by this diff).
- Targeted reruns, all green: `cargo test --lib` filtered to
  `sweep_registry::` (340 passed), `live_claim` (36 passed, including the
  two new tests and every pre-existing `#4556`/leg-1/leg-2/leg-3 test), and
  `ipc::` (85 passed, including the existing `#5218` inner-error-surfacing
  test).
- `cargo clippy --lib -- -D warnings` and `cargo fmt -- --check`: clean.
- Confirmed a genuinely live sweep is still refused by the live-claim
  guard after this change: `probe_excluding_ignores_a_leaked_provisional_lock_owned_by_self`
  spawns a real distinct sweep process (`FakeSweep`) for a second issue with
  the same exclusion pid in play and asserts it is still reported as live
  evidence — the exclusion only ever matches on exact pid equality, never
  weakening the guard for a real duplicate.

Closes #5236