### PR TITLE
fix(daemon): verify claim ownership against the forge timeline before cancel/reap label-restore

### DIFF
--- a/loom-daemon/src/sweep_registry/guards.rs
+++ b/loom-daemon/src/sweep_registry/guards.rs
@@ -2,6 +2,7 @@
 //! open-PR / park-label label probes.
 
 use super::*;
+use crate::claim_reconciliation::forge::parse_max_timestamp;
 
 /// Three-state result of the open-linked-PR probe (Issue #4452), replacing the
 /// old `Option<u32>` that conflated a *verified* "no open linked PR" with a
@@ -136,6 +137,114 @@ impl SweepRegistry {
             CollisionClass::Collision { labels }
         } else {
             CollisionClass::Clean
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Cross-host claim-ownership verification before release/reclaim
+    // (Issue #5017 / #5282)
+    // ------------------------------------------------------------------------
+    //
+    // `.loom/locks/issue-<N>` (see `locks.rs`'s `release_lock_owned`) is
+    // strictly HOST-LOCAL filesystem state: it is written by `acquire_lock`
+    // when *this* daemon dispatches *its own* sweep, and no other host's
+    // daemon ever sees it. That makes it structurally blind to a genuine
+    // cross-host race: when host B cancels its own losing duplicate dispatch
+    // for an issue host A is actively (and validly) building, host B's local
+    // lock names host B's own (about-to-be-cancelled) sweep as the owner —
+    // it matches, so `release_lock_owned` returns `Released`, not
+    // `Superseded`, and the caller proceeds to call `restore_label_to_ready`,
+    // destroying the ONLY cross-host mutex (the `loom:building` label)
+    // out from under host A's still-live sweep. This is exactly what
+    // happened on loom#5270 (2026-08-04): cancelling loom-worker-1's losing
+    // duplicate reverted `loom:building` on the issue robb-studio's sweep
+    // still owned, reopening it to a third dispatch.
+    //
+    // The forge's own label-event timeline, by contrast, is observed
+    // identically by every host — it is the one piece of claim state that is
+    // NOT host-local. `fetch_claim_labeled_at` / `claim_superseded_on_forge`
+    // below add that cross-host signal as an ADDITIONAL guard alongside (not
+    // a replacement for) the cheaper host-local `Superseded`/`HolderAlive`
+    // checks: every call site short-circuits on the existing local check
+    // first, so the extra `gh api .../timeline` round trip is only paid when
+    // the local lock could not already answer the question.
+
+    /// Fetch the most recent `labeled loom:building` timeline event timestamp
+    /// for `issue` (Issue #5017/#5282) — the forge-side, cross-host claim
+    /// signal every host observes identically, unlike the host-local
+    /// `.loom/locks/issue-<N>` claim lock.
+    ///
+    /// Mirrors [`crate::claim_reconciliation::forge`]'s own
+    /// `fetch_claim_labeled_at` (used there for PR-claim reconciliation) —
+    /// the underlying `issues/{n}/timeline` REST endpoint is identical for
+    /// issues and PRs, so the query shape is reused verbatim; this copy lives
+    /// in `sweep_registry` so the cancel/reap label-restore path (this
+    /// module) can call it without a cross-module `pub(crate)` promotion of a
+    /// function whose doc comments are specific to PR-claim reconciliation.
+    ///
+    /// FAIL-OPEN: returns `None` on any `gh` failure/timeout/non-zero
+    /// exit/unparseable output, or when the label was never applied. Callers
+    /// MUST treat `None` as "cannot verify, proceed with existing behavior"
+    /// — same fail-open contract as every other forge probe in this module
+    /// ([`classify_preflip_labels`](Self::classify_preflip_labels),
+    /// [`issue_is_closed_or_pr`](Self::issue_is_closed_or_pr)).
+    pub(crate) fn fetch_claim_labeled_at(&self, issue: u32) -> Option<DateTime<Utc>> {
+        let gh = self
+            .config
+            .gh_bin
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("gh"));
+        let mut cmd = Command::new(&gh);
+        cmd.arg("api")
+            .arg(format!("repos/{{owner}}/{{repo}}/issues/{issue}/timeline"))
+            .arg("--paginate")
+            .arg("--jq")
+            .arg(
+                r#"[.[] | select(.event == "labeled" and .label.name == "loom:building") | .created_at] | max // empty"#,
+            );
+        cmd.current_dir(&self.config.workspace_root);
+        if let Ok(repo) = std::env::var("LOOM_REPO") {
+            cmd.arg("--repo").arg(repo);
+        }
+        let timeout = reap_gh_timeout();
+        let output = output_with_timeout(cmd, timeout).ok().flatten()?;
+        if !output.status.success() {
+            return None;
+        }
+        parse_max_timestamp(&output.stdout)
+    }
+
+    /// Whether the forge's `loom:building` claim on `issue` was (re-)applied
+    /// STRICTLY AFTER `claimed_at` (Issue #5017/#5282) — i.e. a different
+    /// claimant, possibly on another host entirely invisible to this host's
+    /// `.loom/locks/issue-<N>`, has (re-)claimed the issue since this sweep's
+    /// own claim/dispatch time. When `true`, the caller MUST skip
+    /// [`restore_label_to_ready`](Self::restore_label_to_ready) — exactly the
+    /// same "leave the live claim alone" contract as a host-local
+    /// `Superseded`/`HolderAlive` verdict from `release_lock_owned`.
+    ///
+    /// FAIL-OPEN: an unverifiable read ([`fetch_claim_labeled_at`] returns
+    /// `None`) resolves to `false` (not superseded) — an unreachable forge
+    /// must never permanently wedge a claim, matching every other check in
+    /// this module's fail-open posture (see `restore_label_to_ready`'s own
+    /// doc comment).
+    ///
+    /// [`fetch_claim_labeled_at`]: Self::fetch_claim_labeled_at
+    pub(crate) fn claim_superseded_on_forge(&self, issue: u32, claimed_at: DateTime<Utc>) -> bool {
+        match self.fetch_claim_labeled_at(issue) {
+            Some(labeled_at) if labeled_at > claimed_at => {
+                log::warn!(
+                    "sweep_registry: issue #{issue}'s `loom:building` claim was (re-)applied at \
+                     {} — AFTER this sweep's own claim/dispatch time {} — leaving the label \
+                     alone instead of restoring it (#5017/#5282 cross-host claim-ownership \
+                     guard). A different claimant, possibly on another host, now owns this \
+                     issue; destroying its claim here would repeat the loom#5270 incident.",
+                    labeled_at.to_rfc3339(),
+                    claimed_at.to_rfc3339(),
+                );
+                true
+            }
+            _ => false,
         }
     }
 

--- a/loom-daemon/src/sweep_registry/reaper.rs
+++ b/loom-daemon/src/sweep_registry/reaper.rs
@@ -735,7 +735,20 @@ impl SweepRegistry {
             // sweep owns the claim and runs its own lifecycle. #4556 extends the
             // same skip to `HolderAlive`: the cancelled sweep's OWN pid is still
             // a live `/loom:sweep <N>` process, so the claim is not free either.
-            let superseded = self.release_lock_owned(*issue, sweep_id).retained();
+            //
+            // #5017/#5282: `release_lock_owned` only ever sees THIS host's own
+            // local `.loom/locks/issue-<N>` — a different host's live claim on
+            // the SAME issue is invisible to it (there is no shared lock
+            // directory across hosts), so a purely local check can return
+            // "Released" even while a peer host's sweep is actively building.
+            // `claim_superseded_on_forge` is the cross-host backstop: it only
+            // runs (short-circuits via `||`) when the local check did NOT
+            // already answer the question, and compares the forge's current
+            // `loom:building` labeled-event timestamp against this sweep's own
+            // `started_at` — a labeling event strictly after `started_at` means
+            // a different claimant (possibly on another host) now owns it.
+            let claim_held_elsewhere = self.release_lock_owned(*issue, sweep_id).retained()
+                || self.claim_superseded_on_forge(*issue, started_at);
             // Best-effort tidy-up of the machine-level liveness journal
             // (#3953) — this cancelled sweep no longer exists.
             self.journal_remove_best_effort(*issue);
@@ -749,9 +762,10 @@ impl SweepRegistry {
             // produced no PR, so we never yank the label out from under an
             // in-flight PR's issue. Gated on `!skip_label_flip`, mirroring the
             // reaper path. `SweepKind::PrSet` cancels never reach here.
-            // #4463: a superseded release means a newer sweep now holds the
-            // claim — never restore the label out from under it.
-            if !self.config.skip_label_flip && !produced_pr && !superseded {
+            // #4463/#5017/#5282: a claim held elsewhere (locally superseded OR
+            // forge-superseded) means a different sweep now holds the claim —
+            // never restore the label out from under it.
+            if !self.config.skip_label_flip && !produced_pr && !claim_held_elsewhere {
                 let _ = self.restore_label_to_ready(*issue);
                 self.note_label_flip(*issue); // #4485 flap detection
             }
@@ -925,7 +939,15 @@ impl SweepRegistry {
                         // in `HolderAlive` (this sweep's own pid is still a live
                         // `/loom:sweep <N>` process, so the reap verdict was
                         // wrong) via the shared `retained()` predicate.
-                        let superseded = self.release_lock_owned(issue, &sweep_id).retained();
+                        //
+                        // #5017/#5282: the local lock is host-local (see the
+                        // `finish_cancel` comment above this same check) so it
+                        // cannot see a peer host's live claim on this issue —
+                        // `claim_superseded_on_forge` is the cross-host
+                        // backstop, only invoked (via `||` short-circuit) when
+                        // the local check did not already answer the question.
+                        let superseded = self.release_lock_owned(issue, &sweep_id).retained()
+                            || self.claim_superseded_on_forge(issue, started_at);
                         // Best-effort tidy-up of the machine-level liveness
                         // journal (#3953): the reaper just confirmed this
                         // PID is dead, so drop its entry now rather than
@@ -2470,6 +2492,165 @@ mod tests {
         assert!(
             !gh_calls.contains("--remove-label loom:building"),
             "a superseded cancel must not restore loom:building -> loom:issue; got: {gh_calls:?}"
+        );
+    }
+
+    /// Issue #5017/#5282 regression: the LOCAL lock check alone cannot see a
+    /// cross-host race — `.loom/locks/issue-<N>` is host-local, so a peer
+    /// host's live claim on the same issue leaves the local check believing
+    /// nothing else owns the lock (`Released`, not `Superseded`). This test
+    /// simulates exactly that: no local lock at all (mirrors the real
+    /// incident, where the cancelling host's own `.loom/locks/` never
+    /// recorded the OTHER host's claim), but the forge's `loom:building`
+    /// labeled-event timeline shows the label was (re-)applied AFTER this
+    /// sweep's own `started_at` — the cross-host claim-ownership signal.
+    /// `finish_cancel` MUST leave the label alone in that case; restoring it
+    /// would repeat the loom#5270 incident (cancelling a losing duplicate
+    /// destroyed a live peer host's claim).
+    #[test]
+    fn cancel_skips_restore_when_forge_shows_a_newer_claim_from_another_host() {
+        let dir = tempdir().unwrap();
+        let gh_log = dir.path().join("gh-invocations.log");
+        let fake_gh = dir.path().join("fake-gh.sh");
+        // Any `gh api ... /timeline ...` call answers with a labeling
+        // timestamp comfortably AFTER this sweep's `started_at` (set below to
+        // `now - 1h`); every other `gh` call (the label-restore edit itself)
+        // behaves like the other fixtures: logged, empty stdout, exit 0. A
+        // real `restore_label_to_ready` call would show up in the log as a
+        // `--remove-label loom:building` invocation, so asserting its absence
+        // is sufficient to prove the forge check vetoed the restore.
+        let script = format!(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [[ \"$1\" == \"api\" ]]; then\n  echo '\"2026-08-04T15:59:59Z\"'\nfi\nexit 0\n",
+            gh_log.display()
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+        if let Ok(f) = std::fs::File::open(&fake_gh) {
+            let _ = f.sync_all();
+        }
+
+        let mut config = SweepRegistryConfig::new(dir.path().to_path_buf());
+        config.gh_bin = Some(fake_gh);
+        config.skip_label_flip = false; // real restore path enabled but must NOT fire
+        let mut registry = SweepRegistry::new(config);
+
+        // No local lock at all — models the cross-host case where this
+        // host's `.loom/locks/issue-<N>` never recorded the other host's
+        // claim (release_lock_owned would answer `Released`, not
+        // `Superseded`, with no forge-side check).
+        let kind = SweepKind::Issue(8802);
+        let started_at = Utc::now() - chrono::Duration::hours(1);
+        let sweep_id = "sweep-issue-8802-loser".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                pgid: None,
+                sweep_id: sweep_id.clone(),
+                kind: kind.clone(),
+                pid: 2_147_483_640,
+                token_name: "unknown".into(),
+                runtime: "unknown".into(),
+                runtime_source: None,
+                log_path: registry.compute_log_path(8802),
+                idempotency_key: None,
+                started_at,
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                repo: None,
+            },
+        );
+
+        let outcome = registry.finish_cancel(&sweep_id, 2_147_483_640, &kind, started_at, true);
+        assert!(outcome.was_running);
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.contains("api repos/{owner}/{repo}/issues/8802/timeline"),
+            "expected finish_cancel to consult the forge-side claim timeline; got: {gh_calls:?}"
+        );
+        assert!(
+            !gh_calls.contains("--remove-label loom:building"),
+            "a cancel whose forge timeline shows a newer claim must NOT restore \
+             loom:building -> loom:issue (would destroy a peer host's live claim, #5017/#5282); \
+             got gh invocations: {gh_calls:?}"
+        );
+    }
+
+    /// Issue #5017/#5282: the SAME cross-host claim-ownership check must
+    /// apply to the reaper's natural-exit/crash label-restore path
+    /// (`reap_once`'s checkpoint-present branch), not just `finish_cancel` —
+    /// the Curator's "Suspected Cause (unverified)" flagged this as the
+    /// likely-but-unconfirmed second call site by code-path symmetry; this
+    /// test confirms it.
+    #[test]
+    fn reap_skips_restore_when_forge_shows_a_newer_claim_from_another_host() {
+        let dir = tempdir().unwrap();
+        let (mut registry, gh_log) = fixture_registry(dir.path());
+        // Override the fixture's fake `gh` so `gh api .../timeline` answers
+        // with a labeling timestamp AFTER `started_at` (set below).
+        let fake_gh = dir.path().join("fake-gh-timeline.sh");
+        let script = format!(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [[ \"$1\" == \"api\" ]]; then\n  echo '\"2026-08-04T15:59:59Z\"'\nfi\nexit 0\n",
+            gh_log.display()
+        );
+        std::fs::write(&fake_gh, &script).unwrap();
+        let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_gh, perms).unwrap();
+        registry.config.gh_bin = Some(fake_gh);
+        registry.config.skip_label_flip = false;
+
+        // Checkpoint present so the reaper picks the Crashed/label-restore
+        // branch under test.
+        let cp_dir = registry.config.checkpoint_dir();
+        std::fs::create_dir_all(&cp_dir).unwrap();
+        std::fs::write(cp_dir.join("issue-8803.json"), r#"{"phase":"builder","issue":8803}"#)
+            .unwrap();
+
+        let started_at = Utc::now() - chrono::Duration::hours(1);
+        let sweep_id = "sweep-issue-8803-loser".to_string();
+        registry.entries.insert(
+            sweep_id.clone(),
+            SweepInfo {
+                pgid: None,
+                sweep_id: sweep_id.clone(),
+                kind: SweepKind::Issue(8803),
+                pid: 2_147_483_640, // near-certainly dead
+                token_name: "unknown".into(),
+                runtime: "unknown".into(),
+                runtime_source: None,
+                log_path: registry.compute_log_path(8803),
+                idempotency_key: None,
+                started_at,
+                state: SweepState::Running,
+                latest_phase: None,
+                pr_number: None,
+                model: None,
+                effort: None,
+                depends_on: None,
+                repo: None,
+            },
+        );
+
+        let changed = registry.reap_once();
+        assert!(changed >= 1);
+
+        let gh_calls = std::fs::read_to_string(&gh_log).unwrap_or_default();
+        assert!(
+            gh_calls.contains("api repos/{owner}/{repo}/issues/8803/timeline"),
+            "expected reap_once to consult the forge-side claim timeline; got: {gh_calls:?}"
+        );
+        assert!(
+            !gh_calls.contains("--remove-label loom:building"),
+            "a reap whose forge timeline shows a newer claim must NOT restore \
+             loom:building -> loom:issue (would destroy a peer host's live claim, #5017/#5282); \
+             got gh invocations: {gh_calls:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Adds a forge-side, cross-host claim-ownership check before the daemon's
`finish_cancel` / `reap_once` label-restore paths remove `loom:building`.
`.loom/locks/issue-<N>` is host-local filesystem state — a peer host's live
claim on the same issue is structurally invisible to it — so a host cancelling
(or reaping) its own losing side of a cross-host duplicate dispatch could
previously restore `loom:building -> loom:issue` and destroy a still-live
peer host's claim, reopening the issue to a third dispatch (the loom#5270
incident, root-caused in #5282).

## Background / scope note

#5017 was originally filed with two distinct symptoms: a genuine live-vs-live
collision (issue #12 in the report) and a wedged sweep silently holding its
claim for 6.5h (issue #87). The operator's most recent disposition on #5017
(2026-08-04, after a third live reproduction on loom#5270) redefined this
issue's concrete scope to: *"claim-ownership verification before any
release/reclaim (timeline `labeled`-event check, judge-reclaim style), and
reclaim must never treat a live peer's claim as stealable on age alone —
liveness evidence... gates reclaim"* — explicitly shared with sibling issue
#5282's independently-curated acceptance criteria for the same defect. This PR
implements that redefined scope in full.

The original wedge-*detection*/escalation gap (#87) and the harder live-vs-live
dispatch-time race (#12) are **not** addressed here — split out to follow-up
issue #5302 (see "Deferred" below) so #5017 itself can close against its own
operator-redefined scope.

## Changes

- `loom-daemon/src/sweep_registry/guards.rs`: new `fetch_claim_labeled_at`
  (fetches the most recent `labeled loom:building` timeline event for an
  issue via `gh api .../timeline`, fail-open on any error) and
  `claim_superseded_on_forge` (true iff that event postdates this sweep's own
  claim/dispatch time).
- `loom-daemon/src/sweep_registry/reaper.rs`: wire the new check into all
  three label-restore call sites — `finish_cancel`, and `reap_once`'s
  checkpoint-present (crash) and no-checkpoint (clean-exit) branches — as an
  additional `||` guard alongside (never a replacement for) the existing
  host-local `Superseded`/`HolderAlive` check, so the extra `gh api` round
  trip is only paid when the local lock could not already answer the
  question.

## Acceptance Criteria Verification

| Criterion (operator-redefined scope) | Status | Verification |
|-----------|--------|--------------|
| Claim-ownership verification before any release/reclaim (forge timeline `labeled`-event check) | ✅ | `fetch_claim_labeled_at` + `claim_superseded_on_forge`, wired into `finish_cancel`/`reap_once` before every `restore_label_to_ready` call |
| Reclaim must not treat a live peer's claim as stealable on age alone — liveness evidence gates it | ✅ | The forge's own `labeled loom:building` event, observed identically by every host, is the liveness evidence; a claim newer than this sweep's own `started_at` blocks the restore regardless of how "old"/wedged this sweep looks locally |
| Fail-open (a forge outage must not permanently wedge a claim) | ✅ | `fetch_claim_labeled_at` returns `None` on any `gh` failure/timeout/non-zero-exit/unparseable output; `claim_superseded_on_forge` treats `None` as "not superseded" (unit-tested via the pre-existing `cancel_restores_label_when_no_pr_produced`-style tests, whose fake `gh` returns empty stdout for the timeline call and still restore correctly) |
| Existing host-local fast path still short-circuits (no extra `gh` call when the local lock already answers) | ✅ | `||` short-circuit — `release_lock_owned(...).retained()` is evaluated first at every call site |
| Regression test: cancelling/reaping the loser must leave the winner's claim intact | ✅ | New tests below |

## Deferred (split to follow-up issue #5302, not this PR)

- **#87's wedge-*detection*/escalation gap**: a hung-sweep watchdog already
  exists (`sweep_registry/watchdog.rs`, #3887) with a bounded one-shot
  auto-restart, but after it gives up nothing further reaches an operator —
  it just logs. This PR does not add an escalation path beyond the existing
  log line.
- **The genuine live-vs-live dispatch-time race** (#12): two hosts both
  starting a *fresh* dispatch near-simultaneously, before either label exists
  to observe. The existing soft peer-claim advertisement (`peer_claims.rs`,
  #4028 Phase 1) is explicitly documented as "a fast backoff, not a lock";
  closing that race for real needs #4028 Phase 2 (a cross-host CAS), which
  was never built.
- Both items, plus the still-unrun #4146 baseline measurement, are now
  tracked by follow-up issue #5302 rather than left implicit on a closed
  #5017.

## Coordination note

This PR's fix is scoped identically to sibling issue #5282 (independently
curated, root-caused the same `finish_cancel`/`release_lock_owned`
host-local-lock gap in detail) — implemented here because #5017's own
operator disposition pointed at the same fix. Left a comment on #5282 so
whoever picks it up next can check this PR first rather than duplicate the
fix; not claiming `Closes #5282` here since that issue is independently
owned/claimed.

## Test Plan

- `cargo check -p loom-daemon` — clean.
- `cargo clippy -p loom-daemon --all-targets -- -D warnings` — clean.
- `cargo fmt -p loom-daemon -- --check` — clean.
- `cargo test -p loom-daemon --lib sweep_registry::reaper::tests::` — 52/52
  pass, including 2 new regression tests:
  - `cancel_skips_restore_when_forge_shows_a_newer_claim_from_another_host`
  - `reap_skips_restore_when_forge_shows_a_newer_claim_from_another_host`
- `cargo test -p loom-daemon --lib sweep_registry::guards::tests::` — 14/14
  pass (unchanged).
- `cargo test -p loom-daemon --lib` (full suite, 3424 tests): passed in full
  on unmodified `main` (3385/3385). In this worktree it showed exactly 1
  flaky failure per run, but a **different** test each time
  (`forge_listing::tests::errors_carry_stderr_for_the_rate_limit_classifier`
  on one run, `sweep_registry::guards::tests::restore_label_to_ready_does_not_add_loom_issue_when_target_is_pr`
  — pre-existing, untouched by this diff — on another), and both pass
  cleanly in isolation. Neither touches `forge_listing.rs`, which this PR
  never modifies. This matches known load-sensitive flakiness under the
  host's heavy concurrent-sweep load at the time of the run, not a
  regression from this change.

Closes #5017
