### PR TITLE
Surface outstanding loom-quarantine: stashes to the operator

### DIFF
--- a/defaults/.claude/commands/loom/sweep.md
+++ b/defaults/.claude/commands/loom/sweep.md
@@ -2208,6 +2208,23 @@ This is advisory-only. The script always exits `0` and **must not block** the sw
 
 If the check warns, the operator should refresh local `main` (and re-sync installed copies if their install flow does so) before relying on stacked-dependency or auto-reconcile behavior mid-sweep.
 
+## Outstanding Quarantine Stashes (#5185)
+
+`check-main-clean.sh --quarantine` (see the Wave Lifecycle "Backstop" step above) rescues contamination it finds in the main worktree into a labeled `git stash` entry — `On <branch>: loom-quarantine: run=<RUN_ID> issue=<N>` — rather than discarding it. This is correct and loses no data, but the quarantine is otherwise recorded only in the structured `.loom/logs/main-quarantine.log` JSON log; nothing surfaces that a rescue stash is outstanding. A labeled stash can therefore sit indefinitely with nobody aware there is quarantined work to reconcile — noticed, if at all, only by chance (e.g. an unrelated command that happens to count stashes).
+
+**Before the first wave — or, on the daemon path, before the first `mcp__loom__dispatch_sweep` call** — run the quarantine-stash check and surface its output to the user (same timing and sibling role as the Host Sleep Readiness and Main Branch Freshness checks above):
+
+```bash
+./.loom/scripts/check-quarantine-stashes.sh
+```
+
+This is advisory-only. The script always exits `0` and **must not block** the sweep — proceed regardless of what it prints. It is strictly **read-only**: it never pops, drops, or applies a stash. `refs/stash` is shared across every worktree of the repo (not per-worktree — see the #4821 note under "CRITICAL: Only Builders parallelize"), so the check is meaningful regardless of which worktree it runs from:
+
+- **≥1 outstanding `loom-quarantine:` stash:** prints a bordered warning to stderr listing each stash's `stash@{N}` selector, relative age, and label (run id / issue number), with `git stash show -p <ref>` / `git stash apply <ref>` as the inspection/reconciliation commands.
+- **None outstanding:** prints nothing to stderr; a one-line stdout confirmation (suppressible with `--quiet`, matching `check-host-sleep.sh` / `check-main-freshness.sh`).
+
+If the check warns, the operator should reconcile each listed stash into the issue worktree it belongs to (or consciously drop it) — this does not block the current sweep, but stale quarantines accumulate silently otherwise.
+
 ## Sweep Child Working-Set Contract (#3980)
 
 Every dispatched child of a sweep — Curator/Builder/Judge/Doctor/Champion subagents, and any test suite or tool subprocess they invoke — is expected to stay within a fixed filesystem working set:

--- a/defaults/docs/troubleshooting.md
+++ b/defaults/docs/troubleshooting.md
@@ -464,6 +464,22 @@ in the primary clone (`stash_ref`/`stash_commit` are logged to
 `.loom/logs/main-quarantine.log`) rather than simply finding your branch
 intact.
 
+**Discovering an outstanding quarantine without prior knowledge that one
+occurred (#5185).** Both #5185 incidents above were noticed only by chance —
+an unrelated hygiene command happened to count stashes and flag one that had
+not existed at session start. `git stash list` and the structured
+`.loom/logs/main-quarantine.log` are both authoritative, but neither is
+something an operator thinks to check unprompted. `/loom:sweep` now runs
+`./.loom/scripts/check-quarantine-stashes.sh` before its first wave (see
+"Outstanding Quarantine Stashes" in `defaults/.claude/commands/loom/sweep.md`)
+— a non-blocking, read-only advisory that lists every outstanding
+`loom-quarantine:` stash (its `stash@{N}` selector, age, and run/issue label)
+whenever one exists. Run it manually at any time to check without waiting for
+a sweep:
+```bash
+./.loom/scripts/check-quarantine-stashes.sh
+```
+
 **A note on the quarantine's stash message**: `check-main-clean.sh` passes an
 explicit `-m "loom-quarantine: $QUARANTINE_LABEL"` message to `git stash
 push`, but `git stash list` always prefixes stash entries with `On

--- a/defaults/scripts/check-quarantine-stashes.sh
+++ b/defaults/scripts/check-quarantine-stashes.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# check-quarantine-stashes.sh - Surface outstanding `loom-quarantine:` stashes.
+#
+# This is a NON-BLOCKING, advisory check, mirroring check-host-sleep.sh (#3350)
+# and check-main-freshness.sh (#3770) in structure and contract.
+#
+# check-main-clean.sh --quarantine (see the Wave Lifecycle "Backstop" step in
+# defaults/.claude/commands/loom/sweep.md) rescues contamination it finds in the
+# primary clone's working tree into a labeled `git stash` entry rather than
+# discarding it — by design, this never loses data. But the quarantine is
+# recorded only in a structured JSON log line
+# (.loom/logs/main-quarantine.log); nothing surfaces that a rescue stash is
+# outstanding. Absent an operator who happens to notice, a labeled
+# `loom-quarantine:` stash can sit indefinitely with nobody aware there is
+# quarantined work to reconcile (#5185).
+#
+# refs/stash is shared across every worktree of a repo (not per-worktree —
+# see the #4821 note in defaults/.claude/commands/loom/sweep.md), so this
+# check is meaningful regardless of which worktree it runs from.
+#
+# It MUST NOT block — even if git fails, it returns 0. It is strictly
+# read-only: it never pops, drops, or applies a stash.
+#
+# Usage:
+#   ./.loom/scripts/check-quarantine-stashes.sh          # print warning (or nothing) and exit 0
+#   ./.loom/scripts/check-quarantine-stashes.sh --quiet   # suppress the stdout one-liner
+#   ./.loom/scripts/check-quarantine-stashes.sh --help    # show usage
+#
+# Exit codes:
+#   0 - Always. This script is advisory; it never blocks Loom.
+#
+# See also: check-host-sleep.sh (#3350), check-main-freshness.sh (#3770) — the
+# sibling pre-flight advisories this script mirrors in structure and contract.
+
+set -uo pipefail  # NOTE: no -e — this script must never exit non-zero
+
+# ---------- output helpers ----------
+
+# Colors (only when stderr is a tty)
+if [[ -t 2 ]]; then
+    YELLOW='\033[1;33m'
+    GREEN='\033[1;32m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    YELLOW=''
+    GREEN=''
+    BOLD=''
+    NC=''
+fi
+
+QUIET=0
+for arg in "$@"; do
+    case "$arg" in
+        --quiet|-q)
+            QUIET=1
+            ;;
+        --help|-h)
+            sed -n '2,29p' "$0" | sed 's/^# //; s/^#//'
+            exit 0
+            ;;
+        *)
+            # Unknown args are ignored — this script must never fail.
+            ;;
+    esac
+done
+
+warn() {
+    # Print a multi-line warning block to stderr. Always returns 0.
+    printf '%b\n' "$*" >&2 || true
+}
+
+info_oneliner() {
+    # Print a single status line to stdout (suppressed by --quiet).
+    if [[ "$QUIET" -eq 0 ]]; then
+        printf '%b\n' "$*" || true
+    fi
+}
+
+# ---------- pre-flight: must be inside a git repo ----------
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    info_oneliner "${YELLOW}[quarantine-check] not inside a git repository; skipping.${NC}"
+    exit 0
+fi
+
+# ---------- collect loom-quarantine: stash entries ----------
+#
+# `git stash list` never dates its entries; `git log -g` over refs/stash does
+# (via the reflog), and %gs (reflog subject) is the same "On <branch>: <msg>"
+# text `git stash list` shows. Reading the reflog directly also survives a
+# repo with zero stashes (an empty/absent refs/stash) without erroring.
+#
+# NOTE: do NOT pass --date=relative here — it leaks into %gd itself, turning
+# the copy-pasteable "stash@{0}" selector into "stash@{49 minutes ago}" (not
+# a valid ref). %cr already gives a relative date independent of --date.
+
+STASH_LINES=""
+if git rev-parse --verify --quiet refs/stash >/dev/null 2>&1; then
+    STASH_LINES="$(git log -g --format='%gd|%cr|%gs' refs/stash 2>/dev/null || true)"
+fi
+
+if [[ -z "$STASH_LINES" ]]; then
+    info_oneliner "${GREEN}[quarantine-check] no outstanding loom-quarantine: stashes.${NC}"
+    exit 0
+fi
+
+QUARANTINE_LINES="$(printf '%s\n' "$STASH_LINES" | grep 'loom-quarantine:' || true)"
+
+if [[ -z "$QUARANTINE_LINES" ]]; then
+    info_oneliner "${GREEN}[quarantine-check] no outstanding loom-quarantine: stashes.${NC}"
+    exit 0
+fi
+
+COUNT="$(printf '%s\n' "$QUARANTINE_LINES" | grep -c '.' || true)"
+[[ "$COUNT" =~ ^[0-9]+$ ]] || COUNT=0
+
+# ---------- outstanding quarantines found: warn (non-blocking) ----------
+
+warn ""
+warn "${YELLOW}${BOLD}========================================================================${NC}"
+warn "${YELLOW}${BOLD}  WARNING: ${COUNT} outstanding loom-quarantine: stash(es) found (#5185)${NC}"
+warn "${YELLOW}${BOLD}========================================================================${NC}"
+warn "${YELLOW}check-main-clean.sh --quarantine rescued contaminated main-worktree${NC}"
+warn "${YELLOW}changes into these stashes rather than discarding them. Nothing was${NC}"
+warn "${YELLOW}lost, but nobody has reconciled them back into their owning issue yet.${NC}"
+warn ""
+
+while IFS='|' read -r ref age subject; do
+    [[ -n "$ref" ]] || continue
+    # subject looks like "On main: loom-quarantine: run=... issue=N [...]" —
+    # strip the "On <branch>: " prefix so the label reads cleanly.
+    label="${subject#On*: }"
+    warn "${YELLOW}  ${BOLD}${ref}${NC}${YELLOW} (${age}): ${label}${NC}"
+done <<< "$QUARANTINE_LINES"
+
+warn ""
+warn "${BOLD}To inspect a quarantine's contents:${NC}"
+warn "      ${BOLD}git stash show -p <ref>${NC}"
+warn "${BOLD}To reconcile it into the issue worktree it belongs to, then drop it:${NC}"
+warn "      ${BOLD}git stash apply <ref>${NC}   # or: git stash pop <ref>"
+warn "${BOLD}Structured records (label, paths, stash sha) for every quarantine:${NC}"
+warn "      ${BOLD}.loom/logs/main-quarantine.log${NC}"
+warn ""
+warn "${YELLOW}========================================================================${NC}"
+warn ""
+
+info_oneliner "${YELLOW}[quarantine-check] WARNING: ${COUNT} outstanding loom-quarantine: stash(es). See stderr for details.${NC}"
+
+# Always succeed — this script is advisory only.
+exit 0

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -37,6 +37,7 @@ test-check-git-identity.sh
 test-check-host-sleep.sh
 test-check-main-clean.sh
 test-check-main-freshness.sh
+test-check-quarantine-stashes.sh
 test-check-runtime-capabilities.sh
 test-clean-stale-binary.sh
 test-cleanup-branches-pr-review-branch.sh

--- a/defaults/scripts/tests/test-check-quarantine-stashes.sh
+++ b/defaults/scripts/tests/test-check-quarantine-stashes.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# test-check-quarantine-stashes.sh - Smoke tests for check-quarantine-stashes.sh (#5185)
+#
+# Constructs a throwaway local git repo so it can deterministically exercise:
+#   (a) no stashes at all         -> exit 0, no warning, "no outstanding" one-liner
+#   (b) a stash with an unrelated message -> exit 0, no warning (not a quarantine)
+#   (c) one or more loom-quarantine: stashes -> exit 0, warns, lists each with a
+#       copy-pasteable `stash@{N}` selector (not a date-corrupted one)
+#   (d) outside a git repo        -> exit 0 (never blocks)
+# Plus the flag/contract checks mirrored from test-check-main-freshness.sh:
+#   - always exits 0
+#   - --quiet suppresses the stdout one-liner
+#   - --help prints usage
+#   - unknown args don't break it
+#
+# Usage:
+#   ./.loom/scripts/tests/test-check-quarantine-stashes.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$HELPERS_DIR/check-quarantine-stashes.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: $1"
+}
+
+fail() {
+    TESTS_RUN=$((TESTS_RUN + 1))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: $1"
+}
+
+# Scratch area for fixtures — cleaned on exit.
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/test-quarantine-stashes.XXXXXX")"
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
+cleanup() { rm -rf "$WORKDIR" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# git needs an identity in a clean CI environment.
+export GIT_AUTHOR_NAME="test" GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="test" GIT_COMMITTER_EMAIL="test@example.com"
+
+# --- fixture builder ---------------------------------------------------------
+# Creates $WORKDIR/repo — a plain local repo with one commit on main, ready
+# for stashes to be layered on top by each test.
+make_fixture() {
+    local repo="$WORKDIR/repo"
+    rm -rf "$repo"
+    git init --quiet "$repo"
+    git -C "$repo" checkout -q -b main
+    echo "v1" > "$repo/file.txt"
+    git -C "$repo" add file.txt
+    git -C "$repo" commit -q -m "c1"
+}
+
+# Push a stash entry onto refs/stash with an explicit message, via a dirty
+# working-tree edit (git stash push requires something to stash).
+push_stash() {
+    local repo="$WORKDIR/repo" msg="$1" content="$2"
+    echo "$content" >> "$repo/file.txt"
+    git -C "$repo" stash push -q -m "$msg"
+}
+
+# -------- Test 1: script exists and is executable --------
+echo "Test 1: script exists and is executable"
+if [[ -x "$SCRIPT" ]]; then
+    pass "check-quarantine-stashes.sh is executable"
+else
+    fail "check-quarantine-stashes.sh is missing or not executable: $SCRIPT"
+    echo "FAILED: $TESTS_FAILED/$TESTS_RUN"
+    exit 1
+fi
+
+# -------- Test 2: no stashes at all -> exit 0, no warning --------
+echo "Test 2: no stashes at all exits 0 with no warning"
+make_fixture
+stderr_out="$(cd "$WORKDIR/repo" && "$SCRIPT" 2>&1 >/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "no-stashes exit code is 0"
+else
+    fail "no-stashes expected exit 0, got $rc"
+fi
+if ! printf '%s' "$stderr_out" | grep -qi "WARNING"; then
+    pass "no-stashes prints no warning"
+else
+    fail "no-stashes unexpectedly warned: $stderr_out"
+fi
+stdout_out="$(cd "$WORKDIR/repo" && "$SCRIPT" 2>/dev/null)"
+if printf '%s' "$stdout_out" | grep -qi "no outstanding"; then
+    pass "no-stashes prints the 'no outstanding' one-liner"
+else
+    fail "no-stashes missing one-liner. Got: $stdout_out"
+fi
+
+# -------- Test 3: an unrelated stash -> exit 0, no warning --------
+echo "Test 3: unrelated stash message does not trigger a warning"
+make_fixture
+push_stash "WIP on main: unrelated scratch edit" "unrelated-$RANDOM"
+stderr_out="$(cd "$WORKDIR/repo" && "$SCRIPT" 2>&1 >/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "unrelated-stash exit code is 0"
+else
+    fail "unrelated-stash expected exit 0, got $rc"
+fi
+if ! printf '%s' "$stderr_out" | grep -qi "WARNING"; then
+    pass "unrelated-stash prints no warning"
+else
+    fail "unrelated-stash unexpectedly warned: $stderr_out"
+fi
+
+# -------- Test 4: a loom-quarantine: stash -> exit 0, warns --------
+echo "Test 4: a loom-quarantine: stash triggers a warning"
+make_fixture
+push_stash "loom-quarantine: run=sweep-test-1 issue=999" "contamination-$RANDOM"
+stderr_out="$(cd "$WORKDIR/repo" && "$SCRIPT" 2>&1 >/dev/null)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "quarantine-stash exit code is 0"
+else
+    fail "quarantine-stash expected exit 0, got $rc"
+fi
+if printf '%s' "$stderr_out" | grep -qi "WARNING"; then
+    pass "quarantine-stash prints a warning"
+else
+    fail "quarantine-stash did not warn. Got: $stderr_out"
+fi
+if printf '%s' "$stderr_out" | grep -q "5185"; then
+    pass "quarantine-stash warning references issue #5185"
+else
+    fail "quarantine-stash warning missing #5185 reference"
+fi
+if printf '%s' "$stderr_out" | grep -q "issue=999"; then
+    pass "quarantine-stash warning names the quarantined issue label"
+else
+    fail "quarantine-stash warning missing the issue label. Got: $stderr_out"
+fi
+if printf '%s' "$stderr_out" | grep -qE 'stash@\{[0-9]+\}'; then
+    pass "quarantine-stash warning lists a copy-pasteable stash@{N} selector"
+else
+    fail "quarantine-stash warning missing a valid stash@{N} selector (date-corrupted #gd?). Got: $stderr_out"
+fi
+if printf '%s' "$stderr_out" | grep -q -- "git stash show -p"; then
+    pass "quarantine-stash warning suggests git stash show -p remediation"
+else
+    fail "quarantine-stash warning missing git stash show -p remediation"
+fi
+stdout_out="$(cd "$WORKDIR/repo" && "$SCRIPT" 2>/dev/null)"
+if printf '%s' "$stdout_out" | grep -qi "1 outstanding"; then
+    pass "quarantine-stash one-liner reports the count"
+else
+    fail "quarantine-stash one-liner missing count. Got: $stdout_out"
+fi
+
+# -------- Test 5: multiple loom-quarantine: stashes -> all listed --------
+echo "Test 5: multiple quarantine stashes are all listed"
+make_fixture
+push_stash "loom-quarantine: issue=100" "c1-$RANDOM"
+push_stash "loom-quarantine: run=sweep-test-2 issue=200" "c2-$RANDOM"
+push_stash "WIP on main: unrelated" "c3-$RANDOM"
+stderr_out="$(cd "$WORKDIR/repo" && "$SCRIPT" 2>&1 >/dev/null)"
+if printf '%s' "$stderr_out" | grep -q "issue=100" && printf '%s' "$stderr_out" | grep -q "issue=200"; then
+    pass "both quarantine stashes are listed"
+else
+    fail "not all quarantine stashes listed. Got: $stderr_out"
+fi
+if printf '%s' "$stderr_out" | grep -q "2 outstanding"; then
+    pass "count reflects only the quarantine stashes, not the unrelated one"
+else
+    fail "count did not correctly exclude the unrelated stash. Got: $stderr_out"
+fi
+
+# -------- Test 6: --quiet suppresses the stdout one-liner --------
+echo "Test 6: --quiet suppresses stdout"
+make_fixture
+push_stash "loom-quarantine: issue=1" "c-$RANDOM"
+stdout_out="$(cd "$WORKDIR/repo" && "$SCRIPT" --quiet 2>/dev/null)"
+if [[ -z "$stdout_out" ]]; then
+    pass "--quiet produces no stdout"
+else
+    fail "--quiet unexpectedly produced stdout: $stdout_out"
+fi
+stderr_out="$(cd "$WORKDIR/repo" && "$SCRIPT" --quiet 2>&1 >/dev/null)"
+if printf '%s' "$stderr_out" | grep -qi "WARNING"; then
+    pass "--quiet still warns on stderr"
+else
+    fail "--quiet suppressed the stderr warning too (should not)"
+fi
+
+# -------- Test 7: --help prints usage --------
+echo "Test 7: --help prints usage and exits 0"
+help_out="$("$SCRIPT" --help 2>&1)"
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "--help exit code is 0"
+else
+    fail "--help exit expected 0, got $rc"
+fi
+if printf '%s' "$help_out" | grep -qi "Usage"; then
+    pass "--help mentions Usage"
+else
+    fail "--help did not mention Usage. Got: $help_out"
+fi
+
+# -------- Test 8: unknown args do not break it --------
+echo "Test 8: unknown args do not break the script"
+make_fixture
+rc=0
+( cd "$WORKDIR/repo" && "$SCRIPT" --some-nonsense-flag --another 99 >/dev/null 2>&1 ) || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "unknown args tolerated; exit 0"
+else
+    fail "unknown args caused non-zero exit ($rc)"
+fi
+
+# -------- Test 9: outside a git repo -> exit 0, skip gracefully --------
+echo "Test 9: outside a git repo exits 0"
+non_git="$WORKDIR/not-a-repo"
+mkdir -p "$non_git"
+rc=0
+( cd "$non_git" && "$SCRIPT" >/dev/null 2>&1 ) || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+    pass "non-git dir exit code is 0"
+else
+    fail "non-git dir expected exit 0, got $rc"
+fi
+
+# -------- Summary --------
+echo ""
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    echo -e "${RED}FAILED${NC}: $TESTS_FAILED test(s) failed"
+    exit 1
+fi
+echo -e "${GREEN}OK${NC}: all tests passed"
+exit 0


### PR DESCRIPTION
## Summary

`check-main-clean.sh --quarantine` safely rescues contaminated main-worktree changes into a labeled `git stash` entry (`loom-quarantine: run=... issue=...`), but nothing surfaces that a rescue is outstanding — the only record is a structured JSON log line in `.loom/logs/main-quarantine.log`. A quarantine can therefore sit indefinitely with nobody aware there is work to reconcile, discovered only by chance (exactly what happened in the consumer-repo incident this issue documents, and again live in this repo mid-build — see test plan).

This adds `check-quarantine-stashes.sh`, a non-blocking, read-only advisory (mirroring `check-host-sleep.sh` / `check-main-freshness.sh` in structure and contract) that lists every outstanding `loom-quarantine:` stash by its `stash@{N}` selector, relative age, and run/issue label, and wires it into `/loom:sweep`'s existing pre-wave advisory checks.

- `defaults/scripts/check-quarantine-stashes.sh` — the advisory script (always exits 0, never mutates a stash)
- `defaults/scripts/tests/test-check-quarantine-stashes.sh` — 21 tests against synthetic fixtures
- `defaults/scripts/tests/ci-wired.txt` — registers the new suite
- `defaults/.claude/commands/loom/sweep.md` — new "Outstanding Quarantine Stashes (#5185)" section, run before wave 1 / first daemon dispatch, alongside Host Sleep Readiness and Main Branch Freshness
- `defaults/docs/troubleshooting.md` — cross-reference from the existing quarantine section

## Test plan

- [x] `defaults/scripts/tests/test-check-quarantine-stashes.sh` — 21/21 passing
- [x] `defaults/scripts/tests/check-ci-suite-manifest.sh` — new suite correctly wired
- [x] Ran the script live against this repo's actual stash stack (14 outstanding quarantines at the time) — confirmed correct listing, selectors, ages, and labels
- [x] Dogfooded unintentionally: mid-implementation, a concurrent peer sweep's `check-main-clean.sh --quarantine` rescued this PR's own uncommitted WIP from the main checkout into a new `loom-quarantine:` stash — recovered cleanly via `git stash show -p` / `git show <sha>^3:<path>` into this issue's worktree, no data lost, exactly the discoverability gap this PR closes

Closes #5185