### PR TITLE
docs: point install.sh reinstall refusal at resync-installed.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,12 @@
 #                              when the target already has Loom installed -- without
 #                              it, non-interactive runs stop and ask you to inventory
 #                              customizations first (interactive runs still get a
-#                              y/N prompt instead).
+#                              y/N prompt instead). If you only want to bring an
+#                              existing install's surfaces up to date -- not replace
+#                              the payload -- use the non-destructive
+#                              .loom/scripts/resync-installed.sh in the target repo
+#                              instead; --confirm-reinstall uninstalls before
+#                              reinstalling.
 #   --allow-non-main-source    Permit installing from a non-main / detached-HEAD Loom source
 #                              (forwarded to scripts/install-loom.sh)
 #   --allow-stale-target       Permit installing over a target whose Loom is newer/stale
@@ -687,7 +692,12 @@ while [[ "${1:-}" == -* ]]; do
       echo "                             when the target already has Loom installed -- without"
       echo "                             it, non-interactive runs stop and ask you to inventory"
       echo "                             customizations first (interactive runs still get a"
-      echo "                             y/N prompt instead)."
+      echo "                             y/N prompt instead). If you only want to bring an"
+      echo "                             existing install's surfaces up to date -- not replace"
+      echo "                             the payload -- use the non-destructive"
+      echo "                             .loom/scripts/resync-installed.sh in the target repo"
+      echo "                             instead; --confirm-reinstall uninstalls before"
+      echo "                             reinstalling."
       echo "  --allow-non-main-source    Permit installing from a non-main / detached-HEAD"
       echo "                             Loom source (forwarded to scripts/install-loom.sh)"
       echo "  --allow-stale-target       Permit installing over a newer/stale target"
@@ -1020,7 +1030,7 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     # legacy) install now MUST pass --confirm-reinstall explicitly -- it
     # cannot silently cross this boundary just because it also passed
     # --quick/--yes/--full.
-    error "Existing Loom installation detected at $TARGET_PATH/.loom -- refusing to run a non-interactive reinstall without explicit acknowledgement.\n       Reinstalling uninstalls the existing Loom payload before writing the new version; inventory and back up any project-owned Loom hooks, scripts, and agent configuration first.\n       Re-run with --confirm-reinstall once you have done so, or omit --quick/--yes/--full to get an interactive y/N prompt instead."
+    error "Existing Loom installation detected at $TARGET_PATH/.loom -- refusing to run a non-interactive reinstall without explicit acknowledgement.\n       Reinstalling uninstalls the existing Loom payload before writing the new version; inventory and back up any project-owned Loom hooks, scripts, and agent configuration first.\n       If you only want to bring the existing install up to date -- not replace it -- run the non-destructive '$TARGET_PATH/.loom/scripts/resync-installed.sh' instead; it copies forward the latest hooks/scripts/roles/docs without uninstalling anything.\n       Re-run with --confirm-reinstall once you have done so, or omit --quick/--yes/--full to get an interactive y/N prompt instead."
   fi
 
   # Issue #4888: the chained uninstall below (`uninstall-loom.sh --yes --local`)


### PR DESCRIPTION
## Summary
`install.sh`'s non-interactive reinstall-refusal message, its `--help` text for `--confirm-reinstall`, and the usage header comment all now name `.loom/scripts/resync-installed.sh` as the non-destructive way to bring an existing install up to date, distinguishing it from `--confirm-reinstall`'s destructive uninstall-then-reinstall path.

## Changes
- `install.sh:1033` (reinstall refusal error message) — added a sentence pointing at `$TARGET_PATH/.loom/scripts/resync-installed.sh` as the non-destructive alternative before the `--confirm-reinstall` instruction
- `install.sh:685-695` (`--help` output for `--confirm-reinstall`) — same distinction added to the help text
- `install.sh:9-19` (usage header comment) — same distinction added to keep the header comment, help text, and error message in sync

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| The reinstall-refusal message (`install.sh:1023`, now ~1033) names `.loom/scripts/resync-installed.sh` as the non-destructive way to bring an existing install's surfaces up to date, distinguishing it from `--confirm-reinstall`'s destructive uninstall-then-reinstall | ✅ | Manually ran `./install.sh --quick -y /tmp/fake-target` against a pre-seeded `.loom/` dir; refusal now reads "...run the non-destructive '.../resync-installed.sh' instead; it copies forward the latest hooks/scripts/roles/docs without uninstalling anything." |
| `install.sh --help`'s `--confirm-reinstall` description (`install.sh:685-690`) makes the same distinction | ✅ | Ran `./install.sh --help`; output includes the same resync pointer under `--confirm-reinstall` |
| The usage header comment (lines 9-14) is updated consistently with the above | ✅ | Header comment text matches the `--help` output wording |
| Optional/stretch: first-class `install.sh --resync` flag | Not attempted | Explicitly marked non-blocking in the issue; the required text-only scope was prioritized and is the full extent of this PR |

## Test Plan
- `bash -n install.sh` — syntax check passes
- `shellcheck install.sh` — no new warnings introduced by this change (all pre-existing warnings are on unrelated lines)
- Manual: `mkdir -p /tmp/fake-target/.loom` (in a git-initialized dir) then `./install.sh --quick -y /tmp/fake-target` — refusal message now mentions `resync-installed.sh`
- Manual: `./install.sh --help` — `--confirm-reinstall` section mentions the resync alternative
- `bash scripts/test-installer.sh` — full 166-case installer suite passes (includes existing `--help` and reinstall-refusal coverage)
- Edge case: interactive y/N prompt path (`install.sh:1007-1013`, taken when `NON_INTERACTIVE` is not set) is untouched by this change — confirmed by diff scope (only the non-interactive `error(...)` branch, `--help` text, and header comment changed)

Closes #5265