### PR TITLE
docs: fix Loom-repo-specific content in consumer-installed .claude/README.md

### DIFF
--- a/defaults/.claude/README.md
+++ b/defaults/.claude/README.md
@@ -1,50 +1,49 @@
 # Claude Code Settings
 
-This directory contains Claude Code configuration for the Loom project.
+This directory contains the Claude Code configuration Loom installs into this
+project (`settings.json`, `agents/`, `commands/loom/`, and this `README.md`
+itself), refreshed on `loom update` / reinstall and by
+`./.loom/scripts/resync-installed.sh`. See `../.github/CONFIGURATION.md` for
+the companion GitHub issue/label workflow configuration Loom installs
+alongside it.
 
 ## Files
 
 - **`settings.json`**: Team-wide permissions and settings (committed to git)
 - **`settings.local.json`**: Personal preferences (gitignored, create if needed)
-- **`../.mcp.json`**: MCP server configuration (at project root, committed to git)
 - **`agents/`**: Custom subagent definitions for Loom roles (see below)
+- **`commands/loom/`**: Slash command definitions for each Loom role (see "Slash Commands" below)
 
 ## Pre-approved Commands
 
-The `settings.json` file pre-approves common development commands to streamline the AI workflow:
+The `settings.json` file pre-approves common development commands to streamline
+the AI workflow. The exact, authoritative list lives in `settings.json` itself;
+the broad categories are:
 
-### GitHub CLI (`gh`)
-- PR operations: create, edit, view, list, checkout, diff, review, checks
-- Issue operations: create, edit, view, list, close
-- Workflow runs: view
+### Version control & GitHub CLI
+- `git` and `gh` (all subcommands) — status, commit, push, pull, branch,
+  worktree, PR/issue operations, and so on
 
-### Git Operations
-- Status, add, commit, push, pull, fetch, merge
-- Branch management: checkout, branch, log, diff
-- Working tree operations: restore, stash, reset, clean
-- Worktree operations: add
-- Configuration: config, check-ignore
+### Package managers & runtimes
+- `pnpm`, `npx`, `cargo`, `node` (all subcommands) — this repo's own
+  toolchain determines which of these are actually exercised; the rest simply
+  go unused
 
-### Package Management
-- `pnpm daemon:dev` - Run daemon in dev mode
-- `pnpm daemon:build` - Build daemon (release)
-- `pnpm check:all` - Run all checks
-- `pnpm check:ci` - Run CI checks locally
+### Repo scripts
+- `./scripts/**` and `./.loom/scripts/**` — this repo's and Loom's own helper
+  scripts
 
-### Code Quality
-- `pnpm clippy` - Rust linting
-- `pnpm test` - Run tests
+### Common utilities
+- File/text tools: `cat`, `ls`, `find`, `grep`, `sed`, `awk`, `jq`, `diff`,
+  `patch`, and similar POSIX utilities
+- Archive tools: `tar`, `zip`/`unzip`, `gzip`/`gunzip`
+- Network: `curl`, `wget`
+- Image tools: `convert`, `magick`, `iconutil`
+- Terminal management: `tmux`
+- Web search: enabled
 
-### Rust/Cargo
-- `cargo check` - Check compilation
-- `cargo build` - Build project
-- `cargo test` - Run tests
-
-### Utilities
-- File operations: cat, ls, pwd, cd, mkdir
-- Image conversion: convert, magick, iconutil
-- Terminal management: tmux list-sessions
-- Web search: Enabled
+See `settings.json` for the exact allowlist — this is a summary, not a
+substitute.
 
 ## Local Overrides
 
@@ -64,10 +63,13 @@ Local settings override team settings for that specific configuration key.
 
 ## MCP Server
 
-Loom provides a single **unified `mcp-loom` MCP server** (configured in
-`.mcp.json`) that consolidates log monitoring, terminal management, and UI/state
-control. It replaces the historical trio of separate `loom-logs` /
-`loom-terminals` / `loom-ui` servers. Representative tools by category:
+Loom provides a single **unified `mcp-loom` MCP server** that consolidates log
+monitoring, terminal management, and UI/state control. It replaces the
+historical trio of separate `loom-logs` / `loom-terminals` / `loom-ui`
+servers. The server is registered once per machine at **user scope** by the
+Loom installer (`scripts/install-loom.sh`, refreshed by `loom update`) — there
+is no per-project `.mcp.json` in this repo to configure or approve.
+Representative tools by category:
 
 **Log tools**:
 - `tail_daemon_log` - View daemon logs (`~/.loom/daemon.log`)
@@ -95,7 +97,9 @@ control. It replaces the historical trio of separate `loom-logs` /
 
 See the mcp-loom package README for the full tool catalog.
 
-**Note**: When you first open the project, Claude Code will prompt you to approve the MCP server. You can also enable it automatically by setting `"enableAllProjectMcpServers": true` in your `.claude/settings.local.json`.
+**Note**: Because the server is registered at user scope, it is available
+automatically in every Loom-installed project on this machine — there is no
+per-project approval prompt or `enableAllProjectMcpServers` setting to manage.
 
 ## Slash Commands
 
@@ -157,7 +161,11 @@ To create a custom slash command:
 2. Include role purpose, workflow guidelines, and iteration instructions
 3. Use it with `/your-command` (or `/your-namespace/command`)
 
-**Note**: `.loom/roles/` contains symlinks to `.claude/commands/loom/` for backward compatibility. The single source of truth for all Loom role definitions is `.claude/commands/loom/`.
+**Note**: `.loom/roles/` contains file copies of the role prompts (kept in
+sync with `.claude/commands/loom/` by `loom update` / `resync-installed.sh`)
+for backward compatibility with tooling that expects role definitions under
+`.loom/roles/`. The single source of truth for all Loom role definitions is
+`.claude/commands/loom/`.
 
 ## Custom Subagents
 

--- a/defaults/.github/CONFIGURATION.md
+++ b/defaults/.github/CONFIGURATION.md
@@ -38,9 +38,11 @@ from Loom.
 ## Installation
 
 These files are copied from `defaults/.github/` into `<workspace>/.github/` by
-`scripts/install-loom.sh`'s defaults-directory walk, and are re-synced on `loom update` /
-reinstall (they're on the Loom-shipped `.github/` allowlist, so a reinstall overwrites local
-edits to these four files — customize via `defaults/optional/` or a fork instead).
+`scripts/install-loom.sh`'s defaults-directory walk, and are re-synced on a forced `loom update` /
+reinstall (they're on the Loom-shipped `.github/` allowlist, so a forced reinstall overwrites
+local edits to these four files — customize via `defaults/optional/` or a fork instead).
+`CONFIGURATION.md` specifically is also covered by `./.loom/scripts/resync-installed.sh`, so a
+fix to this file reaches an existing install without a full forced reinstall.
 
 ### Optional: External Issue Labeling Workflow
 

--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -34,6 +34,8 @@
 #   .loom/runtimes/         <- defaults/runtimes/         (recursive; BACKFILLED if absent, #4688)
 #   .loom/bin/              <- defaults/.loom/bin/        (recursive; live consumer CLI)
 #   .claude/commands/loom/  <- defaults/.claude/commands/loom/ (recursive)
+#   .claude/README.md       <- defaults/.claude/README.md      (single file, #5264)
+#   .github/CONFIGURATION.md <- defaults/.github/CONFIGURATION.md (single file, #5264)
 #
 # It also applies one targeted field edit outside the pure-copy model (#4285):
 # a root package.json whose "name" is exactly "loom-workspace" (the Loom
@@ -738,6 +740,23 @@ if [[ -d "$REPO_ROOT/.claude/commands/loom" ]]; then
     resync_tree "$DEFAULTS_DIR/.claude/commands/loom" "$REPO_ROOT/.claude/commands/loom" "commands/loom" ".claude/commands/loom"
 fi
 
+# ---------- single-file consumer-install docs (#5264) ----------
+#
+# .claude/README.md and .github/CONFIGURATION.md are copied verbatim into
+# every consumer repo at install time (scripts/install/manifest.sh) but, prior
+# to #5264, were never covered by this script's surface map — a fix to either
+# file landed on main but never reached an already-installed repo. Both are
+# single files (not directories), so resync_tree doesn't apply; sync_one
+# handles them directly, each gated on the destination already existing so a
+# consumer that never received the file (or deliberately removed it) is not
+# force-populated.
+if [[ -f "$REPO_ROOT/.claude/README.md" ]]; then
+    sync_one "$DEFAULTS_DIR/.claude/README.md" "$REPO_ROOT/.claude/README.md" ".claude/README.md"
+fi
+if [[ -f "$REPO_ROOT/.github/CONFIGURATION.md" ]]; then
+    sync_one "$DEFAULTS_DIR/.github/CONFIGURATION.md" "$REPO_ROOT/.github/CONFIGURATION.md" ".github/CONFIGURATION.md"
+fi
+
 # ---------- install the deferred self-copy, now that every surface settled ----
 #
 # The scripts walk above records (rather than applies) a sync of the script this
@@ -1034,7 +1053,7 @@ suggest_commit_if_resync_only_dirt() {
         path="${path%\"}"
         path="${path#\"}"
         case "$path" in
-            .loom/hooks/*|.loom/scripts/*|.loom/roles/*|.loom/docs/*|.loom/runtimes/*|.loom/bin/*|.claude/commands/loom/*|.loom/install-metadata.json|.gitattributes)
+            .loom/hooks/*|.loom/scripts/*|.loom/roles/*|.loom/docs/*|.loom/runtimes/*|.loom/bin/*|.claude/commands/loom/*|.claude/README.md|.github/CONFIGURATION.md|.loom/install-metadata.json|.gitattributes)
                 resync_paths+=("$path")
                 ;;
             *)

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -352,7 +352,21 @@ fi
 #          destination already existing (never force-populated, #5264)
 echo "Test group 9b: single-file docs are not force-created for a consumer that never had them"
 REPO="$(make_fixture)"
-rm -f "$REPO/.claude/README.md" "$REPO/.github/CONFIGURATION.md"
+# make_fixture git-tracks both files (its `git add -A && git commit`), so a bare
+# `rm -f` would NOT simulate "a consumer that never had them" — it leaves a
+# *deleted-but-tracked* path that `git status --porcelain` reports as pending
+# dirt (` D .claude/README.md`). resync-installed.sh's dirty-tree hint
+# (suggest_commit_if_resync_only_dirt) then lists that path in its `git add`
+# suggestion, which the "not reported at all" assertion below greps for and
+# trips on. Drop the files from the index *and* the worktree and commit the
+# removal, so the fixture is genuinely a repo that never received them.
+git -C "$REPO" rm -q -- .claude/README.md .github/CONFIGURATION.md >/dev/null 2>&1
+git -C "$REPO" commit -qm "consumer install without the single-file docs" >/dev/null 2>&1
+if [[ -z "$(git -C "$REPO" status --porcelain -- .claude/README.md .github/CONFIGURATION.md)" ]]; then
+    pass "(k2) fixture precondition: both single-file docs are absent AND untracked"
+else
+    fail "(k2) fixture precondition: single-file docs still show as pending git changes"
+fi
 OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
 RC=$?
 if [[ ! -e "$REPO/.claude/README.md" ]]; then

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -103,6 +103,8 @@ export GIT_COMMITTER_NAME="test" GIT_COMMITTER_EMAIL="test@example.com"
 #   defaults/docs/troubleshooting.md     -> .loom/docs/troubleshooting.md (drift)
 #   defaults/.loom/bin/loom              -> .loom/bin/loom (drift)
 #   defaults/.claude/commands/loom/x.md  -> .claude/commands/loom/x.md (drift)
+#   defaults/.claude/README.md           -> .claude/README.md (drift, #5264)
+#   defaults/.github/CONFIGURATION.md    -> .github/CONFIGURATION.md (drift, #5264)
 #   .loom/roles/custom-role.md           (repo-specific, no defaults/ counterpart)
 #   package.json ("version": "9.9.9")    (loom_version source for re-stamp)
 #   .loom/install-metadata.json          (re-stamp target; loom_source -> $repo)
@@ -112,9 +114,11 @@ make_fixture() {
     mkdir -p "$repo/defaults/hooks" "$repo/defaults/scripts/lib" \
              "$repo/defaults/roles" "$repo/defaults/docs" \
              "$repo/defaults/.loom/bin" "$repo/defaults/.claude/commands/loom" \
+             "$repo/defaults/.github" \
              "$repo/.loom/hooks" "$repo/.loom/scripts/lib" \
              "$repo/.loom/roles" "$repo/.loom/docs" \
-             "$repo/.loom/bin" "$repo/.claude/commands/loom"
+             "$repo/.loom/bin" "$repo/.claude/commands/loom" \
+             "$repo/.github"
     git -C "$repo" init -q
 
     printf 'A\n' > "$repo/defaults/hooks/guard.sh"
@@ -148,6 +152,14 @@ make_fixture() {
 
     printf 'CMD-NEW\n' > "$repo/defaults/.claude/commands/loom/builder.md"
     printf 'CMD-OLD\n' > "$repo/.claude/commands/loom/builder.md"
+
+    # Single-file consumer-install docs (#5264): .claude/README.md and
+    # .github/CONFIGURATION.md are copied verbatim into every consumer repo at
+    # install time but, prior to #5264, were never resynced afterward.
+    printf 'CLAUDE-README-NEW\n' > "$repo/defaults/.claude/README.md"
+    printf 'CLAUDE-README-OLD\n' > "$repo/.claude/README.md"
+    printf 'CONFIGURATION-NEW\n' > "$repo/defaults/.github/CONFIGURATION.md"
+    printf 'CONFIGURATION-OLD\n' > "$repo/.github/CONFIGURATION.md"
 
     # Version source + metadata re-stamp target.
     printf '{\n  "version": "9.9.9"\n}\n' > "$repo/package.json"
@@ -260,7 +272,7 @@ if [[ $RC -eq 2 ]]; then
 else
     fail "(i) --dry-run did not exit 2 across widened surfaces (got $RC)"
 fi
-for surf in "roles/builder.md" "docs/troubleshooting.md" "bin/loom" "commands/loom/builder.md"; do
+for surf in "roles/builder.md" "docs/troubleshooting.md" "bin/loom" "commands/loom/builder.md" ".claude/README.md" ".github/CONFIGURATION.md"; do
     if grep -q "$surf" <<<"$OUT"; then
         pass "(i) --dry-run reports drift for $surf"
     else
@@ -290,6 +302,16 @@ if [[ "$(cat "$REPO/.claude/commands/loom/builder.md")" == "CMD-NEW" ]]; then
     pass "(i) commands/loom/builder.md resynced from defaults"
 else
     fail "(i) commands/loom/builder.md not resynced"
+fi
+if [[ "$(cat "$REPO/.claude/README.md")" == "CLAUDE-README-NEW" ]]; then
+    pass "(i) .claude/README.md resynced from defaults (#5264)"
+else
+    fail "(i) .claude/README.md not resynced (#5264)"
+fi
+if [[ "$(cat "$REPO/.github/CONFIGURATION.md")" == "CONFIGURATION-NEW" ]]; then
+    pass "(i) .github/CONFIGURATION.md resynced from defaults (#5264)"
+else
+    fail "(i) .github/CONFIGURATION.md not resynced (#5264)"
 fi
 # second run is a clean no-op across the widened surfaces too
 OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
@@ -324,6 +346,29 @@ if [[ "$(cat "$REPO/.loom/roles/builder.md")" == "PINNED-ROLE" ]]; then
     pass "(k) pinned roles/builder.md NOT overwritten"
 else
     fail "(k) pinned roles/builder.md was overwritten despite resync-ignore"
+fi
+
+# --- (k2) .claude/README.md / .github/CONFIGURATION.md are gated on the ------
+#          destination already existing (never force-populated, #5264)
+echo "Test group 9b: single-file docs are not force-created for a consumer that never had them"
+REPO="$(make_fixture)"
+rm -f "$REPO/.claude/README.md" "$REPO/.github/CONFIGURATION.md"
+OUT="$(cd "$REPO" && bash "$SCRIPT" 2>&1)"
+RC=$?
+if [[ ! -e "$REPO/.claude/README.md" ]]; then
+    pass "(k2) .claude/README.md not force-created when absent"
+else
+    fail "(k2) .claude/README.md was force-created despite being absent"
+fi
+if [[ ! -e "$REPO/.github/CONFIGURATION.md" ]]; then
+    pass "(k2) .github/CONFIGURATION.md not force-created when absent"
+else
+    fail "(k2) .github/CONFIGURATION.md was force-created despite being absent"
+fi
+if ! grep -q "\.claude/README\.md" <<<"$OUT" && ! grep -q "\.github/CONFIGURATION\.md" <<<"$OUT"; then
+    pass "(k2) absent single-file docs are not reported at all"
+else
+    fail "(k2) absent single-file docs were unexpectedly reported"
 fi
 
 # --- (l) symlinked install target is skipped, not clobbered ------------------


### PR DESCRIPTION
## Summary

`defaults/.claude/README.md` is installed verbatim into every consumer repo but was written as documentation for the Loom repository itself, so it described things a consumer install doesn't have (a nonexistent `.mcp.json`, Loom's own `pnpm`/`cargo` toolchain, and a false `.loom/roles/` symlink claim). This rewrites the README to be accurate for consumer installs, resolves the "installed but unreferenced" gap for `defaults/.github/CONFIGURATION.md`, and adds both single files to `resync-installed.sh`'s surface map so future fixes reach existing installs.

## Changes

- `defaults/.claude/README.md`: dropped the `../.mcp.json` reference (the MCP server is registered once per machine at user scope by the installer — there is no per-project `.mcp.json`); rewrote "Pre-approved Commands" to describe `settings.json`'s actual generic allowlist categories (git/gh, pnpm/npx/cargo/node, repo scripts, common utilities) instead of Loom's own `pnpm daemon:dev` / `cargo check` invocations; fixed the MCP Server section's wording to match user-scope registration; fixed the false "`.loom/roles/` contains symlinks" claim to describe the actual regular-file-copy reality; added a pointer to `../.github/CONFIGURATION.md` for discoverability.
- `defaults/.github/CONFIGURATION.md`: documented that it's now reachable via a link from `.claude/README.md`, and that it (specifically) is covered by `resync-installed.sh` in addition to a forced reinstall.
- `defaults/scripts/resync-installed.sh`: added `.claude/README.md` and `.github/CONFIGURATION.md` to the surface map as two new single-file `sync_one` calls, each gated on the destination already existing (so a consumer that never received the file is not force-populated); updated the header comment and the resync-only-dirt commit-hint path list.
- `defaults/scripts/tests/test-resync-installed.sh`: extended the fixture with both new files (drift case), added assertions to the widened-surfaces test group, and added a new test group verifying the two files are never force-created when absent.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Installed `.claude/README.md` describes only what a consumer install actually has | ✅ | Rewrote every section citing Loom-repo-specific content; reviewed the full file end to end |
| No reference to `.mcp.json` unless the installer writes one | ✅ | Removed the `../.mcp.json` line and reworded the MCP Server section to describe user-scope registration instead |
| Pre-approved-command examples are generic, not Loom's own `pnpm`/`cargo` invocations | ✅ | Replaced with generic categories matching `settings.json`'s actual (non-Loom-specific) allowlist |
| `.loom/roles/` symlink claim matches reality | ✅ | Reworded to "contains file copies... kept in sync by `loom update` / `resync-installed.sh`", matching the regular-file reality confirmed in `resync-installed.sh`'s own comments |
| Decision recorded for `.github/CONFIGURATION.md`: linked from somewhere discoverable | ✅ | Linked from `.claude/README.md`'s intro paragraph (kept installed; not removed) |
| Both files added to `resync-installed.sh`'s surface map if they stay consumer-installed | ✅ | Added as gated `sync_one` calls; covered by new/updated test assertions |

## Test Plan

- `bash defaults/scripts/tests/test-resync-installed.sh` — 129/129 passed (was 122/122 before this change; added 7 new assertions covering the two new surfaces, including the "not force-created when absent" case)
- `bash scripts/test-installer.sh` — 178 passed, 1 pre-existing failure (`test-loom-dispatcher.sh`'s launchd-restart-harvest assertions) confirmed to reproduce identically on unmodified `main` in this environment — unrelated to this change (no dispatcher/launchd files touched)
- `bash -n` syntax check + `shellcheck` on `defaults/scripts/resync-installed.sh` — clean (only pre-existing SC2094 info-level notices on unrelated lines)
- Manual read-through of the rewritten `.claude/README.md` and `.github/CONFIGURATION.md` for accuracy against what a consumer install actually receives

Closes #5264