### PR TITLE
fix(daemon): surface per-repo token-pool ranking staleness in health/status

### DIFF
--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -530,6 +530,52 @@ to the same registry-membership check `#4299` established for CLI
 `--workspace` defaulting (`workspace_registry::resolve_client_workspace_default`)
 rather than a second, parallel detection path.
 
+### `loom-daemon health`'s daemon-CWD-vs-operator-repo distinction (#5269)
+
+The precedence above governs **two separate mechanisms** that do not share a
+scope, and conflating them was the root cause of a "5h-stale ranking" incident
+where the documented remediation refreshed the wrong pool:
+
+1. **The self-refresh loop is per-repo-correct.** The daemon's own
+   `token_ranking_refresh.rs` background task re-runs `tokens check --ranking`
+   for **every registered repo independently**, resolving each repo's own pool
+   via the *unanchored* `resolve_tokens_dir(&repo.root)` (step 1/2 of the
+   precedence above, evaluated separately per repo). On a multi-repo daemon
+   this keeps every registered repo's OWN `.ranking` fresh on its own cadence,
+   regardless of which repo the daemon process happens to be running in.
+2. **`loom-daemon health`'s (and `status`'s) single machine-level tokens
+   section is anchored to the daemon's OWN `fallback_root`** — its launch CWD
+   or `LOOM_WORKSPACE`, resolved via `resolve_tokens_dir_anchored` (the full
+   precedence above). On a daemon managing several repos from a launch CWD
+   that is only one of them (e.g. a daemon started under `~/GitHub/anvil`
+   managing `~/GitHub/loom` too), this reports staleness for whichever pool
+   *that* anchoring resolves to — which is not necessarily any particular
+   other registered repo's own pool, and was never designed to answer "is
+   *my* repo's pool fresh" for an operator running the command from a
+   different registered repo.
+
+**The fix (#5269)**: `loom-daemon status`'s `per_repo` breakdown (see
+[daemon-reference.md](daemon-reference.md)) now carries each registered repo's
+own `token_pool_dir`/`ranking_present`/`ranking_age_secs`, populated with the
+exact same unanchored `resolve_tokens_dir(&repo.root)` the self-refresh loop
+already uses — so an operator asking about a specific repo gets that repo's
+own answer, independent of the daemon's launch CWD. `loom-daemon health`'s
+`tokens` section detail JSON (`--json`) surfaces this as `per_repo: [...]`
+alongside the existing single-pool `pool_path`/`ranking_present`/
+`ranking_age_secs` fields (which keep their original, narrower
+`fallback_root`-anchored meaning — the top-level fields are NOT replaced,
+only supplemented), and folds a bounded "`N of M` registered repos have their
+own pool's `.ranking` stale/missing" note into the human summary line when any
+repo is affected.
+
+**The workaround this incident's remediation used** — refreshing from `$HOME`
+happened to "fix" the daemon's top-level reading only because
+`per_repo_tokens_dir($HOME)` collapses to the same path as the default shared
+pool (`~/.loom/tokens`) — is now unnecessary for diagnosing (not necessarily
+for actually refreshing) a specific repo's own staleness: read that repo's
+line in `loom-daemon status --json`'s `per_repo` array, or
+`loom-daemon health --json`'s `tokens.detail.per_repo`, instead.
+
 ## Hard-fail on missing pool
 
 `spawn-claude.sh` exits `78` (`EX_CONFIG`) with a message instructing the user to

--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -3656,6 +3656,20 @@ pool, gated by that repo's own config (an empty registry reduces to the single
 daemon workspace). See `loom-daemon/src/token_ranking_refresh.rs` for the
 implementation.
 
+**This loop's scope is per-repo; `loom-daemon health`'s tokens section used to
+be single-pool only (#5269).** This refresher keeps every registered repo's
+OWN pool fresh independently — but through v0.18.0, `loom-daemon health`/
+`status` reported staleness for only the daemon's single
+`fallback_root`-anchored pool (its launch CWD, see [Full anchoring precedence,
+and machine-level daemon startup](token-pool.md#full-anchoring-precedence-and-machine-level-daemon-startup-4292)
+in token-pool.md), which on a multi-repo daemon is not necessarily any
+particular *other* registered repo's own pool. `status`'s `per_repo` array now
+carries each repo's own `token_pool_dir`/`ranking_present`/
+`ranking_age_secs` (populated with the same unanchored `resolve_tokens_dir`
+this loop uses), and `health --json`'s `tokens.detail.per_repo` surfaces it —
+see [token-pool.md's `loom-daemon health` distinction](token-pool.md#loom-daemon-healths-daemon-cwd-vs-operator-repo-distinction-5269)
+for the full incident writeup and the now-obsolete `$HOME`-refresh workaround.
+
 ### Merged-PR worktree reaper (#4876)
 
 CLAUDE.md states the contract: *"Loom-managed worktrees (with the

--- a/defaults/docs/token-pool.md
+++ b/defaults/docs/token-pool.md
@@ -530,6 +530,52 @@ to the same registry-membership check `#4299` established for CLI
 `--workspace` defaulting (`workspace_registry::resolve_client_workspace_default`)
 rather than a second, parallel detection path.
 
+### `loom-daemon health`'s daemon-CWD-vs-operator-repo distinction (#5269)
+
+The precedence above governs **two separate mechanisms** that do not share a
+scope, and conflating them was the root cause of a "5h-stale ranking" incident
+where the documented remediation refreshed the wrong pool:
+
+1. **The self-refresh loop is per-repo-correct.** The daemon's own
+   `token_ranking_refresh.rs` background task re-runs `tokens check --ranking`
+   for **every registered repo independently**, resolving each repo's own pool
+   via the *unanchored* `resolve_tokens_dir(&repo.root)` (step 1/2 of the
+   precedence above, evaluated separately per repo). On a multi-repo daemon
+   this keeps every registered repo's OWN `.ranking` fresh on its own cadence,
+   regardless of which repo the daemon process happens to be running in.
+2. **`loom-daemon health`'s (and `status`'s) single machine-level tokens
+   section is anchored to the daemon's OWN `fallback_root`** — its launch CWD
+   or `LOOM_WORKSPACE`, resolved via `resolve_tokens_dir_anchored` (the full
+   precedence above). On a daemon managing several repos from a launch CWD
+   that is only one of them (e.g. a daemon started under `~/GitHub/anvil`
+   managing `~/GitHub/loom` too), this reports staleness for whichever pool
+   *that* anchoring resolves to — which is not necessarily any particular
+   other registered repo's own pool, and was never designed to answer "is
+   *my* repo's pool fresh" for an operator running the command from a
+   different registered repo.
+
+**The fix (#5269)**: `loom-daemon status`'s `per_repo` breakdown (see
+[daemon-reference.md](daemon-reference.md)) now carries each registered repo's
+own `token_pool_dir`/`ranking_present`/`ranking_age_secs`, populated with the
+exact same unanchored `resolve_tokens_dir(&repo.root)` the self-refresh loop
+already uses — so an operator asking about a specific repo gets that repo's
+own answer, independent of the daemon's launch CWD. `loom-daemon health`'s
+`tokens` section detail JSON (`--json`) surfaces this as `per_repo: [...]`
+alongside the existing single-pool `pool_path`/`ranking_present`/
+`ranking_age_secs` fields (which keep their original, narrower
+`fallback_root`-anchored meaning — the top-level fields are NOT replaced,
+only supplemented), and folds a bounded "`N of M` registered repos have their
+own pool's `.ranking` stale/missing" note into the human summary line when any
+repo is affected.
+
+**The workaround this incident's remediation used** — refreshing from `$HOME`
+happened to "fix" the daemon's top-level reading only because
+`per_repo_tokens_dir($HOME)` collapses to the same path as the default shared
+pool (`~/.loom/tokens`) — is now unnecessary for diagnosing (not necessarily
+for actually refreshing) a specific repo's own staleness: read that repo's
+line in `loom-daemon status --json`'s `per_repo` array, or
+`loom-daemon health --json`'s `tokens.detail.per_repo`, instead.
+
 ## Hard-fail on missing pool
 
 `spawn-claude.sh` exits `78` (`EX_CONFIG`) with a message instructing the user to

--- a/loom-daemon/src/capacity.rs
+++ b/loom-daemon/src/capacity.rs
@@ -236,6 +236,32 @@ pub fn read_ranking(workspace_root: &Path) -> Option<RankingSnapshot> {
     read_ranking_at(&crate::tokens_pool::paths::resolve_tokens_dir(workspace_root))
 }
 
+/// `(present, age_secs)` for `<pool_dir>/.ranking` — whether the file exists
+/// and, when readable, how many seconds old its mtime is.
+///
+/// This is the single shared "is this pool's ranking present/stale" probe
+/// (Issue #5269): both the daemon's own per-repo status snapshot
+/// ([`crate::ipc::build_daemon_status`], which resolves each registered
+/// repo's *own* pool via [`crate::tokens_pool::paths::resolve_tokens_dir`])
+/// and the `loom-daemon health` CLI's single anchored-pool probe
+/// (`cli::health::ranking_state`) call this, so the two surfaces can never
+/// disagree about what "present" or "age" means for the same directory.
+/// Returns `(false, None)` when the file is missing or its metadata can't be
+/// read; a readable-but-unstattable mtime is `(true, None)`.
+#[must_use]
+pub fn ranking_file_state(pool_dir: &Path) -> (bool, Option<u64>) {
+    let path = pool_dir.join(".ranking");
+    let Ok(meta) = std::fs::metadata(&path) else {
+        return (false, None);
+    };
+    let age = meta
+        .modified()
+        .ok()
+        .and_then(|m| m.elapsed().ok())
+        .map(|d| d.as_secs());
+    (true, age)
+}
+
 // ============================================================================
 // Fresh-probe capacity (issue #3936)
 // ============================================================================

--- a/loom-daemon/src/cli/health.rs
+++ b/loom-daemon/src/cli/health.rs
@@ -223,19 +223,14 @@ fn probe_ranking(status: Option<&DaemonStatusReport>) -> (bool, Option<u64>) {
     ranking_state(&dir)
 }
 
-/// `(present, age_secs)` for `<dir>/.ranking`. Extracted (and pure w.r.t. the
-/// filesystem argument) so the age computation is unit-testable.
+/// `(present, age_secs)` for `<dir>/.ranking`. Delegates to
+/// [`loom_daemon::capacity::ranking_file_state`] (#5269) — the same probe
+/// `ipc::build_daemon_status` uses to populate each registered repo's own
+/// `RepoStatus::ranking_present`/`ranking_age_secs`, so this CLI's single
+/// anchored-pool probe and the daemon's per-repo snapshot can never disagree
+/// about what "present"/"age" means for the same directory.
 fn ranking_state(dir: &Path) -> (bool, Option<u64>) {
-    let path = dir.join(".ranking");
-    let Ok(meta) = std::fs::metadata(&path) else {
-        return (false, None);
-    };
-    let age = meta
-        .modified()
-        .ok()
-        .and_then(|m| m.elapsed().ok())
-        .map(|d| d.as_secs());
-    (true, age)
+    loom_daemon::capacity::ranking_file_state(dir)
 }
 
 #[cfg(test)]

--- a/loom-daemon/src/health.rs
+++ b/loom-daemon/src/health.rs
@@ -1157,6 +1157,59 @@ pub fn assess_tokens(inputs: &HealthInputs) -> HealthSection {
         "{}/{} healthy ({} exhausted), {ranking_age}",
         cap.healthy_accounts, cap.total_accounts, cap.exhausted_accounts
     );
+
+    // Per-repo ranking staleness (#5269). `inputs.ranking_present`/
+    // `ranking_age_secs` above cover only the daemon's single
+    // `fallback_root`-anchored pool (`status.token_pool_dir`) — on a
+    // multi-repo daemon that can be a *different* repo's pool than the one an
+    // operator asking about a specific registered repo actually cares about.
+    // `status.per_repo` carries each registered repo's OWN resolved pool +
+    // staleness (`RepoStatus::token_pool_dir`/`ranking_present`/
+    // `ranking_age_secs`, populated via the unanchored
+    // `resolve_tokens_dir(&repo.root)` — the same resolution
+    // `token_ranking_refresh.rs`'s self-refresh loop uses), independent of
+    // the daemon's launch CWD. Grouped by (repo, own pool age) rather than by
+    // pool path — this is the answer to "is THIS repo's own pool fresh"
+    // regardless of whether it happens to share a directory with another
+    // registered repo's pool.
+    let per_repo_detail: Vec<serde_json::Value> = status
+        .per_repo
+        .iter()
+        .map(|r| {
+            let stale = r.ranking_present
+                && r.ranking_age_secs
+                    .is_some_and(|age| age > RANKING_STALE_SECS);
+            serde_json::json!({
+                "root": r.root,
+                "pool_path": r.token_pool_dir,
+                "ranking_present": r.ranking_present,
+                "ranking_age_secs": r.ranking_age_secs,
+                "stale": stale,
+            })
+        })
+        .collect();
+    let affected_repos: Vec<&crate::types::RepoStatus> = status
+        .per_repo
+        .iter()
+        .filter(|r| {
+            !r.ranking_present
+                || r.ranking_age_secs
+                    .is_some_and(|age| age > RANKING_STALE_SECS)
+        })
+        .collect();
+    if !affected_repos.is_empty() {
+        // Bounded summary line (unlike the full `per_repo` JSON detail below,
+        // which is always complete) — mirrors the roles section's
+        // `MAX_ROLES_SUMMARY_LINE_CHARS` rationale: an operator with many
+        // registered repos sharing one stale pool should see a short count in
+        // the human summary, not a repeated per-repo essay.
+        degraded.push(format!(
+            "{} of {} registered repo(s) have their OWN pool's .ranking stale/missing (see tokens.per_repo detail)",
+            affected_repos.len(),
+            status.per_repo.len()
+        ));
+    }
+
     let (verdict, summary) = if degraded.is_empty() {
         (Verdict::Green, base)
     } else {
@@ -1172,10 +1225,16 @@ pub fn assess_tokens(inputs: &HealthInputs) -> HealthSection {
             "exhausted": cap.exhausted_accounts,
             "token_axis_limit": cap.token_axis_limit,
             "token_bound": cap.token_bound,
+            // The single pool this section's headline numbers above are
+            // scoped to — the daemon's `fallback_root`-anchored primary
+            // workspace pool (#5269 AC2), NOT necessarily any particular
+            // registered repo's own pool. See `per_repo` for that.
+            "pool_path": status.token_pool_dir,
             "ranking_present": inputs.ranking_present,
             "ranking_age_secs": inputs.ranking_age_secs,
             "ranking_stale_threshold_secs": RANKING_STALE_SECS,
             "issues": degraded,
+            "per_repo": per_repo_detail,
         }),
     )
 }
@@ -2952,6 +3011,162 @@ mod tests {
         let section = assess_tokens(&inputs);
         assert_eq!(section.verdict, Verdict::Degraded);
         assert!(section.summary.contains("EMPTY token pool"));
+    }
+
+    /// Issue #5269: the machine-level `pool_path` this section's headline
+    /// numbers are scoped to is always named in the detail JSON, even when
+    /// everything is green — so `--json` consumers never have to guess which
+    /// directory the healthy verdict is about.
+    #[test]
+    fn tokens_detail_names_the_evaluated_pool_path() {
+        let mut inputs = healthy_inputs();
+        inputs.status.as_mut().unwrap().token_pool_dir =
+            Some(PathBuf::from("/repos/anvil/.loom/tokens"));
+        let section = assess_tokens(&inputs);
+        assert_eq!(section.detail["pool_path"], serde_json::json!("/repos/anvil/.loom/tokens"));
+    }
+
+    /// Issue #5269 (the reported scenario): the top-level `ranking_present`/
+    /// `ranking_age_secs`/verdict cover only the daemon's single
+    /// `fallback_root`-anchored pool — which can be fresh (or even absent, on
+    /// a machine-level daemon with no primary-workspace pool of its own)
+    /// while a DIFFERENT registered repo's own pool is stale. The `per_repo`
+    /// detail must still surface that repo's own staleness, and the overall
+    /// verdict must degrade for it, even though the top-level ranking inputs
+    /// alone would report Green.
+    #[test]
+    fn tokens_degraded_when_a_registered_repos_own_ranking_is_stale_even_if_the_anchored_pool_is_fresh(
+    ) {
+        let mut inputs = healthy_inputs();
+        // Top-level (anchored) pool: fresh — would be Green on its own.
+        assert!(inputs.ranking_present);
+        assert!(inputs.ranking_age_secs.unwrap() < RANKING_STALE_SECS);
+
+        let status = inputs.status.as_mut().unwrap();
+        status.per_repo = vec![
+            crate::types::RepoStatus {
+                root: PathBuf::from("/repos/loom"),
+                priority: crate::workspace_registry::default_priority(),
+                in_flight_count: 0,
+                health_gate_halted: false,
+                quarantined_issues: vec![],
+                health_gate_not_evaluated: false,
+                health_gate_not_evaluated_reason: None,
+                health_gate_enabled: None,
+                health_gate_verdict_at: None,
+                root_missing: false,
+                health_gate_deferred: false,
+                health_gate_deferred_reason: None,
+                health_gate_verdict_tier: None,
+                role_runner_enabled: false,
+                role_runner_roles: vec![],
+                role_runner_on_idle_roles: vec![],
+                // This repo's OWN pool: present but stale.
+                token_pool_dir: Some(PathBuf::from("/repos/loom/.loom/tokens")),
+                ranking_present: true,
+                ranking_age_secs: Some(RANKING_STALE_SECS + 3600),
+            },
+            crate::types::RepoStatus {
+                root: PathBuf::from("/repos/anvil"),
+                priority: crate::workspace_registry::default_priority(),
+                in_flight_count: 0,
+                health_gate_halted: false,
+                quarantined_issues: vec![],
+                health_gate_not_evaluated: false,
+                health_gate_not_evaluated_reason: None,
+                health_gate_enabled: None,
+                health_gate_verdict_at: None,
+                root_missing: false,
+                health_gate_deferred: false,
+                health_gate_deferred_reason: None,
+                health_gate_verdict_tier: None,
+                role_runner_enabled: false,
+                role_runner_roles: vec![],
+                role_runner_on_idle_roles: vec![],
+                // This repo's OWN pool: fresh.
+                token_pool_dir: Some(PathBuf::from("/repos/anvil/.loom/tokens")),
+                ranking_present: true,
+                ranking_age_secs: Some(30),
+            },
+        ];
+
+        let section = assess_tokens(&inputs);
+        assert_eq!(
+            section.verdict,
+            Verdict::Degraded,
+            "a stale per-repo ranking must degrade the section even though the \
+             anchored top-level pool is fresh"
+        );
+        assert!(
+            section.summary.contains("1 of 2 registered repo"),
+            "summary should name the affected count, got: {}",
+            section.summary
+        );
+        let per_repo = section.detail["per_repo"]
+            .as_array()
+            .expect("per_repo detail is an array");
+        assert_eq!(per_repo.len(), 2);
+        let loom_entry = per_repo
+            .iter()
+            .find(|r| r["root"] == "/repos/loom")
+            .expect("loom repo entry present");
+        assert_eq!(loom_entry["stale"], true);
+        assert_eq!(loom_entry["pool_path"], "/repos/loom/.loom/tokens");
+        let anvil_entry = per_repo
+            .iter()
+            .find(|r| r["root"] == "/repos/anvil")
+            .expect("anvil repo entry present");
+        assert_eq!(anvil_entry["stale"], false);
+    }
+
+    /// A registered repo with no `.ranking` of its own (never bootstrapped)
+    /// also counts as "affected" — distinct from, but reported alongside, the
+    /// stale-age case above.
+    #[test]
+    fn tokens_per_repo_missing_ranking_counts_as_affected() {
+        let mut inputs = healthy_inputs();
+        let status = inputs.status.as_mut().unwrap();
+        status.per_repo = vec![crate::types::RepoStatus {
+            root: PathBuf::from("/repos/never-bootstrapped"),
+            priority: crate::workspace_registry::default_priority(),
+            in_flight_count: 0,
+            health_gate_halted: false,
+            quarantined_issues: vec![],
+            health_gate_not_evaluated: false,
+            health_gate_not_evaluated_reason: None,
+            health_gate_enabled: None,
+            health_gate_verdict_at: None,
+            root_missing: false,
+            health_gate_deferred: false,
+            health_gate_deferred_reason: None,
+            health_gate_verdict_tier: None,
+            role_runner_enabled: false,
+            role_runner_roles: vec![],
+            role_runner_on_idle_roles: vec![],
+            token_pool_dir: Some(PathBuf::from("/repos/never-bootstrapped/.loom/tokens")),
+            ranking_present: false,
+            ranking_age_secs: None,
+        }];
+
+        let section = assess_tokens(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(section.summary.contains("1 of 1 registered repo"));
+        let entry = &section.detail["per_repo"][0];
+        assert_eq!(entry["ranking_present"], false);
+        assert_eq!(entry["stale"], false, "absent is reported distinctly from stale");
+    }
+
+    /// An empty `per_repo` (single-workspace daemon, no registry) must not
+    /// introduce a spurious per-repo note — byte-for-byte the pre-#5269
+    /// summary/verdict when nothing is registered.
+    #[test]
+    fn tokens_no_per_repo_note_when_registry_is_empty() {
+        let inputs = healthy_inputs();
+        assert!(inputs.status.as_ref().unwrap().per_repo.is_empty());
+        let section = assess_tokens(&inputs);
+        assert_eq!(section.verdict, Verdict::Green);
+        assert!(!section.summary.contains("registered repo"));
+        assert_eq!(section.detail["per_repo"], serde_json::json!([]));
     }
 
     // ===================================================================

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1550,6 +1550,17 @@ pub fn build_daemon_status(
                 .iter()
                 .map(|spec| spec.name.to_string())
                 .collect();
+        // This root's OWN resolved token pool (#5269) — the unanchored
+        // `resolve_tokens_dir(root)`, i.e. the exact resolution
+        // `token_ranking_refresh.rs`'s self-refresh loop already uses to
+        // decide which pool to keep fresh for this repo. Deliberately not
+        // `resolve_tokens_dir_anchored`, which is scoped to the daemon's own
+        // `fallback_root`/launch CWD, not this loop's `root` — the whole
+        // point of this per-repo field is to answer "is THIS repo's own pool
+        // fresh" regardless of which repo the daemon happened to start in.
+        let repo_token_pool_dir = crate::tokens_pool::paths::resolve_tokens_dir(root);
+        let (repo_ranking_present, repo_ranking_age_secs) =
+            crate::capacity::ranking_file_state(&repo_token_pool_dir);
         per_repo.push(crate::types::RepoStatus {
             root: root.clone(),
             priority: workspace_registry.priority_of(root),
@@ -1577,6 +1588,9 @@ pub fn build_daemon_status(
             role_runner_enabled,
             role_runner_roles,
             role_runner_on_idle_roles,
+            token_pool_dir: Some(repo_token_pool_dir),
+            ranking_present: repo_ranking_present,
+            ranking_age_secs: repo_ranking_age_secs,
         });
         in_flight.extend(live);
         unregistered_locked.extend(locked_unregistered.into_iter().map(|(issue, owner_pid)| {
@@ -5785,6 +5799,9 @@ exit 0
                 role_runner_enabled: true,
                 role_runner_roles: vec!["champion".to_string()],
                 role_runner_on_idle_roles: vec![],
+                token_pool_dir: Some(std::path::PathBuf::from("/repo/a/.loom/tokens")),
+                ranking_present: true,
+                ranking_age_secs: Some(120),
             }],
             credential_preflight: Some(test_credential_preflight()),
             draining: false,
@@ -6568,6 +6585,117 @@ exit 0
         assert_eq!(a.health_gate_verdict_at, None);
         assert_eq!(b.health_gate_verdict_at, None);
 
+        std::env::remove_var(REGISTRY_PATH_ENV);
+    }
+
+    /// Issue #5269: a daemon whose `fallback_root` (launch CWD) is repo A must
+    /// still report repo B's OWN `.ranking` freshness in `per_repo`, reading
+    /// repo B's own per-repo pool — NOT repo A's, and not whatever the
+    /// top-level `fallback_root`-anchored `token_pool_dir`/`capacity` fields
+    /// resolved to. This is the exact scope mismatch the issue reports: an
+    /// operator asking about repo B from a daemon anchored at repo A
+    /// previously got no answer about repo B's pool at all.
+    #[test]
+    #[serial_test::serial]
+    fn test_build_daemon_status_per_repo_ranking_reflects_each_repos_own_pool() {
+        use crate::main_health_gate::WorkspaceHealthStates;
+        use crate::workspace_registry::{normalize_path, WorkspaceRegistry, REGISTRY_PATH_ENV};
+
+        let (sr_a, dir_a, _rec_a) = setup_sweep_registry_in_tempdir();
+        let (sr_b, dir_b, _rec_b) = setup_sweep_registry_in_tempdir();
+        let root_a = dir_a.path().to_path_buf();
+        let root_b = dir_b.path().to_path_buf();
+
+        // Disable the shared machine-level pool fallback so each repo's own
+        // per-repo `.loom/tokens/` is the only pool `resolve_tokens_dir` can
+        // find for it — otherwise a repo with no per-repo pool would silently
+        // fall through to the host's real `~/.loom/tokens` (or a stale value
+        // left by another `#[serial]` test) instead of reporting "absent".
+        let prev_shared = std::env::var("LOOM_SHARED_TOKENS_DIR").ok();
+        std::env::set_var("LOOM_SHARED_TOKENS_DIR", "");
+
+        // A registry listing BOTH managed repos, exactly like the sibling
+        // multi-workspace test above.
+        let reg_path = dir_a.path().join("workspaces.json");
+        let mut reg = WorkspaceRegistry::default();
+        reg.add(&root_a, None).unwrap();
+        reg.add(&root_b, None).unwrap();
+        reg.save(&reg_path).unwrap();
+        std::env::set_var(REGISTRY_PATH_ENV, &reg_path);
+
+        let canon_a = normalize_path(&root_a);
+        let canon_b = normalize_path(&root_b);
+
+        // Repo A's own pool: present but STALE (mtime forced far in the past).
+        let tokens_a = canon_a.join(".loom").join("tokens");
+        std::fs::create_dir_all(&tokens_a).unwrap();
+        std::fs::write(tokens_a.join("acct-a.token"), "sk-ant-oat01-a").unwrap();
+        let ranking_a_path = tokens_a.join(".ranking");
+        std::fs::write(&ranking_a_path, "acct-a|available|0.1\n").unwrap();
+        let stale_mtime = std::time::SystemTime::now() - std::time::Duration::from_secs(7200);
+        std::fs::File::options()
+            .write(true)
+            .open(&ranking_a_path)
+            .unwrap()
+            .set_modified(stale_mtime)
+            .unwrap();
+
+        // Repo B's own pool: present and FRESH.
+        let tokens_b = canon_b.join(".loom").join("tokens");
+        std::fs::create_dir_all(&tokens_b).unwrap();
+        std::fs::write(tokens_b.join("acct-b.token"), "sk-ant-oat01-b").unwrap();
+        std::fs::write(tokens_b.join(".ranking"), "acct-b|available|0.1\n").unwrap();
+
+        let pool = Arc::new(WorkspacePool::new(Arc::new(EventBus::new()), test_runtime_handle()));
+        pool.seed(canon_a.clone(), sr_a.clone());
+        pool.seed(canon_b.clone(), sr_b.clone());
+        let health = WorkspaceHealthStates::new();
+
+        // The daemon's own `fallback_root`/launch CWD is repo A.
+        let report = build_daemon_status(&pool, &health, &root_a, &test_credential_preflight());
+        assert_eq!(report.per_repo.len(), 2, "both managed repos are listed");
+
+        let a = report
+            .per_repo
+            .iter()
+            .find(|r| r.root == canon_a)
+            .expect("repo A present");
+        let b = report
+            .per_repo
+            .iter()
+            .find(|r| r.root == canon_b)
+            .expect("repo B present");
+
+        // Each repo's own resolved pool is its OWN per-repo directory, not the
+        // daemon's single anchored `token_pool_dir`.
+        assert_eq!(a.token_pool_dir.as_deref(), Some(tokens_a.as_path()));
+        assert_eq!(b.token_pool_dir.as_deref(), Some(tokens_b.as_path()));
+
+        // Repo A's own ranking is present but stale.
+        assert!(a.ranking_present, "repo A has its own .ranking");
+        assert!(
+            a.ranking_age_secs.unwrap_or(0) >= 7000,
+            "repo A's own ranking must read as ~2h old, got {:?}",
+            a.ranking_age_secs
+        );
+
+        // Repo B's own ranking is present and fresh — this is the exact
+        // scenario the bug report describes ("worker-1: 5h-stale machine
+        // pool" while the operator's own repo's self-refresh loop kept its
+        // OWN pool current): the per-repo report must reflect repo B's own
+        // freshness, independent of the daemon's `fallback_root`-anchored
+        // primary-workspace value.
+        assert!(b.ranking_present, "repo B has its own .ranking");
+        assert!(
+            b.ranking_age_secs.unwrap_or(u64::MAX) < 60,
+            "repo B's own ranking must read as fresh, got {:?}",
+            b.ranking_age_secs
+        );
+
+        match prev_shared {
+            Some(v) => std::env::set_var("LOOM_SHARED_TOKENS_DIR", v),
+            None => std::env::remove_var("LOOM_SHARED_TOKENS_DIR"),
+        }
         std::env::remove_var(REGISTRY_PATH_ENV);
     }
 

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -2429,6 +2429,9 @@ mod tests {
             role_runner_enabled: false,
             role_runner_roles: vec![],
             role_runner_on_idle_roles: vec![],
+            token_pool_dir: None,
+            ranking_present: false,
+            ranking_age_secs: None,
         }];
         report
     }

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -2056,6 +2056,31 @@ pub struct RepoStatus {
     /// vec).
     #[serde(default)]
     pub role_runner_on_idle_roles: Vec<String>,
+    /// This root's OWN resolved token-pool directory (Issue #5269) —
+    /// `tokens_pool::paths::resolve_tokens_dir(&root)`, the exact resolution
+    /// [`crate::token_ranking_refresh`]'s self-refresh loop already uses to
+    /// decide which pool to refresh for this repo. Deliberately **not** the
+    /// anchored/CWD-based resolution the top-level
+    /// [`DaemonStatusReport::token_pool_dir`] uses — that field answers "which
+    /// pool is the daemon's own primary workspace's", which for a multi-repo
+    /// daemon can be a different repo's pool entirely. `#[serde(default)]`
+    /// keeps pre-#5269 wire data compatible (an absent field parses as
+    /// `None`).
+    #[serde(default)]
+    pub token_pool_dir: Option<PathBuf>,
+    /// Whether this root's own resolved pool (`Self::token_pool_dir`) has a
+    /// `.ranking` file (Issue #5269) — same semantics as the top-level
+    /// [`DaemonStatusReport`]'s `health`/`capacity` staleness inputs, just
+    /// scoped to this repo's own pool instead of the daemon's anchored
+    /// primary workspace. `#[serde(default)]` keeps pre-#5269 wire data
+    /// compatible (an absent field parses as `false`).
+    #[serde(default)]
+    pub ranking_present: bool,
+    /// Age in seconds of this root's own `.ranking`, when readable (Issue
+    /// #5269). `#[serde(default)]` keeps pre-#5269 wire data compatible (an
+    /// absent field parses as `None`).
+    #[serde(default)]
+    pub ranking_age_secs: Option<u64>,
 }
 
 /// One active insta-crash quarantine (Issue #4215), as surfaced by
@@ -2953,6 +2978,9 @@ mod tests {
             role_runner_enabled: false,
             role_runner_roles: vec![],
             role_runner_on_idle_roles: vec![],
+            token_pool_dir: None,
+            ranking_present: false,
+            ranking_age_secs: None,
         }
     }
 


### PR DESCRIPTION
## Summary

`loom-daemon health` (and `status`) reported token-pool ranking staleness for only a single "anchored primary workspace" pool (`resolve_tokens_dir_anchored` on the daemon's launch CWD / `fallback_root`), even though the token-ranking self-refresh loop (`spawn_multi_token_ranking_refresh_task` in `token_ranking_refresh.rs`) already refreshes **every registered repo's own pool independently** via `resolve_tokens_dir(&repo.root)`. An operator running `loom-daemon health` from a repo other than the daemon's own launch-CWD repo got a health verdict about the wrong pool, while their own repo's actual (correctly-refreshed) `.ranking` freshness went unreported entirely.

This closed the gap between the two mechanisms:

- **`loom-daemon/src/types.rs`**: `RepoStatus` gains `token_pool_dir: Option<PathBuf>`, `ranking_present: bool`, `ranking_age_secs: Option<u64>` (all `#[serde(default)]` for wire compatibility).
- **`loom-daemon/src/ipc.rs`**: the per-repo status-construction loop now resolves each repo's own pool via the *unanchored* `resolve_tokens_dir(&repo.root)` — the same resolution the self-refresh loop uses — and populates the new fields. The existing top-level `fallback_root`-anchored fields (`token_pool_dir`, `capacity`) are unchanged.
- **`loom-daemon/src/capacity.rs`**: new shared `ranking_file_state(pool_dir) -> (bool, Option<u64>)` probe, used both by `ipc.rs`'s per-repo snapshot and by `cli/health.rs`'s existing single-pool probe (which used to duplicate this logic as a private `ranking_state` fn).
- **`loom-daemon/src/health.rs`** (`assess_tokens`): the tokens section detail JSON now names the evaluated `pool_path` (AC2), adds a `per_repo` array (root/pool_path/ranking_present/ranking_age_secs/stale per registered repo), and folds a bounded `"N of M registered repos have their own pool's .ranking stale/missing"` note into the summary + verdict when any registered repo's own pool is stale or missing — even when the top-level anchored pool is fresh.
- **`.loom/docs/token-pool.md`** / **`defaults/docs/daemon-reference.md`**: document the daemon-CWD-vs-operator-repo distinction, explain why the "refresh from `$HOME`" workaround happened to "fix" the old single-pool reading, and point at the new per-repo surface for diagnosis.

## Test plan

- [x] `cargo test -p loom-daemon` — all library + binary unit tests pass (3379 + 106 tests). The only failures are in `tests/integration_basic.rs` (tmux-backed terminal-lifecycle tests, pre-existing/host-load-sensitive and explicitly excluded from the build gate per `.loom/docs/build-gate.md` — unrelated to this change, not touched by this diff).
- [x] New test `ipc::tests::test_build_daemon_status_per_repo_ranking_reflects_each_repos_own_pool`: a daemon whose `fallback_root`/launch CWD is repo A, with repo B also registered and holding its own fresh pool while repo A's own pool is stale — asserts `per_repo` reflects each repo's own `.ranking` freshness independently.
- [x] New `health::tests::tokens_*` tests: `pool_path` is always named in the detail JSON; a stale/missing per-repo ranking degrades the verdict even when the top-level anchored pool is fresh; an empty `per_repo` (single-workspace daemon) introduces no spurious note (byte-for-byte pre-#5269 behavior).
- [x] `cargo fmt -p loom-daemon -- --check` and `cargo clippy -p loom-daemon --all-targets` clean.

Closes #5269