### PR TITLE
fix(scripts): stop .gitignore resync from trusting a stale loom-daemon binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Thumbs.db
 .loom/interventions/
 .loom/worktrees/
 .loom/worktrees-local/
+.claude/worktrees/
 .loom/state.json
 .loom/mcp-command.json
 .loom/activity.db

--- a/defaults/scripts/resync-installed.sh
+++ b/defaults/scripts/resync-installed.sh
@@ -942,6 +942,55 @@ ensure_install_metadata_merge_driver() {
 }
 ensure_install_metadata_merge_driver
 
+# #5294: EPHEMERAL_PATTERNS is single-sourced in
+# loom-daemon/src/init/post_init.rs. Extract the pattern list directly from
+# that source file (not from a compiled binary) so refresh_gitignore_block can
+# verify the freshly-regenerated .gitignore against ground truth, independent
+# of which loom-daemon binary happened to write it. Best-effort: echoes
+# nothing (not a failure) if $SOURCE_ROOT isn't a full checkout with the daemon
+# crate present (e.g. a stripped-down install source).
+_gitignore_source_ephemeral_patterns() {
+    local post_init="$SOURCE_ROOT/loom-daemon/src/init/post_init.rs"
+    [[ -f "$post_init" ]] || return 0
+    awk '/pub const EPHEMERAL_PATTERNS/ { flag=1; next } flag && /^\];/ { exit } flag' "$post_init" \
+        | sed -n -E 's/^[[:space:]]*"([^"]*)",?[[:space:]]*$/\1/p'
+}
+
+# #5294: verify the managed block `$bin update-gitignore` just wrote actually
+# contains every pattern the CURRENT source declares. A `loom-daemon` binary
+# older than the just-pulled source has EPHEMERAL_PATTERNS compiled in from
+# whenever it was built — if that predates a pattern addition (e.g. #5280's
+# `.claude/worktrees/`), `update-gitignore` exits 0 having *silently* dropped
+# that pattern from the regenerated block. That is precisely how 05cf67e8
+# reintroduced #5267's gitlink hazard 34 minutes after #5280 fixed it, entirely
+# undetected until this issue. Never trust the exit code alone: name any
+# dropped pattern in a loud warning instead of a silent no-op.
+_gitignore_warn_if_stale() {
+    local bin="$1" post_init="$SOURCE_ROOT/loom-daemon/src/init/post_init.rs"
+    local -a missing=()
+    local pattern block
+
+    [[ -f "$post_init" ]] || return 0
+    [[ -f "$REPO_ROOT/.gitignore" ]] || return 0
+
+    block="$(sed -n '/# >>> loom-managed/,/# <<< loom-managed/p' "$REPO_ROOT/.gitignore")"
+    [[ -n "$block" ]] || return 0
+
+    while IFS= read -r pattern; do
+        [[ -n "$pattern" ]] || continue
+        grep -qxF -- "$pattern" <<<"$block" || missing+=("$pattern")
+    done < <(_gitignore_source_ephemeral_patterns)
+
+    if [[ "${#missing[@]}" -gt 0 ]]; then
+        warn "The resolved loom-daemon binary ($bin) regenerated .gitignore WITHOUT ${#missing[@]} pattern(s) that $post_init currently declares:"
+        for pattern in "${missing[@]}"; do
+            warn "    $pattern"
+        done
+        warn "  '$bin' is likely older than the source just synced (#5294) — rebuild loom-daemon"
+        warn "  (cargo build --release -p loom-daemon under $SOURCE_ROOT) and re-run resync-installed.sh."
+    fi
+}
+
 refresh_gitignore_block() {
     local locate_lib bin
     locate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/locate-daemon-bin.sh"
@@ -953,12 +1002,20 @@ refresh_gitignore_block() {
     # shellcheck source=lib/locate-daemon-bin.sh
     # shellcheck disable=SC1091
     source "$locate_lib"
-    # Prefer a binary in the source checkout (matches the version being synced);
-    # the resolver falls back to $LOOM_DAEMON_BIN / `loom-daemon` on PATH.
-    bin="$(loom_locate_daemon_bin "$SOURCE_ROOT")"
+    # #5294: this resync runs specifically because source just changed, so for
+    # THIS call only, hoist the resolver's normally-opt-in $LOOM_PREFER_REPO_BUILD=1
+    # precedence (repo build ahead of PATH / the machine-level install) -- a
+    # stale PATH/machine-level binary can predate a just-merged
+    # EPHEMERAL_PATTERNS entry and silently drop it from the regenerated block
+    # (exactly what happened in 05cf67e8, 34 minutes after #5280 added
+    # `.claude/worktrees/`). An explicit $LOOM_DAEMON_BIN still wins regardless
+    # -- loom_locate_daemon_bin checks it before this precedence tier. Scoped to
+    # this one call via a subshell env override; the library's own default
+    # (off) is unchanged for loom-daemon-start.sh and other production callers.
+    bin="$(LOOM_PREFER_REPO_BUILD=1 loom_locate_daemon_bin "$SOURCE_ROOT")"
     if [[ -z "$bin" ]]; then
         warn "Could not refresh the Loom-managed .gitignore block: no loom-daemon binary resolved"
-        warn "  (\$LOOM_DAEMON_BIN -> 'loom-daemon' on PATH -> build-output under $SOURCE_ROOT)."
+        warn "  (\$LOOM_DAEMON_BIN -> repo build under $SOURCE_ROOT -> 'loom-daemon' on PATH -> machine-level install)."
         warn "  Newer runtime paths (e.g. .loom/sweep-checkpoint/, .loom/worktrees-local/) may stay untracked-and-unignored."
         return 0
     fi
@@ -978,7 +1035,13 @@ refresh_gitignore_block() {
     else
         warn ".gitignore refresh failed: '$bin update-gitignore' errored"
         warn "  (a pre-#4280 daemon lacks this subcommand — rebuild loom-daemon)."
+        return 0
     fi
+    # #5294: defense in depth -- verify the write actually landed every pattern
+    # the source declares, even after preferring a repo build above (that repo
+    # build itself might be stale, or absent so resolution fell through to
+    # PATH/machine-level anyway).
+    _gitignore_warn_if_stale "$bin"
 }
 refresh_gitignore_block
 

--- a/defaults/scripts/tests/test-resync-installed.sh
+++ b/defaults/scripts/tests/test-resync-installed.sh
@@ -637,6 +637,119 @@ else
     fail "(#4280) missing binary did not produce the expected warning"
 fi
 
+# --- (#5294) stale-binary regression: a loom-daemon binary compiled before a
+# given EPHEMERAL_PATTERNS entry existed, resolved ahead of a fresher
+# repo-local build under default (no LOOM_PREFER_REPO_BUILD) resolver
+# precedence, must not silently drop that pattern from the regenerated
+# .gitignore -- this is the exact mechanism that reintroduced #5267's gitlink
+# hazard 34 minutes after #5280 fixed it (05cf67e8). These fixtures use fake
+# `loom-daemon` shell-script stand-ins (each emitting a canned managed block
+# from a fixed pattern list) rather than the real Rust binary, so the
+# regression is reproducible without compiling two different daemon versions.
+#
+# make_fake_daemon_bin <dest> <pattern>... -- writes an executable at <dest>
+# that supports exactly `update-gitignore --help` (prints usage, exit 0) and
+# `update-gitignore <repo>` (rewrites <repo>/.gitignore's loom-managed block
+# to contain exactly the given patterns, preserving surrounding content).
+make_fake_daemon_bin() {
+    local dest="$1"; shift
+    mkdir -p "$(dirname "$dest")"
+    printf '%s\n' "$@" > "$dest.patterns"
+    cat > "$dest" <<'FAKE_DAEMON_EOF'
+#!/usr/bin/env bash
+set -u
+PATFILE="$0.patterns"
+if [[ "${1:-}" == "update-gitignore" ]]; then
+    if [[ "${2:-}" == "--help" ]]; then
+        echo "usage: loom-daemon update-gitignore <repo>"
+        exit 0
+    fi
+    repo="$2"
+    gi="$repo/.gitignore"
+    [[ -f "$gi" ]] || : > "$gi"
+    tmp="$(mktemp)"
+    awk 'BEGIN{skip=0} /# >>> loom-managed/{skip=1;next} /# <<< loom-managed/{skip=0;next} skip==0{print}' "$gi" > "$tmp"
+    {
+        cat "$tmp"
+        echo "# >>> loom-managed (do not edit) >>>"
+        echo "# Loom runtime state (don't commit these)"
+        cat "$PATFILE"
+        echo "# <<< loom-managed <<<"
+    } > "$gi"
+    rm -f "$tmp"
+    exit 0
+fi
+exit 1
+FAKE_DAEMON_EOF
+    chmod +x "$dest"
+}
+
+# A synthetic post_init.rs declaring an "old" pattern (present in every fake
+# binary below) plus a "just-added" pattern (present ONLY in the fresh
+# repo-local build) -- mirrors #5280 adding `.claude/worktrees/` to source
+# while a stale resolved binary still lacked it.
+write_fake_post_init() {
+    local repo="$1"
+    mkdir -p "$repo/loom-daemon/src/init"
+    cat > "$repo/loom-daemon/src/init/post_init.rs" <<'RUST_EOF'
+pub const EPHEMERAL_PATTERNS: &[&str] = &[
+    ".loom-in-use",
+    ".fake-newly-added-pattern/",
+];
+RUST_EOF
+}
+
+echo "Test group 12h: gitignore refresh prefers a repo-local build over a stale PATH binary when no \$LOOM_DAEMON_BIN override is set (#5294)"
+REPO="$(make_fixture)"
+write_fake_post_init "$REPO"
+make_fake_daemon_bin "$REPO/loom-daemon/target/release/loom-daemon" ".loom-in-use" ".fake-newly-added-pattern/"
+STALE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fake-path.XXXXXX")"
+make_fake_daemon_bin "$STALE_DIR/loom-daemon" ".loom-in-use"
+NO_BIN_HOME="$(mktemp -d)"
+OUT="$(cd "$REPO" && env -u LOOM_DAEMON_BIN PATH="$STALE_DIR:/usr/bin:/bin" HOME="$NO_BIN_HOME" \
+    LOOM_DAEMON_BIN_DIR="/nonexistent" bash "$SCRIPT" 2>&1)"
+RC=$?
+rm -rf "$NO_BIN_HOME" "$STALE_DIR"
+if [[ $RC -eq 0 ]]; then
+    pass "(#5294) apply exits 0 with a stale PATH binary and a fresh repo-local build present"
+else
+    fail "(#5294) apply exits 0 with stale PATH + fresh repo build (got $RC)"
+fi
+GI_BLOCK="$(sed -n '/# >>> loom-managed/,/# <<< loom-managed/p' "$REPO/.gitignore")"
+if grep -qxF ".fake-newly-added-pattern/" <<<"$GI_BLOCK"; then
+    pass "(#5294) the newly-added source pattern landed in .gitignore (repo-local build was preferred over stale PATH)"
+else
+    fail "(#5294) newly-added pattern missing from .gitignore -- the stale PATH binary was used instead of the repo build"
+fi
+if grep -qi "regenerated .gitignore WITHOUT" <<<"$OUT"; then
+    fail "(#5294) unexpected stale-binary warning even though the repo build covered every source pattern"
+else
+    pass "(#5294) no stale-binary warning printed when the resolved binary satisfies all source patterns"
+fi
+
+echo "Test group 12i: gitignore refresh warns loudly -- never silently -- when only a stale binary resolves (#5294)"
+REPO="$(make_fixture)"
+write_fake_post_init "$REPO"
+# No repo-local build this time: resolution falls through to the stale PATH
+# binary (the pre-#5294-fix behavior this whole issue is about).
+STALE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fake-path.XXXXXX")"
+make_fake_daemon_bin "$STALE_DIR/loom-daemon" ".loom-in-use"
+NO_BIN_HOME="$(mktemp -d)"
+OUT="$(cd "$REPO" && env -u LOOM_DAEMON_BIN PATH="$STALE_DIR:/usr/bin:/bin" HOME="$NO_BIN_HOME" \
+    LOOM_DAEMON_BIN_DIR="/nonexistent" bash "$SCRIPT" 2>&1)"
+RC=$?
+rm -rf "$NO_BIN_HOME" "$STALE_DIR"
+if [[ $RC -eq 0 ]]; then
+    pass "(#5294) apply still exits 0 when only a stale binary resolves"
+else
+    fail "(#5294) apply exits 0 with only a stale binary resolvable (got $RC)"
+fi
+if grep -qi "regenerated .gitignore WITHOUT" <<<"$OUT" && grep -qF ".fake-newly-added-pattern/" <<<"$OUT"; then
+    pass "(#5294) the dropped pattern is named in a loud warning instead of being silently lost"
+else
+    fail "(#5294) stale-binary warning did not name the missing pattern"
+fi
+
 # --- (#4285) targeted loom-workspace package.json version field edit --------
 echo "Test group 12d: loom-workspace package.json decoy version field removal (#4285)"
 REPO="$(make_fixture)"


### PR DESCRIPTION
## Summary

`refresh_gitignore_block()` in `resync-installed.sh` resolves the `loom-daemon`
binary it uses to regenerate the Loom-managed `.gitignore` block via the
resolver's default precedence (`$LOOM_DAEMON_BIN` -> `$PATH` ->
machine-level install -> repo build). That precedence can pick a binary
compiled **before** a just-pulled source change to `EPHEMERAL_PATTERNS`,
silently dropping that pattern from the regenerated block.

This is confirmed, not just hypothesized: commit `05cf67e8` ("resync
installed copies from defaults after main pull") dropped `.claude/worktrees/`
from the committed `.gitignore` even though the source commit it was
resyncing to (`850f9ad1`) already had `.claude/worktrees/` in
`EPHEMERAL_PATTERNS` (added by #5280, merged ~34 minutes earlier). The
machine-level `loom-daemon` install on this very host (`~/.local/bin/loom-daemon`)
is currently that stale pre-#5280 binary — verified directly with
`strings ~/.local/bin/loom-daemon | grep claude/worktrees` returning nothing.
This silently reintroduced the exact `.claude/worktrees/` gitlink hazard
#5267/#5280 fixed.

## Changes

- **Immediate hygiene fix**: re-add `.claude/worktrees/` to the repo-root
  `.gitignore`'s loom-managed block.
- **Root-cause fix** (`defaults/scripts/resync-installed.sh`,
  `refresh_gitignore_block()`):
  - Hoist `LOOM_PREFER_REPO_BUILD=1` for this one call site only (via a
    subshell env override passed into `loom_locate_daemon_bin`), so a
    repo-local build is preferred over a possibly-stale `$PATH`/machine-level
    install for *this* refresh — since the resync runs specifically because
    source just changed. An explicit `$LOOM_DAEMON_BIN` still wins regardless.
    `locate-daemon-bin.sh`'s own default precedence is unchanged for other
    callers (`loom-daemon-start.sh`, etc. — per its own precedence-hoist
    rationale comment).
  - Added defense-in-depth: after `update-gitignore` runs, verify the
    resulting `.gitignore`'s managed block actually contains every pattern
    `EPHEMERAL_PATTERNS` declares in the source tree being resynced
    (extracted straight from `loom-daemon/src/init/post_init.rs`, not from
    a compiled binary). Any pattern the resolved binary dropped is now named
    in a loud, specific `WARN`, never a silent no-op.
- **Tests** (`defaults/scripts/tests/test-resync-installed.sh`, new groups
  12h/12i): reproduce the stale-binary-drop failure mode using fake
  `loom-daemon` shell-script stand-ins (so the test doesn't need to compile
  two different daemon binaries) and assert:
  - 12h: with a stale `$PATH` binary + a fresh repo-local build both present,
    the repo build is preferred and the newly-added pattern lands correctly,
    with no spurious warning.
  - 12i: with only the stale binary resolvable, the missing pattern is named
    in a loud warning instead of being silently dropped.
  - Verified both new tests actually catch the regression: reverting only
    the `resync-installed.sh` fix (keeping the new tests) makes both fail;
    restoring the fix makes them pass again.

## Acceptance Criteria Verification

- [x] `.claude/worktrees/` is present in the committed `.gitignore` again.
- [x] The "suspected cause" hypothesis is verified with direct evidence
  (source commit already had the pattern; the resolved machine-level binary
  on this host does not) rather than taken on faith.
- [x] The resync call site no longer trusts a stale binary silently for this
  call, without changing `loom_locate_daemon_bin`'s global default
  precedence.
- [x] Regression tests reproduce the failure mode and pass with the fix,
  fail without it (verified manually, see below).
- [x] `bash defaults/scripts/tests/test-resync-installed.sh` passes:
  127/127 (122 pre-existing + 5 new).

## Test Plan

- `bash defaults/scripts/tests/test-resync-installed.sh` — 127/127 passed.
- `bash defaults/scripts/tests/test-locate-daemon-bin.sh` — 20/20 passed
  (unmodified library, confirms no regression to its own precedence
  contract).
- `shellcheck --severity=warning --format=gcc defaults/scripts/resync-installed.sh
  defaults/scripts/tests/test-resync-installed.sh` — clean (CI's exact
  invocation).
- `git show origin/main:.gitignore | grep -c '^\.claude/worktrees/$'` on this
  branch's `.gitignore` returns `1`.
- Manually reverted the source fix while keeping the new tests: both new
  tests failed as expected, confirming they actually reproduce the
  regression rather than passing vacuously.

Closes #5294
