### PR TITLE
fix(ci): wire tests/install/ + tests/hermit/ suites into shell-suite-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
               - 'defaults/**'
               - 'tests/hooks/**'
               - 'tests/install/**'
+              - 'tests/hermit/**'
               - 'install.sh'
               # .loom/hooks/** is git-tracked (self-install dogfooding) and
               # several defaults/hooks/tests/*.sh + tests/hooks/*.sh suites
@@ -323,6 +324,14 @@ jobs:
     # expected to be faster (no per-exec Gatekeeper/codesign overhead, cheaper
     # fork/exec) but this is the suites' first CI run — watch the actual
     # ubuntu wall-clock here and tighten LOOM_CI_SUITE_TIMEOUT only if needed.
+    #
+    # Since #5275 ci-wired.txt also covers tests/install/ (installer/
+    # uninstaller unit suites — previously appeared in this job's `changes`
+    # paths-filter trigger only, never actually invoked) and tests/hermit/
+    # (the Hermit role's stateless-ceremony heuristic regression guard,
+    # previously not referenced by CI at all). All 8 suites are hermetic
+    # (fake/stub binaries or local python3 AST fixtures, no live network or
+    # forge calls) and run in well under a second each.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/defaults/scripts/tests/check-ci-suite-manifest.sh
+++ b/defaults/scripts/tests/check-ci-suite-manifest.sh
@@ -14,10 +14,14 @@
 # Since #4769 the invariant also covers tests/hooks/ (repo root) — the
 # Claude-path guard suites. Since #4451 it also covers defaults/hooks/tests/
 # (the Repo Skills' own guard-hook suites — background-subagents,
-# loom-workspace, worktree-paths, methodology-inject, skill-router). Entries
-# for either external directory are qualified with their path relative to the
-# repo root (e.g. `tests/hooks/test-guard-destructive.sh`,
-# `defaults/hooks/tests/test-skill-router.sh`) so they can't collide with a
+# loom-workspace, worktree-paths, methodology-inject, skill-router). Since
+# #5275 it also covers tests/install/ (installer/uninstaller unit suites) and
+# tests/hermit/ (the Hermit role's stateless-ceremony heuristic regression
+# guard) -- both were previously orphaned (no CI runner at all). Entries for
+# any external directory are qualified with their path relative to the repo
+# root (e.g. `tests/hooks/test-guard-destructive.sh`,
+# `defaults/hooks/tests/test-skill-router.sh`,
+# `tests/install/test-forge-detect.sh`) so they can't collide with a
 # same-named suite in this directory.
 #
 # Exit 0 = invariant holds; exit 1 = violation (details printed to stderr).
@@ -29,8 +33,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 WIRED_MANIFEST="$SCRIPT_DIR/ci-wired.txt"
 EXCLUDED_MANIFEST="$SCRIPT_DIR/ci-excluded.txt"
 # Directories of suites outside defaults/scripts/tests/ that this manifest
-# also governs, each relative to the repo root (#4769, #4451).
-EXTERNAL_TEST_DIRS=("tests/hooks" "defaults/hooks/tests")
+# also governs, each relative to the repo root (#4769, #4451, #5275).
+EXTERNAL_TEST_DIRS=("tests/hooks" "defaults/hooks/tests" "tests/install" "tests/hermit")
 
 fail=0
 err() { printf 'ERROR: %s\n' "$1" >&2; fail=1; }

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -132,3 +132,20 @@ defaults/hooks/tests/test-guard-loom-workspace.sh
 defaults/hooks/tests/test-guard-worktree-paths.sh
 defaults/hooks/tests/test-methodology-inject.sh
 defaults/hooks/tests/test-skill-router.sh
+
+# tests/install/ — installer/uninstaller unit suites, wired since #5275 (were
+# previously orphaned entirely — appeared in ci.yml only as a paths-filter
+# trigger, never as an invoked job step). All confirmed hermetic (no live
+# network/forge calls, fake/stub binaries only) and ubuntu-portable.
+tests/install/test-daemon-build-shortcut.sh
+tests/install/test-forge-detect.sh
+tests/install/test-git-repo-detection.sh
+tests/install/test-hooks-preserve.sh
+tests/install/test-provision-daemon.sh
+tests/install/test-uninstall-labels-block.sh
+tests/install/test-uninstall-preserve-siblings.sh
+
+# tests/hermit/ — the Hermit role's stateless-ceremony heuristic regression
+# guard, wired since #5275 (was previously orphaned, no CI runner at all).
+# Hermetic: python3 AST parsing over local fixtures only, no network.
+tests/hermit/test-stateless-ceremony.sh


### PR DESCRIPTION
## Summary

Wires or deletes the 8 orphaned test suites identified in #5275 — all 8 are
wired (none deleted, since all were valid, hermetic regression tests worth
keeping):

- `tests/install/test-daemon-build-shortcut.sh`
- `tests/install/test-forge-detect.sh`
- `tests/install/test-git-repo-detection.sh`
- `tests/install/test-hooks-preserve.sh`
- `tests/install/test-provision-daemon.sh`
- `tests/install/test-uninstall-labels-block.sh`
- `tests/install/test-uninstall-preserve-siblings.sh`
- `tests/hermit/test-stateless-ceremony.sh`

Before this PR, `tests/install/**` appeared in `ci.yml` only as a
paths-filter trigger (never an invoked job step), and
`tests/hermit/test-stateless-ceremony.sh` (the Hermit role's
stateless-ceremony heuristic regression guard) wasn't referenced by CI at
all.

## Changes

- **`defaults/scripts/tests/ci-wired.txt`**: added all 8 suites, following
  the existing external-directory pattern used for `tests/hooks/` (#4769)
  and `defaults/hooks/tests/` (#4451) — each entry is qualified with its
  path relative to the repo root so `run-ci-suites.sh` /
  `check-ci-suite-manifest.sh` resolve it against `REPO_ROOT` instead of
  `defaults/scripts/tests/`.
- **`defaults/scripts/tests/check-ci-suite-manifest.sh`**: extended
  `EXTERNAL_TEST_DIRS` to include `tests/install` and `tests/hermit`, so the
  wired/excluded partition invariant now covers these two directories going
  forward — a new, unwired suite dropped into either directory will fail
  this check instead of silently riding to main untested.
- **`.github/workflows/ci.yml`**: added `tests/hermit/**` to the `scripts`
  paths-filter (`tests/install/**` was already present) so a hermit-only PR
  correctly triggers the `shell-suite-tests` job; also documented the #5275
  addition in that job's header comment, matching the existing #4769/#4451
  documentation pattern.

## Verification

- Investigated all 8 suites: each is hermetic (fake/stub binaries built via
  `mktemp`, or local `python3` AST parsing over fixture files under
  `tests/hermit/fixtures/`) — no live network, forge, or credential
  dependency.
- Ran each suite directly on current `main` (via this branch) — all 8 pass.
- Ran `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — invariant
  holds (113 suites: 110 wired, 3 excluded, all accounted for).
- Ran the full `bash defaults/scripts/tests/run-ci-suites.sh` locally — all
  8 newly-wired suites pass. Two *pre-existing* wired suites
  (`test-loom-daemon-update.sh`, `test-loom-status.sh`) failed in this local
  run due to environmental contamination from other concurrently-running
  Loom daemon/sweep processes on this shared dev machine (live daemon
  state pollution flagged by the suite's own #5179 regression guard, and
  "No agents running." message mismatches caused by real daemon activity)
  — unrelated to this PR's changes, which touch only the CI manifest/wiring
  files, not `loom-status.sh`/`loom-daemon-update.sh` or their tests.

No suite was deleted — all 8 were valid, well-written, currently-passing
regression tests; the orphan problem was purely a missing CI wire-up, not
staleness.

Closes #5275