### PR TITLE
feat(daemon): seed ~/.claude.json workspace trust at registration time

### DIFF
--- a/defaults/scripts/claude-wrapper.sh
+++ b/defaults/scripts/claude-wrapper.sh
@@ -662,6 +662,61 @@ PYEOF
     return 0  # Always succeed — this is a warning-only check
 }
 
+# Warn — but never abort — when the current workspace is not marked trusted
+# in ~/.claude.json (issue #5314). Claude Code silently ignores every
+# `permissions.allow` entry in an untrusted workspace's `.claude/settings.json`
+# and only says so on a line buried inside the session transcript ("Ignoring
+# N permissions.allow entries ... this workspace has not been trusted"),
+# which is easy to miss in a headless sweep log. This is a sibling of
+# check_global_mcp_configs (#5033) above: same warn-only, non-aborting
+# contract, same ~/.claude.json read.
+#
+# Provisioning (`loom-daemon workspace add`, and transitively `fleet
+# add-worker` / `loom migrate`, which both shell out to it) is the primary
+# fix — it seeds the trust bit at registration time. This check exists for
+# the residual cases provisioning cannot cover: a workspace spawned into
+# without ever having been registered, or a `~/.claude.json` edited/reset
+# after registration.
+#
+# Scoped to the `claude` runtime only: `hasTrustDialogAccepted` is a
+# Claude-Code-CLI-specific concept with no equivalent in the other runtime
+# adapters' (`spawn-codex.sh` / `spawn-aider.sh` / `spawn-generic.sh`) config
+# surfaces, so this check has no reason to run for them.
+check_workspace_trust() {
+    local global_config="${HOME}/.claude.json"
+    local workspace="${WORKSPACE}"
+
+    if [[ ! -f "${global_config}" ]]; then
+        log_warn "⚠ ~/.claude.json not found — workspace '${workspace}' is not marked trusted; permissions.allow entries will be silently ignored until it is registered (loom-daemon workspace add ${workspace}) or the trust dialog is accepted interactively once"
+        return 0
+    fi
+
+    # Emits "1" (trusted), "0" (present but not trusted / missing entry), or
+    # nothing on unparseable JSON / missing python3 — mirrors
+    # check_global_mcp_configs's silent-fallthrough-on-malformed-input
+    # contract so a broken ~/.claude.json never turns this into a false
+    # warning (or a crash).
+    local trusted
+    trusted=$(python3 - "${global_config}" "${workspace}" 2>/dev/null <<'PYEOF'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        cfg = json.load(f)
+    entry = cfg.get('projects', {}).get(sys.argv[2], {})
+    print('1' if entry.get('hasTrustDialogAccepted') is True else '0')
+except Exception:
+    pass
+PYEOF
+)
+
+    if [[ "${trusted}" == "0" ]]; then
+        log_warn "⚠ Workspace '${workspace}' is not trusted in ~/.claude.json (projects[\"${workspace}\"].hasTrustDialogAccepted != true) — permissions.allow entries will be silently ignored"
+        log_warn "Fix: loom-daemon workspace add ${workspace}  (or accept the trust dialog interactively once)"
+    fi
+
+    return 0  # Always succeed — this is a warning-only check
+}
+
 # Ordered explicit candidate directories for the node toolchain (#5032).
 # claude-wrapper.sh runs from launchd jobs and `ssh host 'cmd'` non-login
 # shells that never source the login profile, so /opt/homebrew/bin (Apple
@@ -2309,6 +2364,10 @@ run_preflight_checks() {
     # Warn about missing global MCP binaries from ~/.claude.json (issue #3033).
     # This is non-fatal: warnings are logged but pre-flight always succeeds.
     check_global_mcp_configs
+
+    # Warn about an untrusted workspace surfacing only inside sweep transcripts
+    # (issue #5314). Non-fatal, same as the check above.
+    check_workspace_trust
 
     log_info "All pre-flight checks passed"
     return 0

--- a/defaults/scripts/tests/test-mcp-config.sh
+++ b/defaults/scripts/tests/test-mcp-config.sh
@@ -873,6 +873,89 @@ else
 fi
 
 # ============================================================
+# Section 12: check_workspace_trust preflight check (#5314)
+#
+# The function must warn — but never abort — when the current workspace's
+# ~/.claude.json entry is missing or `hasTrustDialogAccepted` is not `true`,
+# and stay silent when it is `true`. Mirrors Section 11's structure.
+# ============================================================
+echo ""
+echo "Testing check_workspace_trust preflight check (#5314)..."
+
+if $HAVE_PYTHON3; then
+    _ws_dir="$(mktemp -d)"
+
+    # 12a. ~/.claude.json missing entirely -> warns (with the fix command),
+    # never aborts.
+    _home_no_state="$(mktemp -d)"
+    _out_no_state="$(HOME="$_home_no_state" LOOM_WORKSPACE="$_ws_dir" CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1"
+        check_workspace_trust
+        echo "RC=$?"
+    ' _ "$WRAPPER" 2>&1)"
+    assert_contains "not marked trusted" "$_out_no_state" \
+        "user .claude.json missing entirely: warns that the workspace is not trusted"
+    assert_contains "workspace add" "$_out_no_state" \
+        "missing-state-file warning names the 'loom-daemon workspace add' fix"
+    assert_contains "RC=0" "$_out_no_state" \
+        "missing-state-file check never aborts (warning-only contract)"
+    rm -rf "$_home_no_state"
+
+    # 12b. ~/.claude.json present, but no entry for this workspace -> warns.
+    _home_no_entry="$(mktemp -d)"
+    cat >"$_home_no_entry/.claude.json" <<JSON
+{ "projects": { "/some/other/workspace": { "hasTrustDialogAccepted": true } } }
+JSON
+    _out_no_entry="$(HOME="$_home_no_entry" LOOM_WORKSPACE="$_ws_dir" CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1"
+        check_workspace_trust
+        echo "RC=$?"
+    ' _ "$WRAPPER" 2>&1)"
+    assert_contains "is not trusted" "$_out_no_entry" \
+        "workspace has no projects[] entry: warns that it is not trusted"
+    assert_contains "RC=0" "$_out_no_entry" \
+        "no-entry check never aborts"
+    rm -rf "$_home_no_entry"
+
+    # 12c. ~/.claude.json has this workspace with hasTrustDialogAccepted=false
+    # -> warns.
+    _home_false="$(mktemp -d)"
+    cat >"$_home_false/.claude.json" <<JSON
+{ "projects": { "$_ws_dir": { "hasTrustDialogAccepted": false } } }
+JSON
+    _out_false="$(HOME="$_home_false" LOOM_WORKSPACE="$_ws_dir" CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1"
+        check_workspace_trust
+        echo "RC=$?"
+    ' _ "$WRAPPER" 2>&1)"
+    assert_contains "is not trusted" "$_out_false" \
+        "workspace explicitly untrusted (hasTrustDialogAccepted=false): warns"
+    assert_contains "RC=0" "$_out_false" \
+        "explicitly-untrusted check never aborts"
+    rm -rf "$_home_false"
+
+    # 12d. ~/.claude.json has this workspace trusted -> no warning.
+    _home_trusted="$(mktemp -d)"
+    cat >"$_home_trusted/.claude.json" <<JSON
+{ "projects": { "$_ws_dir": { "hasTrustDialogAccepted": true } } }
+JSON
+    _out_trusted="$(HOME="$_home_trusted" LOOM_WORKSPACE="$_ws_dir" CLAUDE_WRAPPER_SOURCE_ONLY=1 bash -c '
+        source "$1"
+        check_workspace_trust
+        echo "RC=$?"
+    ' _ "$WRAPPER" 2>&1)"
+    assert_not_contains "is not trusted" "$_out_trusted" \
+        "workspace trusted: no warning"
+    assert_eq "RC=0" "$_out_trusted" \
+        "workspace trusted: no output at all, RC=0"
+    rm -rf "$_home_trusted"
+
+    rm -rf "$_ws_dir"
+else
+    echo -e "  ${YELLOW}SKIP${NC}: check_workspace_trust tests (python3 not installed)"
+fi
+
+# ============================================================
 # Summary
 # ============================================================
 echo ""

--- a/loom-daemon/src/cli/workspace_fleet.rs
+++ b/loom-daemon/src/cli/workspace_fleet.rs
@@ -211,10 +211,17 @@ pub(crate) fn handle_workspace_command(action: WorkspaceAction) -> Result<()> {
                 None => None,
             };
             let mut registry = WorkspaceRegistry::load(&path)?;
-            match registry.add_with_priority(
+            // Mark the canonical workspace root trusted in ~/.claude.json as
+            // part of registration (issue #5314) — merges, never clobbers,
+            // and is idempotent on an already-registered workspace so a
+            // pre-existing registry entry self-heals on the next `workspace
+            // add` of the same path.
+            let claude_state_path = loom_daemon::terminal::claude_config_state_path();
+            match registry.add_and_trust(
                 std::path::Path::new(&repo_path),
                 overrides,
                 priority,
+                &claude_state_path,
             )? {
                 AddOutcome::AlreadyPresent { canonical } => {
                     println!("Already registered: {}", canonical.display());

--- a/loom-daemon/src/terminal.rs
+++ b/loom-daemon/src/terminal.rs
@@ -1265,8 +1265,27 @@ pub fn claude_config_validate(agent_name: &str, repo_root: &Path) -> bool {
 /// Mark `project_dir` as trusted in the resolved Claude Code state file, so
 /// a non-interactive spawn into it never stalls on the folder-trust modal.
 pub fn claude_config_trust(project_dir: &Path) {
-    let state_path = claude_config::default_state_file();
-    claude_config::ensure_project_trusted(&state_path, project_dir);
+    claude_config_trust_at(&claude_config_state_path(), project_dir);
+}
+
+/// Resolve the real Claude Code state file path (issue #5314) — a public
+/// wrapper over the private `claude_config::default_state_file`, so callers
+/// outside this module (e.g. `loom-daemon workspace add`) can resolve the
+/// same path [`claude_config_trust`] uses without duplicating the resolution
+/// order, and can pass it explicitly to [`claude_config_trust_at`] when they
+/// already need the path for other purposes.
+#[must_use]
+pub fn claude_config_state_path() -> PathBuf {
+    claude_config::default_state_file()
+}
+
+/// Mark `project_dir` trusted at an explicit `state_path` (issue #5314) — the
+/// test/CLI seam over [`claude_config_trust`], which always resolves the real
+/// `~/.claude.json` via [`claude_config_state_path`]. Lets a caller (workspace
+/// registration, or a unit test) point at a scratch state file instead of
+/// mutating the process-wide `$HOME`.
+pub fn claude_config_trust_at(state_path: &Path, project_dir: &Path) {
+    claude_config::ensure_project_trusted(state_path, project_dir);
 }
 
 pub struct TerminalManager {

--- a/loom-daemon/src/workspace_registry.rs
+++ b/loom-daemon/src/workspace_registry.rs
@@ -299,6 +299,45 @@ impl WorkspaceRegistry {
         })
     }
 
+    /// Register a workspace ([`add_with_priority`](Self::add_with_priority))
+    /// and mark its canonical root trusted in the given Claude Code state
+    /// file (issue #5314), so a headless spawn into a freshly-registered
+    /// workspace never silently drops its `permissions.allow` list waiting on
+    /// an interactive trust dialog that never happens on a worker host.
+    ///
+    /// This is the single call site `fleet add-worker`, `loom migrate`, and
+    /// `loom-daemon workspace add` all converge on (they each shell out to
+    /// `workspace add`), so seeding trust here — rather than patching each of
+    /// those three call sites separately — covers all of them plus any future
+    /// caller of `workspace add`.
+    ///
+    /// Runs on **both** [`AddOutcome::Added`] and [`AddOutcome::AlreadyPresent`]
+    /// — trust-marking is idempotent (see
+    /// [`claude_config_trust_at`](crate::terminal::claude_config_trust_at)) and
+    /// self-heals a workspace that was registered before this fix existed,
+    /// without re-registering it or touching its stored priority/overrides.
+    ///
+    /// `claude_state_path` is caller-resolved (normally
+    /// [`crate::terminal::claude_config_state_path`]) rather than resolved
+    /// here, so tests can point it at a scratch file instead of mutating the
+    /// process-wide `$HOME`.
+    pub fn add_and_trust(
+        &mut self,
+        root: &Path,
+        config_overrides: Option<serde_json::Value>,
+        priority: u32,
+        claude_state_path: &Path,
+    ) -> Result<AddOutcome> {
+        let outcome = self.add_with_priority(root, config_overrides, priority)?;
+        let canonical = match &outcome {
+            AddOutcome::Added { canonical, .. } | AddOutcome::AlreadyPresent { canonical } => {
+                canonical
+            }
+        };
+        crate::terminal::claude_config_trust_at(claude_state_path, canonical);
+        Ok(outcome)
+    }
+
     /// Set the dispatch priority of an already-registered workspace (Issue
     /// #3946). Normalizes `root` and updates the matching entry's `priority`,
     /// returning `true` when an entry was updated, `false` when no matching
@@ -603,6 +642,129 @@ mod tests {
             } => assert!(looks_like_workspace),
             AddOutcome::AlreadyPresent { .. } => panic!("expected Added"),
         }
+    }
+
+    #[test]
+    fn add_and_trust_marks_canonical_root_trusted_on_fresh_add() {
+        let dir = tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let claude_state_path = dir.path().join(".claude.json");
+        std::fs::write(&claude_state_path, r#"{"unrelatedTopLevelKey": "keep-me"}"#).unwrap();
+
+        let mut reg = WorkspaceRegistry::default();
+        let outcome = reg
+            .add_and_trust(&repo, None, DEFAULT_WORKSPACE_PRIORITY, &claude_state_path)
+            .unwrap();
+        let canonical = match outcome {
+            AddOutcome::Added { canonical, .. } => canonical,
+            AddOutcome::AlreadyPresent { .. } => panic!("expected Added"),
+        };
+
+        // The workspace itself is registered...
+        assert!(reg.contains(&canonical));
+
+        // ...and the trust bit is merged into the state file, preserving
+        // unrelated existing content (issue #5314's core requirement).
+        let contents = std::fs::read_to_string(&claude_state_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents).unwrap();
+        assert_eq!(parsed["unrelatedTopLevelKey"], "keep-me");
+        assert_eq!(
+            parsed["projects"][canonical.to_string_lossy().to_string()]["hasTrustDialogAccepted"],
+            true
+        );
+    }
+
+    #[test]
+    fn add_and_trust_preserves_other_projects_entries() {
+        let dir = tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let other_project = dir.path().join("some-other-project");
+        let claude_state_path = dir.path().join(".claude.json");
+        std::fs::write(
+            &claude_state_path,
+            serde_json::json!({
+                "projects": {
+                    other_project.to_string_lossy().to_string(): {
+                        "hasTrustDialogAccepted": true,
+                        "someOtherProjectField": "keep-me-too",
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let mut reg = WorkspaceRegistry::default();
+        reg.add_and_trust(&repo, None, DEFAULT_WORKSPACE_PRIORITY, &claude_state_path)
+            .unwrap();
+
+        let contents = std::fs::read_to_string(&claude_state_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents).unwrap();
+        // The pre-existing, unrelated project entry must survive untouched.
+        assert_eq!(
+            parsed["projects"][other_project.to_string_lossy().to_string()]
+                ["someOtherProjectField"],
+            "keep-me-too"
+        );
+        assert_eq!(
+            parsed["projects"][other_project.to_string_lossy().to_string()]
+                ["hasTrustDialogAccepted"],
+            true
+        );
+    }
+
+    #[test]
+    fn add_and_trust_creates_missing_claude_state_file() {
+        let dir = tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let claude_state_path = dir.path().join(".claude.json");
+        assert!(!claude_state_path.exists());
+
+        let mut reg = WorkspaceRegistry::default();
+        reg.add_and_trust(&repo, None, DEFAULT_WORKSPACE_PRIORITY, &claude_state_path)
+            .unwrap();
+
+        assert!(claude_state_path.exists());
+        let contents = std::fs::read_to_string(&claude_state_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents).unwrap();
+        let canonical = normalize_path(&repo);
+        assert_eq!(
+            parsed["projects"][canonical.to_string_lossy().to_string()]["hasTrustDialogAccepted"],
+            true
+        );
+    }
+
+    #[test]
+    fn add_and_trust_is_idempotent_and_self_heals_already_present_workspace() {
+        let dir = tempdir().unwrap();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let claude_state_path = dir.path().join(".claude.json");
+
+        let mut reg = WorkspaceRegistry::default();
+        // Simulate a workspace registered before this fix existed: present in
+        // the registry, but never marked trusted.
+        reg.add(&repo, None).unwrap();
+        assert!(!claude_state_path.exists());
+
+        // Re-running `workspace add` (the self-heal path) must not
+        // re-register or error, and must still seed the trust bit.
+        let outcome = reg
+            .add_and_trust(&repo, None, DEFAULT_WORKSPACE_PRIORITY, &claude_state_path)
+            .unwrap();
+        assert!(matches!(outcome, AddOutcome::AlreadyPresent { .. }));
+        assert_eq!(reg.workspaces.len(), 1);
+
+        let contents = std::fs::read_to_string(&claude_state_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&contents).unwrap();
+        let canonical = normalize_path(&repo);
+        assert_eq!(
+            parsed["projects"][canonical.to_string_lossy().to_string()]["hasTrustDialogAccepted"],
+            true
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Seeds `hasTrustDialogAccepted: true` into `~/.claude.json` at workspace-registration time so a headless spawn into a managed workspace never silently drops its `permissions.allow` list waiting on a trust dialog no worker host can answer.
- Adds a warn-only preflight check in `claude-wrapper.sh` that surfaces an untrusted workspace before a session starts, instead of only inside a buried sweep-transcript log line.

## Changes

- `loom-daemon/src/workspace_registry.rs`: new `WorkspaceRegistry::add_and_trust()` — wraps `add_with_priority()` and marks the canonical workspace root trusted via the existing (already-tested, merge-safe, symlink-aware) `terminal::claude_config_trust_at()` helper. Runs on both `Added` and `AlreadyPresent` outcomes so it self-heals workspaces registered before this fix, without re-registering them or touching stored priority/overrides.
- `loom-daemon/src/cli/workspace_fleet.rs`: `loom-daemon workspace add` now calls `add_and_trust()` instead of `add_with_priority()`. Because `fleet add-worker` (`add_worker.rs`) and `loom migrate` (`migrate-consumer.sh`) both shell out to `workspace add` for registration, this one change point covers all three provisioning paths named in the issue, plus any future caller.
- `loom-daemon/src/terminal.rs`: exposes two small public wrappers — `claude_config_state_path()` (resolve the real `~/.claude.json` path) and `claude_config_trust_at(state_path, project_dir)` (mark trusted at an explicit path) — over the pre-existing private `claude_config::ensure_project_trusted` merge logic (added in #4471 for a different call site: per-agent-spawn trust of the spawn target). These wrappers let `workspace add` reuse that same proven merge-not-clobber implementation instead of a second reimplementation, and let tests target a scratch state file instead of mutating the process-wide `$HOME`.
- `defaults/scripts/claude-wrapper.sh`: new `check_workspace_trust()`, a sibling of the existing `check_global_mcp_configs()` preflight — warns (never aborts) when the current workspace's `~/.claude.json` entry is missing or `hasTrustDialogAccepted` isn't `true`, wired into `run_preflight_checks()`.

### Note on curator verification claim

The curator enhancement stated `grep -rn "hasTrustDialogAccepted"` returned zero hits on `origin/main` at `998e2390`. That grep was actually incorrect at the time it was run — `loom-daemon/src/terminal.rs`'s `ensure_project_trusted`/`claude_config_trust` (added by #4471, well before `998e2390`) already implements this exact merge for a *different* call site (marking the per-agent spawn target trusted at native-`agent_session::spawn` time). That existing mechanism does not cover the actual reported symptom, though: headless sweep dispatch runs through the bash `spawn-claude.sh` → `exec claude` path (no `CLAUDE_CONFIG_DIR` isolation, no trust step at all), not the native Rust `agent_session::spawn` path. This PR reuses the existing, already-tested merge logic from a new call site (workspace registration) rather than reinventing it, which resolves the actual gap.

## Acceptance Criteria Verification

- [x] `loom-daemon workspace add` merges `projects["<canonical-workspace-path>"].hasTrustDialogAccepted: true` into `~/.claude.json`, touching only that one key/path — verified by 4 new unit tests plus a manual end-to-end run of the built binary against a scratch `HOME`/registry (unrelated top-level keys and other `projects` entries survive byte-for-byte).
- [x] `fleet add-worker` and `loom migrate` both shell out to `loom-daemon workspace add` (confirmed via existing `add_worker.rs` step-ordering tests and `test-migrate-consumer.sh`, both re-run and passing unaffected) — one fix point covers both.
- [x] New `check_workspace_trust()` in `claude-wrapper.sh`, sibling to `check_global_mcp_configs()`, warns without ever aborting — 9 new tests in `test-mcp-config.sh` covering missing state file, missing/false trust entry, and the already-trusted no-op case.
- [x] Scoped to the `claude` runtime only: the fix only ever touches `~/.claude.json`, a Claude-Code-CLI-specific file with no equivalent in `spawn-codex.sh` / `spawn-aider.sh` / `spawn-generic.sh`; no changes to those adapters.
- [x] `~/.claude.json` is treated as potentially absent or holding unrelated content: read-modify-write via the existing merge helper, tested for a missing file (created fresh), an existing file with unrelated top-level keys, and an existing file with other `projects` entries — all preserved.

## Test Plan

- `cargo test --lib` (loom-daemon): `workspace_registry::tests::add_and_trust_*` (4 new), `terminal::...::test_ensure_project_trusted_*` (2 pre-existing, unaffected), `fleet::add_worker::*` (44, unaffected) — all pass.
- `cargo clippy --quiet -- -D warnings` and `cargo fmt -- --check` on all changed files: clean.
- `bash defaults/scripts/tests/test-mcp-config.sh`: 100/100 passing (9 new `check_workspace_trust` tests).
- `shellcheck defaults/scripts/claude-wrapper.sh defaults/scripts/tests/test-mcp-config.sh`: no new warnings (one pre-existing info-level `SC2016` unrelated to this change).
- `bash scripts/test-migrate-consumer.sh`: 38/38 passing, unaffected.
- Manual: built `loom-daemon` and ran `workspace add` against a scratch `HOME`/registry with a pre-seeded `~/.claude.json` containing an unrelated top-level key and another project's entry — both survived untouched; the new workspace's `hasTrustDialogAccepted` was set to `true`; a second `workspace add` of the same path correctly reported `AlreadyPresent` while re-confirming the trust bit (self-heal path).

Closes #5314
