### PR TITLE
fix(daemon): derive reaper claim-timeline test fixtures from Utc::now(), not a fixed date

### DIFF
--- a/loom-daemon/src/sweep_registry/reaper.rs
+++ b/loom-daemon/src/sweep_registry/reaper.rs
@@ -2519,9 +2519,19 @@ mod tests {
         // real `restore_label_to_ready` call would show up in the log as a
         // `--remove-label loom:building` invocation, so asserting its absence
         // is sufficient to prove the forge check vetoed the restore.
+        //
+        // The fixture timestamp is computed relative to `Utc::now()` at
+        // test-run time (NOT a hardcoded calendar date) so the "newer claim"
+        // branch keeps firing on every future test run — a fixed absolute
+        // date silently stops being "after `started_at`" once wall-clock
+        // time passes it, which is exactly what broke this test permanently
+        // on 2026-08-04 (issue #5319).
+        let forge_labeled_at = (Utc::now() + chrono::Duration::minutes(5))
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
         let script = format!(
-            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [[ \"$1\" == \"api\" ]]; then\n  echo '\"2026-08-04T15:59:59Z\"'\nfi\nexit 0\n",
-            gh_log.display()
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [[ \"$1\" == \"api\" ]]; then\n  echo '\"{}\"'\nfi\nexit 0\n",
+            gh_log.display(),
+            forge_labeled_at
         );
         std::fs::write(&fake_gh, &script).unwrap();
         let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();
@@ -2593,11 +2603,17 @@ mod tests {
         let dir = tempdir().unwrap();
         let (mut registry, gh_log) = fixture_registry(dir.path());
         // Override the fixture's fake `gh` so `gh api .../timeline` answers
-        // with a labeling timestamp AFTER `started_at` (set below).
+        // with a labeling timestamp AFTER `started_at` (set below). Computed
+        // relative to `Utc::now()` at test-run time, not a hardcoded
+        // calendar date — see the sibling `cancel_skips_restore_...` test's
+        // comment for why (#5319).
         let fake_gh = dir.path().join("fake-gh-timeline.sh");
+        let forge_labeled_at = (Utc::now() + chrono::Duration::minutes(5))
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
         let script = format!(
-            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [[ \"$1\" == \"api\" ]]; then\n  echo '\"2026-08-04T15:59:59Z\"'\nfi\nexit 0\n",
-            gh_log.display()
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"{}\"\nif [[ \"$1\" == \"api\" ]]; then\n  echo '\"{}\"'\nfi\nexit 0\n",
+            gh_log.display(),
+            forge_labeled_at
         );
         std::fs::write(&fake_gh, &script).unwrap();
         let mut perms = std::fs::metadata(&fake_gh).unwrap().permissions();


### PR DESCRIPTION
## Summary

`Rust Unit Tests` and `Rust OTLP Feature Build & Test` have been failing on `main`
for every PR since ~17:00 UTC on 2026-08-04, independent of any PR's own diff. Two
cross-host claim-ownership tests added by #5301 hard-coded their fake `gh api
.../timeline` response as the absolute calendar timestamp `"2026-08-04T15:59:59Z"`,
while the sweep they compare against is anchored to wall clock
(`started_at = Utc::now() - 1h`).

`SweepRegistry::claim_superseded_on_forge` (`sweep_registry/guards.rs:233`) returns
`true` only when `labeled_at > claimed_at`. Once real UTC passed
`2026-08-04T16:59:59Z`, the fixed fixture stopped being newer than `started_at`, the
supersession veto never fired, the code fell through to the real
`restore_label_to_ready` path, and both tests' "must NOT restore `loom:building`"
assertions failed — permanently, on every subsequent run, not intermittently.

This PR makes both fixtures relative to `Utc::now()` so they can never expire again.

## Changes

- `loom-daemon/src/sweep_registry/reaper.rs`: `cancel_skips_restore_when_forge_shows_a_newer_claim_from_another_host`
  and `reap_skips_restore_when_forge_shows_a_newer_claim_from_another_host` now build
  the mocked timeline timestamp as `Utc::now() + 5min`, rendered with
  `to_rfc3339_opts(SecondsFormat::Secs, true)`, instead of the literal
  `"2026-08-04T15:59:59Z"`. That is strictly after each test's own
  `started_at = Utc::now() - 1h` on every future run, preserving the original intent
  ("a newer claim than this sweep's `started_at`").
- Added comments at both fixtures recording why the timestamp must stay relative, so
  the same time bomb is not reintroduced.

Test-only change; no production code path is touched.

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|--------------|
| Confirm the diagnosis against the real comparison logic | ✅ | `claim_superseded_on_forge` (guards.rs:233-249) matches `Some(labeled_at) if labeled_at > claimed_at`; both call sites (`reaper.rs:751` in `finish_cancel`, `reaper.rs:950` in `reap_once`) pass the entry's `started_at` as `claimed_at`. |
| Both named tests fixed to use a relative fixture | ✅ | Fixtures now `Utc::now() + chrono::Duration::minutes(5)`; no literal date remains in either test body. |
| Original test intent preserved ("newer claim") | ✅ | `now + 5min > now - 1h` holds unconditionally; both tests still assert the timeline probe happened AND that no `--remove-label loom:building` was issued. |
| No other test in the repo has the same time-bomb shape | ✅ | Scanned every `.rs`/`.ts`/`.sh` file for literal RFC3339 dates and cross-referenced against `Utc::now()`/`SystemTime::now()` usage per function. The only other literal-date-vs-ordering fixture (`quarantine.rs::quarantine_ttl_expiry_never_releases_a_later_manual_repark`, `2020-01-01` vs `2030-01-01`) compares the two literals against **each other**, never against the wall clock, so its ordering is stable forever. All remaining hits (`tokens_pool`, `capacity`, `pipeline_snapshot`, `metrics_collector`, `observability`, dashboard tests) are round-trip/format or fixed-clock tests with no `now()` comparison. |
| Two named tests pass | ✅ | Each run in isolation with `--exact` (see Test Plan). |
| Reaper suite passes | ✅ | `cargo test --lib sweep_registry::reaper` — 52 passed, 0 failed. |

## Test Plan

```
# Both previously-failing tests, in isolation (the repro from the issue):
cargo test --package loom-daemon --lib \
  "sweep_registry::reaper::tests::cancel_skips_restore_when_forge_shows_a_newer_claim_from_another_host" \
  -- --exact --nocapture
  => test result: ok. 1 passed; 0 failed

cargo test --package loom-daemon --lib \
  "sweep_registry::reaper::tests::reap_skips_restore_when_forge_shows_a_newer_claim_from_another_host" \
  -- --exact --nocapture
  => test result: ok. 1 passed; 0 failed

# Whole module:
cargo test --lib sweep_registry::reaper
  => test result: ok. 52 passed; 0 failed; 3429 filtered out

# Lint/format:
cargo fmt      => clean
cargo clippy --all-targets -- -D warnings   => clean
```

Note on provenance: this issue was double-dispatched — a concurrent `--claim-owned 5319`
sweep pushed the commit on this branch first while an independent builder was preparing
an equivalent fix (same root cause, same relative-timestamp approach). Per the
"defer to the PR that pushed first, don't force-push" convention the pushed commit was
kept as-is and independently re-verified (all runs above are against `8372dd0`) rather
than force-pushed over. The concurrent sweep had not opened a PR after its push, so this
PR carries the work forward.

Closes #5319