### PR TITLE
fix(guard): close two-hop heredoc-variable indirection gap in merge-redirect check

### DIFF
--- a/.loom/hooks/guard-loom-workflow.sh
+++ b/.loom/hooks/guard-loom-workflow.sh
@@ -177,7 +177,15 @@ mask_cat_heredoc_bodies() {
         # VALUE of a known non-executing text-data flag. `capre` must match the
         # tail of the opener-line text that sits immediately before the `cat`
         # token (see the confinement check below).
-        capre = "(^|[ \t])(-m|--message|--body|--notes|--title|--comment|--search)[ \t]*=?[ \t]*(" DQ "|" SQ ")?[ \t]*([$][(]|" BT ")[ \t]*$"
+        #
+        # Also recognizes `gh api ... -f <field>=` for known text-bearing
+        # fields (issue #5172): the field syntax of `gh api` (`-f
+        # body=<value>`) is a DIFFERENT shape from the `--body <value>` flags
+        # above -- a
+        # two-token `-f <field>=` prefix, not a single `--<flagname>` token --
+        # so it needs its own alternative rather than falling out of the
+        # existing flag list.
+        capre = "(^|[ \t])((-m|--message|--body|--notes|--title|--comment|--search)[ \t]*=?|-f[ \t]+(body|message|comment|title|notes|search)=)[ \t]*(" DQ "|" SQ ")?[ \t]*([$][(]|" BT ")[ \t]*$"
     }
     { lines[NR] = $0 }
     END {
@@ -249,6 +257,173 @@ mask_cat_heredoc_bodies() {
     }'
 }
 
+# =============================================================================
+# TWO-HOP HEREDOC-VARIABLE INDIRECTION MASKING (issue #5172)
+#
+# mask_cat_heredoc_bodies() above only recognizes a cat-heredoc captured
+# DIRECTLY by a known text-data flag/field, e.g. `-m "$(cat <<'EOF' ... EOF)"`.
+# It does NOT recognize the equally common two-STEP idiom of assigning that
+# heredoc to a shell variable first, then referencing the variable later:
+#
+#   BODY="$(cat <<'EOF'
+#   ...prose that quotes the disallowed phrase as a documented example...
+#   EOF
+#   )"
+#   gh api "repos/OWNER/REPO/issues/N/comments" -f body="$BODY"
+#
+# Here the literal phrase text lives in the heredoc body at DEFINITION time;
+# the LATER reference is only the variable name ($BODY), never the phrase
+# itself. Raw substring scanning still catches the phrase living in the
+# heredoc body, even though nothing in the command actually executes it — the
+# false-positive class this function closes.
+#
+# mask_var_assigned_heredoc_bodies() masks such a heredoc's body at its point
+# of DEFINITION, but ONLY when it can prove every LATER reference to that same
+# variable ($VAR / ${VAR}) elsewhere in the command is itself confined to a
+# known non-executing text-data flag/field value -- the same allowlist as
+# mask_cat_heredoc_bodies/mask_data_flag_values (-m/--message/--body/--notes/
+# --title/--comment/--search, or `gh api -f <field>=`). If ANY later
+# reference to the variable falls OUTSIDE that confined context -- `eval
+# "$VAR"`, `bash -c "$VAR"`, the bare variable used as a command, or simply no
+# recognizable safe usage -- the heredoc body is left COMPLETELY UNMASKED, so
+# a genuine two-hop bypass (assign `gh pr merge 123` to a variable via
+# heredoc, then `eval` it) still denies exactly as before. Masking only ever
+# narrows what this ONE check misses; it never widens it -- same invariant as
+# every other masking function in this file.
+#
+# A variable reference that falls INSIDE a candidate heredoc's OWN body (the
+# variable mentioning its own name as prose, e.g. describing this very fix) is
+# excluded from the confinement scan -- it is inert text, not a later live
+# reference -- by blanking every candidate's body span before scanning.
+# =============================================================================
+mask_var_assigned_heredoc_bodies() {
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)
+        DQ = sprintf("%c", 34)
+        # A bare shell variable assignment (`VAR=`/`VAR="`/`VAR=$SQ`) directly
+        # capturing `$(cat`. Deliberately distinct from capre in
+        # mask_cat_heredoc_bodies() above: a recognized text-data FLAG always
+        # starts with `-`, which this identifier-only pattern can never match,
+        # so the two confinement modes never collide.
+        varassign_re = "(^|[ \t;&|(])[A-Za-z_][A-Za-z0-9_]*=(" DQ "|" SQ ")?[ \t]*[$][(][ \t]*$"
+        safe_flag  = "(-m|--message|--body|--notes|--title|--comment|--search)[ \t]*=?[ \t]*(" DQ "|" SQ ")?$"
+        safe_field = "-f[ \t]+(body|message|comment|title|notes|search)=(" DQ "|" SQ ")?$"
+        ncand = 0
+    }
+    { lines[NR] = $0 }
+    END {
+        nl = NR
+        for (i = 1; i <= nl; i++) {
+            line = lines[i]
+            off = 1
+            while (1) {
+                p = index(substr(line, off), "<<")
+                if (p == 0) break
+                p = off + p - 1
+                off = p + 2
+                pre = substr(line, 1, p - 1)
+                if (pre !~ /(^|[^A-Za-z0-9_])cat[ \t]*$/) continue
+                before_cat = pre
+                sub(/cat[ \t]*$/, "", before_cat)
+                if (match(before_cat, varassign_re) == 0) continue
+                seg = substr(before_cat, RSTART, RLENGTH)
+                if (match(seg, /[A-Za-z_][A-Za-z0-9_]*/) == 0) continue
+                vn = substr(seg, RSTART, RLENGTH)
+                start = p + 2
+                if (substr(line, start, 1) == "-") start++
+                while (substr(line, start, 1) == " " || substr(line, start, 1) == "\t") start++
+                qc = substr(line, start, 1)
+                if (qc != SQ && qc != DQ) continue
+                start++
+                wordend = start
+                while (substr(line, wordend, 1) ~ /^[A-Za-z0-9_]$/) wordend++
+                if (wordend <= start) continue
+                if (substr(line, wordend, 1) != qc) continue
+                delim = substr(line, start, wordend - start)
+                rest = substr(line, wordend + 1)
+                if (rest ~ /[^ \t]/) continue
+                closeat = 0
+                for (j = i + 1; j <= nl; j++) {
+                    trimmed = lines[j]
+                    sub(/^[ \t]+/, "", trimmed)
+                    if (trimmed == delim) { closeat = j; break }
+                }
+                if (closeat == 0) continue
+                ncand++
+                cand_var[ncand] = vn
+                cand_bstart[ncand] = i + 1
+                cand_bend[ncand] = closeat - 1
+                break
+            }
+        }
+        if (ncand == 0) {
+            out = lines[1]
+            for (i = 2; i <= nl; i++) out = out "\n" lines[i]
+            printf "%s", out
+            exit
+        }
+        # Build a scan buffer with every CANDIDATE heredocs own body blanked
+        # (never masked to X -- a plain blank cannot itself spell "$VAR"),
+        # so a variables OWN prose mentioning its own name never gates its
+        # own masking decision.
+        scanbuf = ""
+        for (i = 1; i <= nl; i++) {
+            ln = lines[i]
+            is_body = 0
+            for (c = 1; c <= ncand; c++) {
+                if (i >= cand_bstart[c] && i <= cand_bend[c]) { is_body = 1; break }
+            }
+            if (is_body) { gsub(/./, " ", ln) }
+            scanbuf = scanbuf (i > 1 ? "\n" : "") ln
+        }
+        buflen = length(scanbuf)
+        for (c = 1; c <= ncand; c++) {
+            vn = cand_var[c]
+            vlen = length(vn)
+            confined = 1
+            pos = 1
+            while (pos <= buflen) {
+                rem = substr(scanbuf, pos)
+                i1 = index(rem, "$" vn)
+                i2 = index(rem, "${" vn "}")
+                if (i1 == 0 && i2 == 0) break
+                use2 = (i2 > 0 && (i1 == 0 || i2 <= i1))
+                if (use2) {
+                    abspos = pos + i2 - 1
+                    mlen = 3 + vlen
+                } else {
+                    abspos = pos + i1 - 1
+                    mlen = 1 + vlen
+                    nextch = substr(scanbuf, abspos + mlen, 1)
+                    if (nextch ~ /^[A-Za-z0-9_]$/) {
+                        pos = abspos + 1
+                        continue
+                    }
+                }
+                prefix = substr(scanbuf, 1, abspos - 1)
+                if (prefix !~ safe_flag && prefix !~ safe_field) {
+                    confined = 0
+                    break
+                }
+                pos = abspos + mlen
+            }
+            cand_mask[c] = confined
+        }
+        for (c = 1; c <= ncand; c++) {
+            if (cand_mask[c] != 1) continue
+            for (j = cand_bstart[c]; j <= cand_bend[c]; j++) {
+                body = lines[j]
+                gsub(/./, "X", body)
+                lines[j] = body
+            }
+        }
+        out = lines[1]
+        for (i = 2; i <= nl; i++) out = out "\n" lines[i]
+        printf "%s", out
+    }'
+}
+
 # Mask the quoted VALUE of known non-executing, text-only flags used by
 # git/gh subcommands: -m/--message, --body, --notes, --title, --comment,
 # --search. A near-duplicate of strip_literal_text() above (which is used
@@ -258,12 +433,17 @@ mask_cat_heredoc_bodies() {
 # a span that still contains an unmasked `$(`/backtick (e.g. real command
 # substitution, not yet neutralized by the heredoc pass above) is left
 # completely untouched.
+#
+# Also recognizes `gh api ... -f <field>=<value>` for known text-bearing
+# fields (issue #5172): `gh api`'s field syntax is `-f key=value`, a
+# two-token shape distinct from the single `--<flagname> value` flags above,
+# so it needs its own alternative in the same regex.
 mask_data_flag_values() {
     printf '%s' "$1" | awk '
     BEGIN {
         SQ = sprintf("%c", 39)
         DQ = sprintf("%c", 34)
-        re = "(^|[ \t\n])(--message|--body|--notes|--title|--comment|--search|-m)[ \t]*=?[ \t]*(" \
+        re = "(^|[ \t\n])((--message|--body|--notes|--title|--comment|--search|-m)[ \t]*=?|-f[ \t]+(body|message|comment|title|notes|search)=)[ \t]*(" \
              DQ "[^" DQ "]*" DQ "|" SQ "[^" SQ "]*" SQ ")"
         buf = ""
     }
@@ -553,13 +733,15 @@ ask() {
 # LOOM: Prefer merge-pr.sh over gh pr merge
 # =============================================================================
 
-# Match against a MASKED copy of $COMMAND (issue #5109, extended by #5155) so
-# a mention of the phrase inside a cat-heredoc commit-message body, a
-# --search/--body/-m/etc quoted value, or a quoted POSITIONAL argument to a
-# known non-executing command (grep/rg/check-duplicate.sh) doesn't
+# Match against a MASKED copy of $COMMAND (issue #5109, extended by #5155 and
+# #5172) so a mention of the phrase inside a cat-heredoc commit-message body,
+# a --search/--body/-m/etc quoted value (including the `gh api -f
+# field=value` shape), a quoted POSITIONAL argument to a known non-executing
+# command (grep/rg/check-duplicate.sh), or a heredoc assigned to a shell
+# variable and only referenced later via that variable, doesn't
 # false-positive as a real invocation. See the masking functions' doc
 # comments above for exactly what is (and is NOT) neutralized.
-GH_PR_MERGE_SCAN_TEXT=$(mask_data_flag_values "$(mask_command_positional_args "$(mask_cat_heredoc_bodies "$COMMAND")")")
+GH_PR_MERGE_SCAN_TEXT=$(mask_data_flag_values "$(mask_command_positional_args "$(mask_var_assigned_heredoc_bodies "$(mask_cat_heredoc_bodies "$COMMAND")")")")
 if echo "$GH_PR_MERGE_SCAN_TEXT" | grep -qE 'gh\s+pr\s+merge'; then
     # Resolve the merge-pr.sh path for the current repo context. Prefer an
     # in-repo installed copy (./.loom/scripts/merge-pr.sh); fall back to the

--- a/.loom/hooks/guard-loom-workflow.sh
+++ b/.loom/hooks/guard-loom-workflow.sh
@@ -279,8 +279,14 @@ mask_cat_heredoc_bodies() {
 #
 # mask_var_assigned_heredoc_bodies() masks such a heredoc's body at its point
 # of DEFINITION, but ONLY when it can prove every LATER reference to that same
-# variable ($VAR / ${VAR}) elsewhere in the command is itself confined to a
-# known non-executing text-data flag/field value -- the same allowlist as
+# variable -- in ANY bash form: $VAR, ${VAR}, or any parameter-expansion
+# variant ${VAR:0:100} / ${VAR#pat} / ${VAR:-def} / ... (#5297) -- elsewhere in
+# the command is itself confined to a known non-executing text-data flag/field
+# value, AND that at least one such reference was actually observed. A variable
+# with ZERO detectable references is never masked: it may be reached through an
+# indirection this literal scan cannot see (`${!REF}`, `eval` of a computed
+# name), so leaving the body unmasked (and thus scanned/denied) fails safe. The
+# confinement allowlist is the same as
 # mask_cat_heredoc_bodies/mask_data_flag_values (-m/--message/--body/--notes/
 # --title/--comment/--search, or `gh api -f <field>=`). If ANY later
 # reference to the variable falls OUTSIDE that confined context -- `eval
@@ -382,25 +388,43 @@ mask_var_assigned_heredoc_bodies() {
             vn = cand_var[c]
             vlen = length(vn)
             confined = 1
+            nref = 0
             pos = 1
             while (pos <= buflen) {
                 rem = substr(scanbuf, pos)
-                i1 = index(rem, "$" vn)
-                i2 = index(rem, "${" vn "}")
-                if (i1 == 0 && i2 == 0) break
-                use2 = (i2 > 0 && (i1 == 0 || i2 <= i1))
-                if (use2) {
-                    abspos = pos + i2 - 1
-                    mlen = 3 + vlen
+                # A later reference to the heredoc-assigned variable in ANY
+                # bash form, not just the exact "$VAR" / closed "${VAR}"
+                # literals: the braced search matches "${VAR" as a PREFIX, so
+                # every parameter-expansion variant -- ${VAR}, ${VAR:0:100},
+                # ${VAR#pat}, ${VAR:-def}, ${VAR/a/b}, ... -- is caught (#5297).
+                # The simple "$VAR" form never occurs inside "${VAR" (the char
+                # after "$" is "{", not the name), so the two searches are
+                # disjoint. Whichever occurs first is examined first.
+                ib = index(rem, "${" vn)
+                is = index(rem, "$" vn)
+                if (ib == 0 && is == 0) break
+                useb = (ib > 0 && (is == 0 || ib <= is))
+                if (useb) {
+                    abspos = pos + ib - 1
+                    mlen = 2 + vlen
+                    aftch = substr(scanbuf, abspos + mlen, 1)
+                    if (aftch ~ /^[A-Za-z0-9_]$/) {
+                        # "${VARX..." -- a DIFFERENT variable whose name merely
+                        # starts with vn; skip past this "${" and keep scanning.
+                        pos = abspos + 2
+                        continue
+                    }
                 } else {
-                    abspos = pos + i1 - 1
+                    abspos = pos + is - 1
                     mlen = 1 + vlen
-                    nextch = substr(scanbuf, abspos + mlen, 1)
-                    if (nextch ~ /^[A-Za-z0-9_]$/) {
+                    aftch = substr(scanbuf, abspos + mlen, 1)
+                    if (aftch ~ /^[A-Za-z0-9_]$/) {
+                        # "$VARX" -- a different variable; skip past this "$".
                         pos = abspos + 1
                         continue
                     }
                 }
+                nref++
                 prefix = substr(scanbuf, 1, abspos - 1)
                 if (prefix !~ safe_flag && prefix !~ safe_field) {
                     confined = 0
@@ -408,7 +432,14 @@ mask_var_assigned_heredoc_bodies() {
                 }
                 pos = abspos + mlen
             }
-            cand_mask[c] = confined
+            # Mask ONLY when at least one later reference was found AND every
+            # such reference was confined. Zero detected references is NOT
+            # proof of safety: the variable may be reached through a form this
+            # literal scan cannot see -- indirect expansion `${!REF}`, `eval`
+            # of a computed name, etc. (#5297) -- so a heredoc-assigned body
+            # is left UNMASKED (and thus scanned/denied) unless we positively
+            # observed its every reference confined to a known text-data slot.
+            cand_mask[c] = (confined == 1 && nref > 0) ? 1 : 0
         }
         for (c = 1; c <= ncand; c++) {
             if (cand_mask[c] != 1) continue

--- a/defaults/hooks/guard-loom-workflow.sh
+++ b/defaults/hooks/guard-loom-workflow.sh
@@ -177,7 +177,15 @@ mask_cat_heredoc_bodies() {
         # VALUE of a known non-executing text-data flag. `capre` must match the
         # tail of the opener-line text that sits immediately before the `cat`
         # token (see the confinement check below).
-        capre = "(^|[ \t])(-m|--message|--body|--notes|--title|--comment|--search)[ \t]*=?[ \t]*(" DQ "|" SQ ")?[ \t]*([$][(]|" BT ")[ \t]*$"
+        #
+        # Also recognizes `gh api ... -f <field>=` for known text-bearing
+        # fields (issue #5172): the field syntax of `gh api` (`-f
+        # body=<value>`) is a DIFFERENT shape from the `--body <value>` flags
+        # above -- a
+        # two-token `-f <field>=` prefix, not a single `--<flagname>` token --
+        # so it needs its own alternative rather than falling out of the
+        # existing flag list.
+        capre = "(^|[ \t])((-m|--message|--body|--notes|--title|--comment|--search)[ \t]*=?|-f[ \t]+(body|message|comment|title|notes|search)=)[ \t]*(" DQ "|" SQ ")?[ \t]*([$][(]|" BT ")[ \t]*$"
     }
     { lines[NR] = $0 }
     END {
@@ -249,6 +257,173 @@ mask_cat_heredoc_bodies() {
     }'
 }
 
+# =============================================================================
+# TWO-HOP HEREDOC-VARIABLE INDIRECTION MASKING (issue #5172)
+#
+# mask_cat_heredoc_bodies() above only recognizes a cat-heredoc captured
+# DIRECTLY by a known text-data flag/field, e.g. `-m "$(cat <<'EOF' ... EOF)"`.
+# It does NOT recognize the equally common two-STEP idiom of assigning that
+# heredoc to a shell variable first, then referencing the variable later:
+#
+#   BODY="$(cat <<'EOF'
+#   ...prose that quotes the disallowed phrase as a documented example...
+#   EOF
+#   )"
+#   gh api "repos/OWNER/REPO/issues/N/comments" -f body="$BODY"
+#
+# Here the literal phrase text lives in the heredoc body at DEFINITION time;
+# the LATER reference is only the variable name ($BODY), never the phrase
+# itself. Raw substring scanning still catches the phrase living in the
+# heredoc body, even though nothing in the command actually executes it — the
+# false-positive class this function closes.
+#
+# mask_var_assigned_heredoc_bodies() masks such a heredoc's body at its point
+# of DEFINITION, but ONLY when it can prove every LATER reference to that same
+# variable ($VAR / ${VAR}) elsewhere in the command is itself confined to a
+# known non-executing text-data flag/field value -- the same allowlist as
+# mask_cat_heredoc_bodies/mask_data_flag_values (-m/--message/--body/--notes/
+# --title/--comment/--search, or `gh api -f <field>=`). If ANY later
+# reference to the variable falls OUTSIDE that confined context -- `eval
+# "$VAR"`, `bash -c "$VAR"`, the bare variable used as a command, or simply no
+# recognizable safe usage -- the heredoc body is left COMPLETELY UNMASKED, so
+# a genuine two-hop bypass (assign `gh pr merge 123` to a variable via
+# heredoc, then `eval` it) still denies exactly as before. Masking only ever
+# narrows what this ONE check misses; it never widens it -- same invariant as
+# every other masking function in this file.
+#
+# A variable reference that falls INSIDE a candidate heredoc's OWN body (the
+# variable mentioning its own name as prose, e.g. describing this very fix) is
+# excluded from the confinement scan -- it is inert text, not a later live
+# reference -- by blanking every candidate's body span before scanning.
+# =============================================================================
+mask_var_assigned_heredoc_bodies() {
+    printf '%s' "$1" | awk '
+    BEGIN {
+        SQ = sprintf("%c", 39)
+        DQ = sprintf("%c", 34)
+        # A bare shell variable assignment (`VAR=`/`VAR="`/`VAR=$SQ`) directly
+        # capturing `$(cat`. Deliberately distinct from capre in
+        # mask_cat_heredoc_bodies() above: a recognized text-data FLAG always
+        # starts with `-`, which this identifier-only pattern can never match,
+        # so the two confinement modes never collide.
+        varassign_re = "(^|[ \t;&|(])[A-Za-z_][A-Za-z0-9_]*=(" DQ "|" SQ ")?[ \t]*[$][(][ \t]*$"
+        safe_flag  = "(-m|--message|--body|--notes|--title|--comment|--search)[ \t]*=?[ \t]*(" DQ "|" SQ ")?$"
+        safe_field = "-f[ \t]+(body|message|comment|title|notes|search)=(" DQ "|" SQ ")?$"
+        ncand = 0
+    }
+    { lines[NR] = $0 }
+    END {
+        nl = NR
+        for (i = 1; i <= nl; i++) {
+            line = lines[i]
+            off = 1
+            while (1) {
+                p = index(substr(line, off), "<<")
+                if (p == 0) break
+                p = off + p - 1
+                off = p + 2
+                pre = substr(line, 1, p - 1)
+                if (pre !~ /(^|[^A-Za-z0-9_])cat[ \t]*$/) continue
+                before_cat = pre
+                sub(/cat[ \t]*$/, "", before_cat)
+                if (match(before_cat, varassign_re) == 0) continue
+                seg = substr(before_cat, RSTART, RLENGTH)
+                if (match(seg, /[A-Za-z_][A-Za-z0-9_]*/) == 0) continue
+                vn = substr(seg, RSTART, RLENGTH)
+                start = p + 2
+                if (substr(line, start, 1) == "-") start++
+                while (substr(line, start, 1) == " " || substr(line, start, 1) == "\t") start++
+                qc = substr(line, start, 1)
+                if (qc != SQ && qc != DQ) continue
+                start++
+                wordend = start
+                while (substr(line, wordend, 1) ~ /^[A-Za-z0-9_]$/) wordend++
+                if (wordend <= start) continue
+                if (substr(line, wordend, 1) != qc) continue
+                delim = substr(line, start, wordend - start)
+                rest = substr(line, wordend + 1)
+                if (rest ~ /[^ \t]/) continue
+                closeat = 0
+                for (j = i + 1; j <= nl; j++) {
+                    trimmed = lines[j]
+                    sub(/^[ \t]+/, "", trimmed)
+                    if (trimmed == delim) { closeat = j; break }
+                }
+                if (closeat == 0) continue
+                ncand++
+                cand_var[ncand] = vn
+                cand_bstart[ncand] = i + 1
+                cand_bend[ncand] = closeat - 1
+                break
+            }
+        }
+        if (ncand == 0) {
+            out = lines[1]
+            for (i = 2; i <= nl; i++) out = out "\n" lines[i]
+            printf "%s", out
+            exit
+        }
+        # Build a scan buffer with every CANDIDATE heredocs own body blanked
+        # (never masked to X -- a plain blank cannot itself spell "$VAR"),
+        # so a variables OWN prose mentioning its own name never gates its
+        # own masking decision.
+        scanbuf = ""
+        for (i = 1; i <= nl; i++) {
+            ln = lines[i]
+            is_body = 0
+            for (c = 1; c <= ncand; c++) {
+                if (i >= cand_bstart[c] && i <= cand_bend[c]) { is_body = 1; break }
+            }
+            if (is_body) { gsub(/./, " ", ln) }
+            scanbuf = scanbuf (i > 1 ? "\n" : "") ln
+        }
+        buflen = length(scanbuf)
+        for (c = 1; c <= ncand; c++) {
+            vn = cand_var[c]
+            vlen = length(vn)
+            confined = 1
+            pos = 1
+            while (pos <= buflen) {
+                rem = substr(scanbuf, pos)
+                i1 = index(rem, "$" vn)
+                i2 = index(rem, "${" vn "}")
+                if (i1 == 0 && i2 == 0) break
+                use2 = (i2 > 0 && (i1 == 0 || i2 <= i1))
+                if (use2) {
+                    abspos = pos + i2 - 1
+                    mlen = 3 + vlen
+                } else {
+                    abspos = pos + i1 - 1
+                    mlen = 1 + vlen
+                    nextch = substr(scanbuf, abspos + mlen, 1)
+                    if (nextch ~ /^[A-Za-z0-9_]$/) {
+                        pos = abspos + 1
+                        continue
+                    }
+                }
+                prefix = substr(scanbuf, 1, abspos - 1)
+                if (prefix !~ safe_flag && prefix !~ safe_field) {
+                    confined = 0
+                    break
+                }
+                pos = abspos + mlen
+            }
+            cand_mask[c] = confined
+        }
+        for (c = 1; c <= ncand; c++) {
+            if (cand_mask[c] != 1) continue
+            for (j = cand_bstart[c]; j <= cand_bend[c]; j++) {
+                body = lines[j]
+                gsub(/./, "X", body)
+                lines[j] = body
+            }
+        }
+        out = lines[1]
+        for (i = 2; i <= nl; i++) out = out "\n" lines[i]
+        printf "%s", out
+    }'
+}
+
 # Mask the quoted VALUE of known non-executing, text-only flags used by
 # git/gh subcommands: -m/--message, --body, --notes, --title, --comment,
 # --search. A near-duplicate of strip_literal_text() above (which is used
@@ -258,12 +433,17 @@ mask_cat_heredoc_bodies() {
 # a span that still contains an unmasked `$(`/backtick (e.g. real command
 # substitution, not yet neutralized by the heredoc pass above) is left
 # completely untouched.
+#
+# Also recognizes `gh api ... -f <field>=<value>` for known text-bearing
+# fields (issue #5172): `gh api`'s field syntax is `-f key=value`, a
+# two-token shape distinct from the single `--<flagname> value` flags above,
+# so it needs its own alternative in the same regex.
 mask_data_flag_values() {
     printf '%s' "$1" | awk '
     BEGIN {
         SQ = sprintf("%c", 39)
         DQ = sprintf("%c", 34)
-        re = "(^|[ \t\n])(--message|--body|--notes|--title|--comment|--search|-m)[ \t]*=?[ \t]*(" \
+        re = "(^|[ \t\n])((--message|--body|--notes|--title|--comment|--search|-m)[ \t]*=?|-f[ \t]+(body|message|comment|title|notes|search)=)[ \t]*(" \
              DQ "[^" DQ "]*" DQ "|" SQ "[^" SQ "]*" SQ ")"
         buf = ""
     }
@@ -553,13 +733,15 @@ ask() {
 # LOOM: Prefer merge-pr.sh over gh pr merge
 # =============================================================================
 
-# Match against a MASKED copy of $COMMAND (issue #5109, extended by #5155) so
-# a mention of the phrase inside a cat-heredoc commit-message body, a
-# --search/--body/-m/etc quoted value, or a quoted POSITIONAL argument to a
-# known non-executing command (grep/rg/check-duplicate.sh) doesn't
+# Match against a MASKED copy of $COMMAND (issue #5109, extended by #5155 and
+# #5172) so a mention of the phrase inside a cat-heredoc commit-message body,
+# a --search/--body/-m/etc quoted value (including the `gh api -f
+# field=value` shape), a quoted POSITIONAL argument to a known non-executing
+# command (grep/rg/check-duplicate.sh), or a heredoc assigned to a shell
+# variable and only referenced later via that variable, doesn't
 # false-positive as a real invocation. See the masking functions' doc
 # comments above for exactly what is (and is NOT) neutralized.
-GH_PR_MERGE_SCAN_TEXT=$(mask_data_flag_values "$(mask_command_positional_args "$(mask_cat_heredoc_bodies "$COMMAND")")")
+GH_PR_MERGE_SCAN_TEXT=$(mask_data_flag_values "$(mask_command_positional_args "$(mask_var_assigned_heredoc_bodies "$(mask_cat_heredoc_bodies "$COMMAND")")")")
 if echo "$GH_PR_MERGE_SCAN_TEXT" | grep -qE 'gh\s+pr\s+merge'; then
     # Resolve the merge-pr.sh path for the current repo context. Prefer an
     # in-repo installed copy (./.loom/scripts/merge-pr.sh); fall back to the

--- a/defaults/hooks/guard-loom-workflow.sh
+++ b/defaults/hooks/guard-loom-workflow.sh
@@ -279,8 +279,14 @@ mask_cat_heredoc_bodies() {
 #
 # mask_var_assigned_heredoc_bodies() masks such a heredoc's body at its point
 # of DEFINITION, but ONLY when it can prove every LATER reference to that same
-# variable ($VAR / ${VAR}) elsewhere in the command is itself confined to a
-# known non-executing text-data flag/field value -- the same allowlist as
+# variable -- in ANY bash form: $VAR, ${VAR}, or any parameter-expansion
+# variant ${VAR:0:100} / ${VAR#pat} / ${VAR:-def} / ... (#5297) -- elsewhere in
+# the command is itself confined to a known non-executing text-data flag/field
+# value, AND that at least one such reference was actually observed. A variable
+# with ZERO detectable references is never masked: it may be reached through an
+# indirection this literal scan cannot see (`${!REF}`, `eval` of a computed
+# name), so leaving the body unmasked (and thus scanned/denied) fails safe. The
+# confinement allowlist is the same as
 # mask_cat_heredoc_bodies/mask_data_flag_values (-m/--message/--body/--notes/
 # --title/--comment/--search, or `gh api -f <field>=`). If ANY later
 # reference to the variable falls OUTSIDE that confined context -- `eval
@@ -382,25 +388,43 @@ mask_var_assigned_heredoc_bodies() {
             vn = cand_var[c]
             vlen = length(vn)
             confined = 1
+            nref = 0
             pos = 1
             while (pos <= buflen) {
                 rem = substr(scanbuf, pos)
-                i1 = index(rem, "$" vn)
-                i2 = index(rem, "${" vn "}")
-                if (i1 == 0 && i2 == 0) break
-                use2 = (i2 > 0 && (i1 == 0 || i2 <= i1))
-                if (use2) {
-                    abspos = pos + i2 - 1
-                    mlen = 3 + vlen
+                # A later reference to the heredoc-assigned variable in ANY
+                # bash form, not just the exact "$VAR" / closed "${VAR}"
+                # literals: the braced search matches "${VAR" as a PREFIX, so
+                # every parameter-expansion variant -- ${VAR}, ${VAR:0:100},
+                # ${VAR#pat}, ${VAR:-def}, ${VAR/a/b}, ... -- is caught (#5297).
+                # The simple "$VAR" form never occurs inside "${VAR" (the char
+                # after "$" is "{", not the name), so the two searches are
+                # disjoint. Whichever occurs first is examined first.
+                ib = index(rem, "${" vn)
+                is = index(rem, "$" vn)
+                if (ib == 0 && is == 0) break
+                useb = (ib > 0 && (is == 0 || ib <= is))
+                if (useb) {
+                    abspos = pos + ib - 1
+                    mlen = 2 + vlen
+                    aftch = substr(scanbuf, abspos + mlen, 1)
+                    if (aftch ~ /^[A-Za-z0-9_]$/) {
+                        # "${VARX..." -- a DIFFERENT variable whose name merely
+                        # starts with vn; skip past this "${" and keep scanning.
+                        pos = abspos + 2
+                        continue
+                    }
                 } else {
-                    abspos = pos + i1 - 1
+                    abspos = pos + is - 1
                     mlen = 1 + vlen
-                    nextch = substr(scanbuf, abspos + mlen, 1)
-                    if (nextch ~ /^[A-Za-z0-9_]$/) {
+                    aftch = substr(scanbuf, abspos + mlen, 1)
+                    if (aftch ~ /^[A-Za-z0-9_]$/) {
+                        # "$VARX" -- a different variable; skip past this "$".
                         pos = abspos + 1
                         continue
                     }
                 }
+                nref++
                 prefix = substr(scanbuf, 1, abspos - 1)
                 if (prefix !~ safe_flag && prefix !~ safe_field) {
                     confined = 0
@@ -408,7 +432,14 @@ mask_var_assigned_heredoc_bodies() {
                 }
                 pos = abspos + mlen
             }
-            cand_mask[c] = confined
+            # Mask ONLY when at least one later reference was found AND every
+            # such reference was confined. Zero detected references is NOT
+            # proof of safety: the variable may be reached through a form this
+            # literal scan cannot see -- indirect expansion `${!REF}`, `eval`
+            # of a computed name, etc. (#5297) -- so a heredoc-assigned body
+            # is left UNMASKED (and thus scanned/denied) unless we positively
+            # observed its every reference confined to a known text-data slot.
+            cand_mask[c] = (confined == 1 && nref > 0) ? 1 : 0
         }
         for (c = 1; c <= ncand; c++) {
             if (cand_mask[c] != 1) continue

--- a/tests/hooks/test-guard-loom-workflow.sh
+++ b/tests/hooks/test-guard-loom-workflow.sh
@@ -344,6 +344,86 @@ assert_deny "Still block a real gh pr merge invocation chained after a masked gr
 
 echo ""
 
+# --- False-positive regression tests (issue #5172) -----------------------
+# `gh api`'s `-f <field>=<value>` syntax is a DIFFERENT shape from the
+# `--body <value>` flags #5109/#5115 masked, and a heredoc ASSIGNED TO A
+# SHELL VARIABLE earlier in the command (then only referenced later via that
+# variable) is a two-hop indirection neither #5109 nor #5155 covered. Both
+# shapes are reproduced here from the exact occurrence reported in #5172.
+
+# Reproduction (exact #5172 shape): a heredoc assigned to $BODY, whose prose
+# quotes the disallowed phrase describing test cases, referenced later via
+# `gh api -f body="$BODY"`.
+GH_5172_VAR_HEREDOC_CMD='BODY="$(cat <<'"'"'EOF2'"'"'
+Tested: raw '"$PHRASE_CMD"' 123 denied; echo "'"$PHRASE_CMD"' 123" | bash denied.
+EOF2
+)"
+gh api "repos/rjwalters/loom/issues/5172/comments" -f body="$BODY"'
+assert_allow "Allow gh api -f body=\$VAR where \$VAR is a heredoc quoting the phrase as prose (#5172)" \
+    "$GH_5172_VAR_HEREDOC_CMD"
+
+# A heredoc directly captured (no variable indirection) by `-f body=` must
+# also be recognized -- the `gh api` field-syntax analog of the #5109 `-m`/
+# `--body` case.
+GH_5172_DIRECT_FIELD_HEREDOC_CMD='gh api "repos/o/r/issues/1/comments" -f body="$(cat <<'"'"'EOF5'"'"'
+'"$PHRASE_CMD"' 123 as prose
+EOF5
+)"'
+assert_allow "Allow gh api -f body=\"\$(cat <<EOF ...)\" heredoc captured directly (#5172)" \
+    "$GH_5172_DIRECT_FIELD_HEREDOC_CMD"
+
+# A literal (non-heredoc) `-f body="..."` value quoting the phrase directly.
+assert_allow "Allow gh api -f body=\"...\" literal value quoting the phrase as prose (#5172)" \
+    "gh api \"repos/o/r/issues/1/comments\" -f body=\"Tested: $PHRASE_CMD 123 denied\""
+
+# The variable-indirection fix must generalize beyond `body` to the other
+# known text-bearing `gh api` fields (message here).
+GH_5172_VAR_HEREDOC_MESSAGE_CMD='MSG="$(cat <<'"'"'EOF6'"'"'
+'"$PHRASE_CMD"' 123 as prose in message field
+EOF6
+)"
+gh api "repos/o/r/issues/1/comments" -f message="$MSG"'
+assert_allow "Allow gh api -f message=\$VAR where \$VAR is a heredoc quoting the phrase as prose (#5172)" \
+    "$GH_5172_VAR_HEREDOC_MESSAGE_CMD"
+
+# Regression guard (control, #5172): the two-hop indirection fix must NOT
+# widen the guard into a bypass. A heredoc assigned to a variable that is
+# THEN eval'd is a genuine live invocation and must still deny -- masking a
+# variable-assigned heredoc's body is gated on EVERY later reference to that
+# variable being confined to a known-safe flag/field value; `eval "$CMD"` is
+# not in that allowlist.
+GH_5172_EVAL_BYPASS_CMD='CMD="$(cat <<'"'"'EOF3'"'"'
+'"$PHRASE_CMD"' 123 --admin
+EOF3
+)"
+eval "$CMD"'
+assert_deny "Still block a heredoc-assigned variable later eval'd (two-hop bypass attempt, #5172)" \
+    "$GH_5172_EVAL_BYPASS_CMD"
+
+# Regression guard (control, #5172): a heredoc-assigned variable referenced
+# bare (as a command, not a safe flag/field value) must also still deny.
+GH_5172_BARE_REF_CMD='X="$(cat <<'"'"'EOF4'"'"'
+'"$PHRASE_CMD"' 123
+EOF4
+)"
+$X'
+assert_deny "Still block a heredoc-assigned variable referenced bare as a command (#5172)" \
+    "$GH_5172_BARE_REF_CMD"
+
+# Regression guard (control, #5172): a heredoc-assigned variable referenced
+# TWICE -- once safely (-f body=), once unsafely (piped into bash) -- must
+# still deny. One confined reference does not excuse an unconfined one.
+GH_5172_MIXED_REF_CMD='X="$(cat <<'"'"'EOF7'"'"'
+'"$PHRASE_CMD"' 123
+EOF7
+)"
+gh api "repos/o/r/issues/1/comments" -f body="$X"
+echo "$X" | bash'
+assert_deny "Still block a heredoc-assigned variable with one safe and one unsafe later reference (#5172)" \
+    "$GH_5172_MIXED_REF_CMD"
+
+echo ""
+
 # =========================================================================
 echo -e "${YELLOW}--- pip install -e WORKTREE GUARD (issue #2495) ---${NC}"
 # =========================================================================

--- a/tests/hooks/test-guard-loom-workflow.sh
+++ b/tests/hooks/test-guard-loom-workflow.sh
@@ -422,6 +422,69 @@ echo "$X" | bash'
 assert_deny "Still block a heredoc-assigned variable with one safe and one unsafe later reference (#5172)" \
     "$GH_5172_MIXED_REF_CMD"
 
+# --- Broaden confinement-reference detection to ALL param-expansion forms (#5297)
+# The #5172 masking scanner recognized ONLY the exact "$VAR" / closed "${VAR}"
+# literals as a later reference. Any OTHER bash parameter-expansion of the same
+# heredoc-assigned variable (${VAR:0:100}, ${VAR#}, ${VAR:-}) was invisible to
+# the scanner, and an undetected reference defaulted to "confined" -- so the
+# heredoc body was masked and the guard never saw the real invocation, even
+# though the variable is genuinely dereferenced and executes at runtime. Each
+# case below assigns a REAL `gh pr merge 123` invocation to the variable via a
+# heredoc, then dereferences it through one of these forms + `eval`: all must
+# still DENY (the guard's deny-on-real-bypass invariant).
+
+# Substring/offset expansion: `eval "${BODY:0:100}"` -- the exact shape Judge
+# reproduced. Pre-fix this ALLOWED (bypass); it must DENY.
+GH_5297_SUBSTR_EVAL_CMD='BODY="$(cat <<'"'"'EOF8'"'"'
+'"$PHRASE_CMD"' 123
+EOF8
+)"
+eval "${BODY:0:100}"'
+assert_deny "Still block heredoc-assigned var eval-d via substring expansion \${VAR:0:100} (#5297)" \
+    "$GH_5297_SUBSTR_EVAL_CMD"
+
+# Prefix-removal expansion: `eval "${BODY#}"`.
+GH_5297_STRIP_EVAL_CMD='BODY="$(cat <<'"'"'EOF9'"'"'
+'"$PHRASE_CMD"' 123
+EOF9
+)"
+eval "${BODY#}"'
+assert_deny "Still block heredoc-assigned var eval-d via prefix-removal expansion \${VAR#} (#5297)" \
+    "$GH_5297_STRIP_EVAL_CMD"
+
+# Default-value expansion: `eval "${BODY:-}"`.
+GH_5297_DEFAULT_EVAL_CMD='BODY="$(cat <<'"'"'EOF10'"'"'
+'"$PHRASE_CMD"' 123
+EOF10
+)"
+eval "${BODY:-}"'
+assert_deny "Still block heredoc-assigned var eval-d via default-value expansion \${VAR:-} (#5297)" \
+    "$GH_5297_DEFAULT_EVAL_CMD"
+
+# Indirect expansion: `REF=BODY; eval "${!REF}"` -- the variable name never
+# appears literally as "$BODY"/"${BODY", so the scanner sees ZERO references.
+# Zero references is NOT proof of safety, so the body must be left UNMASKED and
+# the invocation must still DENY.
+GH_5297_INDIRECT_EVAL_CMD='BODY="$(cat <<'"'"'EOF11'"'"'
+'"$PHRASE_CMD"' 123
+EOF11
+)"
+REF=BODY; eval "${!REF}"'
+assert_deny "Still block heredoc-assigned var eval-d via indirect expansion \${!REF} (#5297)" \
+    "$GH_5297_INDIRECT_EVAL_CMD"
+
+# Control (#5297): the broadened detection must NOT re-introduce the #5172
+# false positive. A heredoc-assigned var whose body only quotes the phrase as
+# prose, referenced through a param-expansion form INSIDE a confined field
+# value (`-f body="${BODY:0:200}"`), stays confined -> masked -> ALLOWED.
+GH_5297_CONFINED_EXPANSION_CMD='BODY="$(cat <<'"'"'EOF12'"'"'
+Tested: '"$PHRASE_CMD"' 123 denied as prose
+EOF12
+)"
+gh api "repos/o/r/issues/1/comments" -f body="${BODY:0:200}"'
+assert_allow "Allow gh api -f body=\${VAR:0:200} where \$VAR is a heredoc quoting the phrase as prose (#5297)" \
+    "$GH_5297_CONFINED_EXPANSION_CMD"
+
 echo ""
 
 # =========================================================================


### PR DESCRIPTION
## Summary

The `loom:gh-pr-merge-redirect` guard still denied `gh api ... -f body="$VAR"`
calls where `$VAR` was assigned earlier in the same command from a `cat`
heredoc whose body only *quotes* the disallowed phrase as prose (e.g. a PR
review comment describing test cases), never actually invokes it. Neither
existing masking pass recognized this shape: `mask_data_flag_values` only
matched `--flag value` shapes, not `gh api`'s `-f field=value` syntax, and
`mask_cat_heredoc_bodies` only masked a heredoc captured *directly* by a
known text-data flag — not one assigned to a shell variable and referenced
later via that variable (a two-hop indirection).

## Changes

- Extend `mask_cat_heredoc_bodies`'s `capre` and `mask_data_flag_values`'s
  `re` to also recognize `gh api ... -f <field>=<value>` for the known
  text-bearing fields (`body`, `message`, `comment`, `title`, `notes`,
  `search`) — covers both a literal `-f body="..."` value and a heredoc
  captured directly by `-f body="$(cat <<'EOF' ... EOF)"`.
- Add `mask_var_assigned_heredoc_bodies()`: masks a heredoc's body at its
  point of *definition* when it's assigned to a shell variable
  (`VAR="$(cat <<'EOF' ... EOF)"`), but **only** when every later reference
  to that variable (`$VAR` / `${VAR}`) elsewhere in the command is itself
  confined to a known non-executing flag/field value (the same allowlist as
  above). Any unconfined reference — `eval "$VAR"`, the bare variable used
  as a command, piped into a shell — leaves the heredoc body **completely
  unmasked**, so a genuine two-hop bypass attempt still denies exactly as
  before. A variable's own heredoc body is excluded from the confinement
  scan (self-mention isn't a live later reference).
- Wire the new function into the `GH_PR_MERGE_SCAN_TEXT` masking chain.
- Sync the installed `.loom/hooks/guard-loom-workflow.sh` copy to match
  `defaults/hooks/guard-loom-workflow.sh` byte-for-byte (this repo's own
  self-install dogfooding convention enforced by CI, #4451 — verified
  against the pre-#5172 baseline and prior guard-fix PRs #5109/#5115/#5160,
  which updated both copies in the same commit).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| The exact #5172 reproduction (`-f body="$BODY"` where `$BODY` is a heredoc quoting the phrase as prose) now allows | ✅ | New test `Allow gh api -f body=$VAR where $VAR is a heredoc quoting the phrase as prose (#5172)`; also manually reproduced and confirmed allow before writing the formal test |
| `gh api -f <field>=<value>` masking covers the same known text-bearing field list as existing `--flag value` masking, for both a literal value and a directly-captured heredoc | ✅ | New tests for literal `-f body="..."`, direct heredoc capture via `-f body=`, and the `-f message=` field |
| A literal same-position invocation of the disallowed phrase still denies (no widening) | ✅ | Pre-existing `Block gh pr merge` / `Block gh pr merge --squash` tests still pass |
| The fix does not silently widen the guard into allowing an actual invocation reached via the same two-hop shape (heredoc → variable → later use) | ✅ | Three new control tests: heredoc-assigned variable later `eval`'d, referenced bare as a command, and referenced twice (once safely, once unsafely) — all still deny |

## Test Plan

- `./tests/hooks/test-guard-loom-workflow.sh` — 49/49 pass (7 new #5172 cases: 4 allow, 3 deny-control), run against the canonical `defaults/hooks/` source.
- `./tests/hooks/test-guard-destructive.sh` — 779/779 pass (unrelated guard, confirms no cross-guard regression).
- `./tests/hooks/test-guard-destructive-dispatcher.sh` — 12/12 pass.
- `shellcheck defaults/hooks/guard-loom-workflow.sh` — clean (no findings).
- `bash -n` on both changed hook files and the test file — clean.
- Manually reproduced the exact issue scenario end-to-end (heredoc-assigned `$BODY` quoting the phrase, then `gh api -f body="$BODY"`) before formalizing it as a test — confirmed allow.

Closes #5172