### PR TITLE
fix(guard): right-hand anchor gh release delete so it doesn't match delete-asset

### DIFF
--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -3710,7 +3710,16 @@ ASK_PATTERNS=(
     # were REMOVED from this array (#3757): they are trivially undone (gh pr
     # reopen / gh issue reopen / recreate the label) and are only asked for when
     # a repo opts IN via guards.reversibleGh (REVERSIBLE_GH_ASK_PATTERNS below).
-    '(^|[;&|[:space:]])gh release delete'
+    #
+    # Right-hand anchored (#5260): the old pattern had no boundary after
+    # `delete`, so it substring-matched `gh release delete-asset` — a distinct,
+    # far-less-destructive subcommand that only removes one uploaded artifact,
+    # not the whole release/tag. Requiring the match to end at a shell
+    # separator/whitespace or end-of-string (mirroring the existing left-hand
+    # `(^|[;&|[:space:]])` anchor) lets `delete-asset`'s immediate hyphen break
+    # the match while the bare/argumented `gh release delete` case (and any
+    # other `gh release delete-*` subcommand) is unaffected.
+    '(^|[;&|[:space:]])gh release delete([;&|[:space:]]|$)'
 
     # Cloud IAM credential deletion — retiered from the catastrophic ALWAYS_BLOCK
     # list to this UNGATED ask tier (#4216). Kept OUT of CLOUD_ASK_PATTERNS on

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -3710,7 +3710,16 @@ ASK_PATTERNS=(
     # were REMOVED from this array (#3757): they are trivially undone (gh pr
     # reopen / gh issue reopen / recreate the label) and are only asked for when
     # a repo opts IN via guards.reversibleGh (REVERSIBLE_GH_ASK_PATTERNS below).
-    '(^|[;&|[:space:]])gh release delete'
+    #
+    # Right-hand anchored (#5260): the old pattern had no boundary after
+    # `delete`, so it substring-matched `gh release delete-asset` — a distinct,
+    # far-less-destructive subcommand that only removes one uploaded artifact,
+    # not the whole release/tag. Requiring the match to end at a shell
+    # separator/whitespace or end-of-string (mirroring the existing left-hand
+    # `(^|[;&|[:space:]])` anchor) lets `delete-asset`'s immediate hyphen break
+    # the match while the bare/argumented `gh release delete` case (and any
+    # other `gh release delete-*` subcommand) is unaffected.
+    '(^|[;&|[:space:]])gh release delete([;&|[:space:]]|$)'
 
     # Cloud IAM credential deletion — retiered from the catastrophic ALWAYS_BLOCK
     # list to this UNGATED ask tier (#4216). Kept OUT of CLOUD_ASK_PATTERNS on

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -1067,6 +1067,45 @@ assert_allow "#3757: gh label delete no longer asks by default (reversible)" \
 assert_ask "Ask for gh release delete" \
     "gh release delete v1.0"
 
+# --- #5260: right-hand anchor so `gh release delete` doesn't substring-match
+# `gh release delete-asset` (a distinct, far-less-destructive subcommand that
+# only removes one uploaded artifact, not the whole release/tag). ---
+assert_allow "#5260: gh release delete-asset no longer false-asks" \
+    "gh release delete-asset v0.18.0 loom-daemon-aarch64-unknown-linux-gnu -y"
+
+assert_allow "#5260: gh release delete-asset after a ; separator no longer false-asks" \
+    "git status; gh release delete-asset v0.18.0 asset.tar.gz -y"
+
+assert_allow "#5260: gh release delete-asset after a && separator no longer false-asks" \
+    "gh release upload v0.18.0 asset.tar.gz && gh release delete-asset v0.18.0 old-asset.tar.gz -y"
+
+assert_allow "#5260: sudo-wrapped gh release delete-asset no longer false-asks" \
+    "sudo gh release delete-asset v0.18.0 asset.tar.gz -y"
+
+assert_allow "#5260: other gh release subcommands remain unaffected (list)" \
+    "gh release list"
+
+assert_allow "#5260: other gh release subcommands remain unaffected (view)" \
+    "gh release view v1.0"
+
+assert_allow "#5260: other gh release subcommands remain unaffected (create)" \
+    "gh release create v1.0"
+
+assert_allow "#5260: other gh release subcommands remain unaffected (download)" \
+    "gh release download v1.0"
+
+assert_ask "#5260: bare gh release delete (no args, end-of-string) still asks" \
+    "gh release delete"
+
+assert_ask "#5260: gh release delete after a ; separator still asks" \
+    "git status; gh release delete v1.0"
+
+assert_ask "#5260: gh release delete after a && separator still asks" \
+    "git status && gh release delete v1.0"
+
+assert_ask "#5260: gh release delete after a | separator still asks" \
+    "echo v1.0 | xargs gh release delete"
+
 # --- #3756: ask-tier command-position anchoring + literal-text redaction ---
 # The ASK_PATTERNS loop used to grep bare, unanchored substrings against a copy
 # that was only comment-stripped (never literal-redacted), so an ask-phrase that


### PR DESCRIPTION
## Summary

Fixes an `ask`-tier false positive where the ungated `gh release delete`
pattern substring-matched `gh release delete-asset` -- a distinct,
far-less-destructive subcommand that only removes one uploaded artifact,
not the whole release/tag. This caused a routine, safe, reversible
release-fixup step to trip an ASK-tier guard block with no human to answer
in headless/autonomous runs.

## Root cause

The ask pattern in `ASK_PATTERNS` (`defaults/hooks/guard-destructive-generic.sh:3713`)
was anchored only on the left (`(^|[;&|[:space:]])`, per #3756's
command-position anchoring), with no boundary on the right. So
`gh release delete-asset v0.18.0 asset.tar.gz -y` matched as a prefix of
the intended `gh release delete` phrase, even though it invokes a
different, much narrower subcommand.

## Fix

Added a right-hand anchor requiring the match to end at a shell
separator/whitespace character or end-of-string, mirroring the existing
left-hand anchor already used throughout the array:

```
'(^|[;&|[:space:]])gh release delete([;&|[:space:]]|$)'
```

`delete-asset`'s immediate hyphen now breaks the match (ALLOW), while
`gh release delete` -- bare, with args, or after a `;`/`&&`/`|` separator --
still asks exactly as before. Other `gh release` subcommands (`list`,
`view`, `create`, `download`) were already unmatched and remain so.

Both `defaults/hooks/guard-destructive-generic.sh` and the tracked mirror
`.loom/hooks/guard-destructive-generic.sh` are edited identically (verified
with `diff`), matching how #5214/PR #5221 handled the parallel systemctl
false-positive fix.

## Test plan

- [x] `tests/hooks/test-guard-destructive.sh` passes (762/762), including
      13 new #5260 assertions: `gh release delete-asset` (bare, after
      `;`/`&&` separators, sudo-wrapped) now allows; `gh release delete`
      (bare, after `;`/`&&`/`|` separators) still asks; other `gh release`
      subcommands (`list`/`view`/`create`/`download`) remain unaffected.
- [x] `tests/hooks/test-guard-destructive-dispatcher.sh` passes (12/12).
- [x] `shellcheck` on the modified file shows no new warnings vs. `main`
      (only pre-existing SC2016/SC1003 info-level notices elsewhere in the
      file).
- [x] Manually verified the issue's exact repro command
      (`gh release delete-asset v0.18.0 loom-daemon-aarch64-unknown-linux-gnu -y`)
      no longer produces an `ask`/`deny` `permissionDecision`.

Closes #5260