### PR TITLE
fix(install): stash root CLAUDE.md before --quick reinstall's chained uninstall

### DIFF
--- a/defaults/scripts/tests/test-install-stash-scope.sh
+++ b/defaults/scripts/tests/test-install-stash-scope.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # test-install-stash-scope.sh — regression tests for the reinstall stash guard
-# scoping (issue #3597).
+# scoping (issue #3597; issue #5289 added tests 4-5).
 #
 # The `--quick` reinstall (install.sh) and `--clean` install (install-loom.sh)
 # guards used to run an unscoped `git stash push`, sweeping sibling installers'
 # uncommitted tracked changes into the stash and leaving a half-old/half-new
 # hybrid tree. The fix scopes the stash to the intersection of the dirty set
-# with Loom's ownership set (manifest paths + .gitignore) via
+# with Loom's ownership set (manifest paths + .gitignore + CLAUDE.md) via
 # scripts/install/stash-scope.sh::_emit_loom_owned_dirty_paths.
 #
 # Strategy: source the real helper against a temp git repo seeded with both a
@@ -15,7 +15,14 @@
 #   2. a pathspec-scoped `git stash push` leaves the sibling change untouched
 #      in the working tree and absent from the stash,
 #   3. a tree dirty with ONLY sibling changes yields no owned-dirty paths
-#      (callers skip the stash entirely).
+#      (callers skip the stash entirely),
+#   4. root CLAUDE.md carries the same explicit ownership-set carve-out
+#      `.gitignore` already has (issue #5289 — CLAUDE.md's Loom section is
+#      synthesized at install time, not copied from a literal defaults/
+#      file, so the manifest walk alone never lists it),
+#   5. a dirty root CLAUDE.md is actually selected for stashing by
+#      `_emit_loom_owned_dirty_paths` (the property the reinstall's
+#      in-block-edit conflict guard at install.sh:~1290 depends on).
 #
 # Usage:
 #   bash defaults/scripts/tests/test-install-stash-scope.sh
@@ -143,6 +150,50 @@ printf '{"version":"newer"}\n' > "$TMP_REPO/$SIBLING_PATH"
 
 SELECTED_SIBLING_ONLY="$(_emit_loom_owned_dirty_paths "$REPO_ROOT" "$TMP_REPO")"
 assert_eq "" "$SELECTED_SIBLING_ONLY" "sibling-only dirty tree produces no owned-dirty paths"
+
+echo "== Test 4: root CLAUDE.md is explicitly carved into the ownership set (issue #5289) =="
+# Root CLAUDE.md's Loom section is synthesized at install time from
+# LOOM_ROOT_POINTER (loom-daemon/src/init/scaffolding.rs) rather than copied
+# verbatim from a defaults/CLAUDE.md file, so `_emit_installed_files_manifest`'s
+# walk-of-defaults/ never enumerates it -- exactly the same gap `.gitignore`
+# already has an explicit carve-out for (it too is rewritten by
+# `loom-daemon init` but isn't part of the defaults/ walk). Without that
+# carve-out, `_emit_loom_owned_dirty_paths` never selects a dirty root
+# CLAUDE.md, so `install.sh --quick`'s reinstall never stashes an uncommitted
+# CLAUDE.md edit before the chained uninstall's marker-based `sed` strips the
+# Loom block -- silently destroying the edit with no conflict ever surfaced,
+# even when it landed *inside* the `<!-- BEGIN/END LOOM ORCHESTRATION -->`
+# markers (reproduction: issue #5289).
+if printf '%s\n' "$OWNERSHIP" | grep -qxF "CLAUDE.md"; then
+  pass "CLAUDE.md present in the Loom ownership set"
+else
+  fail "CLAUDE.md present in the Loom ownership set" "ownership set: $OWNERSHIP"
+fi
+if printf '%s\n' "$OWNERSHIP" | grep -qxF ".gitignore"; then
+  pass ".gitignore present in the Loom ownership set (sibling carve-out, #3588)"
+else
+  fail ".gitignore present in the Loom ownership set (sibling carve-out, #3588)" "ownership set: $OWNERSHIP"
+fi
+
+echo "== Test 5: a dirty root CLAUDE.md is selected for stashing (issue #5289) =="
+CLAUDE_TMP_REPO="$(mktemp -d "${TMPDIR:-/tmp}/loom-stash-scope-claude.XXXXXX")"
+git -C "$CLAUDE_TMP_REPO" init -q
+git -C "$CLAUDE_TMP_REPO" config user.email test@example.com
+git -C "$CLAUDE_TMP_REPO" config user.name "Test"
+printf '# Project\n\n<!-- BEGIN LOOM ORCHESTRATION -->\nold pointer\n<!-- END LOOM ORCHESTRATION -->\n' \
+  > "$CLAUDE_TMP_REPO/CLAUDE.md"
+git -C "$CLAUDE_TMP_REPO" add -A
+git -C "$CLAUDE_TMP_REPO" commit -qm "seed"
+printf '# Project\n\n<!-- BEGIN LOOM ORCHESTRATION -->\nUSER IN-BLOCK EDIT\n<!-- END LOOM ORCHESTRATION -->\n' \
+  > "$CLAUDE_TMP_REPO/CLAUDE.md"
+
+CLAUDE_SELECTED="$(_emit_loom_owned_dirty_paths "$REPO_ROOT" "$CLAUDE_TMP_REPO")"
+if printf '%s\n' "$CLAUDE_SELECTED" | grep -qxF "CLAUDE.md"; then
+  pass "dirty root CLAUDE.md is selected for stashing"
+else
+  fail "dirty root CLAUDE.md is selected for stashing" "selected: [$CLAUDE_SELECTED]"
+fi
+rm -rf "$CLAUDE_TMP_REPO"
 
 echo ""
 echo "Ran $TESTS_RUN test(s): $TESTS_PASSED passed, $TESTS_FAILED failed"

--- a/scripts/install/stash-scope.sh
+++ b/scripts/install/stash-scope.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # scripts/install/stash-scope.sh — scope the reinstall stash/reconcile guard
-# to Loom-owned paths (issue #3597).
+# to Loom-owned paths (issue #3597; issue #5289 added root CLAUDE.md).
 #
 # Both install.sh (`--quick` reinstall) and scripts/install-loom.sh (`--clean`)
 # guard uncommitted user changes across the uninstall→reinstall cycle by
@@ -13,8 +13,9 @@
 #
 # This helper narrows the guard to paths Loom actually owns: the intersection
 # of the dirty set (unstaged ∪ staged changes) with Loom's ownership set
-# (`_emit_loom_ownership_set` from manifest.sh, plus `.gitignore`, which
-# `loom-daemon init` rewrites but which is not part of the defaults/ walk).
+# (`_emit_loom_ownership_set` from manifest.sh, plus `.gitignore` and root
+# `CLAUDE.md`, both rewritten by `loom-daemon init` but not enumerated by the
+# defaults/ walk).
 #
 # Source with:
 #     source "$LOOM_ROOT/scripts/install/stash-scope.sh"
@@ -22,15 +23,16 @@
 # Public functions:
 #   _emit_loom_ownership_paths <loom_root> <target>
 #       One target-relative path per line: Loom's manifest ownership set plus
-#       `.gitignore`. Missing manifest.sh → just `.gitignore` (loud caller
-#       fallback expected).
+#       `.gitignore` and root `CLAUDE.md`. Missing manifest.sh → just those
+#       two (loud caller fallback expected).
 #
 #   _emit_loom_owned_dirty_paths <loom_root> <target>
 #       One target-relative path per line: the dirty set (unstaged ∪ staged
 #       changes) intersected with the ownership set. Empty output means no
 #       Loom-owned path is dirty → callers skip the stash entirely.
 
-# Emit the Loom ownership set (manifest paths + .gitignore), one per line.
+# Emit the Loom ownership set (manifest paths + .gitignore + root CLAUDE.md),
+# one per line.
 _emit_loom_ownership_paths() {
   local loom_root="$1"
   local target="$2"
@@ -46,7 +48,25 @@ _emit_loom_ownership_paths() {
   # `.gitignore` is rewritten by `loom-daemon init` (update_gitignore in
   # loom-daemon/src/init/post_init.rs) but is not enumerated by the defaults/
   # walk, so add it explicitly.
-  printf '%s\n.gitignore\n' "$ownership_set" | awk 'NF'
+  #
+  # Issue #5289: root `CLAUDE.md` has the identical gap and a worse failure
+  # mode. `_emit_installed_files_manifest` walks `defaults/` and translates
+  # each file 1:1 (e.g. `defaults/.loom/CLAUDE.md` -> target `.loom/CLAUDE.md`,
+  # the full-guide copy) -- but the root `CLAUDE.md`'s Loom section is
+  # synthesized at install time from `LOOM_ROOT_POINTER`
+  # (loom-daemon/src/init/scaffolding.rs), not copied from a literal
+  # `defaults/CLAUDE.md` file, so the defaults/ walk never enumerates it and
+  # it was silently absent from the ownership set entirely (unlike
+  # `.gitignore`, which at least got this explicit carve-out). Without it,
+  # `_emit_loom_owned_dirty_paths` never includes a dirty root `CLAUDE.md` in
+  # the reinstall's pre-uninstall stash, so an uncommitted edit -- including
+  # one made *inside* the `<!-- BEGIN/END LOOM ORCHESTRATION -->` marker
+  # block -- sits unprotected in the working tree while
+  # `scripts/uninstall-loom.sh`'s marker-based `sed` unconditionally deletes
+  # the block (STEP 6 "Smart Remove CLAUDE.md"), destroying the edit before
+  # `loom-daemon init --force` ever runs. No stash means no 3-way conflict to
+  # surface later, so the loss is silent -- see the reproduction in #5289.
+  printf '%s\n.gitignore\nCLAUDE.md\n' "$ownership_set" | awk 'NF'
 }
 
 # Emit dirty ∩ ownership-set, one target-relative path per line.


### PR DESCRIPTION
## Summary

`install.sh --quick`'s reinstall could silently discard an uncommitted
in-block edit to root `CLAUDE.md` with no conflict message and no stash
to recover from — the #3663 conflict-surfacing guarantee was violated.
Root cause isolated to hypothesis 2 from the issue: `CLAUDE.md` was never
even entered into the reinstall's pre-uninstall stash in the first place.

## Root Cause

`scripts/install/stash-scope.sh::_emit_loom_ownership_paths` already
carves `.gitignore` explicitly into the Loom ownership set with a comment
explaining why: `loom-daemon init` rewrites it, but it's not enumerated
by the `defaults/` manifest walk (`_emit_installed_files_manifest`).

Root `CLAUDE.md` has the *identical* gap, previously un-carved-out. Its
Loom section is synthesized at install time from `LOOM_ROOT_POINTER`
(`loom-daemon/src/init/scaffolding.rs`) — a short pointer paragraph, not
copied verbatim from a literal `defaults/CLAUDE.md` file (only
`defaults/.loom/CLAUDE.md`, the full-guide copy, exists) — so the
manifest walk never lists root `CLAUDE.md` as Loom-owned at all.

Traced with instrumentation against the issue's exact repro:
- `_emit_loom_owned_dirty_paths` never included `CLAUDE.md` even though
  it was dirty, so `REINSTALL_OWNED_DIRTY` was empty and `install.sh`
  never stashed it (no "Stashing uncommitted Loom-owned changes" message
  at all — confirmed by direct instrumentation before the fix).
- With CLAUDE.md unprotected in the working tree, the chained
  `scripts/uninstall-loom.sh`'s STEP 6 "Smart Remove CLAUDE.md" ran its
  unconditional marker-based `sed '/<!-- BEGIN LOOM ORCHESTRATION -->/,/<!-- END LOOM ORCHESTRATION -->/d'`
  directly against the (uncommitted, unstashed) working tree — destroying
  the user's in-block edit right there, before `loom-daemon init --force`
  ever ran.
- With nothing stashed, there was nothing left to 3-way-merge-conflict
  against later, so the in-block-edit guard at install.sh's stash-restore
  path (the one named in the issue's "Suspected Cause") never even got a
  chance to run — it wasn't buggy, it was simply never reached.

This is a regression relative to #3663's intent (not an intentional
simplification) — the short-pointer-text rewrite didn't change the
guarantee that in-block edits should surface a conflict, it just
shrank what "in-block" contains.

## Changes

- `scripts/install/stash-scope.sh`: add `CLAUDE.md` to the explicit
  ownership-set carve-out alongside `.gitignore`, with a comment
  explaining the parallel gap and its worse (silent-data-loss) failure
  mode. This is the single shared helper both `install.sh --quick` and
  `scripts/install-loom.sh --clean` source, so both reinstall paths gain
  the protection (the `--clean` path had the same latent unprotected-copy
  risk, just without install.sh's more elaborate reset+reapply/conflict
  machinery on top).
- `defaults/scripts/tests/test-install-stash-scope.sh`: two new hermetic
  regression tests (already-CI-wired suite, `ci-wired.txt`) — (4) root
  `CLAUDE.md` is present in the ownership set alongside `.gitignore`, and
  (5) a dirty root `CLAUDE.md` is actually selected by
  `_emit_loom_owned_dirty_paths`. Verified both fail against the pre-fix
  helper and pass post-fix.

## Acceptance Criteria Verification

- [x] Decided the silent overwrite is a **regression** (not intentional)
      and fixed the root cause (missing ownership-set carve-out), restoring
      the #3663 conflict-surfacing guarantee for genuine in-block
      divergence.
- [x] Regression coverage: rather than reinstating the deleted
      `scripts/test-install-quick-gitignore-stash.sh` (a full install.sh
      E2E suite requiring a `cargo build`ed `loom-daemon` binary — outside
      the hermetic ~3min `shell-suite-tests` CI job's scope, and the exact
      kind of unwired/costly suite that led to its original deletion in
      #5276), added two hermetic unit tests to the already-CI-wired
      `test-install-stash-scope.sh` that pin the *exact* root cause
      (the ownership-set gap) at the layer install.sh's logic actually
      depends on. Confirmed they fail pre-fix / pass post-fix (see Test
      Plan). No suite in this repo invokes `install.sh` reinstall without
      `--confirm-reinstall` (verified against `test-install-reinstall-safety.sh`
      and `test-install-full-reinstall-no-target-mutation.sh`, both already
      correct) — finding 1 from the issue only ever affected the
      already-deleted suite, so there was no stale invocation to update.

## Test Plan

- [x] **Manual verification** — re-ran the issue's exact repro script
      end-to-end against the fix:
      ```
      === CLAUDE.md ===
      <!-- BEGIN LOOM ORCHESTRATION -->
      This repository uses [Loom](...) for AI-powered development orchestration ...
      <!-- END LOOM ORCHESTRATION -->
      === stash list ===
      stash@{0}: On main: loom-install: preserving user changes before --quick reinstall
      ```
      Installer output now reports:
      ```
      ⚠ Failed to restore stashed user changes automatically
        Conflicting file(s): CLAUDE.md
        git stash pop --index reported:
          error: Your local changes to the following files would be overwritten by merge:
              CLAUDE.md
      ...
        Your changes are preserved in the stash (stash@{0}).
      ```
      `git stash show -p stash@{0}` contains the user's `USER IN-BLOCK EDIT`
      text, confirming it is fully recoverable, not lost.
- [x] **Automated**: `bash defaults/scripts/tests/test-install-stash-scope.sh`
      → `Ran 10 test(s): 10 passed, 0 failed`. Confirmed the 2 new tests
      fail against a pre-fix checkout of `stash-scope.sh`
      (`Ran 10 test(s): 8 passed, 2 failed`) and pass post-fix.
- [x] **Edge cases** (both manually re-verified against the fix, no
      regression):
      - `.gitignore` HEAD-reset+reapply path (#3588): dirty `.gitignore`
        with a custom user pattern → reinstall reports "User changes
        restored", custom pattern preserved verbatim.
      - Out-of-block CLAUDE.md edit: a dirty line *outside* the marker
        block → reinstall still resets+reapplies cleanly ("User changes
        restored"), out-of-block edit preserved, fresh Loom block applied.
      - Also ran the full pre-existing suites unaffected in scope but
        sharing the touched helper: `test-install-reinstall-safety.sh`
        (21/21 pass) and `test-install-full-reinstall-no-target-mutation.sh`
        (8/8 pass).

Closes #5289