### PR TITLE
fix(install): regenerate manifest after guard-hook wiring to stop spurious settings.json drift

### DIFF
--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -141,6 +141,7 @@ tests/install/test-daemon-build-shortcut.sh
 tests/install/test-forge-detect.sh
 tests/install/test-git-repo-detection.sh
 tests/install/test-hooks-preserve.sh
+tests/install/test-manifest-freshness-after-hook-wiring.sh
 tests/install/test-provision-daemon.sh
 tests/install/test-uninstall-labels-block.sh
 tests/install/test-uninstall-preserve-siblings.sh

--- a/install.sh
+++ b/install.sh
@@ -217,6 +217,41 @@ wire_quick_install_guard_hooks() {
     warning "Project-level guard-hook entries not fully asserted in $target/.claude/settings.json; run scripts/install-loom.sh (Full Install) or re-add them manually — see defaults/docs/guard-hooks.md."
 }
 
+# Regenerate .loom/manifest.json's checksums after this function's caller has
+# finished ALL post-`loom-daemon init` mutations of Loom-tracked files
+# (issue #5279).
+#
+# `loom-daemon init` generates the manifest as its own last internal step
+# (loom-daemon/src/init/post_init.rs::generate_manifest, invoked from
+# loom-daemon/src/init/mod.rs) -- which runs BEFORE `wire_quick_install_guard_hooks`
+# (above) asserts project-level guard-hook entries into `.claude/settings.json`
+# via `ensure_project_hook_wiring`. That means the manifest's stored hash for
+# `.claude/settings.json` reflects its PRE-wiring content, not the genuinely
+# final installed state.
+#
+# Left unfixed, `verify-install.sh verify` reports spurious `DRIFT DETECTED` on
+# `.claude/settings.json` immediately after EVERY quick install -- even a
+# completely vanilla install with zero customization and zero foreign
+# content -- because the on-disk file legitimately changes after the manifest
+# snapshot was taken. This is the concrete, reproducible mechanism behind the
+# "verify-install.sh reports [settings.json] as drift by design" symptom
+# described in #5279 (a stricter, always-reproducible version of it: no
+# foreign/sibling-tool content is even required to trigger it).
+#
+# Call this ONLY after every mutator of Loom-tracked files in the current
+# install path has run (currently: right after `wire_quick_install_guard_hooks`,
+# its last one on the quick-install path). Best-effort: a missing or failing
+# verify-install.sh never aborts the install.
+regenerate_manifest_after_hook_wiring() {
+  local target="$1"
+  local script="$target/.loom/scripts/verify-install.sh"
+
+  if [[ -f "$script" ]]; then
+    ( cd "$target" && bash "$script" generate --quiet ) || \
+      warning "Could not regenerate .loom/manifest.json after guard-hook wiring; 'verify-install.sh verify' may report spurious drift on .claude/settings.json."
+  fi
+}
+
 # Export LOOM_VERSION and LOOM_COMMIT so `loom-daemon init`'s template
 # substitution can fill {{LOOM_VERSION}} / {{LOOM_COMMIT}} placeholders in
 # the CLAUDE.md templates instead of falling back to the literal string
@@ -1180,6 +1215,11 @@ elif [[ -d "$TARGET_PATH/.loom" ]]; then
     # restores a working guard-hook execution path instead of leaving zero.
     wire_quick_install_guard_hooks "$TARGET_PATH"
 
+    # Regenerate the checksum manifest now that ALL settings.json mutations for
+    # this install path are complete (issue #5279 — see the function's own
+    # comment for why this must run after wire_quick_install_guard_hooks).
+    regenerate_manifest_after_hook_wiring "$TARGET_PATH"
+
     # Issue #3545: reconcile the git index after the uninstall→reinstall cycle.
     # The chained uninstall staged the deletion of every prior Loom file (now
     # scoped to Loom-managed paths — see scripts/uninstall-loom.sh), then
@@ -1584,6 +1624,11 @@ case "$METHOD" in
     # copies that nothing references (the 0.16.0 defaults settings.json has no
     # `hooks` block) and no user-scope wiring at all: zero guard coverage.
     wire_quick_install_guard_hooks "$TARGET_PATH"
+
+    # Regenerate the checksum manifest now that ALL settings.json mutations for
+    # this install path are complete (issue #5279 — see the function's own
+    # comment for why this must run after wire_quick_install_guard_hooks).
+    regenerate_manifest_after_hook_wiring "$TARGET_PATH"
 
     echo ""
     success "Quick installation complete!"

--- a/loom-daemon/src/init/scaffolding.rs
+++ b/loom-daemon/src/init/scaffolding.rs
@@ -432,13 +432,37 @@ pub fn load_internal_skip_list(defaults_path: &Path) -> HashSet<String> {
 }
 
 /// Read and parse an existing settings.json file, returning None if missing or invalid.
+///
+/// A missing file is the normal, silent case (fresh install — nothing to
+/// merge). A *present but unparseable* file is a different, noteworthy case:
+/// the caller ([`merge_settings_json`] via `setup_repository_scaffolding`)
+/// treats `None` as "nothing to merge" and leaves Loom's freshly-copied
+/// defaults in place untouched — silently dropping every pre-existing hook,
+/// permission, and top-level key the file contained (issue #5279's
+/// "Suspected Cause" #2: a non-strict-JSON file some other tool wrote — e.g.
+/// containing comments or a trailing comma — would previously fail this
+/// parse with zero warning, discarding its content on the very next
+/// reinstall/upgrade with no diagnostic pointing at why). We now warn on that
+/// specific case so the drop is visible instead of silent; the missing-file
+/// case stays silent since it is not an error.
 fn read_existing_settings(path: &Path) -> Option<Value> {
     let content = fs::read_to_string(path).ok()?;
-    let value: Value = serde_json::from_str(&content).ok()?;
-    if value.is_object() {
-        Some(value)
-    } else {
-        None
+    match serde_json::from_str::<Value>(&content) {
+        Ok(value) if value.is_object() => Some(value),
+        Ok(_) => {
+            eprintln!(
+                "Warning: {} is valid JSON but not a JSON object; skipping settings.json merge (Loom's own settings.json will be used as-is).",
+                path.display()
+            );
+            None
+        }
+        Err(e) => {
+            eprintln!(
+                "Warning: Failed to parse existing {} as JSON ({e}); skipping settings.json merge. Loom's own settings.json will be written as-is, which may drop pre-existing hooks/permissions/keys from this file. Fix the JSON syntax (comments and trailing commas are not valid JSON) and re-run install to merge them back in.",
+                path.display()
+            );
+            None
+        }
     }
 }
 
@@ -3258,6 +3282,143 @@ WARNING: Never run `lake build` inside Docker - causes memory corruption.",
 
         // enabledPlugins should be preserved
         assert_eq!(result["enabledPlugins"]["my-plugin"], true);
+    }
+
+    /// Issue #5279 edge case: a foreign hook under a hook type/matcher pair
+    /// Loom's own defaults ALSO define (both register `PreToolUse`/`Bash`).
+    /// Confirms dedup is by normalized *command*, not by hook type or matcher
+    /// alone -- a foreign command sharing Loom's matcher must survive
+    /// alongside Loom's own command, not be treated as a collision and
+    /// dropped/replaced.
+    #[test]
+    fn test_merge_settings_dedup_preserves_foreign_command_in_shared_matcher() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let defaults = temp_dir.path().join("defaults");
+
+        fs::create_dir(workspace.join(".git")).unwrap();
+
+        fs::create_dir_all(defaults.join(".claude").join("commands")).unwrap();
+        fs::write(
+            defaults.join(".claude").join("settings.json"),
+            r#"{
+                "hooks": {
+                    "PreToolUse": [{
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"}]
+                    }]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        fs::create_dir_all(workspace.join(".claude").join("commands")).unwrap();
+        fs::write(
+            workspace.join(".claude").join("settings.json"),
+            r#"{
+                "hooks": {
+                    "PreToolUse": [{
+                        "matcher": "Bash",
+                        "hooks": [{"type": "command", "command": "repo-skills-bash-guard.sh"}]
+                    }]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let mut report = InitReport::default();
+        setup_repository_scaffolding(workspace, &defaults, true, &mut report).unwrap();
+
+        let result_content =
+            fs::read_to_string(workspace.join(".claude").join("settings.json")).unwrap();
+        let result: serde_json::Value = serde_json::from_str(&result_content).unwrap();
+
+        let pre_tool = result["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre_tool.len(), 1, "Bash matcher should not be duplicated");
+
+        let bash_matcher = &pre_tool[0];
+        let commands: Vec<&str> = bash_matcher["hooks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|h| h["command"].as_str().unwrap())
+            .collect();
+
+        assert!(
+            commands.contains(&"repo-skills-bash-guard.sh"),
+            "Foreign command sharing Loom's hook type+matcher must survive: {commands:?}"
+        );
+        assert!(
+            commands.iter().any(|c| c.contains("guard-destructive.sh")),
+            "Loom's own command must also be present: {commands:?}"
+        );
+    }
+
+    /// Issue #5279 ("Suspected Cause" #2): a pre-existing `.claude/settings.json`
+    /// that fails to parse as JSON (e.g. a sibling tool wrote non-strict JSON
+    /// with a trailing comma) must not silently and invisibly discard the
+    /// existing file's content -- `read_existing_settings` skips merging in
+    /// this case (documented behavior), and this test locks in that the skip
+    /// happens cleanly (no panic, Loom's own settings.json is written) so a
+    /// regression can't turn this into a crash. The accompanying warning text
+    /// (see `read_existing_settings`'s doc comment) is intentionally not
+    /// assertable here -- it goes to stderr, matching this file's other
+    /// eprintln!-based warnings (e.g. the settings-write-failure warning in
+    /// `setup_repository_scaffolding`), none of which are stderr-asserted.
+    #[test]
+    fn test_merge_settings_skips_merge_on_invalid_json_existing_settings() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path();
+        let defaults = temp_dir.path().join("defaults");
+
+        fs::create_dir(workspace.join(".git")).unwrap();
+
+        fs::create_dir_all(defaults.join(".claude").join("commands")).unwrap();
+        fs::write(
+            defaults.join(".claude").join("settings.json"),
+            r#"{
+                "permissions": {
+                    "allow": ["Bash(gh:*)"]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        fs::create_dir_all(workspace.join(".claude").join("commands")).unwrap();
+        // Deliberately invalid JSON: a trailing comma after the last array
+        // element, as a non-strict-JSON-tolerant tool might emit.
+        fs::write(
+            workspace.join(".claude").join("settings.json"),
+            r#"{
+                "permissions": {
+                    "allow": ["Bash(repo-skills-tool:*)",]
+                },
+                "enabledPlugins": {"repo-skills": true}
+            }"#,
+        )
+        .unwrap();
+
+        let mut report = InitReport::default();
+        // Must not panic, and must complete the install.
+        setup_repository_scaffolding(workspace, &defaults, true, &mut report).unwrap();
+
+        let result_content =
+            fs::read_to_string(workspace.join(".claude").join("settings.json")).unwrap();
+        let result: serde_json::Value = serde_json::from_str(&result_content)
+            .expect("Loom's own settings.json must be valid JSON");
+
+        // The merge was skipped (documented current behavior for unparseable
+        // existing content) -- Loom's own settings.json is what's on disk, and
+        // the foreign content is NOT present, since there was nothing valid to
+        // merge it from.
+        assert_eq!(
+            result["permissions"]["allow"][0], "Bash(gh:*)",
+            "Loom's own settings.json should be in place"
+        );
+        assert!(
+            result.get("enabledPlugins").is_none(),
+            "Foreign content from the unparseable file cannot survive a skipped merge"
+        );
     }
 
     // ---------- #3325 legacy-layout migration tests ----------

--- a/tests/install/test-manifest-freshness-after-hook-wiring.sh
+++ b/tests/install/test-manifest-freshness-after-hook-wiring.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Test suite for install.sh::regenerate_manifest_after_hook_wiring() (#5279).
+#
+# Usage: ./tests/install/test-manifest-freshness-after-hook-wiring.sh
+#
+# Background: `loom-daemon init` generates `.loom/manifest.json` as its own
+# last internal step -- BEFORE `wire_quick_install_guard_hooks` (install.sh)
+# asserts project-level guard-hook entries into `.claude/settings.json`. That
+# means the manifest's stored checksum for `.claude/settings.json` reflected
+# PRE-wiring content, so `verify-install.sh verify` reported spurious
+# `DRIFT DETECTED` on that file after EVERY quick install -- even a
+# completely vanilla install with zero customization -- because the on-disk
+# file legitimately changed after the manifest snapshot was taken.
+#
+# `regenerate_manifest_after_hook_wiring()` fixes this by re-running
+# `verify-install.sh generate --quiet` after all `.claude/settings.json`
+# mutations for the install path are complete. This suite extracts just that
+# function (install.sh runs top-level installer logic when sourced, so we use
+# the same awk-extraction + eval technique as test-hooks-preserve.sh) and
+# drives it against a real (copied-in) verify-install.sh + a synthetic
+# install-metadata.json, with no loom-daemon binary or cargo build required.
+#
+# Exit code 0 = all tests pass, 1 = failures detected.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+VERIFY_INSTALL_SH="$REPO_ROOT/defaults/scripts/verify-install.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    echo -e "${GREEN}PASS${NC}: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo -e "${RED}FAIL${NC}: $desc"
+    echo "  expected: '$expected'"
+    echo "  actual:   '$actual'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Stub logging helpers so the extracted function has them in scope.
+info()    { :; }
+success() { :; }
+warning() { echo "warning: $*" >&2; }
+error()   { echo "error: $*" >&2; return 1; }
+
+# Extract regenerate_manifest_after_hook_wiring() from install.sh (same
+# awk-to-closing-brace technique as test-hooks-preserve.sh /
+# test-daemon-build-shortcut.sh).
+_FN_SRC="$(awk '/^regenerate_manifest_after_hook_wiring\(\) \{/{f=1} f{print} f&&/^}$/{exit}' "$INSTALL_SH")"
+if [[ -z "$_FN_SRC" ]]; then
+  echo -e "${RED}FATAL${NC}: could not extract regenerate_manifest_after_hook_wiring() from $INSTALL_SH"
+  exit 1
+fi
+eval "$_FN_SRC"
+
+if [[ ! -f "$VERIFY_INSTALL_SH" ]]; then
+  echo -e "${RED}FATAL${NC}: verify-install.sh not found at $VERIFY_INSTALL_SH"
+  exit 1
+fi
+
+# Build a minimal synthetic "installed" target: a git repo carrying just
+# .claude/settings.json as the sole Loom-tracked file (via a synthetic
+# install-metadata.json), plus a real copy of verify-install.sh so the
+# extracted function has something real to invoke.
+make_target() {
+  local target="$1"
+  mkdir -p "$target/.git" "$target/.claude" "$target/.loom/scripts"
+  cp "$VERIFY_INSTALL_SH" "$target/.loom/scripts/verify-install.sh"
+  chmod +x "$target/.loom/scripts/verify-install.sh"
+  cat > "$target/.loom/install-metadata.json" <<'EOF'
+{"installed_files": [".claude/settings.json"]}
+EOF
+}
+
+# ============================================================================
+# Test 1: manifest is regenerated to match settings.json mutated AFTER the
+# initial `loom-daemon init` manifest snapshot (simulated here by generating
+# once, then mutating the file, then calling the function under test).
+# ============================================================================
+echo ""
+echo "=== regenerate_manifest_after_hook_wiring refreshes a stale settings.json hash ==="
+
+TARGET1="$(mktemp -d)"
+make_target "$TARGET1"
+
+printf '%s\n' '{"permissions": {"allow": ["Bash(gh:*)"]}}' > "$TARGET1/.claude/settings.json"
+
+# Simulate loom-daemon init's own internal manifest generation (BEFORE the
+# hook-wiring mutation below) -- this is the snapshot that used to go stale.
+( cd "$TARGET1" && bash .loom/scripts/verify-install.sh generate --quiet )
+
+# Simulate wire_quick_install_guard_hooks mutating settings.json AFTER that
+# snapshot (e.g. ensure_project_hook_wiring asserting project-level hooks).
+printf '%s\n' \
+  '{"permissions": {"allow": ["Bash(gh:*)"]}, "hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "${CLAUDE_PROJECT_DIR}/.loom/hooks/guard-destructive.sh"}]}]}}' \
+  > "$TARGET1/.claude/settings.json"
+
+# Before the fix: verify would report drift here, since the manifest was
+# generated against the pre-mutation content.
+PRE_STATUS=$(cd "$TARGET1" && bash .loom/scripts/verify-install.sh verify --json 2>/dev/null | jq -r '.status')
+assert_eq "sanity: verify reports drift before regeneration" "drift" "$PRE_STATUS"
+
+regenerate_manifest_after_hook_wiring "$TARGET1"
+
+POST_STATUS=$(cd "$TARGET1" && bash .loom/scripts/verify-install.sh verify --json 2>/dev/null | jq -r '.status')
+assert_eq "verify reports ok after regenerate_manifest_after_hook_wiring" "ok" "$POST_STATUS"
+
+rm -rf "$TARGET1"
+
+# ============================================================================
+# Test 2: a target with no .loom/scripts/verify-install.sh at all is a silent
+# best-effort no-op (never aborts the install).
+# ============================================================================
+echo ""
+echo "=== regenerate_manifest_after_hook_wiring no-ops cleanly when verify-install.sh is absent ==="
+
+TARGET2="$(mktemp -d)"
+mkdir -p "$TARGET2/.git" "$TARGET2/.claude"
+
+set +e
+regenerate_manifest_after_hook_wiring "$TARGET2"
+RC=$?
+set -e
+assert_eq "missing verify-install.sh does not abort (best-effort)" "0" "$RC"
+
+rm -rf "$TARGET2"
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "=========================================="
+echo -e "Results: ${PASS} passed, ${FAIL} failed, ${TOTAL} total"
+echo "=========================================="
+
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Issue #5279's Curator Enhancement framed this as a verify-and-close task: confirm
whether the "wholesale rewrite drops other tools' hooks" premise still reproduces
on current `main` (it likely doesn't, per `merge_settings_json` added in #3185),
and either document a refutation or fix whatever real gap the repro surfaces. I
ran the repro end-to-end and found **both** outcomes apply to different parts of
the issue:

- **Refuted**: the original reported symptom (a foreign hook/permission/top-level
  key silently dropped by install) does **not** reproduce on current `main`. A
  manual repro (scratch target with a foreign `SessionStart` hook + foreign
  permission + foreign top-level key, installed over via `install.sh --quick`)
  preserved all three, confirming `merge_settings_json` works as designed.
- **Found a real, concrete, always-reproducible gap**: `verify-install.sh verify`
  reports spurious `DRIFT DETECTED` on `.claude/settings.json` after **every**
  Quick Install — even a completely vanilla install with **zero** customization
  and zero foreign content. This directly violates the issue's AC #5
  ("byte-identical Loom content → still `ok`, not drift") and is a more precise,
  always-reproducible version of AC #4's "verify-install.sh gives false positives
  on settings.json" concern. Root cause: `loom-daemon init` generates
  `.loom/manifest.json` as its own last internal step — **before**
  `install.sh`'s `wire_quick_install_guard_hooks` (via `ensure_project_hook_wiring`)
  asserts project-level guard-hook entries into `.claude/settings.json`. The
  manifest's stored hash reflects pre-wiring content, so the very next `verify`
  call sees a file that legitimately changed after the snapshot and reports it as
  drift.

I also hardened `read_existing_settings` per the issue's "Suspected Cause" #2
(a present-but-unparseable existing `settings.json` previously skipped the merge
with **zero** warning) and added the two edge-case tests the issue's Test Plan
named explicitly.

## Investigation details (repro steps + findings)

1. Re-ran `cargo test -p loom-daemon --lib init::scaffolding::tests::test_merge_settings_in_scaffolding_reinstall` → **1 passed** (confirmed still passing, as the Curator noted).
2. Manual repro: scratch git repo with `.claude/settings.json` carrying a foreign `SessionStart` hook, a foreign permission (`Bash(repo-skills-tool:*)`), and a foreign top-level key (`enabledPlugins`). Ran `install.sh --quick -y <target>`:
   - All three foreign items **survived** the merge intact (see the settings.json diff in the PR discussion if useful — happy to attach on request).
   - `verify-install.sh verify` reported `DRIFT DETECTED (1 modified)` on `.claude/settings.json` — **but** a control repro with a fully vanilla target (no foreign content at all) showed the **exact same** spurious drift, isolating the cause to something unrelated to foreign content.
3. Traced the mechanism: `install.sh`'s Quick Install flow is `loom-daemon init` (merges settings.json + generates the manifest internally) → `install_hooks_and_cli` → `wire_quick_install_guard_hooks` (→ `ensure_project_hook_wiring`, which mutates `.claude/settings.json` to add project-level `${CLAUDE_PROJECT_DIR}/.loom/hooks/...` entries). The manifest snapshot happens **before** that last mutation.
   - Full Install (`scripts/install-loom.sh`) does **not** have this bug: its only project-settings mutator, `provision_loom_hooks`, runs **before** `loom-daemon init` (and it doesn't call `ensure_project_hook_wiring` at all — Full Install relies solely on user-scope hook wiring). Confirmed via code reading since a live Full Install requires real forge auth/remote infrastructure I did not want to fabricate; both install paths invoke the identical `loom-daemon init --defaults <defaults> <target>` binary command for the settings.json merge itself (already verified via the Quick Install repro + the existing Rust test).
4. Fix: added `regenerate_manifest_after_hook_wiring()` to `install.sh`, called right after each of the two `wire_quick_install_guard_hooks` call sites (the `--confirm-reinstall` branch and the fresh-quick branch). Verified with a real end-to-end run: a vanilla `install.sh --quick` target now reports `ALL FILES MATCH` instead of `DRIFT DETECTED`, and the foreign-content target now reports `ALL FILES MATCH` too (foreign content preserved **and** no false-positive drift).

## Changes

- `install.sh`: new `regenerate_manifest_after_hook_wiring()` helper, called after both `wire_quick_install_guard_hooks "$TARGET_PATH"` call sites, so `.loom/manifest.json` reflects the genuinely final post-install state instead of a pre-hook-wiring snapshot.
- `loom-daemon/src/init/scaffolding.rs`:
  - `read_existing_settings` now emits a `Warning:` (instead of silently returning `None`) when an existing `.claude/settings.json` is present but fails to parse as JSON — the merge is still skipped (documented, unchanged behavior), but the drop is now visible.
  - New test `test_merge_settings_dedup_preserves_foreign_command_in_shared_matcher`: a foreign hook command under a hook type+matcher (`PreToolUse`/`Bash`) Loom's own defaults *also* register — confirms dedup is by normalized command, not by matcher, so neither command is lost.
  - New test `test_merge_settings_skips_merge_on_invalid_json_existing_settings`: a non-strict-JSON existing `settings.json` (trailing comma) doesn't panic and the documented skip-merge behavior is locked in.
- `tests/install/test-manifest-freshness-after-hook-wiring.sh` (new): hermetic suite (no loom-daemon binary/build required, following the existing `test-hooks-preserve.sh` awk-extraction pattern) that reproduces the stale-manifest bug and confirms the fix resolves it, plus a best-effort no-op check when `verify-install.sh` is absent. Wired into `defaults/scripts/tests/ci-wired.txt`.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Reproduce or explicitly refute the reported hook-loss via `install.sh --quick` and Full Install | ✅ | Refuted for Quick Install via live repro (all 3 foreign items survive); Full Install shares the identical `loom-daemon init` binary call and its only settings-mutator runs *before* init, so it cannot exhibit the bug either — documented above rather than re-run live (requires real forge auth/remote). |
| If reproduced: fix the actual gap + extend tests | ✅ (different, real gap found) | Fixed the manifest-freshness ordering bug in `install.sh`; extended `scaffolding.rs` tests for the two named edge cases. |
| If not reproduced: document why | ✅ | Documented above; stale-binary remains the leading hypothesis for the *original* reporter's specific incident, though the manifest-freshness bug found here independently explains why `verify-install.sh` "reports it as drift by design" is true today, universally, not just for foreign content. |
| `verify-install.sh` no longer reports drift purely from legitimately-preserved foreign content | ✅ | Live repro: foreign-content target reports `ALL FILES MATCH` post-fix (was `DRIFT DETECTED`). |
| Existing behavior unchanged for settings.json with ONLY Loom-shipped content (still `ok`) | ✅ | Live repro: vanilla target reports `ALL FILES MATCH` post-fix (was, in fact, incorrectly `DRIFT DETECTED` pre-fix — this AC was violated on `main` and is now satisfied). |

## Test Plan

- `cargo test -p loom-daemon --lib init::scaffolding::` → 64 passed, 0 failed (pre-existing + 2 new tests).
- `cargo clippy -p loom-daemon --lib -- -D warnings` → clean. `cargo fmt --check -p loom-daemon` → clean.
- `bash tests/install/test-manifest-freshness-after-hook-wiring.sh` → 3 passed, 0 failed.
- `bash defaults/scripts/tests/check-ci-suite-manifest.sh` → OK (new suite wired correctly).
- `bash scripts/test-installer.sh` (full suite, 178 assertions across ~87 numbered tests) → 178 passed, 1 failed. The 1 failure (`test-loom-dispatcher.sh`, 3 sub-assertions re: `loom restart --machine` env-var harvesting, issue #4581) is **pre-existing and unrelated** — confirmed by running the same sub-suite from the unmodified primary checkout, which reproduces the identical 3 failures with none of this PR's changes present.
- `bash defaults/scripts/tests/test-install-reinstall-safety.sh` → 21/21 passed.
- `bash scripts/test-install-local-mode.sh` → 19/19 passed.
- Manual end-to-end repro (see Investigation details above): `install.sh --quick` against (a) a vanilla target and (b) a target with foreign `SessionStart` hook + foreign permission + foreign top-level key, both followed by `.loom/scripts/verify-install.sh verify` — both report `ALL FILES MATCH` post-fix.

Closes #5279