### PR TITLE
fix(gitignore): ignore harness .claude/worktrees/ so git add -A can't stage a gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Thumbs.db
 .loom/interventions/
 .loom/worktrees/
 .loom/worktrees-local/
+.claude/worktrees/
 .loom/state.json
 .loom/mcp-command.json
 .loom/activity.db

--- a/loom-daemon/src/init/post_init.rs
+++ b/loom-daemon/src/init/post_init.rs
@@ -114,6 +114,12 @@ const GITIGNORE_BLOCK_HEADER: &str = "# Loom runtime state (don't commit these)"
 /// drifted behind this list (was missing `.no-changes-needed` and `.loom/*.bak`).
 /// `.loom/accounts.json` is intentionally left tracked: it is an optional,
 /// committable per-repo profile allowlist, not runtime state.
+///
+/// #5267: added `.claude/worktrees/` — the agent harness's own
+/// `isolation: worktree` checkouts, which land *inside* the main checkout just
+/// like `.loom/worktrees/` but were never covered here. Unignored, each one is
+/// a nested git repo, so a `git add -A` silently stages an embedded-repo
+/// gitlink (a near-miss in gf180-trng, 2026-08-04, caught only by hand).
 pub const EPHEMERAL_PATTERNS: &[&str] = &[
     ".loom-in-use",
     // Per-worktree builder progress checkpoint. Its WRITER moved from Python to
@@ -146,6 +152,12 @@ pub const EPHEMERAL_PATTERNS: &[&str] = &[
     // in a consumer repo (anvil, 2026-07-28): `.loom/worktrees-local/<repo>/issue-N`
     // (#4280). Runtime worktree state, same class as `.loom/worktrees/`.
     ".loom/worktrees-local/",
+    // Worktrees created inside the main checkout by the agent harness's
+    // `isolation: worktree` mechanism — NOT Loom's own worktree state (that is
+    // `.loom/worktrees/` above). Each is a nested git repo, so leaving it
+    // unignored lets a `git add -A` stage an embedded-repo gitlink behind
+    // nothing but an easily-missed advice block (#5267).
+    ".claude/worktrees/",
     ".loom/state.json",
     ".loom/mcp-command.json",
     ".loom/activity.db",
@@ -610,6 +622,10 @@ mod tests {
         // #4280: machine-local worktree state must be ignored and appear once.
         assert_eq!(contents.matches(".loom/worktrees-local/").count(), 1);
 
+        // #5267: harness `isolation: worktree` checkouts must be ignored and
+        // appear once, else `git add -A` stages an embedded-repo gitlink.
+        assert_eq!(contents.matches(".claude/worktrees/").count(), 1);
+
         // #3778: patterns that had drifted out of this installer-managed list
         // relative to the source .gitignore — a consumer re-sync must now emit
         // them so Loom-owned transient state never surfaces as untracked dirt.
@@ -666,6 +682,9 @@ mod tests {
         assert!(contents.contains(".loom/spawn-loop-state.json"));
         assert!(contents.contains(".loom/daemon-metrics.json"));
         assert!(contents.contains(".loom/activity.db"));
+        // #5267: the harness's `isolation: worktree` directory is added exactly
+        // once on a fresh install over an existing (unmarked) .gitignore.
+        assert_eq!(contents.matches(".claude/worktrees/").count(), 1);
     }
 
     #[test]
@@ -684,6 +703,8 @@ mod tests {
         assert_eq!(contents.matches(".loom/locks/").count(), 1);
         // #4280: `.loom/worktrees-local/` must not duplicate across runs.
         assert_eq!(contents.matches(".loom/worktrees-local/").count(), 1);
+        // #5267: `.claude/worktrees/` must not duplicate across runs either.
+        assert_eq!(contents.matches(".claude/worktrees/").count(), 1);
         // #4635: the builder "no changes needed" marker must not duplicate
         // across runs either.
         assert_eq!(contents.matches(".no-changes-needed").count(), 1);
@@ -719,6 +740,10 @@ mod tests {
             ".loom/interventions/",
             ".loom/worktrees/",
             ".loom/worktrees-local/",
+            // #5267: harness `isolation: worktree` checkouts inside the main
+            // checkout — nested git repos a `git add -A` would otherwise stage
+            // as an embedded-repo gitlink.
+            ".claude/worktrees/",
             ".loom/state.json",
             ".loom/mcp-command.json",
             ".loom/activity.db",
@@ -1175,6 +1200,10 @@ mod tests {
         // The previously-absent runtime patterns are now present exactly once.
         assert_eq!(contents.matches(".loom/sweep-checkpoint/").count(), 1);
         assert_eq!(contents.matches(".loom/worktrees-local/").count(), 1);
+        // #5267: the harness `isolation: worktree` directory is backfilled by
+        // the same in-place refresh — this is exactly what resync-installed.sh's
+        // `loom-daemon update-gitignore` invocation drives for existing installs.
+        assert_eq!(contents.matches(".claude/worktrees/").count(), 1);
         // User content on both sides survived and kept its ordering.
         let begin_pos = contents.find(GITIGNORE_BEGIN_MARKER).unwrap();
         let end_pos = contents.find(GITIGNORE_END_MARKER).unwrap();
@@ -1182,6 +1211,49 @@ mod tests {
         assert!(contents.find("dist/").unwrap() > end_pos);
 
         // Idempotent: a second run is a byte-identical no-op.
+        update_gitignore(tmp.path()).unwrap();
+        let again = fs::read_to_string(&gitignore).unwrap();
+        assert_eq!(contents, again, "second refresh must be a byte-identical no-op");
+    }
+
+    #[test]
+    fn hand_added_claude_worktrees_rule_survives_block_refresh_without_block_duplication() {
+        // #5267, the gf180-bandgap case: before `.claude/worktrees/` was managed,
+        // some repos hand-added the rule *above* the loom-managed block. When the
+        // managed block then gains the same pattern, the block itself must still
+        // carry it exactly once, and the operator's own line must survive — Loom
+        // only rewrites the span between its markers and never strips ignore rules
+        // it did not write. The resulting extra line is a semantic no-op for git
+        // (the same behavior any hand-added `.loom/worktrees/` already gets).
+        let tmp = TempDir::new().unwrap();
+        let gitignore = tmp.path().join(".gitignore");
+
+        let stale_block = format!(
+            "{begin}\n{header}\n.loom-in-use\n.loom/worktrees/\n{end}",
+            begin = GITIGNORE_BEGIN_MARKER,
+            header = GITIGNORE_BLOCK_HEADER,
+            end = GITIGNORE_END_MARKER,
+        );
+        fs::write(
+            &gitignore,
+            format!("# harness worktree isolation\n.claude/worktrees/\n\n{stale_block}\n"),
+        )
+        .unwrap();
+
+        update_gitignore(tmp.path()).unwrap();
+        let contents = fs::read_to_string(&gitignore).unwrap();
+
+        // The operator's pre-existing rule is untouched, above the block.
+        let begin_pos = contents.find(GITIGNORE_BEGIN_MARKER).unwrap();
+        assert!(contents.find("# harness worktree isolation").unwrap() < begin_pos);
+        assert!(contents.find(".claude/worktrees/").unwrap() < begin_pos);
+
+        // The managed block carries the pattern exactly once.
+        let end_pos = contents.find(GITIGNORE_END_MARKER).unwrap();
+        let block = &contents[begin_pos..end_pos];
+        assert_eq!(block.matches(".claude/worktrees/").count(), 1);
+
+        // Idempotent: a second run is a byte-identical no-op (no growth per run).
         update_gitignore(tmp.path()).unwrap();
         let again = fs::read_to_string(&gitignore).unwrap();
         assert_eq!(contents, again, "second refresh must be a byte-identical no-op");


### PR DESCRIPTION
## Summary

The Loom-managed `.gitignore` block covers Loom's own `.loom/worktrees/` but never covered `.claude/worktrees/` — the agent harness's `isolation: worktree` checkouts, which land *inside* the main checkout the same way. Each one is a nested git repo, so an unignored one turns a `git add -A` into a silent embedded-repo **gitlink** commit behind nothing but git's easily-missed advice block. That is a near-miss that already happened once (gf180-trng, 2026-08-04, unwound by hand); gf180-bandgap escaped only because someone had hand-added the rule.

`EPHEMERAL_PATTERNS` in `loom-daemon/src/init/post_init.rs` is the single source of truth for that block, and this repo's own `.gitignore` is kept in sync with it by the convention documented on that constant — so both get the entry, and the Loom source repo stops being exposed to the same gap.

## Changes

- `loom-daemon/src/init/post_init.rs` — add `.claude/worktrees/` to `EPHEMERAL_PATTERNS` (next to `.loom/worktrees/` / `.loom/worktrees-local/`), with an inline comment stating it is the *harness's* isolation mechanism, not Loom's own worktree state; plus a `#5267` note on the constant's doc comment following the existing per-issue convention.
- `.gitignore` (repo root) — same entry, in the same position inside the managed block, so `update_gitignore` run against this repo is a byte-identical no-op.
- Tests (all in `post_init.rs`): extended `creates_gitignore_with_all_patterns_when_none_exists`, `appends_missing_patterns_to_existing_gitignore`, `does_not_duplicate_patterns_on_repeated_runs`, `covers_all_source_repo_gitignore_patterns`, and `refreshes_stale_marked_block_to_include_new_runtime_patterns`; added `hand_added_claude_worktrees_rule_survives_block_refresh_without_block_duplication` for the gf180-bandgap shape.

## Acceptance Criteria Verification

1. **`.claude/worktrees/` in `EPHEMERAL_PATTERNS` with an explanatory comment** — done, immediately after `.loom/worktrees-local/`; the comment spells out that these are the harness's `isolation: worktree` checkouts (nested git repos), distinct from Loom's own `.loom/worktrees/`.
2. **`.claude/worktrees/` in this repo's root `.gitignore`** — done, at the matching position in the managed block.
3. **`covers_all_source_repo_gitignore_patterns` still passes** — passes, with the new pattern added to its `expected` list.
4. **Exactly-once assertions on fresh install and repeated runs** — `appends_missing_patterns_to_existing_gitignore` and `does_not_duplicate_patterns_on_repeated_runs` both now assert `contents.matches(".claude/worktrees/").count() == 1`, mirroring the `.loom/worktrees-local/` shape; same assertion added to `creates_gitignore_with_all_patterns_when_none_exists` and to the stale-block refresh test.
5. **No separate resync backfill path needed** — verified two ways. By code path: `resync-installed.sh`'s `refresh_gitignore_block` invokes `"$bin" update-gitignore "$REPO_ROOT"`, which is `handle_update_gitignore_command` -> `loom_daemon::init::update_gitignore`; when a marker-delimited block exists that function splices the whole `b..=e` span with a freshly built `managed_gitignore_block()`, i.e. it rebuilds from `EPHEMERAL_PATTERNS` in place. By test: `refreshes_stale_marked_block_to_include_new_runtime_patterns` seeds a stale marked block and now asserts `.claude/worktrees/` is backfilled exactly once — that is precisely what resync drives.

## Test Plan

- `cargo test -p loom-daemon --lib init::post_init` — **28 passed, 0 failed** (includes the 6 touched/added tests).
- `cargo clippy -p loom-daemon --all-targets` — clean, `cargo fmt` applied.
- Manual, with the binary built from this branch:
  - **Reproduced the bug (control, no rule)**: fresh repo + `.claude/worktrees/agent-abc` nested repo -> `git add -A` prints the embedded-repo advice block and stages `160000 922f091… .claude/worktrees/agent-abc` (a gitlink).
  - **Fixed**: same shape after `loom-daemon update-gitignore <dir>` -> only `.gitignore` is staged; the gitlink is gone.
  - **gf180-bandgap edge case**: a hand-added `.claude/worktrees/` rule above a stale managed block -> after `update-gitignore` the managed block carries the pattern exactly once, the operator's own line is untouched above the block, `git check-ignore -v` resolves to the managed line, and a second run is a byte-identical no-op.

### Note for the reviewer

In the gf180-bandgap shape the operator's hand-added line **survives** alongside the managed one, so the file contains the pattern twice in total (once outside the markers, once inside). That is deliberate and unchanged behavior: `update_gitignore` only rewrites the span between its markers and never strips ignore rules it did not write — the same thing already happens today for a hand-added `.loom/worktrees/`. It is a semantic no-op for git (`check-ignore` resolves to the managed line). Making the marked-block arm also strip outside duplicates would be a behavior change across every pattern, which felt out of scope for a mechanical fix; the new test pins block-internal uniqueness and the no-op idempotence instead.

Closes #5267