### PR TITLE
fix(gitignore): ignore .claude/worktrees/ so git add -A can't stage a gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Thumbs.db
 .loom/interventions/
 .loom/worktrees/
 .loom/worktrees-local/
+.claude/worktrees/
 .loom/state.json
 .loom/mcp-command.json
 .loom/activity.db

--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -114,6 +114,11 @@ const GITIGNORE_BLOCK_HEADER: &str = "# Loom runtime state (don't commit these)"
 /// drifted behind this list (was missing `.no-changes-needed` and `.loom/*.bak`).
 /// `.loom/accounts.json` is intentionally left tracked: it is an optional,
 /// committable per-repo profile allowlist, not runtime state.
+///
+/// #5267: added `.claude/worktrees/` (the Claude Code harness's own
+/// `isolation: worktree` root, created inside the checkout). Left unignored it
+/// is a nested git repo that `git add -A` stages as an embedded-repo gitlink.
+/// Also re-synced the committed source `.gitignore` for the same entry.
 pub const EPHEMERAL_PATTERNS: &[&str] = &[
     ".loom-in-use",
     // Per-worktree builder progress checkpoint. Its WRITER moved from Python to
@@ -146,6 +151,18 @@ pub const EPHEMERAL_PATTERNS: &[&str] = &[
     // in a consumer repo (anvil, 2026-07-28): `.loom/worktrees-local/<repo>/issue-N`
     // (#4280). Runtime worktree state, same class as `.loom/worktrees/`.
     ".loom/worktrees-local/",
+    // Worktrees created inside the checkout by the Claude Code harness's
+    // `isolation: worktree` mechanism (#5267). This is the HARNESS's own
+    // worktree root and is distinct from Loom's builder worktrees under
+    // `.loom/worktrees/` above — different owner, same hazard class: an
+    // unignored `.claude/worktrees/<name>` is a nested git repo, so a
+    // `git add -A` (e.g. during a resync) stages an embedded-repo gitlink.
+    // That near-miss already happened once in a consumer repo (gf180-trng,
+    // 2026-08-04). Unlike `.claude/commands` / `.claude/skills` — which are
+    // ignored ONLY in loom's own `.gitignore` because consumers keep them
+    // TRACKED — this path is pure machine-local runtime state everywhere, so
+    // it belongs in the consumer-facing managed block.
+    ".claude/worktrees/",
     ".loom/state.json",
     ".loom/mcp-command.json",
     ".loom/activity.db",
@@ -666,6 +683,8 @@ mod tests {
         assert!(contents.contains(".loom/spawn-loop-state.json"));
         assert!(contents.contains(".loom/daemon-metrics.json"));
         assert!(contents.contains(".loom/activity.db"));
+        // #5267: the harness's `isolation: worktree` root must be added too.
+        assert!(contents.contains(".claude/worktrees/"));
     }
 
     #[test]
@@ -687,6 +706,9 @@ mod tests {
         // #4635: the builder "no changes needed" marker must not duplicate
         // across runs either.
         assert_eq!(contents.matches(".no-changes-needed").count(), 1);
+        // #5267: `.claude/worktrees/` (harness `isolation: worktree` root) must
+        // not duplicate across runs.
+        assert_eq!(contents.matches(".claude/worktrees/").count(), 1);
     }
 
     #[test]
@@ -719,6 +741,10 @@ mod tests {
             ".loom/interventions/",
             ".loom/worktrees/",
             ".loom/worktrees-local/",
+            // #5267: the Claude Code harness's `isolation: worktree` root,
+            // created inside the checkout — a nested git repo that `git add -A`
+            // otherwise stages as an embedded-repo gitlink.
+            ".claude/worktrees/",
             ".loom/state.json",
             ".loom/mcp-command.json",
             ".loom/activity.db",


### PR DESCRIPTION
## Summary

`.claude/worktrees/` — the root the Claude Code harness's `isolation: worktree`
mechanism creates **inside the checkout** — was missing from `EPHEMERAL_PATTERNS`
and from loom's own committed `.gitignore`. Each nested worktree therefore sat
untracked-and-unignored, and since it is itself a git repo, a blanket `git add -A`
stages it as an **embedded-repo gitlink**. That near-miss already happened once in
a consumer repo (gf180-trng) during a resync and was only caught by hand.

`.loom/worktrees/` and `.loom/worktrees-local/` were already covered; this closes
the remaining hole for the harness-owned worktree root.

## Changes

- **`loom-daemon/src/init/post_init.rs`** — added `.claude/worktrees/` to
  `EPHEMERAL_PATTERNS`, positioned next to `.loom/worktrees/` /
  `.loom/worktrees-local/`, with a comment explaining it is the *harness's*
  `isolation: worktree` mechanism (distinct owner from Loom's own builder
  worktrees, same hazard class). The comment also records why this differs from
  `.claude/commands` / `.claude/skills`, which the source `.gitignore` explicitly
  documents as loom-only ignores that must **not** enter the managed block
  (consumers keep those tracked) — `.claude/worktrees/` is machine-local runtime
  state in every repo, so it does belong there. Added the matching `#5267:` entry
  to the `EPHEMERAL_PATTERNS` doc-comment changelog, per the existing
  `#4280:`/`#5014:` convention.
- **`.gitignore`** — added `.claude/worktrees/` inside the loom-managed block at
  the same position, keeping the committed source file in sync with
  `EPHEMERAL_PATTERNS` (the source-of-truth convention documented in
  `post_init.rs`).
- **Tests** — extended the three existing gitignore tests (no new tests, no new
  plumbing).

No backfill code path was added: `defaults/scripts/resync-installed.sh:976`
already runs `"$bin" update-gitignore "$REPO_ROOT"`, which rebuilds the
marker-delimited block from `EPHEMERAL_PATTERNS` in place, so existing installs
converge on the next resync.

## Acceptance Criteria Verification

1. **`.claude/worktrees/` added to `EPHEMERAL_PATTERNS` with an explanatory
   comment** — done (`post_init.rs`, immediately after `.loom/worktrees-local/`).
   The comment states it is the harness's `isolation: worktree` mechanism and
   contrasts it with Loom's own `.loom/worktrees/` builder mechanism.
2. **Added to this repo's root `.gitignore`** — done, inside the managed block.
   Verified live: `git check-ignore -v .claude/worktrees/probe` →
   `.gitignore:55:.claude/worktrees/`.
3. **Three existing tests extended** — done:
   - `appends_missing_patterns_to_existing_gitignore`:
     `assert!(contents.contains(".claude/worktrees/"))` (the "new patterns added"
     shape used by its neighbours).
   - `does_not_duplicate_patterns_on_repeated_runs`:
     `assert_eq!(contents.matches(".claude/worktrees/").count(), 1)` — the exact
     shape already used for `.loom/worktrees-local/`.
   - `covers_all_source_repo_gitignore_patterns`: added `".claude/worktrees/"` to
     the `expected` list; verified passing.
4. **No separate resync-backfill path needed** — confirmed by inspection:
   `resync-installed.sh:976` calls `loom-daemon update-gitignore "$REPO_ROOT"`,
   which regenerates the whole marker-delimited block from `EPHEMERAL_PATTERNS`.
   Verified behaviourally in the manual run below (a repo whose block predates
   this entry gains it on the next `update-gitignore`, in place). No new plumbing
   added.

## Test Plan

**Rust tests** — `cargo test -p loom-daemon --lib init::post_init`:
`27 passed; 0 failed`, including all three extended tests. `cargo fmt --check`
clean; `cargo clippy -p loom-daemon --all-targets` clean.

**Manual verification** — built the binary and ran `update-gitignore` against
scratch directories:

- *Fresh directory (no `.gitignore`)*: `.claude/worktrees/` is emitted, once,
  directly after `.loom/worktrees-local/`.
- *Pre-existing hand-added rule above the block* (seed:
  `node_modules/`, `.claude/worktrees/`, `.loom/worktrees/`): after
  `update-gitignore` the file contains `.claude/worktrees/` **exactly once**
  (absorbed into the managed block at line 21; the hand-added duplicate above the
  block is not left behind), and `node_modules/` is preserved.
- *Idempotency*: a second `update-gitignore` run leaves the count at 1.
- *Effectiveness*: `git check-ignore .claude/worktrees/foo` matches, so a nested
  harness worktree can no longer be staged.

Closes #5267
