### PR TITLE
fix(tests): make test-loom-dispatcher.sh Test 16b OS-independent, add real-plist happy path

### DIFF
--- a/defaults/scripts/tests/test-loom-dispatcher.sh
+++ b/defaults/scripts/tests/test-loom-dispatcher.sh
@@ -392,8 +392,20 @@ Environment=LOOM_WORK_FINDER=1
 Environment=LOOM_MAIN_HEALTH_GATE=1
 Environment=PATH=/opt/sentinel-4581/bin:/usr/bin:/bin
 EOF
+# Fake `uname` -> Linux so the systemd-gated harvest branch fires
+# deterministically regardless of the REAL host OS this suite happens to run
+# on (mirrors Test 16d's Darwin override below, in the opposite direction —
+# #5169). Without this, a real Darwin host takes scripts/loom's Darwin branch
+# unconditionally and never reads the systemd-unit fixture this test writes,
+# so the harvest finds nothing and every assertion below fails.
+FAKE_UNAME_LINUX_BIN=$(mktemp -d)
+cat > "$FAKE_UNAME_LINUX_BIN/uname" <<'EOF'
+#!/usr/bin/env bash
+echo "Linux"
+EOF
+chmod +x "$FAKE_UNAME_LINUX_BIN/uname"
 set +e
-out=$(cd "$CONSUMER" && PATH="/usr/bin:/bin" HOME="$HOME_HARVEST" LOOM_HOME="$CHK_HARVEST" bash "$DISPATCHER" restart --machine 2>&1)
+out=$(cd "$CONSUMER" && PATH="$FAKE_UNAME_LINUX_BIN:/usr/bin:/bin" HOME="$HOME_HARVEST" LOOM_HOME="$CHK_HARVEST" bash "$DISPATCHER" restart --machine 2>&1)
 rc=$?
 set -e 2>/dev/null || true
 assert_eq "$rc" "0" "harvest-and-preserve restart fallback still exits 0"
@@ -435,6 +447,61 @@ set -e 2>/dev/null || true
 assert_eq "$rc" "6" "restart fallback aborts (exit 6) when the live plist cannot be parsed"
 assert_contains "$out" "Refusing to fall back" "abort message explains the refusal"
 assert_not_contains "$out" "STUB_START" "aborted fallback never reaches start_target (no silently-narrowed relaunch)"
+
+# Test 16d only covers the UNREADABLE-plist abort path. The happy-path launchd
+# harvest (a real, parseable plist -> re-exported env reaching start_target's
+# re-render) had no coverage anywhere — #5169. Needs a REAL `plutil` + `jq` to
+# exercise harvest_plist_env's actual parse path (a hand-rolled parser would
+# test the test, not the production code), so this mirrors
+# test-loom-daemon-update.sh's scenario-21/22 guard: skip on a host without
+# plutil (i.e. every Linux CI runner) rather than fail on a genuinely
+# macOS-only dependency.
+if command -v plutil >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+    echo "Test 16f: 'loom restart --machine' harvests + re-exports a real, readable launchd plist's LOOM_* env before the bare-exec fallback (#4581 happy path)"
+    CHK_HARVEST_GOOD=$(make_checkout_with_harvest)
+    HOME_LAUNCHD_GOOD=$(mktemp -d)
+    mkdir -p "$HOME_LAUNCHD_GOOD/Library/LaunchAgents"
+    cat > "$HOME_LAUNCHD_GOOD/Library/LaunchAgents/com.rjwalters.loom-daemon.plist" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rjwalters.loom-daemon</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>LOOM_DAEMON_SUPERVISOR</key>
+        <string>launchd</string>
+        <key>LOOM_WORK_FINDER</key>
+        <string>1</string>
+        <key>LOOM_MAIN_HEALTH_GATE</key>
+        <string>1</string>
+        <key>PATH</key>
+        <string>/opt/sentinel-4581/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>
+EOF
+    # Fake `uname` -> Darwin so the launchd-gated harvest branch fires
+    # deterministically regardless of the real host OS (same pattern as Test
+    # 16d/16b). The REAL plutil/jq on PATH do the actual parsing.
+    FAKE_UNAME_BIN2=$(mktemp -d)
+    cat > "$FAKE_UNAME_BIN2/uname" <<'EOF'
+#!/usr/bin/env bash
+echo "Darwin"
+EOF
+    chmod +x "$FAKE_UNAME_BIN2/uname"
+    set +e
+    out=$(cd "$CONSUMER" && PATH="$FAKE_UNAME_BIN2:$PATH" HOME="$HOME_LAUNCHD_GOOD" LOOM_HOME="$CHK_HARVEST_GOOD" bash "$DISPATCHER" restart --machine 2>&1)
+    rc=$?
+    set -e 2>/dev/null || true
+    assert_eq "$rc" "0" "harvest-and-preserve restart fallback from a real launchd plist still exits 0"
+    assert_contains "$out" "LOOM_WORK_FINDER=[1]" "harvested LOOM_WORK_FINDER from a real plist reaches start_target's re-render"
+    assert_contains "$out" "LOOM_MAIN_HEALTH_GATE=[1]" "harvested LOOM_MAIN_HEALTH_GATE from a real plist reaches start_target's re-render"
+    assert_contains "$out" "preserved 2 LOOM_*/token env var(s)" "dispatcher reports the harvested count (real plist)"
+else
+    echo "Test 16f: SKIP (plutil and/or jq not on PATH — harvest_plist_env is a macOS-only production path)"
+fi
 
 echo "Test 16e: 'loom restart --machine' still falls back cleanly when this checkout predates daemon-env-harvest.sh (#4581 backward-compat)"
 CHK_NO_HARVEST_LIB=$(make_checkout)


### PR DESCRIPTION
Closes #5169

## Summary

Issue #5169 flagged two hermeticity bugs in `defaults/scripts/tests/test-loom-dispatcher.sh`:

1. **Test 21 leaked ambient `LOOM_RUNTIME`.** Already fixed on `main` by #5168 (`env -u LOOM_RUNTIME -u LOOM_WORKSPACE` on the Test 21 / Test 19 "no env" invocations). Verified there is no other "no env" invocation in this file with the same gap — grepped all `LOOM_CONFIG_DEFAULTS_FILE=""` call sites and confirmed each one that claims "no env" already scrubs `LOOM_RUNTIME`/`LOOM_WORKSPACE`.

2. **Test 16b's systemd fixture was unreachable on a real Darwin host.** `scripts/loom`'s harvest dispatch branches on the *real* `uname -s`, not on which fixture the test wrote. Test 16b wrote a systemd-unit fixture but never forced `uname`, so on macOS the Darwin branch always ran and the fixture was never read, failing 3 assertions. Fixed by forcing `uname` -> `"Linux"` via a PATH-prepended fake `uname` script — mirroring Test 16d's existing (and already-correct) Darwin override in the other direction.

## Secondary addition

Added **Test 16f**: a companion happy-path launchd-harvest test (a real, parseable plist -> harvested env reaching `start_target`'s re-render). Previously only Test 16d's *unreadable*-plist abort path had coverage; the happy path had none. Gated on real `plutil` + `jq` being on `PATH` (skips on Linux CI, same pattern `test-loom-daemon-update.sh` scenarios 21/22 already use for the same macOS-only dependency) so it never fails a Linux runner on a genuinely unavailable binary.

## Verification

- `bash defaults/scripts/tests/test-loom-dispatcher.sh` — 99/99 passed, with `LOOM_RUNTIME` unset.
- `LOOM_RUNTIME=claude bash defaults/scripts/tests/test-loom-dispatcher.sh` — 99/99 passed identically (reproduces the exact leak scenario from the issue; confirms it's already closed by #5168 and stays closed).
- Locally faked a minimal `plutil` (Python + `plistlib`, `-convert json -o -` only) on `PATH` to force Test 16f to actually run its real-plist path end-to-end on this Linux host: 103/103 passed (99 base + 4 new Test 16f assertions), confirming the new test's logic is correct, not just its skip-guard.
- `shellcheck -x` on the modified file: only pre-existing informational `SC2015`/`SC2012` notes, unrelated to this change.

**What I could and couldn't exercise directly:**
- **Test 16b's fix (forcing `uname` -> Linux)**: exercised directly — this test host is Linux, so before the fix the "real OS" branch already matched by accident; the fake-`uname` override makes the OS the fixture is read against explicit and host-independent rather than accidental, and I verified the fake-Linux-uname path still produces the same 4 passing assertions.
- **The Darwin branch itself** (i.e. would Test 16b/16f *actually* fail/pass on a real macOS host pre/post-fix): reasoned about, not run on real hardware — I don't have a Darwin host available. Reasoning: `scripts/loom`'s branch is a plain `[[ "$(uname -s)" == "Darwin" ]]` string check with no other host-dependent behavior in the harvest path, and the fake-`uname` scripts in both Test 16b and 16f are placed first on `PATH`, so `uname -s` resolves identically regardless of the real host OS. I'm confident this generalizes to a real Darwin host but flagging it as reasoned-not-verified per the issue's ask.

## Files changed

- `defaults/scripts/tests/test-loom-dispatcher.sh`