### PR TITLE
fix(tests): derive reaper cross-host-claim fixture timestamp from the clock (#5317)

### DIFF
--- a/loom-daemon/src/sweep_registry/reaper.rs
+++ b/loom-daemon/src/sweep_registry/reaper.rs
@@ -2520,7 +2520,7 @@ mod tests {
         // `--remove-label loom:building` invocation, so asserting its absence
         // is sufficient to prove the forge check vetoed the restore.
         let script = format!(
-            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [[ \"$1\" == \"api\" ]]; then\n  echo '\"2026-08-04T15:59:59Z\"'\nfi\nexit 0\n",
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [[ \"$1\" == \"api\" ]]; then\n  echo \"\\\"$(date -u '+%Y-%m-%dT%H:%M:%SZ')\\\"\"\nfi\nexit 0\n",
             gh_log.display()
         );
         std::fs::write(&fake_gh, &script).unwrap();
@@ -2596,7 +2596,7 @@ mod tests {
         // with a labeling timestamp AFTER `started_at` (set below).
         let fake_gh = dir.path().join("fake-gh-timeline.sh");
         let script = format!(
-            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [[ \"$1\" == \"api\" ]]; then\n  echo '\"2026-08-04T15:59:59Z\"'\nfi\nexit 0\n",
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [[ \"$1\" == \"api\" ]]; then\n  echo \"\\\"$(date -u '+%Y-%m-%dT%H:%M:%SZ')\\\"\"\nfi\nexit 0\n",
             gh_log.display()
         );
         std::fs::write(&fake_gh, &script).unwrap();


### PR DESCRIPTION
Closes #5317

## Problem

Two tests in `loom-daemon/src/sweep_registry/reaper.rs` hardcoded the literal forge timestamp `"2026-08-04T15:59:59Z"` as their fake `gh api .../timeline` response — the fixture standing in for "a newer `loom:building` claim from another host" — while comparing it against a `started_at` of `Utc::now() - chrono::Duration::hours(1)`:

- `cancel_skips_restore_when_forge_shows_a_newer_claim_from_another_host`
- `reap_skips_restore_when_forge_shows_a_newer_claim_from_another_host`

Once wall-clock time passed `2026-08-04T16:59:59Z`, `now - 1h` overtook the literal, so the fixture no longer described a *newer* claim. The code under test then correctly restored `loom:building` -> `loom:issue` (the forge no longer shows a peer host's live claim), and the "must NOT restore" assertions failed. This broke `Rust Unit Tests` on every open Rust-touching PR fleet-wide on a date trigger rather than any code change — confirmed live on main's tip and on PR #5313, which does not touch `reaper.rs` at all.

## Fix

Both fixtures now compute the "newer claim" timestamp *inside the fake `gh` script, at invocation time*, via a `date -u` command substitution instead of embedding a literal:

```diff
-  echo '"2026-08-04T15:59:59Z"'
+  echo "\"$(date -u '+%Y-%m-%dT%H:%M:%SZ')\""
```

The fake `gh` therefore answers each `gh api .../timeline` probe with the current UTC time, which is unconditionally ~1h greater than each fixture's `started_at` of `Utc::now() - chrono::Duration::hours(1)`. `SweepRegistry::claim_superseded_on_forge` (`sweep_registry/guards.rs`) vetoes the restore on `labeled_at > claimed_at`, so the fixture's premise now holds at any wall-clock time and no time-bomb window remains. `+%Y-%m-%dT%H:%M:%SZ` emits the trailing-`Z` RFC3339 form the production parser (`parse_max_timestamp`) expects, and the escaped surrounding quotes preserve the JSON-string shape the old literal had.

Test-fixture-only change (2 lines, both inside `mod tests`) — no production code path is modified.

## Revision history (why the earlier description differed)

An earlier revision of this branch (`ba0b892`) implemented the same fix with a Rust test helper `newer_claim_timestamp()` returning `Utc::now() + 1min`, plus `#5317` doc comments. That commit was force-pushed over by `8bd3953` — the `date -u` form now under review — by concurrent work on the same issue. This description originally described the superseded helper revision; the Judge rewrote the Fix/Verification sections to match the landed diff (documentation-only edit, no code change).

## Verification (independently re-run by the Judge on `8bd3953`)

- `cargo test -p loom-daemon --lib sweep_registry::reaper::` — **52 passed, 0 failed**, including both named tests.
- **Negative control**: temporarily rewriting the substitution to `date -u -d '-2 hours'` makes both tests **FAIL** with the "must NOT restore" assertion (the gh log shows `issue edit … --remove-label loom:building --add-label loom:issue`), proving the assertions still exercise the cross-host veto path rather than passing vacuously. Reverted; worktree left clean.
- `grep -n '2026-0[0-9]-[0-9][0-9]T' loom-daemon/src/sweep_registry/reaper.rs` returns nothing.
- Remaining date literals elsewhere under `loom-daemon/src/sweep_registry/` (`mod.rs`, `crash_signals.rs`, `dispatch.rs`, `test_support.rs`, `quarantine.rs`) are self-consistent literal-vs-literal pairs or inert log-text payloads never compared against `Utc::now()` — no equivalent near-term time bomb.
- CI on `8bd3953`: all 7 applicable checks green (`Rust Unit Tests`, `Rust OTLP Feature Build & Test`, `Rust Linting & Build Check`, plus the doc/parity gates); 5 path-filtered jobs skipped. `mergeStateStatus: CLEAN`.

## Acceptance criteria

- [x] Both fixtures compute the "newer claim" timestamp relative to the test's own clock at run time
- [x] Both tests pass at any wall-clock time (no time-bomb window remains)
- [x] No hardcoded near-term date literal remains in `reaper.rs`; the rest of `sweep_registry/` re-checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
