### PR TITLE
fix(guard): admit read-only search piped to a read-only sink on the fast path

### DIFF
--- a/defaults/docs/guard-hooks.md
+++ b/defaults/docs/guard-hooks.md
@@ -814,7 +814,7 @@ The fast path is **on by default**. It is resolved in this order (highest preced
 
 **Security — the fast path is a guard bypass by construction**, so admission is purely **structural** and conservative, never content-sensitive. A command is fast-pathed only when **all** of these hold (otherwise it falls through to the full path unchanged):
 
-- The raw command contains **none** of `;` `&` `|` `<` `>` backtick `$(` or a newline — this excludes all chaining, piping, redirection, and command substitution. So `git status && git push --force origin main`, `git status; rm -rf /`, and `git status $(rm -rf /)` all take the full path and are still denied.
+- The raw command contains **none** of `;` `&` `|` `<` `>` backtick `$(` or a newline — this excludes all chaining, piping, redirection, and command substitution. So `git status && git push --force origin main`, `git status; rm -rf /`, and `git status $(rm -rf /)` all take the full path and are still denied. **One narrow exception (#5263):** a read-only search piped to a single read-only sink — `grep`/`egrep`/`fgrep`/`rg <args> | (head|tail|wc|cat|less|more)` — is still admitted (see the search-pipe carve-out below), because a bare `grep 'DROP TABLE' schema.sql` was already fast-pathed and the pipe to a pager/counter does not add any executing command.
 - The **first token** is an exact allowlist match (never a wrapper — `bash -c`, `sh -c`, `eval`, `xargs`, `env … git status`, `sudo git status` are all excluded because their first token isn't allowlisted):
 
 | First token | Admitted form |
@@ -827,10 +827,18 @@ The fast path is **on by default**. It is resolved in this order (highest preced
 | `gh` | `gh <noun> view` / `gh <noun> list` (never `delete`/`close`/`archive`/…) |
 | `aws` | `aws <service> describe*` / `get*` / `list*`, and `aws s3 ls` |
 
-**`cat` and `ssh` are deliberately EXCLUDED** from the built-in list, even though they are read-only in spirit:
+**`cat` and `ssh` are deliberately EXCLUDED** from the built-in first-token list, even though they are read-only in spirit:
 
 - `cat` has a narrow existing `ASK` carve-out (`cat …/.ssh/…`, `cat …/.aws/credentials`); a blanket `cat` fast-path would silently skip it.
 - `ssh <host> '<cmd>'` wraps an **opaque remote command string** that the raw `ALWAYS_BLOCK` catastrophic scan still covers today; fast-pathing any `ssh …` would drop that coverage.
+
+**Search-pipe carve-out (#5263)** — the single documented exception to the "no `|`" rule above. A read-only search piped to one read-only sink is admitted, because the phrase the guard would otherwise fire on lives only inside the search command's quoted pattern argument (which is never executed). This fixes a self-defeating false positive: a bare `grep 'DROP TABLE' schema.sql` was already fast-pathed and allowed, but piping it to `head`/`less` to page the results (`grep 'DROP TABLE' schema.sql | head`) fell through to the full path, where the `sql-ddl` catastrophic check substring-matched the literal `DROP TABLE` in grep's own argument and **denied** — one of the most common interactive idioms. The carve-out admits **only** this exact shape:
+
+- **exactly one `|`**, and **none** of `;` `&` `<` `>` backtick `$(` or a newline anywhere — so wrapper (`bash -c '… | …'`), substitution (`$(…)`), and compound (`&&`/`;`) forms are untouched and keep denying via the full path (obfuscation still caught);
+- the **upstream** command word is a non-executing search: `grep`, `egrep`, `fgrep`, or `rg` (a real DDL executor like `mysql -e '…' | cat` or `psql -c '…' | head` has a non-search first token, so it is **not** admitted and still denies);
+- the **downstream** command word is a read-only sink: `head`, `tail`, `wc` (already fully allowlisted, so any arguments), or `cat`, `less`, `more` (admitted **only** as pure stdin consumers with no positional file operand — so `grep x | cat ~/.ssh/id_rsa` is **not** fast-pathed and the `cat` `.ssh`/`.aws` `ASK` carve-out above still fires).
+
+A second pipe, an unlisted sink, or a `cat`/`less`/`more` with a file operand all decline the carve-out and take the full path unchanged (a false negative is always safe). The carve-out is gated by the same `guards.readOnlyFastPath` / `LOOM_GUARD_READONLY_FASTPATH` toggle — disabling the fast path disables it too.
 
 **Optional extend-only escape hatch** — `guards.readOnlyFastPathExtra` is an array of **literal first-word commands** to add to the built-in list without hand-editing the Loom-managed `.claude/settings.json` (which the installer may overwrite). This directly answers "give operators a supported way to scope the matcher":
 

--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -446,6 +446,91 @@ fastpath_builtin_admits() {
     return 1
 }
 
+# Read-only search-pipe-to-sink admission (#5263). Pure bash builtins, zero forks.
+#
+# The shared fastpath_structural_ok() above disqualifies EVERY pipe, which is
+# correct for the general case but produces a self-defeating false positive for
+# the single most common interactive idiom: piping a read-only search to a pager
+# or counter. `grep 'DROP TABLE' schema.sql | head` is 100% read-only — the DDL
+# phrase lives only inside grep's quoted search argument, and grep never executes
+# what it matches — yet the pipe kicked it to the full path, where SQL_DDL_PATTERN
+# (:~2819) substring-matches the literal phrase in grep's own argument and denies
+# at the catastrophic tier. The bare `grep 'DROP TABLE' schema.sql` (no pipe) was
+# already fast-pathed and allowed; this narrows the gap so the piped form matches.
+#
+# SECURITY: this is a deliberately NARROW carve-out, not a general "pipes are OK"
+# relaxation. It admits ONLY the shape
+#     <search> | <read-only-sink>
+# where:
+#   * exactly ONE pipe, and NO other shell metacharacter (; & < > ` $( newline)
+#     anywhere — so wrapper (`bash -c`), substitution (`$(...)`), and compound
+#     (`&&`/`;`) forms are untouched and keep denying via the full path exactly
+#     as before (satisfying #5263's "obfuscation still caught" requirement);
+#   * the UPSTREAM command word is a non-executing search: grep|egrep|fgrep|rg
+#     (grep/rg are already fully admitted for any args by the built-in allowlist;
+#     egrep/fgrep are the same tool). A real DDL-executing command piped the same
+#     way (`mysql -e '…' | cat`, `psql -c '…' | head`) has a non-search first
+#     token, so it is NOT admitted and still denies;
+#   * the DOWNSTREAM command word is a fixed read-only sink allowlist. head|tail|wc
+#     are already fully allowlisted (any args), so they admit with any args. cat,
+#     less, and more are NOT in the built-in allowlist — cat has a live `.ssh`/
+#     `.aws/credentials` ASK carve-out (:~3764) — so they admit ONLY as pure stdin
+#     consumers (no positional file operand). This keeps `grep x | cat ~/.ssh/id_rsa`
+#     (which would leak a key past the cat ASK) OUT of the fast path: it falls
+#     through to the full path where the cat ASK still fires.
+#
+# False NEGATIVES (declining) are always safe — they just fall through to the
+# existing slower behavior. So anything not matching the exact shape above (a
+# second pipe, an unlisted sink, a non-search upstream, a cat/less/more with a
+# file operand) declines and is handled by the full path unchanged.
+_FASTPATH_PIPE_SINKS_ANYARG=" head tail wc "     # already fully allowlisted → any args
+_FASTPATH_PIPE_SINKS_STDIN=" cat less more "     # stdin-only → no positional operand
+fastpath_grep_pipe_admits() {
+    local cmd="$1"
+    # No shell metacharacter other than a single pipe. Reject substitution,
+    # redirection, chaining, backticks, and newlines outright.
+    case "$cmd" in
+        *';'*|*'&'*|*'<'*|*'>'*|*'`'*|*'$('*) return 1 ;;
+    esac
+    [[ "$cmd" == *$'\n'* ]] && return 1
+    [[ "$cmd" == *'|'* ]] || return 1
+    local left="${cmd%%|*}"
+    local right="${cmd#*|}"
+    # Exactly one pipe: a second one (`grep a | grep b | head`) declines here and
+    # falls through to the full path (conservative — a false negative, not a hole).
+    case "$right" in
+        *'|'*) return 1 ;;
+    esac
+    local -a lt rt
+    read -ra lt <<< "$left"
+    read -ra rt <<< "$right"
+    (( ${#lt[@]} >= 1 && ${#rt[@]} >= 1 )) || return 1
+    # Upstream must be a non-executing search command.
+    case "${lt[0]}" in
+        grep|egrep|fgrep|rg) ;;
+        *) return 1 ;;
+    esac
+    # Downstream must be a read-only sink.
+    local sink="${rt[0]}"
+    if [[ "$_FASTPATH_PIPE_SINKS_ANYARG" == *" $sink "* ]]; then
+        return 0
+    fi
+    if [[ "$_FASTPATH_PIPE_SINKS_STDIN" == *" $sink "* ]]; then
+        # Pure stdin consumer only: reject any positional (non-flag) operand so a
+        # credential-file argument (`| cat ~/.ssh/id_rsa`) is NOT fast-pathed and
+        # the cat `.ssh`/`.aws` ASK carve-out still fires via the full path.
+        local i
+        for (( i = 1; i < ${#rt[@]}; i++ )); do
+            case "${rt[i]}" in
+                -*) ;;          # a flag (e.g. -n, -N) — fine
+                *) return 1 ;;  # a positional file operand — decline
+            esac
+        done
+        return 0
+    fi
+    return 1
+}
+
 # Optional extend-only escape hatch: guards.readOnlyFastPathExtra is an array of
 # literal first-word commands. Read lazily (only when the built-in list did not
 # admit) and cached. Each entry is a full-generality bypass for that word.
@@ -513,6 +598,9 @@ _fastpath_env="${LOOM_GUARD_READONLY_FASTPATH:-}"
 if [[ "$_fastpath_env" != "0" && "$_fastpath_env" != "false" && "$_fastpath_env" != "no" ]]; then
     if fastpath_builtin_admits "$COMMAND"; then
         # Silent allow: no stdout/stderr, no log_hook_error, before REPO_ROOT.
+        fastpath_enabled && exit 0
+    elif fastpath_grep_pipe_admits "$COMMAND"; then
+        # Read-only search piped to a read-only sink (#5263) — same silent allow.
         fastpath_enabled && exit 0
     elif fastpath_extra_admits "$COMMAND"; then
         fastpath_enabled && exit 0

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -2598,15 +2598,70 @@ assert_deny "Fast path security: 'git status ; <force-push main>' still denies" 
 _FP_ROOT="/"
 assert_deny "Fast path security: 'git status \$(rm -rf /)' takes full path and denies" \
     "git status \$(rm -rf $_FP_ROOT)"
-# Pipe: observable — same read-only grep, but the pipe disqualifies the fast
-# path so the full-path SQL-DDL check fires (deny), proving the excluded-char
-# guard truly routes to the full path rather than admitting.
-assert_deny "Fast path security: 'grep <ddl> | cat' pipe disqualifies fast path (SQL-DDL denies)" \
-    "grep '$_FP_DDL' x.sql | cat"
-# Wrapper: first token is bash (not an allowlist word) → not admitted. Observable
-# via the SQL grep the wrapper carries (full path denies).
+# Pipe to a read-only sink: VERDICT CHANGED by #5263. A read-only search piped to
+# a read-only sink (cat/head/tail/wc/less/more) is 100% read-only — the DDL phrase
+# lives only inside grep's quoted search argument, which grep never executes — so
+# the narrow search-pipe carve-out (fastpath_grep_pipe_admits) now admits it,
+# matching the already-allowed bare `grep <ddl>` form. Before #5263 the pipe
+# disqualified the fast path and the full-path SQL-DDL check false-positived on
+# grep's own argument (deny). This was the self-defeating false positive #5263
+# fixes: `grep 'DROP TABLE' … | head` is one of the most common interactive idioms.
+if [[ "$_FP_AMBIENT_ON" == "1" ]]; then
+    assert_allow_silent "Fast path: 'grep <ddl> | cat' read-only search-pipe now admits (#5263)" \
+        "grep '$_FP_DDL' x.sql | cat"
+    assert_allow_silent "Fast path: 'grep <ddl> | head' read-only search-pipe admits (#5263)" \
+        "grep '$_FP_DDL' x.sql | head"
+    assert_allow_silent "Fast path: 'grep <ddl> | head -n 40' (head takes any args) admits (#5263)" \
+        "grep '$_FP_DDL' x.sql | head -n 40"
+    assert_allow_silent "Fast path: 'grep <ddl> | tail -5' read-only search-pipe admits (#5263)" \
+        "grep '$_FP_DDL' x.sql | tail -5"
+    assert_allow_silent "Fast path: 'grep <ddl> | wc -l' read-only search-pipe admits (#5263)" \
+        "grep '$_FP_DDL' x.sql | wc -l"
+    assert_allow_silent "Fast path: 'grep <ddl> | less' stdin-sink admits (#5263)" \
+        "grep '$_FP_DDL' x.sql | less"
+    assert_allow_silent "Fast path: 'grep <ddl> | cat -n' (flag-only cat) admits (#5263)" \
+        "grep '$_FP_DDL' x.sql | cat -n"
+    assert_allow_silent "Fast path: 'rg <ddl> | head' rg upstream admits (#5263)" \
+        "rg '$_FP_DDL' x.sql | head"
+    assert_allow_silent "Fast path: 'egrep <ddl> | wc -l' egrep upstream admits (#5263)" \
+        "egrep '$_FP_DDL' x.sql | wc -l"
+    assert_allow_silent "Fast path: 'fgrep <ddl> | cat' fgrep upstream admits (#5263)" \
+        "fgrep '$_FP_DDL' x.sql | cat"
+fi
+# Security (#5263): the search-pipe carve-out is NARROW. A real DDL-executing
+# command piped to a read-only sink has a non-search first token, so it is NOT
+# admitted and the full-path SQL-DDL check still fires (deny). This is the
+# obfuscation-still-caught guarantee: a pipe to `cat` cannot launder a live DDL.
+assert_deny "Fast path security: 'mysql -e <ddl> | cat' (real DDL executor) still denies (#5263)" \
+    "mysql -e '$_FP_DDL' | cat"
+assert_deny "Fast path security: 'psql -c <ddl> | head' (real DDL executor) still denies (#5263)" \
+    "psql -c '$_FP_DDL' | head"
+# A search piped to a NON-sink command (not in the read-only sink allowlist) is
+# NOT admitted — only the fixed sink allowlist qualifies, so this falls through to
+# the full path where the SQL-DDL check fires on grep's argument (deny).
+assert_deny "Fast path security: 'grep <ddl> | sh' (pipe to non-sink) still denies (#5263)" \
+    "grep '$_FP_DDL' x.sql | sh"
+# cat WITH a credential-file operand must NOT be fast-pathed: the stdin-only sink
+# rule rejects any positional operand, so the command falls through to the full
+# path where cat's existing .ssh ASK carve-out still fires (ask, not silent allow).
+# A NON-DDL search is used here so the verdict isolates the cat carve-out — a DDL
+# phrase in grep's argument would deny at the earlier catastrophic sql-ddl tier
+# first, masking whether the credential ASK was preserved.
+assert_ask "Fast path security: 'grep foo | cat ~/.ssh/id_rsa' still asks (cat operand not fast-pathed, #5263)" \
+    "grep foo x.sql | cat ~/.ssh/id_rsa"
+# A second pipe declines the (single-pipe) carve-out and falls through to the full
+# path, where the SQL-DDL check fires on grep's argument (deny). Conservative by
+# design: a multi-stage read-only pipe is a false negative, never a hole.
+assert_deny "Fast path security: 'grep <ddl> | grep x | head' (two pipes) declines carve-out, denies (#5263)" \
+    "grep '$_FP_DDL' x.sql | grep foo | head"
+# Wrapper: first token is bash (not an allowlist word) → not admitted, and the
+# search-pipe carve-out is UNCHANGED for wrappers (its metachar reject rules out
+# the quoted payload's own pipe too). Observable via the SQL grep the wrapper
+# carries (full path denies). #5263 deliberately does NOT relax this.
 assert_deny "Fast path security: 'bash -c \"grep <ddl>\"' wrapper not admitted (SQL-DDL denies)" \
     "bash -c \"grep '$_FP_DDL' x.sql\""
+assert_deny "Fast path security: 'bash -c \"grep <ddl> | head\"' wrapper+pipe not admitted (SQL-DDL denies, #5263)" \
+    "bash -c \"grep '$_FP_DDL' x.sql | head\""
 # Non-bare git subcommand form: `git -C /p status` is not admitted; still allows
 # via the existing full path (verdict unchanged, just unoptimized).
 assert_allow "Fast path: 'git -C /tmp status' not fast-pathed, still allowed via full path" \
@@ -2618,9 +2673,16 @@ assert_ask "Fast path: 'cat ~/.ssh/id_rsa' still asks (cat excluded from fast pa
 # --- Toggle off restores the full-path verdict byte-for-byte (env + config) ---
 assert_deny_env "Fast path off (env): 'grep <ddl>' takes full path and denies" \
     "LOOM_GUARD_READONLY_FASTPATH=0" "grep '$_FP_DDL' schema.sql"
+# The #5263 search-pipe carve-out is gated by the SAME toggle: with the fast path
+# force-disabled, the piped grep also takes the full path and denies (proving the
+# carve-out is not a separate always-on bypass).
+assert_deny_env "Fast path off (env): 'grep <ddl> | head' search-pipe also denies (#5263)" \
+    "LOOM_GUARD_READONLY_FASTPATH=0" "grep '$_FP_DDL' schema.sql | head"
 FASTPATH_OFF_REPO=$(make_sql_repo '{"guards":{"readOnlyFastPath":false}}')
 assert_deny "Fast path off (config): 'grep <ddl>' takes full path and denies" \
     "grep '$_FP_DDL' schema.sql" "$FASTPATH_OFF_REPO"
+assert_deny "Fast path off (config): 'grep <ddl> | head' search-pipe also denies (#5263)" \
+    "grep '$_FP_DDL' schema.sql | head" "$FASTPATH_OFF_REPO"
 # Env override wins over config (mirrors the sqlDdl/cloudCli precedent): env=1
 # forces the fast path ON even when the config disables it.
 assert_allow_env "Fast path: LOOM_GUARD_READONLY_FASTPATH=1 overrides config-off (allow)" \
@@ -3737,18 +3799,21 @@ assert_allow "stash-scope: git status alone still allowed (read-only fast path u
 assert_allow "ask-tier (#5235): check-duplicate.sh positional TITLE/DESCRIPTION quoting 'git stash pop' as inert prose no longer asks" \
     './.loom/scripts/check-duplicate.sh "Guard false positive: stash-scope redirect" "quotes git stash pop as inert text, not a live invocation"' "$ST_REPO"
 
-# Deliberate scope decision (see mask_ask_positional_args()'s header comment
-# in guard-destructive-generic.sh): grep/rg are NOT in this ask-tier
-# allowlist, unlike guard-loom-workflow.sh's #5155/#5160 fix -- COMMAND_ASK_SCAN
-# also feeds the SQL DDL/DML check, which intentionally still scans a grep
-# invocation's own quoted search pattern for a literal DDL phrase once off
-# the read-only fast path (see the "Fast path security"/"Fast path off" test
-# groups above). Piped to `cat` (same disqualifier the SQL-DDL fast-path
-# tests above use) so this actually reaches the ask-tier scan instead of
-# short-circuiting via the #3687 read-only fast path. So a grep search
-# quoting the ask-phrase as prose still asks here -- this is the documented,
-# deliberately narrower scope, not a miss.
-assert_ask "ask-tier (#5235): grep -n search whose pattern quotes 'git stash pop' mid-sentence still asks (grep deliberately not allowlisted, see SQL-DDL conflict)" \
+# VERDICT CHANGED by #5263. grep/rg are still NOT in the ask-tier positional-arg
+# allowlist (COMMAND_ASK_SCAN also feeds the SQL DDL/DML check, so a grep's own
+# quoted search pattern is deliberately still scanned once a command reaches the
+# full path). This case USED to `cat`-pipe the grep specifically to disqualify
+# the #3687 read-only fast path and thereby REACH the ask-tier scan, so it asked.
+# #5263 added a narrow search-pipe carve-out: `grep|egrep|fgrep|rg … | (read-only
+# sink)` is now fast-pathed to a silent allow, because a read-only search piped to
+# a pager/counter is 100% read-only — the quoted phrase is inert search text grep
+# never executes. So `grep -n "…git stash pop…" file | cat` now ALLOWS silently.
+# This is the same false-positive class #5263 fixes for SQL-DDL, applied to the
+# stash-scope phrase, and is correct: no real stash operation runs. The two
+# regression guards below still prove a REAL invocation (a `&&`-chained stash pop,
+# an `echo … | bash`) is unaffected and still asks — the carve-out only admits the
+# search-to-sink shape, not chains or non-search upstreams.
+assert_allow_silent "ask-tier (#5235/#5263): grep -n search quoting 'git stash pop' piped to cat now fast-paths (read-only search-pipe carve-out)" \
     'grep -n "this example mentions git stash pop mid-sentence" defaults/hooks/guard-destructive-generic.sh | cat' "$ST_REPO"
 
 # Regression guard: masking a matched positional span must not blind the


### PR DESCRIPTION
## Summary

Fixes the `sql-ddl` catastrophic-tier false positive where a **read-only** `grep`/`rg` search for a DDL phrase piped to a read-only sink (`grep 'DROP TABLE' schema.sql | head`) was denied — even though the DDL phrase lives only inside grep's own quoted search argument, which grep never executes.

The bare form `grep 'DROP TABLE' schema.sql` (no pipe) was already fast-pathed and allowed via the #3687/#3772 read-only fast path. The pipe disqualified the fast path and fell through to the full path, where `SQL_DDL_PATTERN` substring-matched the literal phrase in grep's argument and denied. Piping a search to a pager/counter is one of the most common interactive idioms, so this was a frequently-reachable, self-defeating false positive (it even blocked filing a bug report *about* the guard).

## Changes

- **`defaults/hooks/guard-destructive-generic.sh`** — new `fastpath_grep_pipe_admits()` helper (zero forks, pure bash builtins), wired into the fast-path dispatch as a new `elif` branch after `fastpath_builtin_admits`. It admits **only** the shape `grep|egrep|fgrep|rg <args> | <read-only-sink>`:
  - **exactly one pipe**, and **none** of `;` `&` `<` `>` backtick `$(` or newline anywhere — so wrapper (`bash -c`), substitution (`$(...)`), and compound (`&&`/`;`) forms are **untouched** and keep denying via the full path (obfuscation still caught);
  - **upstream** must be a non-executing search (`grep`/`egrep`/`fgrep`/`rg`) — a real DDL executor (`mysql -e '…' | cat`, `psql -c '…' | head`) has a non-search first token and still denies;
  - **downstream** must be a read-only sink: `head`/`tail`/`wc` (any args — already fully allowlisted) or `cat`/`less`/`more` (**only** as pure stdin consumers with no positional file operand, so `grep x | cat ~/.ssh/id_rsa` is NOT fast-pathed and the existing `cat` `.ssh`/`.aws` ASK still fires).
  - Gated by the same `guards.readOnlyFastPath` / `LOOM_GUARD_READONLY_FASTPATH` toggle.
- **`tests/hooks/test-guard-destructive.sh`** — see "Test assertions updated" below.
- **`defaults/docs/guard-hooks.md`** — documents the search-pipe carve-out as the single exception to the "no `|`" fast-path rule.

## Test assertions updated (deliberately, not silently flipped)

- **Flipped deny → allow** (`Fast path security` group): `grep <ddl> | cat` now fast-paths to a silent allow. Comment rewritten to explain the verdict change.
- **Flipped ask → allow** (#5235 ask-tier group): `grep -n "…git stash pop…" file | cat` — its prior premise (pipe-to-cat is used to *reach* the ask-tier scan) no longer holds now that the search-pipe is fast-pathed. Comment rewritten; the two regression guards below it (a `&&`-chained real `git stash pop`, an `echo … | bash`) still correctly ASK, proving only the search-to-sink shape is admitted.
- **New allow coverage**: `| head`, `| head -n 40`, `| tail -5`, `| wc -l`, `| less`, `| cat -n`, plus `rg`/`egrep`/`fgrep` upstreams.
- **New still-must-deny coverage**: `mysql -e <ddl> | cat`, `psql -c <ddl> | head`, `grep <ddl> | sh` (non-sink), `grep <ddl> | grep x | head` (two pipes), `bash -c "grep <ddl> | head"` (wrapper+pipe), `grep foo | cat ~/.ssh/id_rsa` (still asks), and fast-path-off (env+config) piped variants.
- **Not regressed**: all `find -delete`/`-exec`/`-fls`, `&&`/`;`/`$(...)` force-push and rm cases, the `bash -c` wrapper, and the bare-grep fast-path-off assertions keep denying exactly as before.

## Acceptance Criteria Verification

- [x] `grep`/`rg` search for a DDL phrase piped to a read-only sink no longer denies at `sql-ddl` — verified live and via new tests.
- [x] Genuine obfuscation still caught — `mysql -e`/`psql -c` piped to a sink, and `bash -c` wrappers, still deny (new tests).
- [x] Non-grep `Fast path security`/`Fast path off` assertions do not regress.
- [x] Grep-specific piped assertions deliberately updated to allow, with explanatory comments.
- [x] `bash tests/hooks/test-guard-destructive.sh` passes with **0 failures** (779 total, was 762 at baseline).

## Test Plan

- [x] `bash tests/hooks/test-guard-destructive.sh` → 779 passed, 0 failed (baseline 762 passed, 0 failed).
- [x] Manual verification via synthetic `PreToolUse` JSON payloads: bare grep, `| head`, `| head -n 40`, `| wc -l`, `| cat`, `| less`, `rg | head` all allow silently; `mysql -e | cat`, `psql -c | head`, `bash -c "grep | head"`, `grep | sh`, two-pipe chain all deny; `grep foo | cat ~/.ssh/id_rsa` asks.
- [x] `shellcheck --severity=warning` clean (exit 0); only pre-existing info-level SC2016 on `$('` literal-match patterns.

Closes #5263
