### PR TITLE
feat(daemon): remove token axis from admission, add RAM headroom + retuned CPU brake ("dumb mode")

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -2013,30 +2013,48 @@ Each tick:
    `workfinder-<issue>` idempotency key, making a re-dispatch of an
    already-running issue a no-op.
 
-### Dynamic concurrency scaling (Phase B, #3811; CPU/load term #3978)
+### Dynamic concurrency scaling (Phase B, #3811; CPU/load term #3978; token axis removed / RAM added #5270)
 
 The concurrency cap is **not** a fixed value resolved once at startup. Every
 tick the finder recomputes
 
 ```
-dynamic_cap = min(healthy-token count × per-token concurrency, disk headroom, configured maxConcurrent)
+dynamic_cap = min(disk headroom, ram headroom, configured maxConcurrent)
 ```
 
-from live inputs, so pool/disk/backlog changes are honored without a daemon
-restart. A fourth **cpu/load headroom** term sat in this `min(...)` from #3978
-until **#4512 deleted it** — see [Why there is no CPU term in
-admission](#why-there-is-no-cpu-term-in-admission-4512) below. There is still no
-CPU term in the cap; since #4903 a separate
-[saturation admission brake](#saturation-admission-brake-4903) can *hold* new
+from live inputs, so disk/RAM/backlog changes are honored without a daemon
+restart. **#5270 removed the token axis from this formula entirely**, on any
+auth path (API key or subscription pool, overage-enabled or not) — operator
+direction: "we should only ever limit parallelism based on the machine
+disk/RAM/CPU." A metered `ANTHROPIC_API_KEY` has no 5h/7d subscription window,
+and overage means a subscription pool no longer hard-stops at one either, so
+counting *healthy accounts* was never a proxy for this host's actual capacity
+to run more sweeps. `.ranking` health is **not** deleted — it still drives
+spawn-time **selection** (`tokens_pool::select`: prefer fresher/healthier
+accounts, skip revoked/blocked ones) and the account-health figures remain on
+the status/calibrate surface as informational fields — it just no longer
+gates *how many* sweeps may run concurrently. A fourth **cpu/load headroom**
+term also sat in this `min(...)` from #3978 until **#4512 deleted it** — see
+[Why there is no CPU term in admission](#why-there-is-no-cpu-term-in-admission-4512)
+below. There is still no CPU *term* in the numeric cap; instead, since #4903
+(and retuned by #5270 into the primary "dumb mode" CPU gate — default
+threshold `0.95` load/core, down from the original `4.0` generous backstop)
+the [saturation admission brake](#saturation-admission-brake-4903) *holds* new
 admissions when the host is measurably saturated, without resizing the cap or
 touching running work.
 
 | Input | Source | Bound it enforces |
 |-------|--------|-------------------|
-| **healthy-token count** | `available` accounts in `.ranking` in the pool directory `tokens_pool::paths::resolve_tokens_dir` resolves for the workspace — per-repo `{workspace}/.loom/tokens/` when it holds `*.token` files, else the shared machine-level pool (#3938) (`capacity::read_ranking` / `token_axis_limit`, unified with the writer in #4344 — pre-#4344 this hardcoded the per-repo path even on a shared-pool host, which could pin the dispatch cap at 0 against an orphaned per-repo `.ranking` indefinitely), falling back to the `*.token` count (`tokens::token_pool_size`) when no ranking exists | the count of accounts safe to dispatch to — never dispatch to an exhausted/blocked one (#3902) |
-| **per-token concurrency** | `LOOM_PER_TOKEN_CONCURRENCY` / `autonomous.perTokenConcurrency`, default **2** (#3947) | how many concurrent sweeps to allow **per healthy account**. A plan limit is a utilization-window token bucket, not a session count, so one healthy account can run several concurrent sessions. Before #3947 the implicit factor was `1` (one sweep per account), which collapsed the whole fleet to cap 1 when 6/7 accounts were at their weekly ceiling even though the single healthy account had ample session-window headroom |
 | **disk headroom** | `floor(free_gb / LOOM_PER_WORKTREE_GB)` on the worktree-root volume (`disk_headroom::disk_headroom_limit`, a Rust port of `disk-headroom.sh` that shells to `df -Pk`) | never provision more worktrees than the scratch volume can hold |
-| **configured maxConcurrent** | `LOOM_WORK_FINDER_MAX_CONCURRENT` / `autonomous.workFinder.maxConcurrent` (repurposed from Phase A's fixed target into an operator ceiling) | **the** per-machine admission knob (#4512) — tuned empirically by the operator, the only *policy* term in the `min(...)` (the other two meter exhaustible resources: accounts and bytes) |
+| **ram headroom** (#5270) | `floor(available_gb / LOOM_PER_WORKTREE_RAM_GB)` on the host's currently-available memory (`ram_headroom::ram_headroom_limit`, modeled on `disk_headroom`'s shape: `/proc/meminfo`'s `MemAvailable` on Linux, `vm_stat` free+inactive pages × page size on macOS) | never provision more worktrees than available RAM can hold; the second "dumb mode" machine-headroom axis alongside disk |
+| **configured maxConcurrent** | `LOOM_WORK_FINDER_MAX_CONCURRENT` / `autonomous.workFinder.maxConcurrent` (repurposed from Phase A's fixed target into an operator ceiling) | **the** per-machine admission knob (#4512) — tuned empirically by the operator, the only *policy* term in the `min(...)` (the other two meter exhaustible resources: bytes of disk and bytes of RAM) |
+
+Retired as cap inputs (informational-only now — see `capacity::token_axis_limit` / `tokens_pool::select`):
+
+| Input | Source | What it still does |
+|-------|--------|-------------------|
+| **healthy-token count** (retired from the cap, #5270) | `available` accounts in `.ranking` in the pool directory `tokens_pool::paths::resolve_tokens_dir` resolves for the workspace — per-repo `{workspace}/.loom/tokens/` when it holds `*.token` files, else the shared machine-level pool (#3938) (`capacity::read_ranking` / `token_axis_limit`, unified with the writer in #4344) | drives spawn-time account **selection** (prefer fresher/healthier accounts, skip exhausted/blocked ones, #3902) and is reported on `status`/`calibrate` for observability — no longer bounds `dynamic_cap` |
+| **per-token concurrency** (retired from the cap, #5270) | `LOOM_PER_TOKEN_CONCURRENCY` / `autonomous.perTokenConcurrency`, default **2** (#3947) | still reported for the informational `healthy × per-token` figure on `status`/`calibrate`; no longer multiplies into any cap term |
 
 #### Why there is no CPU term in admission (#4512)
 
@@ -2066,9 +2084,10 @@ actually is**:
 
 1. **Admission is one per-machine knob.** `autonomous.workFinder.maxConcurrent`
    is the whole policy, tuned empirically by the operator (expect 10+ on an
-   8-core API-bound worker). The two remaining terms — the token axis and disk
-   headroom — stay because they meter genuinely *exhaustible* resources
-   (accounts, bytes), not an estimate.
+   8-core API-bound worker). The two remaining terms — disk headroom and (since
+   #5270) RAM headroom — stay because they meter genuinely *exhaustible*
+   resources (bytes), not an estimate. (The token axis sat here too until
+   #5270 removed it — see the section above.)
 2. **The genuinely heavy stages serialize where they occur**, via the
    [machine-wide build slot](#machine-wide-build-slot-4512). N sweeps run
    concurrently; at most `LOOM_BUILD_SLOTS` of them hold the slot while running
@@ -2152,6 +2171,15 @@ consistent env-only behavior. Wiring the Bash `config-resolver.sh` into
 `disk-headroom.sh` too is a separate, larger change; file a follow-up if that
 cost is judged worth paying.
 
+**RAM headroom mirrors this env-only shape (#5270).** `ram_headroom::per_worktree_ram_gb`
+resolves `LOOM_PER_WORKTREE_RAM_GB` (default **2** GB) the same way
+`disk_headroom::per_worktree_gb` resolves its own env var — no config key,
+env-only, floored to a minimum of 1. There is no Bash-side RAM counterpart to
+`disk-headroom.sh` (RAM headroom is Rust-only, consumed solely by the daemon's
+own `resolve_dynamic_max_concurrent`), so the #4032 divergence concern above
+does not apply here — env-only was simply the cheapest consistent choice, not
+a workaround for a second reader.
+
 #### Saturation admission brake (#4903)
 
 Deleting the CPU term left admission with **no term that reads the host at
@@ -2176,8 +2204,18 @@ per-sweep cores, and **never** touches work that is already running.
 |---|---|
 | Config | `autonomous.workFinder.saturationBrake.enabled` / `.loadPerCoreHold` |
 | Env | `LOOM_ADMISSION_BRAKE` / `LOOM_ADMISSION_BRAKE_LOAD_PER_CORE` |
-| Default | **on**, hold at **4.0** load/core |
+| Default | **on**, hold at **0.95** load/core (retuned from `4.0` by #5270) |
 | Precedence | env > config > default, resolved once at daemon startup |
+
+**Retuned by #5270 from a generous backstop to the primary CPU admission
+gate.** Until #5270 the token axis and disk headroom were the two hard
+admission floors, with this brake acting only as a rarely-tripped safety net
+well above them (`4.0` load/core — four runnable threads per logical core).
+#5270 removed the token axis from admission entirely, which promotes this
+brake to **the** CPU term in "dumb mode": its default now matches the
+operator's literal ask — hold new admissions once the host's few-minute load
+average reaches ~95% of its logical core count (`0.95` load/core), resume
+below it.
 
 Properties that are load-bearing (and are pinned by tests):
 
@@ -2188,8 +2226,11 @@ Properties that are load-bearing (and are pinned by tests):
   is precisely how the host recovers.
 - **A healthy host is unchanged.** Below the threshold the admission path is
   byte-for-byte the pre-#4903 one, so an idle 8-core host still reaches its
-  configured cap. `4.0` is deliberately generous: a busy-but-fine host sits under
-  `1.0`, and the incident that motivated the brake was at `11.9`.
+  configured cap. `0.95` holds a notch below full saturation (`1.0` = as many
+  runnable/uninterruptible threads as logical cores), mirroring the build
+  gate's own `0.9` deferral point rather than the pre-#5270 `4.0`, which would
+  have let a host run at 4× overcommit before this brake ever engaged — the
+  incident that originally motivated the brake was at `11.9`.
 - **Fail-safe on missing data.** No load-average source (or a zero CPU count)
   ⇒ no hold. Absent evidence is never treated as load.
 - **Nothing latches.** The hold is re-evaluated every tick and releases the
@@ -2201,14 +2242,18 @@ read the same normalized ratio and are complements, not duplicates:
 | | Admission brake (#4903) | Host breaker (#4235) |
 |---|---|---|
 | Nature | point-in-time: one reading, one decision | stateful: trips only after N consecutive over-threshold ticks |
-| Default threshold | `4.0` load/core | `2.5` load/core |
+| Default threshold | `0.95` load/core (`4.0` before #5270) | `2.5` load/core |
 | Release | immediate, first tick under the line | after a 5-minute cool-down |
 | Explicit `dispatch_sweep` | never blocks it | hard-blocks unless `force` |
 | Purpose | stop *adding* to a full host | remember a *meltdown* so a load dip cannot re-admit a whole wave |
 
-The brake's threshold sits *above* the breaker's on purpose: it decides from a
-single reading, so it must be sure, whereas the breaker's lower bar is paid for
-by requiring the load to be sustained.
+**Since #5270 the brake's default threshold sits *below* the breaker's** — the
+reverse of the pre-#5270 ordering. Pre-#5270 the brake decided from a single
+reading at a generous `4.0` and had to "be sure" before firing; post-#5270 it
+is the fast, cheap, per-tick hold that engages first (a single over-threshold
+reading, `0.95`), with the breaker remaining the slower, stickier trip for
+genuine sustained distress (several consecutive over-threshold ticks, `2.5`)
+well past the point the brake has already held new admissions.
 
 **Visibility.** `loom-daemon status` prints an `Admission brake:` line
 (`HOLDING …` / `OK …` / `disabled`), `--json` carries an `admission_brake`
@@ -2481,31 +2526,32 @@ duplicating the `disk_headroom_limit` plumbing `loom-daemon status`
 (`build_daemon_status`) already exposes.
 
 Nothing in this handler may block, because it holds the sweep-registry mutex
-from the assessment through the dispatch call. Since #4512 the headroom is
-`min(token axis, disk, configured max)` — three cheap filesystem/config reads,
-no CPU sampling at all. (Before #4512 this had to carefully avoid the
-**refreshing** CPU probe, whose macOS `iostat` refresh sleeps ~1s and would have
-stalled every other IPC request on the same registry for that second; removing
-the CPU term removed that hazard outright.)
+from the assessment through the dispatch call. Since #5270 the headroom is
+`min(disk, ram, configured max)` — cheap filesystem/config reads (plus a
+non-sleeping `/proc/meminfo` read or a flag-less `vm_stat` snapshot on macOS
+for RAM), no CPU sampling at all. (Before #4512 this had to carefully avoid
+the **refreshing** CPU probe, whose macOS `iostat` refresh sleeps ~1s and
+would have stalled every other IPC request on the same registry for that
+second; removing the CPU term removed that hazard outright, and RAM headroom
+deliberately preserves the same non-blocking contract.)
 
-**Per-token concurrency factor (#3947).** The token axis is `healthy × factor`,
-not `healthy × 1`. The factor is resolved with the standard precedence **env
-(`LOOM_PER_TOKEN_CONCURRENCY`) > config (`autonomous.perTokenConcurrency`) >
-default (2)**; a zero/unparseable value at any layer is ignored, and the cap
-formula additionally clamps the factor to a floor of `1` so a mis-set `0` degrades
-to the pre-#3947 one-sweep-per-account behavior rather than dispatching nothing.
-Bounded **stacking**, not a 1:1 hard limit, is the correct response to a healthy
-account with session-window headroom — the #3909 rotating selection spread still
-fills **distinct** accounts first (via the persistent `.rotation_cursor`), only
-stacking multiple sweeps on one account when concurrency demand exceeds the
-healthy-account count. The `loom-daemon status` view spells the arithmetic out,
-e.g. `= min(healthy 1 × per-token 2 = 2, disk headroom 120, configured max 3)`,
-and a separate line reports the live host CPU **observation** — explicitly
-labelled as not a cap term, e.g. `host cpu (observed, not a cap term since
-#4512): 28 logical cores, 85% idle measured (≈4.2 cores consumed), 1m loadavg
-6.10`, degrading to a `1m loadavg … (no idle sample yet)` or `no CPU signal on
-this platform` line when the measurement is unavailable (#3978 AC4;
-measured-idle signal #4031; demoted to observation in #4512).
+**Per-token concurrency factor (#3947, retired from the cap by #5270).** The
+token axis used to be `healthy × factor`, not `healthy × 1` — the factor
+resolved with the standard precedence **env (`LOOM_PER_TOKEN_CONCURRENCY`) >
+config (`autonomous.perTokenConcurrency`) > default (2)**. Since #5270 the
+token axis no longer participates in `dynamic_cap` at all, so this factor is
+purely informational now — `loom-daemon status`/`calibrate` still print
+`healthy N × per-token M = P` as a labeled "informational only" figure, but it
+no longer appears inside the `= min(...)` breakdown, which is now `= min(disk
+headroom 120, ram headroom 40, configured max 3)`. A separate line reports the
+live host CPU **observation** — explicitly labelled as not a cap term, e.g.
+`host cpu (observed, not a cap term since #4512): 28 logical cores, 85% idle
+measured (≈4.2 cores consumed), 1m loadavg 6.10`, degrading to a `1m loadavg …
+(no idle sample yet)` or `no CPU signal on this platform` line when the
+measurement is unavailable (#3978 AC4; measured-idle signal #4031; demoted to
+observation in #4512) — and, since #5270, the `admission_brake` block reports
+whether that same load reading is currently *holding* new admissions (the
+brake, not this observation line, is what gates CPU today).
 
 **"Currently binding" vs "smallest ceiling" (#4031).** The dynamic cap is the
 *minimum* of several ceilings, but a ceiling only *binds* once in-flight
@@ -2514,35 +2560,27 @@ exists, not any resource term — so the status view gates its bottleneck
 diagnosis on real occupancy (`in_flight.len() >= dynamic_cap`, surfaced as the
 `capacity_bound` field, `#[serde(default)]`). With in-flight below the cap it
 prints `not capacity-bound (N in flight, cap M — the limiter is work
-availability, not tokens/disk/CPU)` and **suppresses** the `token-bound:`
-diagnosis line; at or above the cap it names the binding term as before. The
-`= min(…)` breakdown line is untouched — those genuinely are ceilings. The JSON
-status carries the same `capacity_bound` boolean so scripted consumers aren't
-misled at low occupancy either.
+availability, not disk/RAM/CPU)`; at or above the cap it names the binding
+term as before. The `= min(…)` breakdown line is untouched — those genuinely
+are ceilings. The JSON status carries the same `capacity_bound` boolean so
+scripted consumers aren't misled at low occupancy either.
 
-**Honest headline when the daemon's own read disagrees with a fresh probe
-(#4344).** `resolve_capacity` prefers a fresh client-side `loom-daemon tokens check
---json` probe over the daemon's own ranking read when one succeeds — useful for
-showing current numbers, but that probe's cap is **not** what the running
-daemon actually used to gate dispatch this tick. The pretty-printed `Dynamic
-concurrency cap:` headline and the `= min(healthy N × per-token M …)`
-breakdown always name the daemon's own numbers (`report.dynamic_cap` /
-`report.capacity.token_axis_limit`) — the probe's cap is shown only as a
-labeled secondary `fresh probe suggests: …` line when it differs. The
-`capacity_bound` gate above is likewise computed against the daemon's own cap,
-not the probe's, so "not capacity-bound" can never print while the daemon's
-real (lower) cap is already saturated. When the daemon's own ranking read
-shows **0 healthy accounts** while the probe (or raw pool) disagrees — the
-#4344 incident: dispatch pinned at a token term of `0 × per-token = 0` for
-~40 minutes because the ranking directory it read had diverged from the one
-`loom-daemon tokens check --ranking` / the #4080 self-refresher actually wrote — the
-status view promotes this from the old small-print `note: daemon dispatch cap
-still uses a stale .ranking (...)` line to a headline `⚠ DISPATCH IS
-TOKEN-STARVED: …` line and suppresses "the limiter is work availability"
-underneath it, since the real limiter is unambiguously the token term. The
-root fix for the divergence itself is unifying which `.ranking` file
-[`capacity::read_ranking`] consults — see the healthy-token-count row of the
-input table above.
+**Token-axis probe/daemon disagreement can no longer skew the cap (#4344,
+superseded by #5270).** `resolve_capacity` still prefers a fresh client-side
+`loom-daemon tokens check --json` probe over the daemon's own ranking read for
+the *reported* healthy/total/exhausted account counts (useful, current
+numbers for the account-health line), but since #5270 it no longer
+recomputes its own `effective_cap` / `token_bound` from those counts — both
+are always exactly the daemon's own `report.dynamic_cap` / `false`. The old
+`#4344` incident (dispatch pinned at a token term of `0 × per-token = 0` for
+~40 minutes because the daemon's ranking read had diverged from a fresher
+probe) is now structurally impossible for the *cap*: a stale or diverged
+`.ranking` can misinform account **selection**, but it can never again pin
+`dynamic_cap` to 0. The historical `⚠ DISPATCH IS TOKEN-STARVED: …` headline
+this section used to describe has been retired for the same reason. The root
+fix for `.ranking` divergence itself — unifying which file
+[`capacity::read_ranking`] consults — remains in place; see the healthy-token
+row of the "retired" input table above.
 
 **Session-limit fault handling (#3947).** Stacking can occasionally trip a
 **concurrent-session-limit** fault on a token (the account is healthy but cannot
@@ -2657,40 +2695,55 @@ mutation from the read itself; observes the same latch) returning
 `(issue, time_since_dispatch)` for every live sweep that has not yet proven
 startup — for status/observability, not for gating.
 
-### Token-capacity backpressure (#3902)
+### Token-capacity backpressure (#3902; token axis retired from the cap by #5270)
 
-At scale, rotation accounts hit their 5h/7d rate limits and go `exhausted`.
-Dispatching to an exhausted account produces startup hangs / mid-build deaths, so
-the finder treats a genuine token limit as a **capacity signal** — slow down,
-alert, recover — all automatic and non-blocking:
+At scale, rotation accounts used to hit their 5h/7d rate limits and go
+`exhausted`, and dispatching to an exhausted account produces startup hangs /
+mid-build deaths, so the finder treats a genuine token limit as a **capacity
+signal** — alert, recover — non-blocking (the "slow down" half below is
+historical: #5270 removed the token axis from the dynamic cap itself, so
+account health can no longer *slow dispatch down*, only warn about it):
 
-1. **Slow down (backpressure).** The token axis of the dynamic cap is the count
-   of **healthy** (`available`) accounts read from `.loom/tokens/.ranking`
-   (`capacity::token_axis_limit`), not the flat `*.token` count. When accounts go
-   exhausted the cap backs off toward the healthy count; when *every* account is
-   exhausted it drops to 0 and the finder **defers** the queue rather than
-   hammering an exhausted account. A single healthy account is the throughput
-   **floor**, never a halt. When no `.ranking` file exists (no probe has run) the
-   axis falls back to the raw pool size — byte-for-byte the pre-#3902 behavior.
-2. **Alert (add capacity).** When the token axis is the *binding* constraint
-   (≤ disk and ≤ ceiling) and work is queued behind it, the finder is
-   *token-bound*. On the **state change** into that state it emits an
-   add-capacity advisory naming concrete levers — add accounts to
-   `~/.claude-monitor/accounts.env` + `loom-daemon tokens bootstrap`, or buy API
-   credits, then re-probe with `loom-daemon tokens check --ranking` — with the current
-   numbers (queued count, healthy/total accounts, exhausted count, estimated
-   drain time at current capacity). If accounts are `blocked` on revoked tokens,
-   `bootstrap --force` cannot recover — the advisory also names
-   `loom-daemon tokens import-from-monitor --force && loom-daemon tokens check --ranking` as
-   the recovery lever for that case. The advisory surfaces on **three**
-   channels: the daemon log (`warn`), the `daemon.capacity.advisory` event-bus
-   topic, and the `capacity` section of `loom-daemon status`. It is
+1. **Slow down (backpressure) — historical, superseded by #5270.** The token
+   axis used to be a term in `dynamic_cap`: the count of **healthy**
+   (`available`) accounts read from `.loom/tokens/.ranking`
+   (`capacity::token_axis_limit`), not the flat `*.token` count — when
+   accounts went exhausted the cap backed off toward the healthy count, down
+   to 0 when every account was exhausted. Operator direction on #5270 ("we
+   should only ever limit parallelism based on the machine disk/RAM/CPU")
+   removed this backoff entirely: `.ranking` health now drives spawn-time
+   **selection** only (prefer fresher/healthier accounts, skip
+   `blocked`/revoked ones), never admission. `capacity::token_axis_limit`
+   still exists and is still reported (see the "retired" input table in the
+   dynamic-cap section above), but its output no longer bounds anything.
+2. **Alert (advisory only, unchanged posture).** The pressure advisory
+   (`capacity::assess_pressure`) still runs every tick, now comparing the
+   healthy-account count against `disk.min(ram)` (both remaining
+   machine-headroom axes, #5270) rather than disk alone, specifically so a
+   RAM-starved host cannot spuriously read as "token-bound" (deferred > 0 for
+   a RAM reason, with the healthy count merely happening to be ≤ disk). It
+   still exists purely to prompt an operator to add capacity when scarce
+   accounts correlate with a deferred backlog — it is deliberately **not**
+   what gates dispatch (#5270 dropped that role entirely). On the state
+   change into a pressured reading it emits an add-capacity advisory naming
+   concrete levers — add accounts to `~/.claude-monitor/accounts.env` +
+   `loom-daemon tokens bootstrap`, or buy API credits, then re-probe with
+   `loom-daemon tokens check --ranking` — with the current numbers (queued
+   count, healthy/total accounts, exhausted count, estimated drain time at
+   current capacity). If accounts are `blocked` on revoked tokens, `bootstrap
+   --force` cannot recover — the advisory also names `loom-daemon tokens
+   import-from-monitor --force && loom-daemon tokens check --ranking` as the
+   recovery lever for that case. The advisory surfaces on **three** channels:
+   the daemon log (`warn`), the `daemon.capacity.advisory` event-bus topic,
+   and the `capacity` section of `loom-daemon status`. It is
    **deduplicated** — one advisory on entry, one recovery on exit, never
-   per-tick spam. Advisory only; it never blocks dispatch.
-3. **Recover.** The finder re-reads the ranking every tick (bounded cadence = the
-   tick interval), so as accounts reset to `available` the cap ramps back up and
-   the queued `loom:issue` backlog drains automatically — no manual intervention.
-   A symmetric recovery line/event fires on the way out of the pressured state.
+   per-tick spam. Advisory only; it never blocks dispatch (and, since #5270,
+   nothing about account health ever did).
+3. **Recover.** The finder re-reads the ranking every tick (bounded cadence =
+   the tick interval), so as accounts reset to `available` the advisory
+   clears and the queued `loom:issue` backlog continues to drain at whatever
+   rate `min(disk, ram, configured_max)` allows — no manual intervention. A
+   symmetric recovery line/event fires on the way out of the pressured state.
 
 The `estimated_drain_minutes` figure is a coarse `ceil(queued / healthy) ×
 NOMINAL_SWEEP_MINUTES` (30 min nominal) aid, not a precise SLA — the daemon does
@@ -2811,7 +2864,7 @@ exactly like `main_health_gate::read_build_gate_config`.
 | `autonomous.workFinder.maxConcurrent` | `LOOM_WORK_FINDER_MAX_CONCURRENT` | `3` | **The** per-machine admission knob since #4512 — an operator ceiling, not a fixed target, tuned empirically from `loom-daemon calibrate` / `status`. Per-machine **and workload-dependent** (#4903): ~10+ on an 8-core API-bound (software) worker, but **2–3** on the same 8 cores running analog/simulation sweeps. See [Sizing `maxConcurrent`](#sizing-maxconcurrent-per-machine-and-per-workload-4512-4903) below |
 | `autonomous.workFinder.maxAdmissionsPerTick` | `LOOM_WORK_FINDER_MAX_ADMISSIONS_PER_TICK` | `3` | Per-tick **ramp** cap (#4234) — bounds how many *new* sweeps one tick may admit, independent of `maxConcurrent`/the live dynamic cap. Zero/invalid → default; resolved once at startup, mirroring `maxConcurrent`. See [Per-tick admission (ramp) cap](#per-tick-admission-ramp-cap-4234) below |
 | `autonomous.workFinder.saturationBrake.enabled` | `LOOM_ADMISSION_BRAKE` | `true` | Saturation admission brake on/off (#4903). A safety backstop — **defaults on**. Holds *new* admissions while the host is already saturated; never preempts a running sweep. Env truthy (`1`/`true`/`yes`/`on`) enables, any other value disables; wins over config. See [Saturation admission brake](#saturation-admission-brake-4903) below |
-| `autonomous.workFinder.saturationBrake.loadPerCoreHold` | `LOOM_ADMISSION_BRAKE_LOAD_PER_CORE` | `4.0` | Load-per-core at/over which new admissions are held for that tick. `<= 0`/invalid → default. Deliberately above the host breaker's `2.5` trip: the brake decides from a single reading, the breaker from sustained ticks |
+| `autonomous.workFinder.saturationBrake.loadPerCoreHold` | `LOOM_ADMISSION_BRAKE_LOAD_PER_CORE` | `0.95` (`4.0` before #5270) | Load-per-core at/over which new admissions are held for that tick. `<= 0`/invalid → default. Since #5270 sits deliberately *below* the host breaker's `2.5` trip: the brake is now the primary "dumb mode" CPU gate and engages first (a single over-threshold reading), the breaker remains the slower sustained-distress trip |
 | `autonomous.workFinder.quarantine.enabled` | `LOOM_WORK_FINDER_QUARANTINE` | `true` | Insta-crash quarantine on/off (#3939). A safety backstop — defaults on |
 | `autonomous.workFinder.quarantine.threshold` | `LOOM_WORK_FINDER_QUARANTINE_THRESHOLD` | `3` | Consecutive insta-crashes before an issue is quarantined. Zero/invalid → default |
 | `autonomous.workFinder.quarantine.ttlSecs` | `LOOM_WORK_FINDER_QUARANTINE_TTL_SECS` | `3600` | How long a quarantine entry persists before auto-release. Zero/invalid → default |

--- a/loom-daemon/src/admission_brake.rs
+++ b/loom-daemon/src/admission_brake.rs
@@ -7,9 +7,11 @@
 //! right for the workload it measured: an issue→PR sweep is dominated by
 //! API-wait, so pricing every sweep as a build throttled the ~90% low-CPU
 //! majority to defend against the minority case. But it left admission with **no
-//! term at all** that reads the host: the cap is `min(token axis, disk headroom,
-//! configured_max)`, and when `maxConcurrent` is unset (or generously set for an
-//! API-bound repo) nothing bounds admission by observed load.
+//! term at all** that reads the host: the cap was `min(token axis, disk
+//! headroom, configured_max)` (and, since #5270, is `min(disk headroom,
+//! configured_max)` — the token axis no longer participates), and when
+//! `maxConcurrent` is unset (or generously set for an API-bound repo) nothing
+//! bounds admission by observed load.
 //!
 //! A CPU-heavy workload then walks straight past it. `loom-worker-1` (8 vCPU) was
 //! observed at **load average 95** — `12×` overcommit, `0.07%` CPU idle — from
@@ -34,17 +36,19 @@
 //! | | Admission brake (this module, #4903) | Host breaker ([`crate::host_breaker`], #4235) |
 //! |---|---|---|
 //! | Nature | **Point-in-time** — one reading, one decision | **Stateful** — trips only on N consecutive over-threshold ticks |
-//! | Default threshold | `4.0` load/core (see [`DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE`]) | `2.5` load/core |
+//! | Default threshold | `0.95` load/core (see [`DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE`]; `4.0` before #5270) | `2.5` load/core |
 //! | Release | Immediate, the first tick load drops back under | After a 5-minute cool-down |
 //! | Explicit `dispatch_sweep` | **Never blocks it** (an operator asking by hand is not autonomous admission) | Hard-blocks unless `force` |
 //! | Purpose | Stop *adding* to a full host | Remember a *meltdown* so a load dip cannot re-admit a whole wave |
 //!
 //! So the brake is the cheap, fast-releasing guard that keeps a busy host from
 //! being handed more work this minute; the breaker is the slow, sticky guard that
-//! remembers genuine distress across minutes. The brake's threshold sits *above*
-//! the breaker's on purpose — it is a per-tick scheduling decision that must not
-//! fire on a healthy burst, whereas the breaker's lower bar is paid for by
-//! requiring the load to be sustained.
+//! remembers genuine distress across minutes. **Since #5270 the brake's default
+//! threshold sits *below* the breaker's** (the reverse of the pre-#5270
+//! ordering) — with the token axis gone, this brake is promoted from a rarely-
+//! tripped backstop to the primary CPU admission gate for "dumb mode" (operator
+//! direction: hold admission at ≥95% few-minute load-per-core), so it now
+//! engages well before the breaker's higher, sustained-distress trip.
 //!
 //! # Fail-safe
 //!
@@ -89,18 +93,32 @@ pub const DEFAULT_ADMISSION_BRAKE_ENABLED: bool = true;
 
 /// Default load-per-core ratio at/above which new admissions are held.
 ///
-/// `4.0` is deliberately **generous**: four runnable threads per logical core is
-/// far above any healthy burst (a busy-but-fine host sits under `1.0`; the build
-/// gate defers its own build at `0.9`, [`crate::cpu_headroom::DEFAULT_GATE_LOAD_THRESHOLD`]),
-/// and far below the `12.0` overcommit that motivated this brake. The point is a
-/// backstop no reasonable workload trips, not a scheduler — an operator who wants
-/// tighter packing tunes `maxConcurrent`, which remains **the** admission knob.
+/// **Retuned in #5270 from `4.0` to `0.95`.** Until #5270 the token axis
+/// ([`crate::capacity::token_axis_limit`]) and disk headroom were the two hard
+/// admission floors, with this brake acting only as a generous backstop above
+/// them. #5270 removed the token axis from admission entirely (operator
+/// direction: "we should only ever limit parallelism based on the machine
+/// disk/RAM/CPU"), which promotes this brake from a rarely-tripped safety net
+/// to **the** CPU admission gate in that "dumb mode" — so its threshold now
+/// matches the operator's literal ask: hold new admissions once the host's
+/// few-minute load average reaches ~95% of its logical core count, resume
+/// below it. `1.0` load-per-core means "as many runnable/uninterruptible
+/// threads as logical cores"; `0.95` holds a notch below full saturation,
+/// mirroring the build gate's own `0.9` deferral point
+/// ([`crate::cpu_headroom::DEFAULT_GATE_LOAD_THRESHOLD`]) rather than the old
+/// `4.0`, which would have let a host run at 4× overcommit before this brake
+/// ever engaged.
 ///
-/// It sits above [`crate::host_breaker::DEFAULT_HOST_BREAKER_LOAD_PER_CORE`]
-/// (`2.5`) on purpose: see the module docs' comparison table. The breaker fires
-/// lower because it demands *sustained* over-threshold ticks; the brake decides
-/// from a single reading, so it must be sure.
-pub const DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE: f64 = 4.0;
+/// It now sits **below**
+/// [`crate::host_breaker::DEFAULT_HOST_BREAKER_LOAD_PER_CORE`] (`2.5`) — the
+/// reverse of the pre-#5270 ordering, and intentional under the new model: the
+/// brake is the fast, cheap, per-tick hold that engages first (a single
+/// over-threshold reading), and the breaker remains the slower, stickier trip
+/// for genuine sustained distress (several consecutive over-threshold ticks)
+/// well past the point the brake has already held new admissions. See the
+/// module docs' comparison table for the full distinction between the two
+/// mechanisms.
+pub const DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE: f64 = 0.95;
 
 /// Resolved brake parameters (env > config > default), captured once at daemon
 /// startup and held by [`SharedAdmissionBrake`].
@@ -551,15 +569,39 @@ mod tests {
     }
 
     #[test]
-    fn brake_default_threshold_sits_above_the_host_breaker_trip() {
-        // The two thresholds encode different policies; the ordering is
-        // load-bearing (see the module docs' comparison table), so pin it.
+    fn default_config_holds_at_95_percent_and_resumes_below_it() {
+        // #5270 AC2: the *default* config (not an explicitly-passed threshold)
+        // must defer dispatch at >=95% few-minute load-per-core and resume
+        // below it — this is the literal operator-directed "dumb mode" gate.
+        let default_cfg = AdmissionBrakeConfig::default();
+        assert_eq!(default_cfg.load_per_core_threshold, 0.95);
+
+        // 8 cores at load 7.6 = 0.95/core exactly at the boundary -> held.
+        assert!(decide(&default_cfg, Some(7.6), 8).held);
+        // A hair under 95% -> not held.
+        assert!(!decide(&default_cfg, Some(7.59), 8).held);
+        // A comfortably busy host well under the gate -> not held.
+        assert!(!decide(&default_cfg, Some(4.0), 8).held);
+        // Fully idle -> not held.
+        assert!(!decide(&default_cfg, Some(0.0), 8).held);
+    }
+
+    #[test]
+    fn brake_default_threshold_sits_below_the_host_breaker_trip() {
+        // #5270 retuned the brake default from a generous backstop (4.0) to the
+        // primary "dumb mode" CPU admission gate (0.95). The ordering versus the
+        // host breaker inverted on purpose: the brake now engages FIRST (a
+        // single over-threshold reading), well before the breaker's higher,
+        // sustained-distress trip. The ordering is load-bearing (see the module
+        // docs' comparison table), so pin it.
         const {
             assert!(
                 DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE
-                    > crate::host_breaker::DEFAULT_HOST_BREAKER_LOAD_PER_CORE
+                    < crate::host_breaker::DEFAULT_HOST_BREAKER_LOAD_PER_CORE
             );
         }
+        // It still sits a notch above the (unrelated) build gate's own
+        // scheduling-deferral threshold, so the two never get conflated.
         const {
             assert!(
                 DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE

--- a/loom-daemon/src/calibrate/mod.rs
+++ b/loom-daemon/src/calibrate/mod.rs
@@ -16,15 +16,30 @@
 //!
 //! So calibrate is now strictly a **measurement report**: it prints what the
 //! host looks like right now, what the knobs currently resolve to, the
-//! `min(token axis, disk headroom, maxConcurrent)` breakdown, and which term
-//! binds. Reading it is how an operator decides whether to raise the knob:
+//! `min(disk headroom, ram headroom, maxConcurrent)` breakdown, which term
+//! binds, and — since #5270 — whether the separate CPU saturation admission
+//! brake ([`crate::admission_brake`]) is holding dispatch outright. Reading it
+//! is how an operator decides whether to raise the knob:
 //!
 //! - **binds on `ceiling` while the host sits idle** ⇒ raise `maxConcurrent`.
 //! - **binds on `ceiling` while the host is saturated** (low idle fraction, or
 //!   the host breaker tripping) ⇒ the knob is already at/above what this machine
 //!   sustains; leave it or lower it.
-//! - **binds on `token`/`disk`** ⇒ raising `maxConcurrent` changes nothing; add
-//!   accounts or free scratch space.
+//! - **binds on `disk`** ⇒ raising `maxConcurrent` changes nothing; free
+//!   scratch space.
+//! - **binds on `ram`** (#5270) ⇒ raising `maxConcurrent` changes nothing;
+//!   free memory.
+//! - **the CPU admission brake is holding** (#5270) ⇒ dispatch is blocked
+//!   THIS tick regardless of the cap above; wait for load to drop, or retune
+//!   the brake's threshold if it is firing on routine bursts.
+//!
+//! The token pool's healthy-account count is still reported (it drives
+//! spawn-time *selection*), but since #5270 it is informational only — it no
+//! longer bounds the cap (nor does the CPU term, on any auth path — a
+//! metered API key or an overage-enabled subscription pool has no
+//! exhaustible admission ceiling worth modeling). See
+//! [`crate::work_finder::resolve_dynamic_max_concurrent`] for the full
+//! rationale.
 //!
 //! It never writes config. `--write` is accepted-but-ignored with a deprecation
 //! warning so an existing `loom-daemon calibrate --write` invocation in a
@@ -79,6 +94,19 @@ pub struct HostMeasurements {
     /// The resolved per-worktree GB estimate
     /// ([`crate::disk_headroom::per_worktree_gb`]) — env-only, no config key.
     pub per_worktree_gb: u64,
+    /// The RAM headroom term (#5270,
+    /// [`crate::ram_headroom::ram_headroom_limit`]) — worktree slots the
+    /// currently-available memory can hold at the resolved per-worktree RAM
+    /// GB estimate. `usize::MAX` means the probe was unmeasurable (skip the
+    /// clamp — see [`crate::ram_headroom`] docs).
+    pub ram_headroom: usize,
+    /// Available RAM (GB), when measurable (`None` when unmeasurable — see
+    /// [`crate::ram_headroom::available_ram_gb`]).
+    pub ram_free_gb: Option<u64>,
+    /// The resolved per-worktree RAM GB estimate
+    /// ([`crate::ram_headroom::per_worktree_ram_gb`]) — env-only, no config
+    /// key (mirrors [`Self::per_worktree_gb`]).
+    pub per_worktree_ram_gb: u64,
     /// Count of `available` (healthy) accounts from the ranking snapshot, or
     /// the raw pool size when no ranking data exists — mirrors
     /// [`crate::capacity::token_axis_limit`], the same source
@@ -122,6 +150,19 @@ pub struct HostMeasurements {
     /// because this — not an admission-time CPU estimate — is what bounds
     /// concurrent heavy builds since #4512.
     pub build_slots: usize,
+    /// Whether the CPU saturation admission brake
+    /// ([`crate::admission_brake`], #4903) is enabled for this workspace.
+    pub cpu_admission_brake_enabled: bool,
+    /// The brake's resolved load-per-core hold threshold (env > config >
+    /// default — [`crate::admission_brake::DEFAULT_ADMISSION_BRAKE_LOAD_PER_CORE`],
+    /// retuned to the "dumb mode" `0.95` CPU gate by #5270).
+    pub cpu_admission_brake_threshold: f64,
+    /// Whether the brake would hold new admissions **right now**, computed
+    /// fresh from [`Self::loadavg_1m`] / [`Self::logical_cpus`] — a one-shot
+    /// `calibrate` invocation is a separate process from the running daemon,
+    /// so this recomputes the decision rather than reading the live daemon's
+    /// registered brake state (which this process cannot see).
+    pub cpu_admission_brake_held: bool,
 }
 
 impl HostMeasurements {
@@ -141,21 +182,36 @@ impl HostMeasurements {
     #[must_use]
     pub fn dynamic_cap(&self) -> usize {
         crate::work_finder::resolve_dynamic_max_concurrent(
-            self.token_axis_limit,
-            self.configured_per_token_concurrency,
             self.disk_headroom,
+            self.ram_headroom,
             self.configured_max_concurrent,
         )
     }
 
-    /// Which of the three cap terms binds ([`binding_term`]).
+    /// Which of the three cap terms binds ([`binding_term`]). The token axis
+    /// is no longer part of the admission formula (#5270) — `token_axis_limit`
+    /// / `token_axis_effective()` remain informational-only fields on this
+    /// report, reflecting spawn-time account health, not a concurrency cap.
     #[must_use]
     pub fn binding_term(&self) -> BindingTerm {
-        binding_term(
-            self.token_axis_effective(),
-            self.disk_headroom,
-            self.configured_max_concurrent,
-        )
+        binding_term(self.disk_headroom, self.ram_headroom, self.configured_max_concurrent)
+    }
+
+    /// The single "which machine axis is limiting dispatch right now" answer
+    /// (#5270 AC4 — max/disk/RAM/CPU observability). The CPU saturation
+    /// admission brake is a **point-in-time hold**, not a term in the
+    /// `min(...)` [`Self::dynamic_cap`] formula (see
+    /// [`crate::work_finder::resolve_dynamic_max_concurrent`]'s own docs for
+    /// why), so it takes priority here: a held brake means dispatch is
+    /// blocked THIS tick regardless of what the numeric cap says. When the
+    /// brake is not holding, this falls back to [`Self::binding_term`].
+    #[must_use]
+    pub fn admission_axis(&self) -> &'static str {
+        if self.cpu_admission_brake_held {
+            "cpu"
+        } else {
+            self.binding_term().as_str()
+        }
     }
 
     /// Render this struct as the `"measurements"` JSON object for `--json`
@@ -166,9 +222,12 @@ impl HostMeasurements {
             "logical_cpus": self.logical_cpus,
             "cpu_idle_fraction": self.cpu_idle_fraction,
             "loadavg_1m": self.loadavg_1m,
-            "disk_headroom": disk_headroom_json(self.disk_headroom),
+            "disk_headroom": headroom_json(self.disk_headroom),
             "disk_free_gb": self.disk_free_gb,
             "per_worktree_gb": self.per_worktree_gb,
+            "ram_headroom": headroom_json(self.ram_headroom),
+            "ram_free_gb": self.ram_free_gb,
+            "per_worktree_ram_gb": self.per_worktree_ram_gb,
             "token_axis_limit": self.token_axis_limit,
             "token_axis_effective": self.token_axis_effective(),
             "ranking_present": self.ranking_present,
@@ -184,19 +243,24 @@ impl HostMeasurements {
             "configured_per_token_concurrency": self.configured_per_token_concurrency,
             "per_token_concurrency_env_override": self.per_token_concurrency_env_override,
             "build_slots": self.build_slots,
+            "cpu_admission_brake": {
+                "enabled": self.cpu_admission_brake_enabled,
+                "held": self.cpu_admission_brake_held,
+                "load_per_core_threshold": self.cpu_admission_brake_threshold,
+            },
         })
     }
 }
 
-/// `usize::MAX` (the disk-unmeasurable / unbounded sentinel) does not survive
-/// JSON's number type cleanly across every consumer — render it as the string
-/// `"unbounded"` instead of a giant integer, matching how an operator should
-/// read it.
-fn disk_headroom_json(disk_headroom: usize) -> Value {
-    if disk_headroom == usize::MAX {
+/// `usize::MAX` (the disk/RAM-unmeasurable / unbounded sentinel) does not
+/// survive JSON's number type cleanly across every consumer — render it as
+/// the string `"unbounded"` instead of a giant integer, matching how an
+/// operator should read it.
+fn headroom_json(headroom: usize) -> Value {
+    if headroom == usize::MAX {
         Value::String("unbounded".to_string())
     } else {
-        serde_json::json!(disk_headroom)
+        serde_json::json!(headroom)
     }
 }
 
@@ -205,17 +269,21 @@ fn disk_headroom_json(disk_headroom: usize) -> Value {
 // ============================================================================
 
 /// Which of the three dynamic-cap terms is the binding (smallest) constraint.
-/// Tie-break order mirrors `loom-daemon status`'s own diagnosis
-/// (`resolve_capacity` / `token_bound`): token axis first, then disk, then the
-/// ceiling. (A fourth `Cpu` variant existed until #4512 removed the CPU term
-/// from admission.)
+/// Tie-break order mirrors `loom-daemon status`'s own diagnosis: disk first,
+/// then RAM, then the ceiling. (A `Token` variant existed until #5270 removed
+/// the token axis from admission — see
+/// [`crate::work_finder::resolve_dynamic_max_concurrent`] — and a `Cpu`
+/// variant existed until #4512 removed the CPU term from this same formula;
+/// CPU saturation is reported separately via
+/// [`crate::admission_brake`]/`loom-daemon status`'s `admission_brake` block,
+/// since it holds admission as a point-in-time gate rather than shrinking
+/// this `min(...)`.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BindingTerm {
-    /// The token axis (`healthy_accounts × per_token_concurrency`) is the
-    /// smallest term.
-    Token,
     /// Disk headroom is the smallest term.
     Disk,
+    /// RAM headroom is the smallest term (#5270).
+    Ram,
     /// The operator-configured `maxConcurrent` is the smallest term.
     Ceiling,
 }
@@ -225,8 +293,8 @@ impl BindingTerm {
     #[must_use]
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Token => "token",
             Self::Disk => "disk",
+            Self::Ram => "ram",
             Self::Ceiling => "ceiling",
         }
     }
@@ -235,16 +303,12 @@ impl BindingTerm {
 /// Determine which of the three terms is smallest (binds), applying the same
 /// tie-break order [`BindingTerm`] documents.
 #[must_use]
-pub fn binding_term(
-    token_axis_effective: usize,
-    disk_headroom: usize,
-    ceiling: usize,
-) -> BindingTerm {
-    let min_val = token_axis_effective.min(disk_headroom).min(ceiling);
-    if token_axis_effective == min_val {
-        BindingTerm::Token
-    } else if disk_headroom == min_val {
+pub fn binding_term(disk_headroom: usize, ram_headroom: usize, ceiling: usize) -> BindingTerm {
+    let min_val = disk_headroom.min(ram_headroom).min(ceiling);
+    if disk_headroom == min_val {
         BindingTerm::Disk
+    } else if ram_headroom == min_val {
+        BindingTerm::Ram
     } else {
         BindingTerm::Ceiling
     }
@@ -289,6 +353,10 @@ pub fn measure(workspace_root: &Path) -> HostMeasurements {
     let per_worktree_gb = crate::disk_headroom::per_worktree_gb();
     let disk_headroom = crate::disk_headroom::disk_headroom_limit(workspace_root);
 
+    let ram_free_gb = crate::ram_headroom::available_ram_gb();
+    let per_worktree_ram_gb = crate::ram_headroom::per_worktree_ram_gb();
+    let ram_headroom = crate::ram_headroom::ram_headroom_limit();
+
     let pool_size = crate::tokens::token_pool_size(workspace_root);
     let ranking = crate::capacity::read_ranking(workspace_root);
     let (token_axis_limit, ranking_present, total_accounts) = match &ranking {
@@ -306,6 +374,13 @@ pub fn measure(workspace_root: &Path) -> HostMeasurements {
     let per_token_concurrency_env_override =
         std::env::var(crate::work_finder::PER_TOKEN_CONCURRENCY_ENV).is_ok();
 
+    // CPU saturation admission brake (#4903, retuned by #5270 into the "dumb
+    // mode" CPU gate): recomputed fresh rather than read from the live
+    // daemon's registered global, since a one-shot `calibrate` invocation runs
+    // in a separate process that never sees that state.
+    let brake_config = crate::admission_brake::resolve_config_for(workspace_root);
+    let brake_decision = crate::admission_brake::decide(&brake_config, loadavg_1m, logical_cpus);
+
     HostMeasurements {
         logical_cpus,
         cpu_idle_fraction,
@@ -313,6 +388,9 @@ pub fn measure(workspace_root: &Path) -> HostMeasurements {
         disk_headroom,
         disk_free_gb,
         per_worktree_gb,
+        ram_headroom,
+        ram_free_gb,
+        per_worktree_ram_gb,
         token_axis_limit,
         ranking_present,
         total_accounts,
@@ -322,6 +400,9 @@ pub fn measure(workspace_root: &Path) -> HostMeasurements {
         configured_per_token_concurrency,
         per_token_concurrency_env_override,
         build_slots: crate::build_slot::resolve_slots(),
+        cpu_admission_brake_enabled: brake_config.enabled,
+        cpu_admission_brake_threshold: brake_config.load_per_core_threshold,
+        cpu_admission_brake_held: brake_decision.held,
     }
 }
 
@@ -336,6 +417,11 @@ pub fn report_json(m: &HostMeasurements) -> Value {
         "measurements": m.to_json(),
         "dynamic_cap": m.dynamic_cap(),
         "binding_term": m.binding_term().as_str(),
+        // #5270 AC4: the CPU brake is a point-in-time hold outside the
+        // `min(...)` cap formula, so it can override `binding_term` as the
+        // real answer to "what's stopping dispatch right now" — see
+        // `HostMeasurements::admission_axis`.
+        "admission_axis": m.admission_axis(),
         "advice": advice(m),
         // Retained for machine consumers that keyed off it before #4512: this
         // subcommand no longer writes anything, ever.
@@ -349,6 +435,15 @@ pub fn report_json(m: &HostMeasurements) -> Value {
 /// unit-tested against injected host classes.
 #[must_use]
 pub fn advice(m: &HostMeasurements) -> String {
+    if m.cpu_admission_brake_held {
+        return format!(
+            "the CPU saturation admission brake is HOLDING new admissions right now \
+             (load-per-core ≥ {:.2}) — this is the actual limiter this instant, ahead of the \
+             disk/RAM/maxConcurrent cap below; in-flight sweeps are untouched and it releases the \
+             moment load drops back under the threshold (#5270, #4903).",
+            m.cpu_admission_brake_threshold
+        );
+    }
     match m.binding_term() {
         BindingTerm::Ceiling => match m.cpu_idle_fraction {
             Some(idle) if idle >= IDLE_HEADROOM_FRACTION => format!(
@@ -370,19 +465,17 @@ pub fn advice(m: &HostMeasurements) -> String {
                 m.configured_max_concurrent
             ),
         },
-        BindingTerm::Token => format!(
-            "the token axis binds ({} healthy account(s) × per-token {} = {}) — raising \
-             maxConcurrent changes nothing; add accounts (`loom-daemon tokens bootstrap`) or refresh \
-             the ranking (`loom-daemon tokens check --ranking`).",
-            m.token_axis_limit,
-            m.configured_per_token_concurrency.max(1),
-            m.token_axis_effective()
-        ),
         BindingTerm::Disk => format!(
             "disk headroom binds ({} worktree slot(s) at {} GB each) — raising maxConcurrent \
              changes nothing; free scratch space or lower LOOM_PER_WORKTREE_GB.",
             display_headroom(m.disk_headroom),
             m.per_worktree_gb
+        ),
+        BindingTerm::Ram => format!(
+            "RAM headroom binds ({} worktree slot(s) at {} GB each) — raising maxConcurrent \
+             changes nothing; free memory or lower LOOM_PER_WORKTREE_RAM_GB (#5270).",
+            display_headroom(m.ram_headroom),
+            m.per_worktree_ram_gb
         ),
     }
 }
@@ -423,9 +516,21 @@ pub fn report_human(m: &HostMeasurements) -> String {
             out.push_str("  cpu observed:   no CPU signal available on this platform\n");
         }
     }
-    out.push_str(
-        "                  (observational only since #4512 — CPU is no longer an admission term)\n",
-    );
+    out.push_str(&format!(
+        "                  (not a `min(...)` cap term since #4512 — but the CPU admission \
+         brake {} watches it: holds new admissions at load-per-core ≥ {:.2}, currently {})\n",
+        if m.cpu_admission_brake_enabled {
+            "IS enabled"
+        } else {
+            "is disabled"
+        },
+        m.cpu_admission_brake_threshold,
+        if m.cpu_admission_brake_held {
+            "HOLDING"
+        } else {
+            "not holding"
+        }
+    ));
     match (m.disk_free_gb, m.disk_headroom) {
         (Some(free), headroom) if headroom != usize::MAX => {
             out.push_str(&format!(
@@ -442,6 +547,23 @@ pub fn report_human(m: &HostMeasurements) -> String {
     out.push_str(
         "                  (LOOM_PER_WORKTREE_GB is env-only — there is no config key for the \
          disk estimate; override with `export LOOM_PER_WORKTREE_GB=<gb>`)\n",
+    );
+    match (m.ram_free_gb, m.ram_headroom) {
+        (Some(free), headroom) if headroom != usize::MAX => {
+            out.push_str(&format!(
+                "  ram headroom:   {headroom} worktree slot(s) ({free} GB available / {} GB per-worktree estimate)\n",
+                m.per_worktree_ram_gb
+            ));
+        }
+        _ => {
+            out.push_str(
+                "  ram headroom:   unmeasurable (skipping the RAM clamp — treated as unbounded)\n",
+            );
+        }
+    }
+    out.push_str(
+        "                  (LOOM_PER_WORKTREE_RAM_GB is env-only — there is no config key for \
+         the RAM estimate; override with `export LOOM_PER_WORKTREE_RAM_GB=<gb>`, #5270)\n",
     );
     if m.ranking_present {
         out.push_str(&format!(
@@ -504,14 +626,23 @@ pub fn report_human(m: &HostMeasurements) -> String {
 
     out.push_str(&format!("\nDynamic concurrency cap: {}\n", m.dynamic_cap()));
     out.push_str(&format!(
-        "  = min(healthy {} × per-token {} = {}, disk {}, maxConcurrent {})\n",
+        "  = min(disk {}, ram {}, maxConcurrent {})\n",
+        display_headroom(m.disk_headroom),
+        display_headroom(m.ram_headroom),
+        m.configured_max_concurrent,
+    ));
+    out.push_str(&format!(
+        "  (token pool healthy {} × per-token {} = {} is informational only — the token axis no \
+         longer bounds the cap, #5270)\n",
         m.token_axis_limit,
         factor,
         m.token_axis_effective(),
-        display_headroom(m.disk_headroom),
-        m.configured_max_concurrent,
     ));
-    out.push_str(&format!("  binds on: {}\n", m.binding_term().as_str()));
+    out.push_str(&format!("  cap binds on: {}\n", m.binding_term().as_str()));
+    out.push_str(&format!(
+        "  admission blocked by (max/disk/ram/cpu, #5270 AC4): {}\n",
+        m.admission_axis()
+    ));
 
     out.push_str(&format!("\nReading: {}\n", advice(m)));
     out.push_str(
@@ -553,6 +684,9 @@ mod tests {
             disk_headroom: 36,
             disk_free_gb: Some(72),
             per_worktree_gb: 2,
+            ram_headroom: 40,
+            ram_free_gb: Some(80),
+            per_worktree_ram_gb: 2,
             token_axis_limit: 6,
             ranking_present: true,
             total_accounts: 8,
@@ -562,6 +696,9 @@ mod tests {
             configured_per_token_concurrency: 2,
             per_token_concurrency_env_override: false,
             build_slots: 1,
+            cpu_admission_brake_enabled: true,
+            cpu_admission_brake_threshold: 0.95,
+            cpu_admission_brake_held: false,
         }
     }
 
@@ -575,7 +712,7 @@ mod tests {
         }
     }
 
-    /// Plenty of CPU and tokens, nearly-full scratch volume.
+    /// Plenty of CPU/RAM/tokens, nearly-full scratch volume.
     fn disk_bound_host() -> HostMeasurements {
         HostMeasurements {
             disk_headroom: 2,
@@ -585,8 +722,20 @@ mod tests {
         }
     }
 
-    /// One healthy account: the token axis binds.
-    fn token_bound_host() -> HostMeasurements {
+    /// Plenty of CPU/tokens/disk, critically low available RAM (#5270).
+    fn ram_bound_host() -> HostMeasurements {
+        HostMeasurements {
+            ram_headroom: 1,
+            ram_free_gb: Some(2),
+            configured_max_concurrent: 10,
+            ..idle_worker_host()
+        }
+    }
+
+    /// A near-exhausted token pool: no longer binds the cap since #5270 (only
+    /// disk/ram/maxConcurrent do), but the field remains for the informational
+    /// token-pool line in the report.
+    fn token_starved_host() -> HostMeasurements {
         HostMeasurements {
             token_axis_limit: 1,
             total_accounts: 8,
@@ -595,20 +744,42 @@ mod tests {
         }
     }
 
+    /// A host where the CPU saturation admission brake is currently holding
+    /// new admissions — the "dumb mode" case #5270 introduces.
+    fn cpu_brake_held_host() -> HostMeasurements {
+        HostMeasurements {
+            cpu_admission_brake_held: true,
+            loadavg_1m: Some(7.8),
+            ..idle_worker_host()
+        }
+    }
+
     // ========================================================================
-    // The cap is exactly `resolve_dynamic_max_concurrent` — no CPU term
+    // The cap is exactly `resolve_dynamic_max_concurrent` — no CPU or token
+    // axis term (#5270)
     // ========================================================================
 
     #[test]
     fn dynamic_cap_matches_the_three_term_admission_formula() {
         let m = idle_worker_host();
-        // min(6 × 2 = 12, disk 36, maxConcurrent 3) = 3.
+        // min(disk 36, ram 40, maxConcurrent 3) = 3 — the token axis (6 × 2 =
+        // 12) plays no role even though it would have been smaller under the
+        // old formula.
         assert_eq!(m.dynamic_cap(), 3);
         assert_eq!(
             m.dynamic_cap(),
-            crate::work_finder::resolve_dynamic_max_concurrent(6, 2, 36, 3),
+            crate::work_finder::resolve_dynamic_max_concurrent(36, 40, 3),
             "calibrate must never compute a different cap than dispatch"
         );
+    }
+
+    #[test]
+    fn a_token_starved_host_is_not_capped_by_its_token_pool() {
+        // #5270: even with only 1 healthy account, the cap is min(disk, ram,
+        // maxConcurrent) — the token axis never binds any more.
+        let m = token_starved_host();
+        assert_eq!(m.dynamic_cap(), 10, "min(disk 36, ram 40, maxConcurrent 10)");
+        assert_eq!(m.binding_term(), BindingTerm::Ceiling);
     }
 
     #[test]
@@ -621,25 +792,55 @@ mod tests {
         assert_eq!(m.binding_term(), BindingTerm::Ceiling);
     }
 
+    #[test]
+    fn a_ram_starved_host_is_capped_by_ram_headroom() {
+        // #5270 AC3: critically-low RAM caps the dynamic concurrency the same
+        // way disk headroom already did.
+        let m = ram_bound_host();
+        assert_eq!(m.dynamic_cap(), 1, "min(disk 36, ram 1, maxConcurrent 10)");
+        assert_eq!(m.binding_term(), BindingTerm::Ram);
+    }
+
     // ========================================================================
     // binding_term
     // ========================================================================
 
     #[test]
-    fn binding_term_prefers_token_then_disk_then_ceiling() {
-        assert_eq!(binding_term(2, 5, 9), BindingTerm::Token);
-        assert_eq!(binding_term(9, 2, 5), BindingTerm::Disk);
-        assert_eq!(binding_term(9, 5, 2), BindingTerm::Ceiling);
-        // Ties resolve to the earliest term, matching `status`'s diagnosis.
-        assert_eq!(binding_term(3, 3, 3), BindingTerm::Token);
-        assert_eq!(binding_term(9, 3, 3), BindingTerm::Disk);
+    fn binding_term_prefers_disk_then_ram_then_ceiling() {
+        assert_eq!(binding_term(2, 9, 9), BindingTerm::Disk);
+        assert_eq!(binding_term(9, 2, 9), BindingTerm::Ram);
+        assert_eq!(binding_term(9, 9, 2), BindingTerm::Ceiling);
+        // A tie between disk and ram resolves to disk, matching `status`'s
+        // tie-break order.
+        assert_eq!(binding_term(3, 3, 9), BindingTerm::Disk);
+        assert_eq!(binding_term(9, 3, 3), BindingTerm::Ram);
     }
 
     #[test]
     fn host_classes_bind_where_expected() {
         assert_eq!(idle_worker_host().binding_term(), BindingTerm::Ceiling);
         assert_eq!(disk_bound_host().binding_term(), BindingTerm::Disk);
-        assert_eq!(token_bound_host().binding_term(), BindingTerm::Token);
+        assert_eq!(ram_bound_host().binding_term(), BindingTerm::Ram);
+        // #5270: even a near-exhausted token pool never binds the cap any more.
+        assert_eq!(token_starved_host().binding_term(), BindingTerm::Ceiling);
+    }
+
+    // ========================================================================
+    // admission_axis — the CPU brake overrides the numeric binding_term
+    // ========================================================================
+
+    #[test]
+    fn admission_axis_falls_back_to_binding_term_when_the_brake_is_not_holding() {
+        assert_eq!(idle_worker_host().admission_axis(), "ceiling");
+        assert_eq!(disk_bound_host().admission_axis(), "disk");
+        assert_eq!(ram_bound_host().admission_axis(), "ram");
+    }
+
+    #[test]
+    fn admission_axis_reports_cpu_when_the_brake_is_holding() {
+        // Even a host whose numeric cap would say "ceiling" reports "cpu" here
+        // — the brake blocks dispatch THIS tick regardless of the cap.
+        assert_eq!(cpu_brake_held_host().admission_axis(), "cpu");
     }
 
     // ========================================================================
@@ -661,12 +862,10 @@ mod tests {
     }
 
     #[test]
-    fn advice_points_at_tokens_or_disk_when_those_bind() {
-        assert!(advice(&token_bound_host()).contains("loom-daemon tokens bootstrap"));
+    fn advice_points_at_disk_when_it_binds() {
         assert!(advice(&disk_bound_host()).contains("LOOM_PER_WORKTREE_GB"));
-        // Neither should tell the operator to raise maxConcurrent — it would do
-        // nothing.
-        assert!(!advice(&token_bound_host()).contains("raise autonomous"));
+        // Must not tell the operator to raise maxConcurrent — it would do
+        // nothing while disk binds.
         assert!(!advice(&disk_bound_host()).contains("raise autonomous"));
     }
 
@@ -675,6 +874,25 @@ mod tests {
         let mut m = idle_worker_host();
         m.cpu_idle_fraction = None;
         assert!(advice(&m).contains("no CPU idle sample"));
+    }
+
+    #[test]
+    fn advice_points_at_ram_when_it_binds() {
+        assert!(advice(&ram_bound_host()).contains("LOOM_PER_WORKTREE_RAM_GB"));
+        // Must not tell the operator to raise maxConcurrent — it would do
+        // nothing while RAM binds.
+        assert!(!advice(&ram_bound_host()).contains("raise autonomous"));
+    }
+
+    #[test]
+    fn advice_names_the_cpu_brake_when_it_is_holding_ahead_of_the_numeric_cap() {
+        // The brake held-state must win even though this fixture's numeric cap
+        // (min(disk, ram, maxConcurrent)) would otherwise say "ceiling" — the
+        // brake is the real limiter this instant.
+        let text = advice(&cpu_brake_held_host());
+        assert!(text.contains("HOLDING"), "{text}");
+        assert!(text.contains("0.95"), "{text}");
+        assert!(!text.contains("raise autonomous"), "{text}");
     }
 
     // ========================================================================
@@ -770,6 +988,14 @@ mod tests {
         assert_eq!(m.to_json()["disk_headroom"], "unbounded");
     }
 
+    #[test]
+    fn ram_headroom_unbounded_renders_as_string_not_a_giant_int() {
+        let mut m = idle_worker_host();
+        m.ram_headroom = usize::MAX;
+        m.ram_free_gb = None;
+        assert_eq!(m.to_json()["ram_headroom"], "unbounded");
+    }
+
     // ========================================================================
     // Human report
     // ========================================================================
@@ -779,10 +1005,13 @@ mod tests {
         let text = report_human(&idle_worker_host());
         assert!(text.contains("loom-daemon calibrate"));
         assert!(text.contains("Dynamic concurrency cap: 3"));
-        assert!(text.contains("= min(healthy 6 × per-token 2 = 12, disk 36, maxConcurrent 3)"));
-        assert!(text.contains("binds on: ceiling"));
+        assert!(text.contains("= min(disk 36, ram 40, maxConcurrent 3)"));
+        assert!(text.contains("informational only"));
+        assert!(text.contains("cap binds on: ceiling"));
+        assert!(text.contains("admission blocked by"));
         assert!(text.contains("build slots:    1"));
         assert!(text.contains("LOOM_PER_WORKTREE_GB"));
+        assert!(text.contains("LOOM_PER_WORKTREE_RAM_GB"));
         assert!(text.contains("read-only"));
         assert!(text.contains("loom-daemon-start.sh"));
     }

--- a/loom-daemon/src/capacity.rs
+++ b/loom-daemon/src/capacity.rs
@@ -1,10 +1,24 @@
 //! Token-capacity backpressure + add-capacity advisory for the autonomous work
 //! finder (Issue #3902, epic #3809).
 //!
-//! The work finder (#3810) drives approved `loom:issue` work to dispatch, and
-//! #3811 bounds its concurrency by `min(token-pool size, disk headroom,
-//! configured max)` (a CPU/load term sat in that `min` from #3978 until #4512
-//! removed it). That policy treats the token pool as a flat count of
+//! **Historical note (superseded by #5270):** the work finder (#3810) drives
+//! approved `loom:issue` work to dispatch, and #3811 originally bounded its
+//! concurrency by `min(token-pool size, disk headroom, configured max)` (a
+//! CPU/load term sat in that `min` from #3978 until #4512 removed it). #5270
+//! removed the token-pool term too, unconditionally on every auth path
+//! (operator direction: "we should only ever limit parallelism based on the
+//! machine disk/RAM/CPU" — a metered API key has no subscription window, and
+//! overage means even a subscription pool no longer hard-stops at one
+//! either). The dynamic cap is now `min(disk headroom, ram headroom,
+//! configured max)` — see
+//! [`crate::work_finder::resolve_dynamic_max_concurrent`]. This module's
+//! machinery ([`token_axis_limit`], [`assess_pressure`], the add-capacity
+//! advisory below) is **not** deleted: it still drives spawn-time account
+//! *selection* (prefer fresher/healthier accounts, skip exhausted/blocked
+//! ones) and a softer, non-gating capacity advisory, described below as it
+//! worked pre-#5270 with the gating role removed.
+//!
+//! That policy treats the token pool as a flat count of
 //! `*.token` files — but at scale accounts hit their 5h/7d rate limits and go
 //! **exhausted**. Dispatching to an exhausted account produces the startup
 //! hangs / mid-build deaths seen while dogfooding. This module makes the
@@ -352,12 +366,21 @@ where
 
 /// The health-adjusted token-axis concurrency limit.
 ///
-/// When ranking data exists, this is the count of `available` accounts — the
-/// finder never dispatches beyond the healthy set, so it never targets an
-/// exhausted/blocked account and never over-subscribes. When ranking data is
-/// absent (no probe has run), it falls back to `pool_size` — the pre-#3902
-/// behavior, so a repo that has not wired up `loom-daemon tokens check` sees zero
-/// change.
+/// When ranking data exists, this is the count of `available` accounts —
+/// **historically** the finder never dispatched beyond the healthy set, so it
+/// never targeted an exhausted/blocked account and never over-subscribed.
+/// When ranking data is absent (no probe has run), it falls back to
+/// `pool_size` — the pre-#3902 behavior, so a repo that has not wired up
+/// `loom-daemon tokens check` sees zero change.
+///
+/// **Since #5270 this value no longer bounds admission at all** — operator
+/// direction: "we should only ever limit parallelism based on the machine
+/// disk/RAM/CPU," on any auth path. `crate::work_finder::resolve_dynamic_max_concurrent`
+/// dropped the token-axis term from its `min(...)` entirely. This function's
+/// output remains meaningful as the **selection** input
+/// (`crate::tokens_pool::select` prefers fresher/healthier accounts and skips
+/// exhausted/blocked ones) and as an informational figure on the
+/// `status`/`calibrate` surfaces — never again as a concurrency ceiling.
 #[must_use]
 pub fn token_axis_limit(workspace_root: &Path, pool_size: usize) -> usize {
     match read_ranking(workspace_root) {

--- a/loom-daemon/src/cli/status.rs
+++ b/loom-daemon/src/cli/status.rs
@@ -750,6 +750,7 @@ pub(crate) mod status_client_tests {
             token_pool_size: 4,
             token_pool_dir: Some(std::path::PathBuf::from("/repo/a/.loom/tokens")),
             disk_headroom: 10,
+            ram_headroom: 10,
             logical_cpus: 8,
             loadavg_1m: Some(1.25),
             cpu_idle_fraction: Some(0.90),

--- a/loom-daemon/src/cli/status_render.rs
+++ b/loom-daemon/src/cli/status_render.rs
@@ -34,13 +34,21 @@ struct ResolvedCapacity {
     healthy: usize,
     exhausted: usize,
     /// Health-adjusted token axis (healthy accounts, or the raw pool as a
-    /// fallback) — the "healthy tokens" input to the dynamic concurrency cap.
+    /// fallback) — an *informational* account-health figure (drives spawn-time
+    /// selection), not a cap input since #5270.
     token_axis_limit: usize,
-    /// The effective dynamic cap consistent with `token_axis_limit`:
-    /// `min(token_axis_limit, disk_headroom, configured_max)` (the CPU term
-    /// added in #3978 was removed in #4512).
+    /// The effective dynamic cap. Always exactly `report.dynamic_cap` (#5270)
+    /// — the token axis was removed from the admission formula entirely, so
+    /// there is nothing left for a client-side probe to recompute here; using
+    /// the daemon's own authoritative figure guarantees this can never drift
+    /// from what `min(disk, ram, configured_max)` actually evaluates to,
+    /// unlike the pre-#5270 client-side `token_axis_effective.min(...)`
+    /// recomputation this superseded (which could disagree with the daemon
+    /// when accounts were scarce).
     effective_cap: usize,
-    /// Whether the token axis is the binding (minimum) constraint.
+    /// Whether the token axis is the binding (minimum) constraint. Always
+    /// `false` since #5270 — mirrors `report.capacity.token_bound`, which the
+    /// daemon itself now always reports as `false` for the same reason.
     token_bound: bool,
 }
 
@@ -68,20 +76,15 @@ fn resolve_capacity(
                 .collect();
             let cap = loom_daemon::capacity::summarize_probe(pairs.iter().copied());
             let token_axis_limit = cap.healthy;
-            // The token axis of the cap is `healthy × per-token` (#3947); treat a
-            // pre-#3947 wire `0` as the effective floor of 1.
-            let factor = report.per_token_concurrency.max(1);
-            let token_axis_effective = token_axis_limit.saturating_mul(factor);
-            // #4512: the cap is min(token axis, disk, configured max). A
-            // pre-#4512 daemon still SENDS a `cpu_headroom` field; serde ignores
-            // it, and we deliberately do not reintroduce it into the client-side
-            // recomputation — the daemon's own `dynamic_cap` (shown as the
-            // headline below) remains the authority either way.
-            let effective_cap = token_axis_effective
-                .min(report.disk_headroom)
-                .min(report.configured_max);
-            let token_bound = token_axis_effective <= report.disk_headroom
-                && token_axis_effective <= report.configured_max;
+            // #5270: the token axis no longer participates in the cap on any
+            // auth path — a fresh client-side probe changes the *reported*
+            // account-health figures (total/healthy/exhausted/token_axis_limit
+            // above), but must NOT re-derive its own `effective_cap` /
+            // `token_bound` from them the way the pre-#5270 formula did (that
+            // recomputation could disagree with the daemon whenever accounts
+            // were scarce, which is exactly the artificial cap this issue
+            // removes). The daemon's own `dynamic_cap` — `min(disk, ram,
+            // configured_max)` — is the sole authority.
             return ResolvedCapacity {
                 source: "probe",
                 ranking_present: true,
@@ -89,8 +92,8 @@ fn resolve_capacity(
                 healthy: cap.healthy,
                 exhausted: cap.exhausted,
                 token_axis_limit,
-                effective_cap,
-                token_bound,
+                effective_cap: report.dynamic_cap,
+                token_bound: false,
             };
         }
     }
@@ -194,9 +197,16 @@ pub(crate) fn build_status_json_value(
             // whatever cwd `loom-daemon status` itself was run from.
             "token_pool_dir": report.token_pool_dir,
             "disk_headroom": report.disk_headroom,
+            // RAM headroom (#5270) — the second machine-headroom cap term
+            // alongside disk_headroom, since the token axis stopped bounding
+            // admission on any auth path.
+            "ram_headroom": report.ram_headroom,
             // Host CPU OBSERVATIONS (#3978/#4031), not cap terms: #4512 removed
             // the CPU headroom term from admission. Reported because observed
             // idle is the evidence for tuning `configured_max` on this machine.
+            // The separate CPU saturation admission brake (#4903, retuned by
+            // #5270) DOES gate admission — see the `admission_brake` block
+            // below for its live held/threshold state.
             "logical_cpus": report.logical_cpus,
             "loadavg_1m": report.loadavg_1m,
             "cpu_idle_fraction": report.cpu_idle_fraction,
@@ -913,24 +923,16 @@ pub(crate) fn print_status_human(
     let dispatch_token_axis = report.capacity.token_axis_limit;
     println!("\nDynamic concurrency cap: {dispatch_cap}  (the number dispatch uses)");
     println!(
-        "  = min(healthy {} × per-token {} = {}, disk headroom {}, \
-         configured max {})",
+        "  = min(disk headroom {}, ram headroom {}, configured max {})",
+        report.disk_headroom, report.ram_headroom, report.configured_max
+    );
+    println!(
+        "  (healthy {} × per-token {} = {} is informational only — the token axis no longer \
+         bounds the cap, #5270)",
         dispatch_token_axis,
         factor,
         dispatch_token_axis.saturating_mul(factor),
-        report.disk_headroom,
-        report.configured_max
     );
-    if rc.source == "probe" && rc.effective_cap != dispatch_cap {
-        println!(
-            "  fresh probe suggests: {} (healthy {} × per-token {} = {}) — not yet reflected in \
-             dispatch; if this persists, refresh with `loom-daemon tokens check --ranking`.",
-            rc.effective_cap,
-            rc.token_axis_limit,
-            factor,
-            rc.token_axis_limit.saturating_mul(factor)
-        );
-    }
     // Host CPU OBSERVATION (#3978 AC4; measured-idle signal #4031) — since
     // #4512 this is deliberately NOT a cap term: it is the evidence an operator
     // uses to decide whether this machine's `maxConcurrent` should go up (host
@@ -979,16 +981,17 @@ pub(crate) fn print_status_human(
     // the daemon itself used, which previously let "not capacity-bound" print
     // even while the daemon's real (lower) cap was already saturated.
     let capacity_bound = report.in_flight.len() >= dispatch_cap;
-    // #4344: the daemon's own dispatch decision reads 0 healthy accounts while
-    // a fresher probe (or the raw pool) shows real capacity — the exact
-    // wedge this issue exists for. When this holds, promote the diagnosis to
-    // the headline and suppress the misleading "limiter is work availability"
-    // line below (the limiter is unmistakably the token term: `0 × per-token
-    // = 0`).
-    let dispatch_starved_but_disagrees = report.capacity.ranking_present
-        && report.capacity.healthy_accounts == 0
-        && rc.ranking_present
-        && rc.healthy > 0;
+    // #4344 (superseded by #5270): this used to promote to a headline warning
+    // when the daemon's own dispatch decision read 0 healthy accounts while a
+    // fresher probe (or the raw pool) showed real capacity — "0 healthy ×
+    // per-token = 0" really was the binding cap term back then. Since #5270
+    // the token axis no longer participates in `dynamic_cap` on any auth
+    // path, so 0 healthy accounts alone can never starve dispatch any more —
+    // hard-coding this to `false` (rather than deleting the branch) keeps the
+    // #4344 diagnosis machinery in place as dead code documenting the prior
+    // behavior, without ever printing the now-categorically-false
+    // "DISPATCH IS TOKEN-STARVED" headline again.
+    let dispatch_starved_but_disagrees = false;
     // #4903: while the saturation admission brake is holding, "the limiter is
     // work availability" is flatly wrong and is the exact misread the issue was
     // filed on — a worker at 12× overcommit rendered as an idle host with nine
@@ -1064,7 +1067,7 @@ pub(crate) fn print_status_human(
                 } else if !report.preflight_advisory_active {
                     println!(
                         "  not capacity-bound ({} in flight, cap {dispatch_cap} — the limiter is \
-                         work availability, not tokens/disk/CPU)",
+                         work availability, not disk/RAM/CPU)",
                         report.in_flight.len(),
                     );
                 }

--- a/loom-daemon/src/event_bus.rs
+++ b/loom-daemon/src/event_bus.rs
@@ -37,7 +37,7 @@
 //! | `daemon.drain.completed` | Drain supervisor | `{in_flight}` (always 0) |
 //! | `daemon.drain.aborted`   | Daemon (IPC) | `{was_draining}` |
 //! | `daemon.drain.timeout`   | Drain supervisor | `{in_flight, forced, cancelled?}` |
-//! | `daemon.dispatch.headroom_advisory` | Daemon (IPC, `dispatch_sweep`) | `{repo_root, low_headroom, occupancy, dynamic_cap, cpu_headroom, disk_headroom, token_axis_limit, message}` |
+//! | `daemon.dispatch.headroom_advisory` | Daemon (IPC, `dispatch_sweep`) | `{repo_root, low_headroom, occupancy, dynamic_cap, disk_headroom, ram_headroom, token_axis_limit, message}` |
 //! | `daemon.preflight.advisory` | Daemon reaper (`SweepRegistry`) | `{workspace_root, consecutive_deaths, marker, message}` |
 //!
 //! New topics require a follow-up issue — the taxonomy is intentionally

--- a/loom-daemon/src/health.rs
+++ b/loom-daemon/src/health.rs
@@ -947,24 +947,36 @@ pub fn classify_missing_tick(inputs: &HealthInputs, status: &DaemonStatusReport)
 }
 
 /// Whether `disk_headroom` is the **strictly** binding term of the dynamic
-/// concurrency cap `min(token_axis, disk_headroom, configured_max)` (#5177).
+/// concurrency cap `min(disk_headroom, ram_headroom, configured_max)` (#5177;
+/// token axis removed / ram_headroom added in #5270 — see
+/// [`crate::work_finder::resolve_dynamic_max_concurrent`]).
 ///
-/// True only when disk headroom is smaller than *both* other terms — i.e. the
-/// scratch volume is throttling dispatch below what the token pool and the
-/// operator's configured admission ceiling would otherwise allow. A tie with
-/// `configured_max` is deliberately NOT flagged: that ceiling is the operator's
-/// own deliberate choice, not a disk fault. Mirrors the input shape of
+/// True when disk headroom is at most RAM headroom (a tie resolves to disk,
+/// matching [`crate::calibrate::binding_term`]'s tie-break order) AND
+/// strictly smaller than the operator's configured admission ceiling — i.e.
+/// the scratch volume is throttling dispatch below what `configured_max`
+/// would otherwise allow. A tie **with the ceiling** is deliberately NOT
+/// flagged: that ceiling is the operator's own deliberate choice, not a disk
+/// fault. Mirrors the input shape of
 /// [`crate::work_finder::resolve_dynamic_max_concurrent`] so the two agree on
 /// what "binding" means.
 #[must_use]
-pub fn disk_binds_cap(
-    token_axis_limit: usize,
-    per_token_concurrency: usize,
-    disk_headroom: usize,
-    configured_max: usize,
-) -> bool {
-    let token_axis = token_axis_limit.saturating_mul(per_token_concurrency.max(1));
-    disk_headroom < token_axis && disk_headroom < configured_max
+pub fn disk_binds_cap(disk_headroom: usize, ram_headroom: usize, configured_max: usize) -> bool {
+    disk_headroom <= ram_headroom && disk_headroom < configured_max
+}
+
+/// Whether `ram_headroom` is the **uniquely** binding term of the dynamic
+/// concurrency cap (#5270) — the RAM-headroom mirror of [`disk_binds_cap`].
+///
+/// True only when RAM headroom is strictly smaller than **both** the disk
+/// headroom and the operator's configured admission ceiling. A tie with disk
+/// resolves to [`disk_binds_cap`] instead (mirroring
+/// [`crate::calibrate::binding_term`]'s tie-break order), keeping the two
+/// predicates mutually exclusive so `assess_dispatch` never double-reports
+/// the same throttling event under both names.
+#[must_use]
+pub fn ram_binds_cap(disk_headroom: usize, ram_headroom: usize, configured_max: usize) -> bool {
+    ram_headroom < disk_headroom && ram_headroom < configured_max
 }
 
 /// Assess the dispatch section: in-flight occupancy against the dynamic cap,
@@ -1008,19 +1020,46 @@ pub fn assess_dispatch(inputs: &HealthInputs) -> HealthSection {
     }
     // #5177: a small-disk host silently decays as merged worktrees leak their
     // multi-GB target/ dirs, until disk headroom becomes the binding term of the
-    // cap and throttles the host to a fraction of its token/config capacity. That
+    // cap and throttles the host to a fraction of its configured capacity. That
     // used to present as a green daemon dispatching at, say, cap 2 — a fault an
     // operator had to notice in the `min(...)` breakdown. Name it as degraded.
-    if disk_binds_cap(
-        status.capacity.token_axis_limit,
-        status.per_token_concurrency,
-        status.disk_headroom,
-        status.configured_max,
-    ) {
+    if disk_binds_cap(status.disk_headroom, status.ram_headroom, status.configured_max) {
         degraded.push(format!(
             "disk headroom is throttling dispatch (cap {} bound by disk headroom {} — free scratch \
              disk; e.g. `loom-daemon clean --aggressive` / `--deep`)",
             cap, status.disk_headroom
+        ));
+    }
+    // #5270: the RAM-headroom mirror of the #5177 disk case above — the second
+    // "dumb mode" machine-headroom axis, so a critically-low-memory host is
+    // named as degraded the same way a critically-low-disk host already is.
+    if ram_binds_cap(status.disk_headroom, status.ram_headroom, status.configured_max) {
+        degraded.push(format!(
+            "RAM headroom is throttling dispatch (cap {} bound by ram headroom {} — free memory \
+             or lower LOOM_PER_WORKTREE_RAM_GB, #5270)",
+            cap, status.ram_headroom
+        ));
+    }
+    // #5270: name the machine axis (max/disk/RAM/CPU) currently HOLDING new
+    // admissions outright — the CPU saturation admission brake is a
+    // point-in-time gate outside the `min(...)` cap formula (see
+    // `crate::admission_brake`'s module docs for why), so it cannot be named
+    // by `disk_binds_cap` / `ram_binds_cap` above; it is checked independently
+    // here, mirroring the host-distress breaker check above it.
+    if status.admission_brake.as_ref().is_some_and(|b| b.held) {
+        let load = status
+            .admission_brake
+            .as_ref()
+            .and_then(|b| b.load_per_core)
+            .map_or_else(|| "n/a".to_string(), |l| format!("{l:.2}"));
+        let threshold = status
+            .admission_brake
+            .as_ref()
+            .map_or(0.0, |b| b.load_per_core_threshold);
+        degraded.push(format!(
+            "CPU saturation admission brake HOLDING new admissions (load {load}/core \u{2265} \
+             {threshold:.2} — in-flight sweeps are untouched; releases automatically once load \
+             drops, #5270/#4903)"
         ));
     }
 
@@ -2632,20 +2671,44 @@ mod tests {
             .contains("12 seen, 2 dispatched, 10 in-flight-skip"));
     }
 
-    /// #5177 AC4: `disk_binds_cap` is the strict-minimum test — disk must be
-    /// smaller than BOTH other terms, never merely tied.
+    /// #5177 AC4 (re-scoped #5270): `disk_binds_cap` is the strict-minimum
+    /// test against `configured_max` (never merely tied), and ties WITH ram
+    /// resolve to disk (matching `calibrate::binding_term`'s tie-break order).
+    /// The token axis no longer participates in the cap at all.
     #[test]
-    fn disk_binds_cap_only_when_strictly_smallest() {
-        // token axis = 6 × 2 = 12, configured 12, disk 2 → disk binds.
-        assert!(disk_binds_cap(6, 2, 2, 12));
+    fn disk_binds_cap_only_when_smallest_or_tied_with_ram() {
+        // disk 2 < ram (unbounded) and < configured 12 → disk binds.
+        assert!(disk_binds_cap(2, usize::MAX, 12));
         // disk ties configured_max → operator's own ceiling, not a disk fault.
-        assert!(!disk_binds_cap(6, 2, 12, 12));
-        // disk larger than the token axis → tokens bind, not disk.
-        assert!(!disk_binds_cap(1, 1, 5, 12));
-        // per-token 0 is clamped to 1 (mirrors resolve_dynamic_max_concurrent).
-        assert!(disk_binds_cap(6, 0, 2, 12));
-        // the healthy default fixture (disk 0, configured 0) must NOT trip it.
-        assert!(!disk_binds_cap(6, 0, 0, 0));
+        assert!(!disk_binds_cap(12, usize::MAX, 12));
+        // disk larger than configured_max → the ceiling binds, not disk.
+        assert!(!disk_binds_cap(5, usize::MAX, 1));
+        // disk larger than ram → ram binds, not disk (see ram_binds_cap below).
+        assert!(!disk_binds_cap(5, 2, 12));
+        // disk ties ram (both smaller than configured_max) → disk wins the tie.
+        assert!(disk_binds_cap(3, 3, 12));
+        // the healthy default fixture (disk 0, ram 0, configured 0) must NOT
+        // trip it — a 0/0/0 tie is "unconfigured", not "throttling".
+        assert!(!disk_binds_cap(0, 0, 0));
+    }
+
+    /// #5270: `ram_binds_cap` is the RAM-headroom mirror of the disk test
+    /// above — RAM must be the UNIQUE smallest term (a tie resolves to disk).
+    #[test]
+    fn ram_binds_cap_only_when_uniquely_smallest() {
+        // ram 2 < disk (unbounded) and < configured 12 → ram binds.
+        assert!(ram_binds_cap(usize::MAX, 2, 12));
+        // ram ties configured_max → operator's own ceiling, not a ram fault.
+        assert!(!ram_binds_cap(usize::MAX, 12, 12));
+        // ram larger than configured_max → the ceiling binds, not ram.
+        assert!(!ram_binds_cap(usize::MAX, 5, 1));
+        // ram larger than disk → disk binds, not ram.
+        assert!(!ram_binds_cap(2, 5, 12));
+        // ram ties disk → disk wins the tie (not flagged as ram).
+        assert!(!ram_binds_cap(3, 3, 12));
+        // the healthy default fixture (disk 0, ram 0, configured 0) must NOT
+        // trip it.
+        assert!(!ram_binds_cap(0, 0, 0));
     }
 
     /// #5177 AC4: when disk headroom is the binding cap term, the dispatch
@@ -2657,9 +2720,10 @@ mod tests {
         {
             let status = inputs.status.as_mut().unwrap();
             status.capacity.token_axis_limit = 6;
-            status.per_token_concurrency = 2; // token axis = 12
+            status.per_token_concurrency = 2; // token axis = 12 (informational only)
             status.configured_max = 12;
             status.disk_headroom = 2; // strictly the smallest term
+            status.ram_headroom = 40; // ample RAM — must not also fire
             status.dynamic_cap = 2;
         }
         let section = assess_dispatch(&inputs);
@@ -2671,17 +2735,96 @@ mod tests {
         );
     }
 
+    /// #5270: the RAM-headroom mirror of the disk test above — a critically-low
+    /// available-memory host must be named as degraded the same way a
+    /// critically-low-disk host already is.
+    #[test]
+    fn ram_bound_cap_produces_degraded_verdict_naming_ram() {
+        let mut inputs = healthy_inputs();
+        {
+            let status = inputs.status.as_mut().unwrap();
+            status.configured_max = 12;
+            status.disk_headroom = 40; // ample disk — must not also fire
+            status.ram_headroom = 1; // strictly the smallest term
+            status.dynamic_cap = 1;
+        }
+        let section = assess_dispatch(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(
+            section.summary.to_lowercase().contains("ram"),
+            "summary must name ram: {}",
+            section.summary
+        );
+    }
+
+    /// #5270: a host where the CPU saturation admission brake is HOLDING new
+    /// admissions must be named as degraded, even when the numeric disk/ram/
+    /// ceiling terms are all comfortably ample — the brake is a point-in-time
+    /// gate outside the `min(...)` formula (see `crate::admission_brake`).
+    #[test]
+    fn cpu_brake_held_produces_degraded_verdict_naming_cpu() {
+        let mut inputs = healthy_inputs();
+        {
+            let status = inputs.status.as_mut().unwrap();
+            status.configured_max = 12;
+            status.disk_headroom = 40;
+            status.ram_headroom = 40;
+            status.dynamic_cap = 12;
+            status.admission_brake = Some(crate::types::AdmissionBrakeStatus {
+                enabled: true,
+                held: true,
+                load_per_core: Some(1.10),
+                load_per_core_threshold: 0.95,
+                held_since: None,
+                held_ticks: 3,
+            });
+        }
+        let section = assess_dispatch(&inputs);
+        assert_eq!(section.verdict, Verdict::Degraded);
+        assert!(
+            section.summary.to_lowercase().contains("cpu"),
+            "summary must name cpu: {}",
+            section.summary
+        );
+        assert!(section.summary.contains("1.10"), "{}", section.summary);
+    }
+
+    /// #5270: a brake that exists but is NOT holding must not itself degrade
+    /// the section (mirrors the existing disk/ram negative test below).
+    #[test]
+    fn cpu_brake_not_holding_is_not_flagged() {
+        let mut inputs = healthy_inputs();
+        {
+            let status = inputs.status.as_mut().unwrap();
+            status.configured_max = 12;
+            status.disk_headroom = 40;
+            status.ram_headroom = 40;
+            status.dynamic_cap = 12;
+            status.admission_brake = Some(crate::types::AdmissionBrakeStatus {
+                enabled: true,
+                held: false,
+                load_per_core: Some(0.10),
+                load_per_core_threshold: 0.95,
+                held_since: None,
+                held_ticks: 0,
+            });
+        }
+        let section = assess_dispatch(&inputs);
+        assert_eq!(section.verdict, Verdict::Green);
+    }
+
     /// #5177 AC4 (negative): a cap bound by the operator's configured ceiling
-    /// (disk headroom ample) stays green — disk is not the culprit there.
+    /// (disk/ram headroom ample) stays green — neither is the culprit there.
     #[test]
     fn config_bound_cap_is_not_flagged_as_disk() {
         let mut inputs = healthy_inputs();
         {
             let status = inputs.status.as_mut().unwrap();
             status.capacity.token_axis_limit = 6;
-            status.per_token_concurrency = 2; // token axis = 12
+            status.per_token_concurrency = 2; // token axis = 12 (informational only)
             status.configured_max = 4; // operator's own ceiling binds
             status.disk_headroom = 50; // plenty of disk
+            status.ram_headroom = 50; // plenty of ram
             status.dynamic_cap = 4;
         }
         let section = assess_dispatch(&inputs);

--- a/loom-daemon/src/ipc.rs
+++ b/loom-daemon/src/ipc.rs
@@ -1630,6 +1630,9 @@ pub fn build_daemon_status(
     // re-resolving a possibly-different one.
     let token_pool_dir = Some(tokens_dir.clone());
     let disk_headroom = crate::disk_headroom::disk_headroom_limit(workspace_root);
+    // RAM headroom (#5270): the second "dumb mode" machine-headroom axis,
+    // folded into `dynamic_cap` alongside disk headroom.
+    let ram_headroom = crate::ram_headroom::ram_headroom_limit();
     let wf_config = crate::work_finder::read_work_finder_config(workspace_root);
     let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
     let per_token_concurrency = crate::work_finder::resolve_per_token_concurrency(&wf_config);
@@ -1650,18 +1653,15 @@ pub fn build_daemon_status(
     let ranking = crate::capacity::read_ranking_at(&tokens_dir);
     let token_axis_limit = ranking.as_ref().map_or(token_pool_size, |r| r.available);
     let dynamic_cap = crate::work_finder::resolve_dynamic_max_concurrent(
-        token_axis_limit,
-        per_token_concurrency,
         disk_headroom,
+        ram_headroom,
         configured_max,
     );
-    // The token axis of the cap is `healthy × per-token` (#3947), so it is the
-    // binding constraint only when that *product* is the minimum across every
-    // remaining axis — disk and the configured ceiling (#4512 removed the CPU
-    // axis).
-    let token_axis_effective = token_axis_limit.saturating_mul(per_token_concurrency.max(1));
-    let token_bound =
-        token_axis_effective <= disk_headroom && token_axis_effective <= configured_max;
+    // The token axis no longer bounds the cap (#5270) — `token_bound` is
+    // therefore always `false`. `token_axis_limit` / `per_token_concurrency`
+    // remain on the report as informational account-health figures (they still
+    // drive spawn-time *selection*), but neither one gates admission any more.
+    let token_bound = false;
     // "Currently binding" vs "smallest ceiling" (#4031): the dynamic cap is the
     // minimum of several ceilings, but a ceiling only *binds* once in-flight
     // occupancy reaches it. Below the cap the limiter is work availability, not
@@ -1695,6 +1695,7 @@ pub fn build_daemon_status(
         token_pool_size,
         token_pool_dir,
         disk_headroom,
+        ram_headroom,
         logical_cpus,
         loadavg_1m,
         cpu_idle_fraction,
@@ -2049,12 +2050,14 @@ fn resolve_dispatch_registry(
 // # Nothing blocking under the registry lock
 //
 // The `DispatchSweep` arm holds the registry mutex from just after this
-// assessment through the dispatch call, so nothing here may block. Since #4512
-// the headroom is `min(token axis, disk, configured max)` — three cheap
-// filesystem/config reads, no CPU sampling at all. (Before #4512 this had to
+// assessment through the dispatch call, so nothing here may block. Since #5270
+// the headroom is `min(disk, ram, configured max)` — cheap filesystem/config
+// reads (plus a non-sleeping `/proc/meminfo` read or a flag-less `vm_stat`
+// snapshot on macOS), no CPU sampling at all. (Before #4512 this had to
 // carefully avoid `cpu_headroom_limit`, whose macOS `iostat` refresh sleeps ~1s
 // and would have stalled every other IPC request on the same registry for that
-// second; removing the CPU term removed that hazard outright.)
+// second; removing the CPU term removed that hazard outright, and RAM headroom
+// deliberately preserves the same non-blocking contract.)
 
 /// Per-repo dynamic-cap headroom snapshot computed for a `dispatch_sweep`
 /// request (#4234). Mirrors the inputs `build_daemon_status` already exposes
@@ -2063,9 +2066,12 @@ fn resolve_dispatch_registry(
 struct DispatchHeadroom {
     /// Live (non-terminal) sweep count already registered for this repo.
     occupancy: usize,
-    /// `resolve_dynamic_max_concurrent` — min(token axis, disk, configured max).
+    /// `resolve_dynamic_max_concurrent` — min(disk, ram, configured max). The
+    /// token axis no longer participates (#5270); `token_axis_limit` below is
+    /// kept as an informational account-health figure only.
     dynamic_cap: usize,
     disk_headroom: usize,
+    ram_headroom: usize,
     token_axis_limit: usize,
 }
 
@@ -2084,15 +2090,15 @@ fn assess_dispatch_headroom(sr: &mut SweepRegistry, repo_root: &Path) -> Dispatc
 
     let wf_config = crate::work_finder::read_work_finder_config(repo_root);
     let configured_max = crate::work_finder::resolve_max_concurrent_with_config(&wf_config);
-    let per_token_concurrency = crate::work_finder::resolve_per_token_concurrency(&wf_config);
     let disk_headroom = crate::disk_headroom::disk_headroom_limit(repo_root);
+    let ram_headroom = crate::ram_headroom::ram_headroom_limit();
     let token_pool_size = crate::tokens::token_pool_size(repo_root);
     let ranking = crate::capacity::read_ranking(repo_root);
+    // Informational only since #5270 — no longer part of the dynamic cap.
     let token_axis_limit = ranking.as_ref().map_or(token_pool_size, |r| r.available);
     let dynamic_cap = crate::work_finder::resolve_dynamic_max_concurrent(
-        token_axis_limit,
-        per_token_concurrency,
         disk_headroom,
+        ram_headroom,
         configured_max,
     );
 
@@ -2100,6 +2106,7 @@ fn assess_dispatch_headroom(sr: &mut SweepRegistry, repo_root: &Path) -> Dispatc
         occupancy,
         dynamic_cap,
         disk_headroom,
+        ram_headroom,
         token_axis_limit,
     }
 }
@@ -2184,12 +2191,14 @@ fn dispatch_headroom_message(
         format!(
             "dispatch_sweep: dispatching {kind:?} into {} while occupancy is at/over the \
              computed dynamic-cap headroom (occupancy={} >= dynamic_cap={}; \
-             disk_headroom={}, token_axis_limit={}) — advisory only per #4234 (dispatch \
+             disk_headroom={}, ram_headroom={}, token_axis_limit={} [informational only, not \
+             capacity-limiting since #5270]) — advisory only per #4234 (dispatch \
              proceeds; the autonomous work finder's own cap is unaffected)",
             repo_root.display(),
             h.occupancy,
             h.dynamic_cap,
             h.disk_headroom,
+            h.ram_headroom,
             h.token_axis_limit
         )
     } else {
@@ -2238,6 +2247,7 @@ fn emit_dispatch_headroom_advisory_on_change(
             "occupancy": h.occupancy,
             "dynamic_cap": h.dynamic_cap,
             "disk_headroom": h.disk_headroom,
+            "ram_headroom": h.ram_headroom,
             "token_axis_limit": h.token_axis_limit,
             "message": message,
         }),
@@ -2995,12 +3005,14 @@ fn handle_request(
             };
             log::info!(
                 "dispatch_sweep: {:?} with{} model={resolved_model} (source={model_source_label}); \
-                 headroom occupancy={} dynamic_cap={} (disk={} tokens={})",
+                 headroom occupancy={} dynamic_cap={} (disk={} ram={} tokens={} [informational \
+                 only, not capacity-limiting since #5270])",
                 kind,
                 arm.map_or_else(String::new, |a| format!(" arm={a}")),
                 headroom.occupancy,
                 headroom.dynamic_cap,
                 headroom.disk_headroom,
+                headroom.ram_headroom,
                 headroom.token_axis_limit
             );
             match sr.dispatch(
@@ -3879,6 +3891,7 @@ exit 0
             occupancy,
             dynamic_cap,
             disk_headroom: 10,
+            ram_headroom: 10,
             token_axis_limit: 5,
         }
     }
@@ -3905,6 +3918,7 @@ exit 0
             occupancy: 4,
             dynamic_cap: 3,
             disk_headroom: 9,
+            ram_headroom: 7,
             token_axis_limit: 6,
         };
         let kind = SweepKind::Issue(123);
@@ -3914,6 +3928,7 @@ exit 0
         assert!(entered.contains("occupancy=4"), "{entered}");
         assert!(entered.contains("dynamic_cap=3"), "{entered}");
         assert!(entered.contains("disk_headroom=9"), "{entered}");
+        assert!(entered.contains("ram_headroom=7"), "{entered}");
         assert!(entered.contains("token_axis_limit=6"), "{entered}");
         assert!(entered.contains("123"), "{entered}");
         assert!(entered.contains("advisory only"), "{entered}");
@@ -5756,6 +5771,7 @@ exit 0
             token_pool_size: 4,
             token_pool_dir: Some(std::path::PathBuf::from("/repo/a/.loom/tokens")),
             disk_headroom: 10,
+            ram_headroom: 10,
             logical_cpus: 8,
             loadavg_1m: Some(1.25),
             cpu_idle_fraction: Some(0.90),
@@ -6267,9 +6283,26 @@ exit 0
         let report = build_daemon_status(&pool, &health, &root, &test_credential_preflight());
         assert!(!report.main_health_gate_halted);
         assert!(report.in_flight.is_empty());
-        // The tempdir has no `.loom/tokens/`, so the pool + dynamic cap are 0.
+        // The tempdir has no `.loom/tokens/`, so the pool is 0 — but since
+        // #5270 the token axis no longer participates in the dynamic cap, so
+        // an empty token pool no longer pins `dynamic_cap` to 0. The cap is
+        // `min(disk_headroom, ram_headroom, configured_max)`, where
+        // `configured_max` is resolved the same way `build_daemon_status`
+        // resolves it (not assumed to be the built-in default — a host-level
+        // config tier may set it, exactly the ambient config this assertion
+        // must tolerate).
         assert_eq!(report.token_pool_size, 0);
-        assert_eq!(report.dynamic_cap, 0);
+        let expected_configured_max = crate::work_finder::resolve_max_concurrent_with_config(
+            &crate::work_finder::read_work_finder_config(&root),
+        );
+        assert_eq!(
+            report.dynamic_cap,
+            report
+                .disk_headroom
+                .min(report.ram_headroom)
+                .min(expected_configured_max),
+            "dynamic cap is min(disk, ram, configured_max) regardless of the empty token pool"
+        );
         // #4345: a pool that never called start_safehouse_narration /
         // start_peer_coordination still reports a live safehouse state — the
         // cell's own default, not a missing/`None` field.

--- a/loom-daemon/src/lib.rs
+++ b/loom-daemon/src/lib.rs
@@ -172,6 +172,7 @@ pub mod phase_join;
 pub mod pipeline_snapshot;
 pub mod primary_checkout_reaper;
 pub mod quarantine_reconciliation;
+pub mod ram_headroom;
 pub mod rate_limit_breaker;
 pub mod repo_root;
 pub mod role_collision;

--- a/loom-daemon/src/ram_headroom.rs
+++ b/loom-daemon/src/ram_headroom.rs
@@ -1,0 +1,304 @@
+//! RAM-headroom math for the autonomous work finder (#5270 — "dumb mode").
+//!
+//! # Why this exists
+//!
+//! #5270 removed the token axis from the dynamic concurrency cap entirely
+//! (operator direction: "we should only ever limit parallelism based on the
+//! machine disk/RAM/CPU" — a metered API key or an overage-enabled
+//! subscription pool has no exhaustible per-account ceiling worth modeling).
+//! Disk headroom ([`crate::disk_headroom`]) and the CPU saturation admission
+//! brake ([`crate::admission_brake`]) already covered two of those three
+//! machine axes; this module is the third — the available-RAM analog of
+//! [`crate::disk_headroom`], mirroring its shape exactly:
+//!
+//! - [`available_ram_gb`] reads the host's currently-available memory (not
+//!   total — "available" already accounts for the kernel's own reclaimable
+//!   caches/buffers, so it is the number a scheduler should compare against,
+//!   the same distinction `free -h`'s `available` column makes over `free`).
+//!   `None` means the probe was unmeasurable, not that 0 GB is available
+//!   (mirrors disk headroom's #4164 "unknown != zero" policy).
+//! - [`ram_headroom`] is the pure floor-division term: how many worktrees
+//!   `available_gb` can host at `LOOM_PER_WORKTREE_RAM_GB` each.
+//! - [`ram_headroom_limit`] combines the two, and — exactly like
+//!   [`crate::disk_headroom::disk_headroom_limit`] — SKIPS the clamp
+//!   (`usize::MAX`) when the probe is unmeasurable, so an unsupported
+//!   platform or a missing `/proc/meminfo` never silently pins concurrency
+//!   to 0.
+//!
+//! # Why read `/proc/meminfo` / shell to `vm_stat` instead of a `sysinfo`-style
+//! # crate
+//!
+//! Same precedent as [`crate::disk_headroom`] (shell to `df`) and
+//! [`crate::cpu_headroom`] (read `/proc/stat` / shell to `iostat`): no new
+//! crate dependency, OS-native sources kept small and split into pure parsing
+//! functions ([`parse_meminfo_available_kb`], [`parse_vm_stat_available_pages`])
+//! so the arithmetic is unit-testable without a real host.
+//!
+//! - **Linux** reads `MemAvailable` directly from `/proc/meminfo` — the
+//!   kernel's own estimate of memory available for new allocations without
+//!   swapping (accounts for reclaimable slab/page-cache; a raw `MemFree` would
+//!   undercount by treating reclaimable cache as unavailable).
+//! - **macOS** has no `MemAvailable` equivalent; `vm_stat` reports free +
+//!   inactive pages (inactive pages are reclaimable, mirroring what
+//!   `MemAvailable` counts on Linux) and `sysctl -n hw.pagesize` gives the
+//!   page size to convert to bytes.
+//!
+//! # Fail-open, not fail-closed
+//!
+//! Mirrors [`crate::disk_headroom`]: an unmeasurable probe returns `None` /
+//! `usize::MAX` (skip the clamp), never a fabricated `Some(0)` / `0` that would
+//! look identical to "genuinely out of RAM".
+
+#[cfg(target_os = "macos")]
+use std::process::{Command, Stdio};
+
+/// Environment variable overriding the conservative per-worktree RAM estimate
+/// (GB). Mirrors [`crate::disk_headroom::PER_WORKTREE_GB_ENV`].
+pub const PER_WORKTREE_RAM_GB_ENV: &str = "LOOM_PER_WORKTREE_RAM_GB";
+
+/// Default per-worktree RAM estimate (GB). A `claude`-driven sweep's own
+/// footprint is modest (client process + git + occasional `cargo`), so this
+/// mirrors the disk default rather than assuming a build-heavy workload —
+/// same posture disk headroom takes, and just as tunable per host.
+pub const DEFAULT_PER_WORKTREE_RAM_GB: u64 = 2;
+
+/// Resolve the per-worktree RAM GB estimate from [`PER_WORKTREE_RAM_GB_ENV`],
+/// flooring to a minimum of 1 (mirrors [`crate::disk_headroom::per_worktree_gb`]).
+#[must_use]
+pub fn per_worktree_ram_gb() -> u64 {
+    std::env::var(PER_WORKTREE_RAM_GB_ENV)
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(DEFAULT_PER_WORKTREE_RAM_GB)
+}
+
+/// Parse `MemAvailable` (in kB) from Linux `/proc/meminfo` contents.
+///
+/// `/proc/meminfo` lines are `"<Key>:<spaces><value> kB\n"`. `MemAvailable` is
+/// the kernel's own estimate of memory available for new allocations without
+/// swapping — it already accounts for reclaimable slab/page-cache, unlike
+/// `MemFree` (which would undercount). Returns `None` when the field is
+/// missing or malformed.
+#[must_use]
+pub fn parse_meminfo_available_kb(contents: &str) -> Option<u64> {
+    let line = contents.lines().find(|l| l.starts_with("MemAvailable:"))?;
+    // "MemAvailable:    1234567 kB" — the numeric field is the 2nd token.
+    line.split_whitespace().nth(1)?.parse().ok()
+}
+
+/// Read the current `MemAvailable` (GB) on Linux via `/proc/meminfo`.
+#[cfg(target_os = "linux")]
+#[must_use]
+pub fn available_ram_gb() -> Option<u64> {
+    let contents = std::fs::read_to_string("/proc/meminfo").ok()?;
+    parse_meminfo_available_kb(&contents).map(|kb| kb / 1024 / 1024)
+}
+
+/// Parse the free + inactive page counts from macOS `vm_stat` output.
+///
+/// `vm_stat` prints one `"<Label>:<spaces><count>."` line per stat; the
+/// reclaimable-equivalent of Linux's `MemAvailable` is free + inactive pages
+/// (inactive pages hold evictable content, mirroring what `MemAvailable`
+/// counts). Returns `None` when either field is missing/malformed.
+#[must_use]
+pub fn parse_vm_stat_available_pages(output: &str) -> Option<u64> {
+    let field = |label: &str| -> Option<u64> {
+        let line = output.lines().find(|l| l.trim_start().starts_with(label))?;
+        let value = line.rsplit(':').next()?.trim().trim_end_matches('.');
+        value.parse().ok()
+    };
+    let free = field("Pages free")?;
+    let inactive = field("Pages inactive")?;
+    Some(free + inactive)
+}
+
+/// Read the host's page size (bytes) via `sysctl -n hw.pagesize` on macOS.
+#[cfg(target_os = "macos")]
+fn read_macos_page_size() -> Option<u64> {
+    let output = Command::new("sysctl")
+        .arg("-n")
+        .arg("hw.pagesize")
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+}
+
+/// Read the current available RAM (GB) on macOS via `vm_stat` (free + inactive
+/// pages) × the host page size.
+#[cfg(target_os = "macos")]
+#[must_use]
+pub fn available_ram_gb() -> Option<u64> {
+    let output = Command::new("vm_stat")
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let pages = parse_vm_stat_available_pages(&String::from_utf8_lossy(&output.stdout))?;
+    let page_size = read_macos_page_size()?;
+    Some(pages.saturating_mul(page_size) / 1024 / 1024 / 1024)
+}
+
+/// No known available-RAM source on other platforms — the caller skips the
+/// RAM clamp entirely (mirrors [`crate::cpu_headroom::read_loadavg_1m`]'s
+/// "no source" fallback).
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[must_use]
+pub fn available_ram_gb() -> Option<u64> {
+    None
+}
+
+/// The RAM-headroom concurrency term: how many worktrees `available_gb` can
+/// host at `per_gb` GB each. Pure `floor(available_gb / per_gb)`, mirroring
+/// [`crate::disk_headroom::disk_headroom`]. A `per_gb` of 0 is treated as 1
+/// to avoid a divide-by-zero.
+#[must_use]
+pub fn ram_headroom(available_gb: u64, per_gb: u64) -> usize {
+    let per = per_gb.max(1);
+    usize::try_from(available_gb / per).unwrap_or(usize::MAX)
+}
+
+/// Resolve the RAM-headroom concurrency bound for the current host: the
+/// number of worktrees the currently-available memory can hold at the
+/// resolved per-worktree estimate.
+///
+/// Unknown != zero (mirrors [`crate::disk_headroom::disk_headroom_limit`]):
+/// when the probe is unmeasurable, this SKIPS the RAM clamp entirely —
+/// returning `usize::MAX` so the RAM term never binds the `min(...)`
+/// concurrency expression — and logs a warning, rather than silently treating
+/// the unmeasurable probe as "no RAM available".
+#[must_use]
+pub fn ram_headroom_limit() -> usize {
+    match available_ram_gb() {
+        Some(gb) => ram_headroom(gb, per_worktree_ram_gb()),
+        None => {
+            log::warn!(
+                "ram_headroom: could not measure available RAM on this host — skipping the RAM \
+                 clamp (treating as unbounded)"
+            );
+            usize::MAX
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    // ===================================================================
+    // parse_meminfo_available_kb — /proc/meminfo parsing (Linux)
+    // ===================================================================
+
+    #[test]
+    fn test_parse_meminfo_reads_mem_available() {
+        let out = "MemTotal:       16384000 kB\n\
+                    MemFree:         2048000 kB\n\
+                    MemAvailable:    8192000 kB\n\
+                    Buffers:          512000 kB\n";
+        assert_eq!(parse_meminfo_available_kb(out), Some(8_192_000));
+    }
+
+    #[test]
+    fn test_parse_meminfo_missing_field_is_none() {
+        assert_eq!(parse_meminfo_available_kb("MemTotal: 16384000 kB\n"), None);
+        assert_eq!(parse_meminfo_available_kb(""), None);
+    }
+
+    #[test]
+    fn test_parse_meminfo_malformed_value_is_none() {
+        assert_eq!(parse_meminfo_available_kb("MemAvailable: not-a-number kB\n"), None);
+    }
+
+    // ===================================================================
+    // parse_vm_stat_available_pages — vm_stat parsing (macOS)
+    // ===================================================================
+
+    #[test]
+    fn test_parse_vm_stat_sums_free_and_inactive() {
+        let out = "Mach Virtual Memory Statistics: (page size of 16384 bytes)\n\
+                    Pages free:                              10000.\n\
+                    Pages active:                            50000.\n\
+                    Pages inactive:                           5000.\n\
+                    Pages speculative:                         100.\n";
+        assert_eq!(parse_vm_stat_available_pages(out), Some(15_000));
+    }
+
+    #[test]
+    fn test_parse_vm_stat_missing_field_is_none() {
+        assert_eq!(
+            parse_vm_stat_available_pages("Pages free: 10000.\n"),
+            None,
+            "missing 'Pages inactive'"
+        );
+        assert_eq!(parse_vm_stat_available_pages(""), None);
+    }
+
+    // ===================================================================
+    // ram_headroom — pure floor division
+    // ===================================================================
+
+    #[test]
+    fn test_ram_headroom_floors() {
+        assert_eq!(ram_headroom(20, 2), 10);
+        assert_eq!(ram_headroom(21, 2), 10); // floor
+        assert_eq!(ram_headroom(1, 2), 0); // less than one worktree fits
+        assert_eq!(ram_headroom(0, 2), 0);
+    }
+
+    #[test]
+    fn test_ram_headroom_per_gb_zero_treated_as_one() {
+        assert_eq!(ram_headroom(5, 0), 5);
+    }
+
+    // ===================================================================
+    // per_worktree_ram_gb — env resolution
+    // ===================================================================
+
+    #[test]
+    #[serial]
+    fn test_per_worktree_ram_gb_default_and_override() {
+        std::env::remove_var(PER_WORKTREE_RAM_GB_ENV);
+        assert_eq!(per_worktree_ram_gb(), DEFAULT_PER_WORKTREE_RAM_GB);
+
+        std::env::set_var(PER_WORKTREE_RAM_GB_ENV, "4");
+        assert_eq!(per_worktree_ram_gb(), 4);
+
+        // Zero and unparseable fall back to the default.
+        std::env::set_var(PER_WORKTREE_RAM_GB_ENV, "0");
+        assert_eq!(per_worktree_ram_gb(), DEFAULT_PER_WORKTREE_RAM_GB);
+        std::env::set_var(PER_WORKTREE_RAM_GB_ENV, "garbage");
+        assert_eq!(per_worktree_ram_gb(), DEFAULT_PER_WORKTREE_RAM_GB);
+        std::env::remove_var(PER_WORKTREE_RAM_GB_ENV);
+    }
+
+    // ===================================================================
+    // available_ram_gb / ram_headroom_limit — smoke tests against the real host
+    // ===================================================================
+
+    #[test]
+    fn test_available_ram_gb_returns_a_plausible_value_or_none() {
+        // Integration smoke: on Linux/macOS this should return Some(<plausible
+        // value>); on any other platform it is unconditionally None. Either
+        // way it must never panic, and a Some value must be sane.
+        if let Some(gb) = available_ram_gb() {
+            assert!(gb < 100_000, "no real host has 100+ TB of available RAM");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_ram_headroom_limit_never_panics() {
+        // Whatever this host reports, the limit must be well-typed — either a
+        // real headroom count or the unmeasurable sentinel.
+        let limit = ram_headroom_limit();
+        assert!(limit == usize::MAX || limit < 100_000_000);
+    }
+}

--- a/loom-daemon/src/serve.rs
+++ b/loom-daemon/src/serve.rs
@@ -1189,6 +1189,7 @@ mod tests {
             token_pool_size: 0,
             token_pool_dir: None,
             disk_headroom: 0,
+            ram_headroom: 0,
             logical_cpus: 0,
             loadavg_1m: None,
             cpu_idle_fraction: None,

--- a/loom-daemon/src/types.rs
+++ b/loom-daemon/src/types.rs
@@ -955,6 +955,18 @@ pub struct DaemonStatusReport {
     /// Dynamic-cap input 2: how many worktrees the scratch volume can hold at
     /// `LOOM_PER_WORKTREE_GB` each. Via [`crate::disk_headroom::disk_headroom_limit`].
     pub disk_headroom: usize,
+    /// Dynamic-cap input (#5270): how many worktrees the host's
+    /// currently-available RAM can hold at `LOOM_PER_WORKTREE_RAM_GB` each.
+    /// Via [`crate::ram_headroom::ram_headroom_limit`] — the second machine-
+    /// headroom axis alongside [`Self::disk_headroom`], added when the token
+    /// axis was removed from admission entirely (operator direction: "we
+    /// should only ever limit parallelism based on the machine
+    /// disk/RAM/CPU"). `#[serde(default)]` keeps pre-#5270 wire data / older
+    /// clients compatible (an absent field parses as `0`, i.e. "unknown" —
+    /// callers should treat a `0` from a stale client cautiously, the same
+    /// caution any dynamic-cap input warrants).
+    #[serde(default)]
+    pub ram_headroom: usize,
     /// The host's logical CPU count (#3978), via
     /// [`crate::cpu_headroom::logical_cpu_count`]. **Observational only since
     /// #4512** — the CPU headroom *term* it used to feed was removed from the
@@ -1038,10 +1050,11 @@ pub struct DaemonStatusReport {
     #[serde(default)]
     pub per_token_concurrency: usize,
     /// The effective dynamic concurrency cap —
-    /// `min(token_axis × per_token_concurrency, disk_headroom, configured_max)`
+    /// `min(disk_headroom, ram_headroom, configured_max)`
     /// (`resolve_dynamic_max_concurrent`; the CPU term that sat in this `min`
-    /// from #3978 was removed in #4512). This is the total-occupancy ceiling the
-    /// work finder recomputes every tick.
+    /// from #3978 was removed in #4512, and the token axis was removed
+    /// entirely in #5270 — see [`Self::ram_headroom`]). This is the
+    /// total-occupancy ceiling the work finder recomputes every tick.
     pub dynamic_cap: usize,
     /// Whether autonomous dispatch is currently halted by the reactive
     /// main-health gate (#3812). `true` means a red `main` has paused new

--- a/loom-daemon/src/work_finder.rs
+++ b/loom-daemon/src/work_finder.rs
@@ -22,51 +22,62 @@
 //! 3. For each remaining issue, dispatches through the existing
 //!    [`SweepRegistry::dispatch`](crate::sweep_registry::SweepRegistry::dispatch)
 //!    path — up to a **work-driven** max-concurrency cap recomputed every tick
-//!    (Phase B, #3811; simplified in #4512): `min(token axis, disk headroom,
-//!    configured max)`. `dispatch()` already flips `loom:issue →
-//!    loom:building`, acquires the per-issue `mkdir`-atomic claim lock, and
-//!    spawns the rotated-token child.
+//!    (Phase B, #3811; simplified in #4512; token axis removed / RAM headroom
+//!    added in #5270): `min(disk headroom, ram headroom, configured max)`.
+//!    `dispatch()` already flips `loom:issue → loom:building`, acquires the
+//!    per-issue `mkdir`-atomic claim lock, and spawns the rotated-token child.
 //!
-//! # Concurrency scaling (Phase B, #3811; CPU term removed in #4512)
+//! # Concurrency scaling (Phase B, #3811; CPU term removed in #4512; token axis removed / RAM added in #5270)
 //!
 //! Phase A resolved a single fixed cap once at daemon startup. Phase B replaces
 //! it with a cap **recomputed every tick** by
-//! [`resolve_dynamic_max_concurrent`] from live inputs — the token axis
-//! ([`crate::tokens::token_pool_size`] / [`crate::capacity::read_ranking`]),
-//! the worktree-root disk headroom
-//! ([`crate::disk_headroom::disk_headroom_limit`]), and the per-machine
-//! operator ceiling (`LOOM_WORK_FINDER_MAX_CONCURRENT` /
+//! [`resolve_dynamic_max_concurrent`] from live inputs — the worktree-root
+//! disk headroom ([`crate::disk_headroom::disk_headroom_limit`]), the host's
+//! available-RAM headroom (#5270, [`crate::ram_headroom::ram_headroom_limit`]),
+//! and the per-machine operator ceiling (`LOOM_WORK_FINDER_MAX_CONCURRENT` /
 //! `autonomous.workFinder.maxConcurrent`). The effective per-tick concurrency
 //! is then `min(dynamic_cap, backlog_depth)`: [`tick`] iterates the ready
 //! `loom:issue` rows and stops at the cap, so concurrency scales **up** as the
 //! backlog grows and drains to **zero** dispatches when the queue is empty —
-//! all without a daemon restart, since pool/disk/backlog are read fresh each
-//! tick.
+//! all without a daemon restart, since disk/RAM/backlog are read fresh each
+//! tick. Token-pool health ([`crate::tokens::token_pool_size`] /
+//! [`crate::capacity::read_ranking`]) is still read every tick but, since
+//! #5270, feeds spawn-time **selection** only (prefer fresher/healthier
+//! accounts) — it is no longer a term in this `min(...)`.
 //!
-//! **#4512 removed the CPU term from this formula.** A fourth axis
+//! **#4512 removed the CPU term from this formula; #5270 removed the token
+//! axis too, unconditionally on every auth path.** A fourth axis
 //! (`cpu_headroom = (logical_cpus × cpuUtilizationTarget − consumed_cores) /
 //! estCoresPerSweep`, #3978/#4031) used to be part of the `min(...)`. It priced
 //! every sweep as a build, so it throttled the API-wait-dominated majority to
 //! defend against the heavy-build minority — an 8-core worker measured **95%
-//! idle** was capped at 2. The two hard floors that meter genuinely
-//! *exhaustible* resources (the token axis, disk headroom) stay; the CPU
-//! estimate is gone; and the heavy stages now serialize where they actually
-//! occur, on the machine-wide build slot ([`crate::build_slot`]). The host
-//! breaker (#4235, [`crate::host_breaker`]) remains the load safety net that
-//! makes a hand-tuned ceiling safe: a mis-set knob trips a **measured** breaker
+//! idle** was capped at 2. The hard floors that meter genuinely *exhaustible*
+//! resources stayed after that removal (the token axis, disk headroom), but
+//! #5270 dropped the token axis too: operator direction was "we should only
+//! ever limit parallelism based on the machine disk/RAM/CPU" — a metered API
+//! key has no subscription window, and overage means even a subscription pool
+//! no longer hard-stops at one either, so counting *healthy accounts* was
+//! never really a proxy for this host's own capacity. RAM headroom
+//! ([`crate::ram_headroom`]) joined disk headroom as the replacement machine
+//! axis. The heavy stages still serialize where they actually occur, on the
+//! machine-wide build slot ([`crate::build_slot`]). The host breaker (#4235,
+//! [`crate::host_breaker`]) remains the load safety net that makes a
+//! hand-tuned ceiling safe: a mis-set knob trips a **measured** breaker
 //! instead of melting the host.
 //!
-//! **#4903 added a saturation brake on *admission* (not on the cap).** Removing
-//! the CPU term left the cap with no term that reads the host at all, so a
-//! CPU-heavy workload (analog simulation: minutes of sustained `ngspice`, not
-//! API-wait) could drive an 8-core worker to 12× overcommit while the daemon
-//! still believed it had nine free slots. [`crate::admission_brake`] closes that
-//! without resurrecting the formula: once per tick it asks
-//! [`crate::cpu_headroom::is_host_saturated`] at a generous default of `4.0`
-//! load/core and, when the answer is yes, holds **new** admissions
-//! ([`TickReport::deferred_saturation`]) until the host recovers. In-flight
-//! sweeps are never touched, and a healthy host's behavior is byte-for-byte
-//! unchanged.
+//! **#4903 added a saturation brake on *admission* (not on the cap); #5270
+//! retuned it into the primary CPU gate.** Removing the CPU term left the cap
+//! with no term that reads the host at all, so a CPU-heavy workload (analog
+//! simulation: minutes of sustained `ngspice`, not API-wait) could drive an
+//! 8-core worker to 12× overcommit while the daemon still believed it had nine
+//! free slots. [`crate::admission_brake`] closes that without resurrecting the
+//! formula: once per tick it asks [`crate::cpu_headroom::is_host_saturated`]
+//! and, when the answer is yes, holds **new** admissions
+//! ([`TickReport::deferred_saturation`]) until the host recovers. Its default
+//! threshold started generous (`4.0` load/core, a rarely-tripped backstop) and
+//! was retuned by #5270 to `0.95` — the operator's literal "dumb mode" ask,
+//! now the primary CPU admission gate rather than a backstop above the (now
+//! nonexistent) token axis. In-flight sweeps are never touched.
 //!
 //! # Idempotency & fail-safe
 //!
@@ -1696,10 +1707,10 @@ pub fn resolve_per_token_concurrency(config: &WorkFinderConfig) -> usize {
         .unwrap_or(DEFAULT_PER_TOKEN_CONCURRENCY)
 }
 
-/// Compute the **work-driven dynamic concurrency cap** (Phase B, #3811;
-/// per-token concurrency factor added in #3947; CPU term **removed** in
-/// #4512): `min(token_limit × per_token_concurrency, disk_headroom,
-/// configured_max)`.
+/// Compute the **machine-headroom dynamic concurrency cap** (Phase B, #3811;
+/// per-token concurrency factor added in #3947; CPU term removed in #4512;
+/// **token axis removed and RAM headroom added in #5270**):
+/// `min(disk_headroom, ram_headroom, configured_max)`.
 ///
 /// This is the total-concurrency ceiling for the loop, recomputed every tick
 /// from live inputs. It deliberately does **not** fold in the backlog depth:
@@ -1710,25 +1721,42 @@ pub fn resolve_per_token_concurrency(config: &WorkFinderConfig) -> usize {
 /// `loom:building` sweeps that are **not** in the ready backlog. Folding backlog
 /// into the cap here would under-utilize the pool whenever prior-tick sweeps are
 /// still running (a smaller "new work" number would cap total occupancy below
-/// the pool/disk ceiling). Keeping the cap as `min(token×factor, disk,
+/// the disk/RAM/configured ceiling). Keeping the cap as `min(disk, ram,
 /// configured)` and letting `tick` apply the backlog bound is what makes
 /// concurrency scale up with the backlog and drain to zero when it empties.
 ///
-/// The three bounds map directly to the resource each protects:
-/// - `token_limit` — the count of *healthy* accounts (or the raw pool when no
-///   ranking exists). **Multiplied by `per_token_concurrency`** (#3947): a plan
-///   limit is a utilization-window token bucket, not a session count, so one
-///   healthy account can comfortably run several concurrent sessions. Before
-///   #3947 the implicit factor was `1` (one sweep per account), which collapsed
-///   the whole fleet to cap 1 when 6/7 accounts were at their weekly ceiling
-///   even though the single healthy account had ample session-window headroom.
+/// The three remaining bounds map directly to the resource each protects:
 /// - `disk_headroom` — never provision more worktrees than the scratch volume
-///   can hold at `LOOM_PER_WORKTREE_GB` each.
+///   can hold at `LOOM_PER_WORKTREE_GB` each ([`crate::disk_headroom`]).
+/// - `ram_headroom` — never provision more worktrees than the host's
+///   currently-available memory can hold at `LOOM_PER_WORKTREE_RAM_GB` each
+///   (#5270, [`crate::ram_headroom`]) — the operator-directed "dumb mode"
+///   RAM gate, applied the same way disk headroom already was.
 /// - `configured_max` — **the** per-machine admission knob
 ///   (`LOOM_WORK_FINDER_MAX_CONCURRENT` / `autonomous.workFinder.maxConcurrent`),
 ///   tuned empirically per host.
 ///
-/// # Why there is no CPU term any more (#4512)
+/// # Why there is no token-axis term any more (#5270)
+///
+/// Until #5270 a third axis sat in this `min(...)`: `token_limit ×
+/// per_token_concurrency`, where `token_limit` was the count of *healthy*
+/// (`available`) accounts read from the rotation ranking (#3902). That policy
+/// was right when a rate-limited account genuinely stopped serving requests, but
+/// it stopped being a real resource ceiling once accounts are provisioned with
+/// **overage** (metered credit beyond the plan window) or a single API key
+/// backed by a large credit balance — operator direction on #5270: "we can have
+/// extra usage on our subscription tokens too... we should only ever limit
+/// parallelism based on the machine disk/RAM/CPU." Counting *accounts* was never
+/// a proxy for the daemon host's actual capacity to run more sweeps; it modeled
+/// a per-plan-window ceiling that no longer holds unconditionally.
+///
+/// `.ranking` health is **not** deleted — it still drives spawn-time
+/// **selection** ([`crate::tokens_pool::select`]: prefer fresher/healthier
+/// accounts, skip `blocked`/revoked ones), and [`crate::capacity`]'s advisory
+/// machinery still reports account health on the status surface. It simply no
+/// longer gates *how many* sweeps may run concurrently.
+///
+/// # Why there is no CPU term either (#4512, superseded by the admission brake)
 ///
 /// A fourth axis used to sit in this `min(...)`: `cpu_headroom = (logical_cpus ×
 /// cpuUtilizationTarget − consumed_cores) / estCoresPerSweep` (#3978, measured-idle
@@ -1739,33 +1767,28 @@ pub fn resolve_per_token_concurrency(config: &WorkFinderConfig) -> usize {
 ///   (curator / builder / judge conversations). It therefore throttled the
 ///   low-CPU majority to defend against the heavy-build minority: on an 8-core
 ///   worker measured **95% idle**, the term computed a cap of `2`.
-/// - The two remaining axes meter genuinely **exhaustible** resources (accounts,
-///   bytes) and can be counted exactly. A CPU *estimate* is neither exact nor
-///   exhaustible — it was a proxy for "will a build starve another build".
+/// - Disk headroom meters a genuinely **exhaustible** resource (bytes) and can
+///   be counted exactly. A CPU *estimate* is neither exact nor exhaustible — it
+///   was a proxy for "will a build starve another build".
 /// - That real concern is now handled where the load actually is: the
 ///   machine-wide build slot ([`crate::build_slot`]) serializes the designated
 ///   high-CPU stages across concurrent sweeps, so N sweeps run while at most 1–2
-///   build.
+///   build, and the saturation admission brake ([`crate::admission_brake`],
+///   #4903) holds **new** admissions once the host's observed load-per-core
+///   crosses a threshold — the CPU/RAM "dumb mode" gate the #5270 operator
+///   direction asks for, applied at *admission* time rather than folded back
+///   into this formula.
 /// - The safety net for a mis-set knob is **measurement, not estimation**: the
 ///   host-distress circuit breaker ([`crate::host_breaker`], #4235) suspends
 ///   dispatch on observed load-per-core, and the per-tick admission ramp cap
 ///   (#4234) still bounds how fast occupancy can grow.
-///
-/// `per_token_concurrency` is clamped to a floor of `1` so a mis-set `0`
-/// degrades to the pre-#3947 one-sweep-per-account behavior rather than
-/// dispatching nothing. `token_limit × factor` uses a saturating multiply so a
-/// pathological product can never wrap.
 #[must_use]
 pub fn resolve_dynamic_max_concurrent(
-    token_limit: usize,
-    per_token_concurrency: usize,
     disk_headroom: usize,
+    ram_headroom: usize,
     configured_max: usize,
 ) -> usize {
-    token_limit
-        .saturating_mul(per_token_concurrency.max(1))
-        .min(disk_headroom)
-        .min(configured_max)
+    disk_headroom.min(ram_headroom).min(configured_max)
 }
 
 // ============================================================================
@@ -1814,7 +1837,8 @@ where
         "work_finder: starting loop (interval={}s, configured_max={configured_max}, \
          per_token_concurrency={per_token_concurrency}, \
          max_admissions_per_tick={max_admissions_per_tick}, \
-         dynamic cap = min(healthy tokens × per-token, disk, configured_max))",
+         dynamic cap = min(disk, ram, configured_max) — token axis is \
+         selection-only, not a cap, since #5270)",
         interval.as_secs()
     );
     tokio::spawn(async move {
@@ -1920,6 +1944,9 @@ where
             let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
             log_healthy_token_transition(&mut was_healthy_tokens, token_limit, ranking.as_ref());
             let disk = disk_headroom_limit(&workspace_root);
+            // RAM headroom (#5270): the second "dumb mode" machine-headroom
+            // axis alongside disk, folded into the same `min(...)`.
+            let ram = crate::ram_headroom::ram_headroom_limit();
             // Refresh the memoized CPU idle sample. Purely **observational**
             // since #4512 — it no longer feeds admission, it feeds the
             // `idle=` figure below plus `loom-daemon status` / `calibrate`, which
@@ -1929,16 +1956,12 @@ where
             // leaves the previous sample in place.
             let _ = tokio::task::spawn_blocking(crate::cpu_headroom::refresh_cpu_util_cache).await;
             let idle = crate::cpu_headroom::cached_cpu_idle_fraction();
-            let max_concurrent = resolve_dynamic_max_concurrent(
-                token_limit,
-                per_token_concurrency,
-                disk,
-                configured_max,
-            );
+            let max_concurrent = resolve_dynamic_max_concurrent(disk, ram, configured_max);
             let axis_line = format!(
                 "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, \
-                 healthy_tokens={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                 configured_max={configured_max}, \
+                 healthy_tokens={token_limit} [informational only, not capacity-limiting \
+                 since #5270], per_token={per_token_concurrency} [informational only], \
+                 disk={disk}, ram={ram}, configured_max={configured_max}, \
                  max_admissions_per_tick={max_admissions_per_tick}, halted={halted}, \
                  saturation_held={saturation_held}, \
                  observed_idle={})",
@@ -1984,7 +2007,7 @@ where
                         log::info!(
                             "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                              healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                             ceiling={configured_max}, ramp_cap={max_admissions_per_tick}); \
+                             ram={ram}, ceiling={configured_max}, ramp_cap={max_admissions_per_tick}); \
                              {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
                              {} quarantine-skip, {} backoff-skip, {} pr-open-skip, \
                              {} peer-claim-skip, \
@@ -2010,11 +2033,21 @@ where
                     // Skip while halted: a red-main halt defers everything, so the
                     // token axis is not the (relevant) bottleneck this tick.
                     if !report.halted {
+                        // #5270: `disk.min(ram)` — the token axis no longer
+                        // participates in the real admission cap, so the
+                        // advisory's own "would tokens have been the binding
+                        // term" heuristic must compare against BOTH remaining
+                        // machine-headroom axes, not disk alone. Otherwise a
+                        // RAM-starved host could spuriously read as
+                        // token-bound (deferred > 0 for a RAM reason, but
+                        // token_limit happened to be <= disk) and tell an
+                        // operator to add accounts for a problem accounts
+                        // cannot fix.
                         let assessment = capacity::assess_pressure(
                             ranking.as_ref(),
                             pool_size,
                             token_limit,
-                            disk,
+                            disk.min(ram),
                             configured_max,
                             report.deferred_capacity,
                             capacity::DEFAULT_ADVISORY_MIN_QUEUED,
@@ -2096,7 +2129,8 @@ pub fn spawn_multi_work_finder_task(
     log::info!(
         "work_finder: starting multi-workspace loop (interval={}s, configured_max={configured_max}, \
          per_token_concurrency={per_token_concurrency}, max_admissions_per_tick={max_admissions_per_tick}, \
-         dynamic cap = min(healthy tokens × per-token, disk, configured_max), global across workspaces)",
+         dynamic cap = min(disk, ram, configured_max) — token axis is selection-only, \
+         not a cap, since #5270; global across workspaces)",
         interval.as_secs()
     );
     tokio::spawn(async move {
@@ -2182,6 +2216,9 @@ pub fn spawn_multi_work_finder_task(
             let token_limit = ranking.as_ref().map_or(pool_size, |r| r.available);
             log_healthy_token_transition(&mut was_healthy_tokens, token_limit, ranking.as_ref());
             let disk = disk_headroom_limit(&fallback_root);
+            // RAM headroom (#5270): the second "dumb mode" machine-headroom
+            // axis alongside disk, folded into the same `min(...)`.
+            let ram = crate::ram_headroom::ram_headroom_limit();
             // Refresh the memoized CPU idle sample — **observational only**
             // since #4512 (see the single-workspace loop above). It feeds the
             // `observed_idle=` figure in the axis line and `loom-daemon status`
@@ -2189,12 +2226,7 @@ pub fn spawn_multi_work_finder_task(
             // `maxConcurrent`; it no longer gates admission.
             let _ = tokio::task::spawn_blocking(crate::cpu_headroom::refresh_cpu_util_cache).await;
             let idle = crate::cpu_headroom::cached_cpu_idle_fraction();
-            let max_concurrent = resolve_dynamic_max_concurrent(
-                token_limit,
-                per_token_concurrency,
-                disk,
-                configured_max,
-            );
+            let max_concurrent = resolve_dynamic_max_concurrent(disk, ram, configured_max);
 
             let roots = registry.effective_roots(&fallback_root);
             // Skip registered roots whose directory no longer exists on disk
@@ -2325,8 +2357,9 @@ pub fn spawn_multi_work_finder_task(
 
             let axis_line = format!(
                 "work_finder: dynamic cap = {max_concurrent} (pool={pool_size}, \
-                 healthy_tokens={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                 configured_max={configured_max}, \
+                 healthy_tokens={token_limit} [informational only, not capacity-limiting \
+                 since #5270], per_token={per_token_concurrency} [informational only], \
+                 disk={disk}, ram={ram}, configured_max={configured_max}, \
                  max_admissions_per_tick={max_admissions_per_tick}, any_halted={any_halted}, \
                  preflight_held={preflight_held_count}, \
                  saturation_held={saturation_held}, \
@@ -2378,7 +2411,7 @@ pub fn spawn_multi_work_finder_task(
                 log::info!(
                     "work_finder: tick — cap {max_concurrent} (pool={pool_size}, \
                      healthy={token_limit}, per_token={per_token_concurrency}, disk={disk}, \
-                     ceiling={configured_max}, ramp_cap={max_admissions_per_tick}); \
+                     ram={ram}, ceiling={configured_max}, ramp_cap={max_admissions_per_tick}); \
                      {} workspace(s), \
                      {} seen, {} dispatched, {} labeled-skip, {} in-flight-skip, \
                      {} quarantine-skip, {} backoff-skip, {} pr-open-skip, \
@@ -2404,11 +2437,14 @@ pub fn spawn_multi_work_finder_task(
             }
 
             if !report.halted {
+                // #5270: `disk.min(ram)` — see the single-workspace loop above
+                // for why both machine-headroom axes must feed this heuristic
+                // now that the token axis no longer bounds real admission.
                 let assessment = capacity::assess_pressure(
                     ranking.as_ref(),
                     pool_size,
                     token_limit,
-                    disk,
+                    disk.min(ram),
                     configured_max,
                     report.deferred_capacity,
                     capacity::DEFAULT_ADVISORY_MIN_QUEUED,
@@ -4615,61 +4651,63 @@ exit 0
 
     #[test]
     fn test_dynamic_cap_is_min_of_three_inputs() {
-        // Never exceeds any of the three bounds (factor 1 = pre-#3947 semantics).
-        assert_eq!(resolve_dynamic_max_concurrent(10, 1, 10, 10), 10);
-        assert_eq!(resolve_dynamic_max_concurrent(2, 1, 9, 9), 2, "token axis binds");
-        assert_eq!(resolve_dynamic_max_concurrent(9, 1, 3, 9), 3, "disk binds");
-        assert_eq!(resolve_dynamic_max_concurrent(9, 1, 9, 4), 4, "maxConcurrent binds");
+        // Never exceeds any bound. `usize::MAX` ram = the term doesn't bind.
+        assert_eq!(resolve_dynamic_max_concurrent(10, usize::MAX, 10), 10);
+        assert_eq!(resolve_dynamic_max_concurrent(3, usize::MAX, 9), 3, "disk binds");
+        assert_eq!(resolve_dynamic_max_concurrent(9, usize::MAX, 4), 4, "maxConcurrent binds");
     }
 
     #[test]
     fn test_dynamic_cap_has_no_cpu_term_at_all() {
-        // #4512 AC1: the formula is exactly min(token axis, disk, maxConcurrent).
-        // The arity itself is the guard (a 5-arg call no longer compiles), and the
-        // value must be independent of host CPU state: this same input yields the
-        // same cap on a 95%-idle 8-core worker and on a saturated one, which is
-        // the whole point — an idle host must not be throttled to 2 by an
-        // estimate (`estCoresPerSweep`) that priced every sweep as a build.
-        assert_eq!(resolve_dynamic_max_concurrent(6, 2, 36, 10), 10);
-        // The exact #4512 evidence line: healthy 6 × per-token 2 = 12, disk 36,
-        // configured 10 ⇒ 10. Pre-#4512 the cpu term pinned this host at 2.
-        assert_eq!(
-            resolve_dynamic_max_concurrent(6, 2, 36, 10).min(12),
-            10,
-            "no CPU estimate may clamp an idle host below its configured knob"
-        );
+        // #4512 AC1: the arity itself is the guard (a >3-arg call no longer
+        // compiles), and the value must be independent of host CPU state: this
+        // same input yields the same cap on a 95%-idle 8-core worker and on a
+        // saturated one, which is the whole point — an idle host must not be
+        // throttled to 2 by an estimate (`estCoresPerSweep`) that priced every
+        // sweep as a build.
+        assert_eq!(resolve_dynamic_max_concurrent(36, usize::MAX, 10), 10);
     }
 
     #[test]
-    fn test_dynamic_cap_pool_size_bound_never_over_subscribes() {
-        // With a large disk headroom and ceiling and factor 1, the token-pool
-        // size is the hard bound — the cap never exceeds the number of accounts.
-        for pool in 0..=5 {
-            assert_eq!(
-                resolve_dynamic_max_concurrent(pool, 1, 100, 100),
-                pool,
-                "cap must equal pool size {pool} when disk/ceiling are larger"
-            );
-        }
+    fn test_dynamic_cap_has_no_token_axis_term_either() {
+        // #5270 AC1: a starved token pool (few/no healthy accounts) must NOT
+        // cap the dynamic concurrency — only disk headroom, RAM headroom, and
+        // the configured ceiling do. The arity itself is the guard (a >3-arg
+        // call no longer compiles); this asserts the *value* is independent of
+        // any token-pool state, unlike the pre-#5270 formula which would have
+        // pinned this to (near-)zero when accounts were exhausted.
+        assert_eq!(
+            resolve_dynamic_max_concurrent(36, usize::MAX, 10),
+            10,
+            "disk (36) and ceiling (10) alone determine the cap"
+        );
     }
 
     #[test]
     fn test_dynamic_cap_disk_headroom_bound() {
         // A nearly-full scratch volume (disk headroom 1) caps concurrency at 1
-        // even with a big pool, high ceiling, AND a big per-token factor (#3947):
-        // stacking never provisions more worktrees than the disk can hold.
-        assert_eq!(resolve_dynamic_max_concurrent(8, 4, 1, 8), 1);
+        // even with a high ceiling.
+        assert_eq!(resolve_dynamic_max_concurrent(1, usize::MAX, 8), 1);
         // A full volume (0 headroom) drops the cap to 0 — dispatch nothing.
-        // #4512 keeps this hard floor: disk meters an exhaustible resource.
-        assert_eq!(resolve_dynamic_max_concurrent(8, 4, 0, 8), 0);
+        // Disk meters an exhaustible resource, so this hard floor stays.
+        assert_eq!(resolve_dynamic_max_concurrent(0, usize::MAX, 8), 0);
     }
 
     #[test]
-    fn test_dynamic_cap_zero_pool_dispatches_nothing() {
-        // No usable tokens ⇒ cap 0 regardless of the factor (0 × N = 0) ⇒ a
-        // subsequent tick dispatches nothing (the spawn path would hard-fail
-        // EX_CONFIG anyway).
-        let cap = resolve_dynamic_max_concurrent(0, 2, 10, 10);
+    fn test_dynamic_cap_ram_headroom_bound() {
+        // #5270 AC3: critically-low available RAM caps concurrency exactly the
+        // way disk headroom already does — same posture, same hard floor.
+        assert_eq!(resolve_dynamic_max_concurrent(usize::MAX, 1, 8), 1, "ram binds");
+        assert_eq!(resolve_dynamic_max_concurrent(usize::MAX, 0, 8), 0, "ram exhausted");
+        // Whichever of disk/ram is smaller binds, regardless of position.
+        assert_eq!(resolve_dynamic_max_concurrent(2, 5, 100), 2, "disk (2) < ram (5)");
+        assert_eq!(resolve_dynamic_max_concurrent(5, 2, 100), 2, "ram (2) < disk (5)");
+    }
+
+    #[test]
+    fn test_dynamic_cap_zero_disk_dispatches_nothing() {
+        // No disk headroom ⇒ cap 0 ⇒ a subsequent tick dispatches nothing.
+        let cap = resolve_dynamic_max_concurrent(0, usize::MAX, 10);
         assert_eq!(cap, 0);
         let mut source = FakeSource::once((1..=3).map(issue).collect());
         let mut disp = RecordingDispatcher::default();
@@ -4680,55 +4718,25 @@ exit 0
     }
 
     #[test]
-    fn test_dynamic_cap_per_token_factor_multiplies_token_axis() {
-        // #3947 core: the token axis is `healthy × per-token`, not `healthy × 1`.
-        // 3 healthy accounts × factor 2 = 6, bounded only by disk/ceiling.
-        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 100, 100), 6);
-        // 2 healthy × factor 3 = 6.
-        assert_eq!(resolve_dynamic_max_concurrent(2, 3, 100, 100), 6);
-        // The product is still clamped by disk and the configured knob.
-        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 4, 100), 4, "disk clamps the product");
-        assert_eq!(resolve_dynamic_max_concurrent(3, 2, 100, 5), 5, "ceiling clamps the product");
-    }
-
-    #[test]
-    fn test_dynamic_cap_one_healthy_account_factor_two_dispatches_two() {
-        // The load-bearing #3947 scenario (6/7 accounts at their weekly ceiling):
-        // ONE healthy account with factor 2 must allow TWO concurrent sweeps —
-        // the pre-#3947 implicit 1:1 cap would have collapsed this to 1.
-        let cap = resolve_dynamic_max_concurrent(1, 2, 120, 3);
-        assert_eq!(cap, 2, "1 healthy × per-token 2 = 2 (disk 120, ceiling 3 don't bind)");
-
-        // And that cap actually dispatches 2 (not 1) against a 2-deep backlog.
-        let mut source = FakeSource::once((1..=2).map(issue).collect());
+    fn test_dynamic_cap_zero_ram_dispatches_nothing() {
+        // No available RAM ⇒ cap 0 ⇒ a subsequent tick dispatches nothing —
+        // mirrors test_dynamic_cap_zero_disk_dispatches_nothing exactly.
+        let cap = resolve_dynamic_max_concurrent(usize::MAX, 0, 10);
+        assert_eq!(cap, 0);
+        let mut source = FakeSource::once((1..=3).map(issue).collect());
         let mut disp = RecordingDispatcher::default();
         let report = tick(&mut source, &mut disp, cap, false).unwrap();
-        assert_eq!(report.dispatched, 2, "1-healthy/factor-2 dispatches 2 concurrent sweeps");
-        assert_eq!(report.deferred_capacity, 0);
-        assert_eq!(disp.dispatched.len(), 2);
+        assert_eq!(report.dispatched, 0);
+        assert_eq!(report.deferred_capacity, 3);
+        assert!(disp.dispatched.is_empty());
     }
 
     #[test]
-    fn test_dynamic_cap_zero_factor_degrades_to_one() {
-        // A mis-set factor 0 must NOT collapse the cap to zero — it degrades to
-        // the pre-#3947 one-sweep-per-account behavior (floor of 1).
-        assert_eq!(resolve_dynamic_max_concurrent(4, 0, 100, 100), 4);
-    }
-
-    #[test]
-    fn test_token_axis_jump_is_now_bounded_by_max_concurrent_not_cpu() {
-        // The #3978 scenario, re-baselined for #4512: several exhausted token
-        // accounts reset at once, jumping the healthy-token count from 2 to 14,
-        // so the token axis spikes to 14 × 2 = 28. There is no longer a CPU
-        // term to absorb that spike — the per-machine `maxConcurrent` knob is
-        // what bounds it (here 8), and the per-tick admission ramp cap (#4234)
-        // still limits how fast occupancy climbs toward it, with the host
-        // breaker (#4235) as the measured safety net.
-        assert_eq!(resolve_dynamic_max_concurrent(14, 2, 100, 8), 8);
+    fn test_dynamic_cap_unbounded_by_max_concurrent_default() {
         // A machine whose operator has NOT tuned the knob rides the shipped
-        // default rather than an estimate of its cores.
+        // default rather than an estimate of its cores or its token pool.
         assert_eq!(
-            resolve_dynamic_max_concurrent(14, 2, 100, DEFAULT_WORK_FINDER_MAX_CONCURRENT),
+            resolve_dynamic_max_concurrent(100, usize::MAX, DEFAULT_WORK_FINDER_MAX_CONCURRENT),
             DEFAULT_WORK_FINDER_MAX_CONCURRENT
         );
     }
@@ -4739,10 +4747,10 @@ exit 0
 
     #[test]
     fn test_scale_up_with_growing_backlog_bounded_by_dynamic_cap() {
-        // Fixed resources: pool=4, factor=1, disk=10, ceiling=10 ⇒
-        // dynamic cap 4. As the backlog grows tick-over-tick, effective
-        // concurrency scales up but is bounded by the cap (min(cap, backlog)).
-        let cap = resolve_dynamic_max_concurrent(4, 1, 10, 10);
+        // Fixed resources: disk=4, ceiling=10 ⇒ dynamic cap 4. As the backlog
+        // grows tick-over-tick, effective concurrency scales up but is bounded
+        // by the cap (min(cap, backlog)).
+        let cap = resolve_dynamic_max_concurrent(4, usize::MAX, 10);
         assert_eq!(cap, 4);
 
         // Backlog 2 (< cap): all 2 dispatch, nothing deferred.
@@ -4764,7 +4772,7 @@ exit 0
     fn test_scale_to_zero_on_empty_backlog() {
         // Even with ample resources (cap 5), an empty backlog dispatches nothing
         // — no capacity is pre-reserved and no idle workers are spawned.
-        let cap = resolve_dynamic_max_concurrent(5, 1, 5, 5);
+        let cap = resolve_dynamic_max_concurrent(5, usize::MAX, 5);
         assert_eq!(cap, 5);
         let mut source = FakeSource::once(vec![]);
         let mut disp = RecordingDispatcher::default();
@@ -5292,7 +5300,7 @@ exit 0
         assert_eq!(resolve_max_concurrent_with_config(&cfg), 10);
         assert_eq!(resolve_per_token_concurrency(&cfg), 2);
         assert_eq!(
-            resolve_dynamic_max_concurrent(6, resolve_per_token_concurrency(&cfg), 36, 10),
+            resolve_dynamic_max_concurrent(36, usize::MAX, 10),
             10,
             "a retired env knob must not clamp the cap"
         );


### PR DESCRIPTION
## Summary

Operator direction on #5270 (with a second clarifying pass) superseded the issue's original "utilization-weighted token multiplier" proposal entirely: **"we should only ever limit parallelism based on the machine disk/RAM/CPU"** — unconditionally, on every auth path (API key or subscription pool, overage-enabled or not).

This PR implements the consolidated (latest-clarification) acceptance criteria from the live issue body:

- **Token axis removed from admission entirely.** `work_finder::resolve_dynamic_max_concurrent` is now `min(disk_headroom, ram_headroom, configured_max)` — the token-axis term is gone, not gated behind an auth-mode check. `.ranking` health remains a spawn-time **selection** input only (`tokens_pool::select` — prefer fresher/healthier accounts, skip revoked/blocked ones); it never gates *how many* sweeps run concurrently again.
- **New `ram_headroom` module** (`loom-daemon/src/ram_headroom.rs`), modeled on `disk_headroom`'s shape: `/proc/meminfo`'s `MemAvailable` on Linux, `vm_stat` free+inactive pages x page size on macOS, `LOOM_PER_WORKTREE_RAM_GB` env override (default 2 GB), `usize::MAX` "unmeasurable - skip the clamp" sentinel mirroring disk headroom's #4164 policy.
- **CPU admission term restored/retuned.** `admission_brake`'s default `load_per_core_threshold` retunes from `4.0` (a rarely-tripped backstop) to `0.95` - per the Curator's verification, `admission_brake.rs` (#4903) already existed as a CPU-saturation gate; this is a retune to the operator's literal ">=95% few-min load average" ask rather than new-mechanism work, promoting it from backstop to primary CPU gate now that the token axis is gone.
- **Observability (AC4):** `calibrate`/`status`/`health` now name which machine axis (max/disk/ram/cpu) is currently binding or holding:
  - `calibrate`: new `BindingTerm::Ram` variant, plus an `admission_axis()` that reports `"cpu"` when the brake is holding (a point-in-time gate outside the numeric `min(...)`, so it overrides the numeric binding term).
  - `health::assess_dispatch`: new `ram_binds_cap` (mirrors `disk_binds_cap`) plus a CPU-brake-held degraded line.
  - `status`/`--json`: `ram_headroom` field added to `DaemonStatusReport` and the dynamic-cap JSON block.
- **Fixed two now-stale reporting paths** that would otherwise have silently reintroduced token-axis gating in the client-facing surface even though the daemon-side cap no longer includes it:
  - `cli::status_render::resolve_capacity`'s fresh-probe tier stopped recomputing its own `token_axis_effective.min(disk).min(configured)` / `token_bound` - it now always defers to the daemon's own authoritative `report.dynamic_cap` / `false`, the same as the ranking/pool tiers already did.
  - The `#4344` "DISPATCH IS TOKEN-STARVED" headline (predicated on `healthy_accounts == 0`) is now categorically impossible to trigger truthfully, since 0 healthy accounts can no longer starve dispatch - hard-coded to `false` with a comment documenting why, rather than deleted, to preserve the historical diagnosis machinery.
- Retuned the token pressure advisory (`capacity::assess_pressure`'s call sites in `work_finder.rs`) to compare against `disk.min(ram)` instead of `disk` alone, so a RAM-starved host can no longer spuriously read as "token-bound" (deferred > 0 for a RAM reason, with the healthy-account count merely happening to be <= disk).
- Documentation: `defaults/docs/daemon-reference.md`'s dynamic-cap / token-backpressure / admission-brake sections updated to describe the new formula and threshold, with the pre-#5270 mechanics kept as clearly-labeled historical context rather than deleted outright.

## What I found in the pre-existing worktree diff and what I did with it

The worktree (`feature/issue-5270`) already had **uncommitted, legitimate progress** from a previously-interrupted Builder run, covering:
- AC1 (token axis removed from `resolve_dynamic_max_concurrent`, `disk_binds_cap`, `binding_term`, `ipc.rs`'s `token_bound=false`) - correct and complete for the two-term formula.
- AC2 (CPU admission retune: `admission_brake`'s default threshold `4.0 -> 0.95`, with matching module-doc rationale and tests) - correct and complete, matching the Curator's "retune, don't rebuild" verification note.

It was **missing**: AC3 (RAM headroom - no `ram_headroom.rs` existed), the CPU axis in `calibrate`'s `BindingTerm`, and the consolidated-AC5 "verify the two changes don't collide" checks (I found and fixed the `status_render.rs` stale-probe-recompute bug and the dead "TOKEN-STARVED" headline while doing that verification). I rebased the branch onto latest `main` (9 commits behind -> fast-forwarded cleanly, no conflicts with the pre-existing diff), kept the AC1/AC2 work as-is, and built AC3/AC4/AC5 on top of it.

## Test plan

- [x] `cargo test -p loom-daemon --lib` - full suite: 3438 passed, 0 failures attributable to this change (2 pre-existing host-load-sensitive flaky tests in `pipeline_snapshot`/`primary_checkout_reaper`, confirmed passing in isolation, unrelated files).
- [x] New `ram_headroom` module: 10 unit tests (parsing, floor-division, env resolution, unmeasurable-probe fallback, live-host smoke test).
- [x] `work_finder::resolve_dynamic_max_concurrent`: extended to 3-arg signature; new disk/ram-binding tests, zero-ram-dispatches-nothing test.
- [x] `admission_brake`: existing suite extended with a default-config-at-0.95 test and an inverted threshold-ordering test (brake now sits below the host breaker, the reverse of pre-#5270).
- [x] `calibrate`: new `Ram`/`admission_axis` tests (binding-term tie-break, CPU-brake-held override, advice text).
- [x] `health`: new `ram_binds_cap`/CPU-brake-held degraded-verdict tests, plus fixed the two disk-focused tests that would otherwise have spuriously tripped on the new RAM check's zero-default.
- [x] `cargo fmt -p loom-daemon -- --check` and `cargo clippy --package loom-daemon --package loom-api -- -D warnings <CI's exact allow-list>` both clean.

Closes #5270