### PR TITLE
fix(guard): mask multi-line quoted string bodies in write-confinement scan

### DIFF
--- a/defaults/hooks/guard-destructive-generic.sh
+++ b/defaults/hooks/guard-destructive-generic.sh
@@ -3022,44 +3022,84 @@ extract_write_targets() {
     END {
         # Heredoc-body masking (#5000) runs BEFORE qsplit(): once a heredoc
         # body write-idiom-looking bytes (`>`, `;`, `tee`, ...) are replaced
-        # with inert placeholders, the per-line loop below -- which still
-        # resets mask_gt()/mask_ws() per SEGMENT, exactly as before -- has
-        # nothing dangerous-looking left to misread on those lines,
-        # regardless of that per-line reset. A real write-idiom byte OUTSIDE
-        # any recognized heredoc body, even later in the SAME multi-line
-        # command, is untouched and still flows through the unchanged
-        # pipeline below.
+        # with inert placeholders, nothing dangerous-looking is left to
+        # misread on those lines. A real write-idiom byte OUTSIDE any
+        # recognized heredoc body, even later in the SAME multi-line command,
+        # is untouched and still flows through the unchanged pipeline below.
         buf = mask_heredoc_bodies(buf)
         $0 = qsplit(buf)   # quote-aware segmentation (#3755)
+
+        # Whole-BUFFER quote-aware masking (#5157), not per-segment.
+        #
+        # mask_ws()/mask_gt() themselves track quote state one character at a
+        # time and never special-case "\n" -- an embedded newline inside an
+        # OPEN quoted span (e.g. a plain multi-line double-quoted string,
+        # `msg="line one\necho pwned > /main/checkout/f.sh\nline three"`, no
+        # heredoc involved at all) is simply copied through like any other
+        # byte while quote mode stays "on". qsplit() above already preserves
+        # such an embedded newline as part of the ONE atomic quoted span it
+        # copies verbatim (it finds the matching closing quote by index, not
+        # by line), so by construction every "\n" surviving in its output
+        # already sits OUTSIDE any then-open quote from the perspective of
+        # qsplit() itself -- but mask_ws() and mask_gt() do their own independent
+        # char-by-char quote tracking, and calling them per-SEGMENT (after
+        # `split($0, segs, "\n")`) resets that tracking to "unquoted" at every
+        # such newline, discarding the "still inside this quote" context a
+        # PRIOR segment established. A `>` sitting on the continuation line of
+        # an otherwise-inert multi-line double-quoted string is then
+        # misread as a live redirection operator, manufacturing a phantom
+        # write target for text that never reaches the shell as anything but
+        # quoted data (#5157). This is the direct multi-line analog of the
+        # single-line #4245 fix and the heredoc-body #5000 fix above --
+        # masking the WHOLE buffer once, before any "\n"-splitting happens,
+        # keeps quote state correctly threaded across every embedded newline,
+        # heredoc or not.
+        wbuf = mask_ws($0)
+        gbuf = mask_gt(wbuf)
         n = split($0, segs, "\n")
+        nw = split(wbuf, wsegs, "\n")
+        ng = split(gbuf, gsegs, "\n")
         for (i = 1; i <= n; i++) {
             seg = segs[i]
+            origlen = length(seg)
             sub(/^[ \t]+/, "", seg)
             sub(/^sudo[ \t]+/, "", seg)
             sub(/^[ \t]+/, "", seg)
             if (seg == "") continue
 
-            # Quote-aware whitespace masking (#4934): wseg is byte-for-byte
-            # identical to seg except a space/tab INSIDE a quoted span is
-            # replaced with a non-whitespace placeholder, so splitting on
-            # /[ \t]+/ never breaks a quoted argument (e.g. a quoted path
-            # containing a literal space) into more than one token. toks[]
-            # is then unmasked back to the real whitespace bytes so the
-            # target TEXT downstream is unchanged.
-            wseg = mask_ws(seg)
+            # wsegs[i]/gsegs[i] are byte-for-byte identical in LENGTH to the
+            # unstripped segs[i] (masking only ever substitutes one byte for
+            # one byte, never adds/removes any) -- `stripped` is the number of
+            # leading bytes the three sub() calls above just removed from the
+            # (unmasked) seg, so re-applying that same byte count via substr()
+            # keeps wseg/mseg positionally aligned with the stripped seg
+            # regardless of whether those leading bytes were literal
+            # whitespace or (on a mid-quote continuation segment) already
+            # masked to a placeholder byte.
+            stripped = origlen - length(seg)
+
+            # Quote-aware whitespace masking (#4934, threaded whole-buffer
+            # per #5157 above): wseg is byte-for-byte identical to seg except
+            # a space/tab INSIDE a quoted span is replaced with a
+            # non-whitespace placeholder, so splitting on /[ \t]+/ never
+            # breaks a quoted argument (e.g. a quoted path containing a
+            # literal space) into more than one token. toks[] is then
+            # unmasked back to the real whitespace bytes so the target TEXT
+            # downstream is unchanged.
+            wseg = substr(wsegs[i], stripped + 1)
             m = split(wseg, toks, /[ \t]+/)
             if (m < 1) continue
             for (j = 1; j <= m; j++) toks[j] = unmask_ws(toks[j])
 
-            # Quote-aware parallel tokenization (#4245): mseg is byte-for-byte
-            # identical to wseg except a `>` inside a quoted span is replaced
-            # with an SOH placeholder, so whitespace splitting yields the SAME
-            # token boundaries (mm == m always) but mtoks[] can be tested for
-            # a REAL (unquoted) redirection operator without ever matching a
-            # `>` that was only quoted data. Masking `>` on TOP of wseg (not
-            # seg) keeps the two passes token boundaries in lockstep, since
-            # mask_gt() only ever changes `>` bytes, never whitespace-ness.
-            mseg = mask_gt(wseg)
+            # Quote-aware parallel tokenization (#4245, threaded whole-buffer
+            # per #5157 above): mseg is byte-for-byte identical to wseg except
+            # a `>` inside a quoted span is replaced with an SOH placeholder,
+            # so whitespace splitting yields the SAME token boundaries
+            # (mm == m always) but mtoks[] can be tested for a REAL (unquoted)
+            # redirection operator without ever matching a `>` that was only
+            # quoted data. The actual target text is still read from the
+            # ORIGINAL toks[] (unmasked) once a real operator is confirmed.
+            mseg = substr(gsegs[i], stripped + 1)
             mm = split(mseg, mtoks, /[ \t]+/)
 
             if (toks[1] == "cd") {

--- a/tests/hooks/test-guard-destructive.sh
+++ b/tests/hooks/test-guard-destructive.sh
@@ -3616,6 +3616,64 @@ assert_allow "write-confinement (#4934): CWD=linked worktree, single-quoted spac
 assert_allow "write-confinement (#4934): CWD=linked worktree, double-quoted spaced target inside the worktree allows" \
     "echo x > \"$WT_LINKED_DIR/src/evil file.sh\"" "$WT_LINKED_DIR"
 
+# -------------------------------------------------------------------------
+# Whole-buffer quote masking for PLAIN multi-line quoted strings (#5157) --
+# extract_write_targets() must not misread a `>` write-idiom byte sitting on
+# a CONTINUATION line of an ordinary multi-line double/single-quoted shell
+# string (no heredoc anywhere) as a live redirection target. Distinct from
+# both #4245 (same-line quoted `>`) and #5000 (heredoc-BODY `>`): this covers
+# a `>` character several PHYSICAL LINES into a plain `VAR="...\n...\n..."`
+# assignment. Before this fix, mask_ws()/mask_gt() were still called per
+# SEGMENT (after splitting the qsplit()-segmented buffer on "\n"), so a
+# still-open quote spanning multiple physical lines reset to "unquoted" state
+# at every embedded newline even though the shell never treats it that way --
+# the confirmed #5157 occurrence-1 repro: a guard-test harness assigning a
+# multi-line JSON/text payload to a shell variable, later only echoed/piped
+# to a subprocess (never executed by the outer shell), was denied because a
+# `> /path/to/pwned.txt`-shaped substring several lines into that assignment
+# was misread as a real redirect target.
+assert_allow "write-confinement (#5157): multi-line double-quoted VAR assignment with '>' on a continuation line allows" \
+    "msg=\"line one
+echo pwned > $WT_REPO/defaults/hooks/f.sh
+line three\"
+echo \"\$msg\"" "$WT_REPO"
+
+assert_allow "write-confinement (#5157): same multi-line quoted VAR assignment from a linked-worktree cwd allows" \
+    "msg=\"line one
+echo pwned > $WT_REPO_LINKED/defaults/hooks/f.sh
+line three\"
+echo \"\$msg\"" "$WT_LINKED_DIR"
+
+assert_allow "write-confinement (#5157): multi-line SINGLE-quoted VAR assignment with '>' on a continuation line allows" \
+    "msg='line one
+echo pwned > $WT_REPO/defaults/hooks/f.sh
+line three'
+echo \"\$msg\"" "$WT_REPO"
+
+# Narrows, never widens: a REAL unquoted '>' write AFTER a multi-line quoted
+# block in the same command must still deny.
+assert_deny "write-confinement (#5157): real unquoted '>' write AFTER a multi-line quoted VAR assignment still denies" \
+    "msg=\"line one
+harmless > text
+line three\"
+echo pwned > $WT_REPO/defaults/hooks/g.sh" "$WT_REPO"
+
+# ...and BEFORE it, in the same command.
+assert_deny "write-confinement (#5157): real unquoted '>' write BEFORE a multi-line quoted VAR assignment still denies" \
+    "echo pwned > $WT_REPO/defaults/hooks/h.sh
+msg=\"line one
+harmless > text
+line three\"" "$WT_REPO"
+
+# A genuine write inside the acting worktree, alongside an unrelated
+# multi-line quoted block, must still allow (no over-widening the other
+# direction either).
+assert_allow "write-confinement (#5157): multi-line quoted VAR assignment plus a real write inside the worktree allows" \
+    "msg=\"line one
+harmless > text
+line three\"
+echo x > $WT_DIR/src/f.sh" "$WT_REPO"
+
 rm -rf "$HOME_FIXTURE_OUTSIDE"
 rm -rf "$WT_REPO" "$WT_REPO_NOWT" "$WT_REPO_OFF" "$WT_REPO_LINKED"
 


### PR DESCRIPTION
## Summary

`extract_write_targets()` (the tokenizer behind the `worktree-write-confinement`
catastrophic-tier guard, #4178) was misreading a `>` write-idiom byte sitting on
a **continuation line of an ordinary multi-line quoted shell string** as a live
redirection target, denying commands that never write to the filesystem — the
same class of bug already fixed for heredoc bodies (#5000) and single-line
quoted values (#4245), but for a plain multi-line `VAR="...\n...\n..."` /
`VAR='...\n...\n...'` assignment with no heredoc involved at all.

## Root cause

`extract_write_targets()` already slurps the whole (possibly multi-line) Bash
command into one buffer and runs `qsplit()` and `mask_heredoc_bodies()` once
over that whole buffer (#5000) — but it then called `mask_ws()`/`mask_gt()`
**per line segment**, after splitting on `"\n"`. Those two functions track
quote state (single/double-quoted vs. unquoted) one character at a time and
reset to "unquoted" at the start of every call. So a still-open quote that
began on an earlier physical line lost its "still inside this quote" context
the moment the buffer was split into per-line segments — a `>` on the
*continuation* line of an otherwise-inert multi-line quoted string was then
read as a real, unquoted redirection operator, manufacturing a phantom write
target.

Confirmed local repro of the exact #5157 occurrence-1 shape (pre-fix):

```bash
msg="line one
echo pwned > /main/checkout/f.sh
line three"
echo "$msg"
```

This is inert text assigned to a variable and only ever echoed — never
executed by the outer shell — but the guard denied it as a "worktree-isolation
bypass" because the embedded `>` on the middle line was scanned outside any
quote context.

Heredoc bodies (`<<'EOF' ... EOF`) were **already** correctly masked by the
pre-existing #5000 fix, since `mask_heredoc_bodies()` operates on the whole
buffer *before* any masking-then-splitting order-dependence can bite. The gap
was specifically plain multi-line quoted strings, which never go through that
heredoc-body masking pass at all.

Investigated the issue's occurrence 2 (`cd`/cwd not inside a managed
worktree) separately: the guard is **deliberately** not scoped to "cwd inside
a worktree" — it exists to catch a write that *targets* the main checkout
regardless of the acting cwd (see the existing #4210 test coverage, which
explicitly exercises `CWD=main checkout` denies). This is by design, not a
bug, so no change was made there; the fix here is scoped to the masking gap
only, per the issue's own guidance not to force-fit a second, unconfirmed fix.

## Changes

- `defaults/hooks/guard-destructive-generic.sh`: `extract_write_targets()` now
  computes `mask_ws()`/`mask_gt()` **once over the whole qsplit()-segmented
  buffer** (mirroring the existing whole-buffer `mask_heredoc_bodies()` call),
  then splits the masked buffers on `"\n"` in lockstep with the unmasked
  segments — so quote state threads correctly across every embedded newline,
  heredoc or not. Leading whitespace/`sudo` stripping (which must still run
  per-segment) is re-applied to the masked segments via a byte-offset
  (`substr()`), since masking never changes string length.
- `tests/hooks/test-guard-destructive.sh`: 6 new regression tests in the
  existing "Bash-tool write confinement" section — multi-line double- and
  single-quoted `VAR=` assignments with an inert `>` on a continuation line
  (from both a main-checkout and a linked-worktree cwd), plus narrows-not-widens
  regressions proving a genuine unquoted `>` write before/after such a block,
  or alongside one, still denies/allows correctly.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|---|---|---|
| Locate the `worktree-write-confinement` guard implementation | ✅ | `defaults/hooks/guard-destructive-generic.sh`, `extract_write_targets()` (used by the `worktree-write-confinement` deny at the end of the guard) |
| Locate the masking helper used for #5109/#5115/#5155's analogous fix | ✅ | Reused `mask_heredoc_bodies()` (#5000) as the architectural template — this issue's own gap was that `mask_ws()`/`mask_gt()` were NOT yet threaded whole-buffer the same way |
| Check `.loom/logs/guard-decisions.log` for the two cited denials | ⚠️ | Log had rotated past the cited timestamps by the time this was investigated; reproduced occurrence 1's exact shape locally instead and confirmed pre-fix DENY / post-fix ALLOW |
| Confirm whether cwd-scoping explains occurrence 2, and don't force-fit a second fix if not | ✅ | Confirmed the guard is intentionally NOT scoped to "cwd inside worktree" (existing #4210 coverage) — no change made there; only the masking gap was fixed |
| Implement the fix | ✅ | `extract_write_targets()` now masks the whole buffer once, not per-segment |
| Add/extend tests | ✅ | 6 new tests in `tests/hooks/test-guard-destructive.sh`'s write-confinement section |
| Run the guard's test suite | ✅ | `tests/hooks/test-guard-destructive.sh` (confinement section extracted standalone: 141/141 passed, including the 6 new tests); `tests/hooks/test-guard-destructive-dispatcher.sh`: 12/12 passed |

## Test Plan

```bash
bash tests/hooks/test-guard-destructive-dispatcher.sh   # 12/12 passed
bash tests/hooks/test-guard-destructive.sh               # full suite; confinement section isolated and re-run standalone: 141/141 passed
shellcheck -S error defaults/hooks/guard-destructive-generic.sh   # exit 0, no new findings (pre-existing SC2016 info-only notices unchanged)
```

Manual repro (pre-fix DENY, post-fix ALLOW):
```bash
msg="line one
echo pwned > <main-checkout>/f.sh
line three"
echo "$msg"
```

Closes #5157