### PR TITLE
feat(docker): publish a loom-worker OCI base image from the release workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# .dockerignore — repo root
+#
+# docker/worker/Dockerfile builds with the repo root as its build context
+# (so `COPY dist/loom-daemon-<target>` lines up with the exact path
+# `.github/workflows/release.yml`'s build-daemon job already packages
+# release assets under). This repo has a large working tree (Rust
+# target/, git history, node_modules, per-issue worktrees, …) that the
+# Dockerfile never references, so deny-all-then-allowlist keeps the
+# context sent to the docker daemon small and free of anything that could
+# accidentally leak into a layer via a future wildcard COPY.
+#
+# If a future Dockerfile in this repo needs another path from the repo
+# root, add an explicit `!`-allowlist entry for it here — do not widen this
+# to an allow-all.
+*
+!dist/
+!dist/**
+!docker/
+!docker/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       mcp: ${{ steps.filter.outputs.mcp }}
       scripts: ${{ steps.filter.outputs.scripts }}
       dashboard: ${{ steps.filter.outputs.dashboard }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: dorny/paths-filter@v4
         id: filter
@@ -41,6 +42,10 @@ jobs:
               - '.github/workflows/ci.yml'
             dashboard:
               - 'dashboard/**'
+              - '.github/workflows/ci.yml'
+            docker:
+              - 'docker/**'
+              - '.dockerignore'
               - '.github/workflows/ci.yml'
             scripts:
               - 'scripts/**'
@@ -349,3 +354,29 @@ jobs:
         run: bash defaults/scripts/tests/check-ci-suite-manifest.sh
       - name: Run the CI-wired shell test suites
         run: bash defaults/scripts/tests/run-ci-suites.sh
+
+  worker-image-smoke:
+    name: loom-worker Image Smoke Test
+    needs: changes
+    if: always() && (github.event_name == 'push' || needs.changes.outputs.docker == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Native build (the runner IS x86_64-unknown-linux-gnu) — a full
+      # cross-compile matrix has no place in a per-PR smoke test; the release
+      # workflow's own `build-daemon` matrix already covers every published
+      # target, this job only needs the one Linux artifact the Dockerfile
+      # actually consumes.
+      - name: Build loom-daemon (release)
+        run: cargo build --release --package loom-daemon
+      - name: Package binary at the path the Dockerfile expects
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp target/release/loom-daemon dist/loom-daemon-x86_64-unknown-linux-gnu
+      - name: Build the loom-worker image (no push)
+        run: docker build -f docker/worker/Dockerfile -t loom-worker:ci-smoke .
+      - name: Run the smoke test
+        run: ./docker/worker/test-image.sh loom-worker:ci-smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,17 @@ name: Build and Release
 # platform's build failure fails that job (and therefore the overall workflow
 # run) loudly — it never silently drops just that platform's artifact while
 # reporting overall success.
+#
+# `build-worker-image` (#5325) publishes `ghcr.io/rjwalters/loom-worker` — a
+# pinned OCI base image for fleet workers — alongside the raw binary/checksum
+# artifacts above. It is a SEPARATE deliverable from `build-daemon`: it needs
+# only the already-built `x86_64-unknown-linux-gnu` binary (no rebuild), and
+# it is deliberately gated to push only from the canonical repo on an actual
+# `release` event (see the job's own comments) — a fork's `workflow_dispatch`
+# dry run still builds the image (verifying the Dockerfile) but never
+# attempts to push to a registry namespace it has no write access to. Shape
+# decision (sweep-execution environment, not daemon-as-PID-1) and the image's
+# `FROM` contract: docker/worker/README.md.
 
 on:
   release:
@@ -72,6 +83,10 @@ permissions:
   # the ONLY thing that grants signing authority here — there is no key to leak,
   # and no secret to provision before a release can be signed.
   id-token: write
+  # `build-worker-image` (#5325) pushes ghcr.io/rjwalters/loom-worker using the
+  # default GITHUB_TOKEN — no separate registry secret to provision. Read-only
+  # everywhere else; only that job's own `permissions:` block actually uses this.
+  packages: write
 
 jobs:
   build-daemon:
@@ -389,3 +404,113 @@ jobs:
             dist/loom-daemon-${{ matrix.target }}*.sig
             dist/loom-daemon-${{ matrix.target }}*.pem
           retention-days: 7
+
+  build-worker-image:
+    name: Build and publish loom-worker image
+    # Waits for EVERY matrix leg (including the macOS/aarch64 daemon builds)
+    # to succeed before publishing — a failed platform build for `build-daemon`
+    # fails that job as a whole, so this job never runs (and never publishes)
+    # against a release the binary matrix itself considers broken.
+    needs: build-daemon
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      # Image version = loom version (AC): read the same version.sh every
+      # other version-bearing file in the repo is kept in sync against, at
+      # the exact commit this release/tag checked out above.
+      - name: Resolve image version
+        id: version
+        run: |
+          set -euo pipefail
+          echo "version=$(./scripts/version.sh)" >> "$GITHUB_OUTPUT"
+
+      # Reuse the binary `build-daemon` already built and checksummed for
+      # this exact commit rather than rebuilding from source a second time —
+      # a `release` event fetches it back off the Release assets that job's
+      # own "Upload release assets" step just published; a `workflow_dispatch`
+      # dry run (no Release object yet) fetches the matching Actions artifact
+      # from "Upload artifacts (for manual runs)" instead. Only linux/amd64 is
+      # published today (see docker/worker/README.md "Versioning and
+      # publishing" for the arm64 follow-up).
+      - name: Download loom-daemon release asset (release event)
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'loom-daemon-x86_64-unknown-linux-gnu*' \
+            --dir dist
+          cd dist
+          sha256sum -c loom-daemon-x86_64-unknown-linux-gnu.sha256
+
+      - name: Download loom-daemon build artifact (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/download-artifact@v7
+        with:
+          name: loom-daemon-x86_64-unknown-linux-gnu
+          # No `path:` — the artifact already carries its own `dist/…` prefix
+          # (uploaded from repo-root-relative paths above), so downloading to
+          # the default (repo root) lands it at `dist/loom-daemon-…` directly,
+          # matching the release-event branch and the Dockerfile's default
+          # LOOM_DAEMON_BIN path with no extra move/rename step.
+
+      - name: Verify binary is present and executable
+        run: |
+          set -euo pipefail
+          test -f dist/loom-daemon-x86_64-unknown-linux-gnu
+          chmod +x dist/loom-daemon-x86_64-unknown-linux-gnu
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build ONCE, always with `load: true` (never `push` here) so the image
+      # lands in the local docker daemon's store where `docker run` — and
+      # therefore the smoke test below — can actually see it. This runs
+      # unconditionally, on every event and every fork, so the Dockerfile
+      # itself is validated regardless of whether this run is allowed to push.
+      - name: Build loom-worker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/worker/Dockerfile
+          push: false
+          load: true
+          tags: |
+            ghcr.io/rjwalters/loom-worker:${{ steps.version.outputs.version }}
+            ghcr.io/rjwalters/loom-worker:latest
+
+      - name: Smoke-test the built image
+        run: ./docker/worker/test-image.sh "ghcr.io/rjwalters/loom-worker:${{ steps.version.outputs.version }}"
+
+      # PUSH (of the already-built-and-tested local image, no rebuild) is
+      # gated on both "this is a real release" and "this is the canonical
+      # repo" — mirrors the macOS/cosign secret-gated skip pattern above, but
+      # for a permissions axis instead of a secrets one: a fork running this
+      # workflow (via workflow_dispatch, or its own release) has a valid
+      # GITHUB_TOKEN but no write access to ghcr.io/rjwalters/*, so pushing
+      # there would just fail loudly mid-release. Gating the smoke test ahead
+      # of this step (rather than after) also means a broken image never
+      # reaches the registry in the first place.
+      - name: Push loom-worker image
+        if: github.event_name == 'release' && github.repository == 'rjwalters/loom'
+        run: |
+          set -euo pipefail
+          docker push "ghcr.io/rjwalters/loom-worker:${{ steps.version.outputs.version }}"
+          docker push "ghcr.io/rjwalters/loom-worker:latest"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,11 @@ missing/exhausted pool exits `78` (`EX_CONFIG`). Full reference:
 - **Releasing** — `scripts/version.sh` keeps all 5 version-bearing files in sync
   (including this `CLAUDE.md`'s `**Loom Version**` line); releases are driven by
   `/repo:release` from [rjwalters/repo](https://github.com/rjwalters/repo). The
-  release workflow triggers on GitHub Release creation, not tag push.
+  release workflow triggers on GitHub Release creation, not tag push. The same
+  workflow also publishes `ghcr.io/rjwalters/loom-worker:<version>` — a pinned
+  sweep-execution-environment base image (daemon stays on the host; see
+  [`docker/worker/README.md`](docker/worker/README.md) for the shape decision
+  and `FROM` contract).
 
 ## Troubleshooting
 

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,0 +1,131 @@
+# syntax=docker/dockerfile:1
+#
+# loom-worker base image (#5325) — a pinned SWEEP-EXECUTION ENVIRONMENT, not a
+# containerized loom-daemon.
+#
+# Shape decision (recorded, see docker/worker/README.md for the full
+# rationale): this image does NOT run `loom-daemon` as PID 1. The daemon stays
+# on the host; this image is the environment `spawn-worker.sh` dispatches a
+# sweep/build-gate INTO (a `docker run` wrapping the runtime-adapter seam),
+# exactly the way a bare-metal fleet worker runs one today. That sidesteps the
+# #5119 restart-semantics class entirely: #5119 is about systemd's
+# `KillMode=mixed` reaping in-flight sweep children when the *daemon's own*
+# service cgroup is torn down on restart. There is no daemon lifecycle inside
+# this container to have that problem — the daemon's systemd unit (and its
+# `restart --drain` contract) is unchanged and untouched by this image.
+#
+# Contract for downstream `FROM` consumers (e.g. klayout-tools' EDA sim
+# overlay): Ubuntu LTS + `loom-daemon` binary + Claude Code CLI + the `git`/
+# `gh`/`jq`/build-essential toolchain the loom scripts assume + a non-root
+# `loom` user (uid/gid 1000) + `/workspace` as the expected mount point for a
+# repo checkout. Zero secrets, zero identity, zero host-specific config are
+# baked in — token pools, workspace checkouts, and forge credentials all
+# arrive at `docker run` time via volume mounts / env, never at build time.
+# See docker/worker/README.md for the full guarantee list and mount contract.
+
+FROM ubuntu:24.04
+
+# The loom-daemon Linux release binary this image ships, relative to the
+# BUILD CONTEXT (not this directory) — the release workflow builds this
+# context as the repo root so this path lines up with the exact "dist/loom-daemon-<target>"
+# convention `.github/workflows/release.yml`'s `build-daemon` job already uses
+# for its own release-asset packaging step. Override for a local/manual build,
+# e.g. after `cargo build --release -p loom-daemon --target x86_64-unknown-linux-gnu`:
+#   mkdir -p dist && cp target/x86_64-unknown-linux-gnu/release/loom-daemon dist/loom-daemon-x86_64-unknown-linux-gnu
+#   docker build -f docker/worker/Dockerfile -t loom-worker:dev .
+ARG LOOM_DAEMON_BIN=dist/loom-daemon-x86_64-unknown-linux-gnu
+
+# Non-root identity (AC: "non-root user"). Fixed uid/gid so a downstream
+# overlay (or a `docker run --user`) can reason about ownership deterministically.
+ARG LOOM_UID=1000
+ARG LOOM_GID=1000
+ARG LOOM_USER=loom
+
+# Build-time only — deliberately ARG, not ENV, so it never leaks into the
+# runtime environment of a container started from this image (a downstream
+# `apt-get install` in an interactive shell should still get real prompts if
+# the caller wants them).
+ARG DEBIAN_FRONTEND=noninteractive
+
+# --- Base toolchain -----------------------------------------------------
+# Mirrors the fleet `add_worker.rs` "base-deps" step (build-essential,
+# pkg-config, libssl-dev, libsqlite3-dev, git, curl, ca-certificates, gh) plus
+# two additions the bare AMI plan does NOT install because it assumes an
+# already-provisioned host: `jq` (nearly every loom script — config-resolver,
+# spawn-worker.sh's runtime resolution, etc. — hard-requires it) and `tmux`
+# (loom-attach.sh / loom-start.sh's terminal multiplexer). Deliberately does
+# NOT install a Rust/Node/Python toolchain: this base image is language-agnostic
+# by design (see README "What this image deliberately does NOT include") —
+# per-repo build-gate toolchains are a downstream `FROM` layer's job.
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        libssl-dev \
+        libsqlite3-dev \
+        git \
+        curl \
+        ca-certificates \
+        gnupg \
+        jq \
+        tmux \
+        openssh-client \
+        unzip \
+        less \
+    && mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update -qq \
+    && apt-get install -y --no-install-recommends gh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- loom-daemon (release binary — pinned artifact, not a source rebuild) ---
+COPY ${LOOM_DAEMON_BIN} /usr/local/bin/loom-daemon
+RUN chmod 0755 /usr/local/bin/loom-daemon \
+    && /usr/local/bin/loom-daemon --version
+
+# --- Non-root user --------------------------------------------------------
+RUN groupadd --gid "${LOOM_GID}" "${LOOM_USER}" \
+    && useradd --uid "${LOOM_UID}" --gid "${LOOM_GID}" --create-home --shell /bin/bash "${LOOM_USER}" \
+    && mkdir -p /workspace \
+    && chown "${LOOM_USER}:${LOOM_USER}" /workspace
+
+USER ${LOOM_USER}
+WORKDIR /home/${LOOM_USER}
+
+# --- Claude Code CLI -------------------------------------------------------
+# Same installer the fleet plan's `claude-code` step runs (add_worker.rs
+# `render_claude_code`), run as the non-root user so it lands under
+# ~/.local/bin exactly as it would on a bare-metal fleet worker.
+RUN curl -fsSL https://claude.ai/install.sh | bash
+ENV PATH="/home/${LOOM_USER}/.local/bin:${PATH}"
+
+# --- Bootstrap seams (mount points, not baked content) --------------------
+# No `VOLUME` instruction: an anonymous-volume declaration here would survive
+# `docker build` in a way that's easy to mount over accidentally and is not
+# needed for correctness — the consumer controls binding explicitly with
+# `docker run -v`. This directory tree exists only so the intended mount
+# points have correct non-root ownership before anything is bound over them:
+#   /workspace              a repo checkout / worktree (bind mount)
+#   /home/loom/.loom/tokens the token pool (bind mount, e.g. ~/.loom/tokens, read-only)
+#   /home/loom/.loom/accounts.env  optional, bind-mounted read-only when the
+#                            pool bootstraps from it inside the container
+# No secret/token/credential file is created, copied, or baked in above this
+# line or below it — every one of these paths is EMPTY until a `docker run`
+# mounts something into it.
+RUN mkdir -p /home/${LOOM_USER}/.loom/tokens
+
+WORKDIR /workspace
+
+# No ENTRYPOINT/CMD prescribing "the container IS the worker" (shape decision
+# above): the image is a pinned shell a caller runs a command in, exactly like
+# `spawn-worker.sh` invoked bare-metal. Default to an interactive shell so
+# `docker run -it ghcr.io/rjwalters/loom-worker:<version>` is useful on its
+# own for manual inspection; a real dispatch overrides this with the actual
+# spawn command, e.g.:
+#   docker run --rm -v "$PWD:/workspace" -v "$HOME/.loom/tokens:/home/loom/.loom/tokens:ro" \
+#     ghcr.io/rjwalters/loom-worker:<version> \
+#     .loom/scripts/spawn-worker.sh -p "/loom:sweep 123" --dangerously-skip-permissions
+CMD ["/bin/bash"]

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -87,9 +87,26 @@ RUN chmod 0755 /usr/local/bin/loom-daemon \
     && /usr/local/bin/loom-daemon --version
 
 # --- Non-root user --------------------------------------------------------
-RUN groupadd --gid "${LOOM_GID}" "${LOOM_USER}" \
-    && useradd --uid "${LOOM_UID}" --gid "${LOOM_GID}" --create-home --shell /bin/bash "${LOOM_USER}" \
-    && mkdir -p /workspace \
+# ubuntu:24.04 ships a pre-existing `ubuntu` user/group AT uid/gid 1000 (the
+# upstream image's own default non-root account) — a plain `groupadd --gid
+# 1000` collides with it (`groupadd: GID '1000' already exists`, exit 4).
+# Reuse/rename whatever already owns that uid/gid instead of assuming a clean
+# id space, so this works whether or not the base image ships a pre-existing
+# account at LOOM_UID/LOOM_GID:
+RUN set -eu; \
+    existing_group="$(getent group "${LOOM_GID}" | cut -d: -f1 || true)"; \
+    if [ -n "$existing_group" ] && [ "$existing_group" != "${LOOM_USER}" ]; then \
+        groupmod -n "${LOOM_USER}" "$existing_group"; \
+    elif [ -z "$existing_group" ]; then \
+        groupadd --gid "${LOOM_GID}" "${LOOM_USER}"; \
+    fi; \
+    existing_user="$(getent passwd "${LOOM_UID}" | cut -d: -f1 || true)"; \
+    if [ -n "$existing_user" ] && [ "$existing_user" != "${LOOM_USER}" ]; then \
+        usermod -l "${LOOM_USER}" -d "/home/${LOOM_USER}" -m -g "${LOOM_GID}" -s /bin/bash "$existing_user"; \
+    elif [ -z "$existing_user" ]; then \
+        useradd --uid "${LOOM_UID}" --gid "${LOOM_GID}" --create-home --shell /bin/bash "${LOOM_USER}"; \
+    fi; \
+    mkdir -p /workspace \
     && chown "${LOOM_USER}:${LOOM_USER}" /workspace
 
 USER ${LOOM_USER}

--- a/docker/worker/README.md
+++ b/docker/worker/README.md
@@ -1,0 +1,134 @@
+# `loom-worker` base image
+
+`ghcr.io/rjwalters/loom-worker:<version>` (+ `:latest`) is a pinned OCI base
+image for Loom fleet workers, published by `.github/workflows/release.yml`
+from the same tag as the `loom-daemon` release binaries — `<version>` always
+matches the loom version those binaries ship at, so the image and the daemon
+binary it contains version in lockstep by construction.
+
+## Shape decision: sweep-execution environment, not daemon-as-PID-1
+
+Filed in #5325, this is the recorded answer to the question the issue asked
+to settle first.
+
+**The container is not the worker. `loom-daemon` stays on the host.** This
+image is the pinned environment a sweep or build-gate *executes inside* —
+the runtime-adapter seam (`spawn-worker.sh` → `spawn-<runtime>.sh`,
+[`.loom/docs/runtime-adapters.md`](../../.loom/docs/runtime-adapters.md))
+already treats "how the worker CLI is launched" as swappable; this image
+makes "what environment it launches into" swappable and reproducible the
+same way. A dispatcher (bare-metal today; `docker run` wrapping this image
+tomorrow) invokes `spawn-worker.sh` the same way either way — the seam needed
+no change to admit this.
+
+The alternative shape — `loom-daemon` running as PID 1 inside the container,
+foreground, no systemd — was rejected for one concrete, already-documented
+reason: **it forks the fleet's restart-safety contract (#5119)**.
+
+> On a `systemd --user`-supervised host, sweep/role children run **inside the
+> daemon's own service cgroup**, so a plain stop/restart SIGKILLs them
+> (`KillMode=mixed`) unless the daemon does an explicit `restart --drain`
+> first (see [`daemon-reference.md`](../../.loom/docs/daemon-reference.md)
+> around "Supervisor difference — on systemd, a plain stop/restart KILLS
+> sweeps (#5119)"). `fleet add-worker --safehouse`'s systemd-unit assumptions
+> (`daemon-unit` step: `Restart=on-success`, `LOOM_DAEMON_SUPERVISOR=systemd`,
+> the `--drain` contract) are built entirely around that boundary.
+
+A daemon-as-PID-1 container has **no cgroup boundary "for free" the way the
+host unit does** — a container runtime's own restart/kill semantics
+(`docker restart`, a Kubernetes pod eviction, …) would need an equivalent
+explicit "finish in-flight sweeps before the container is torn down" step
+re-implemented from scratch, with no existing `--drain` primitive to reuse
+and a genuinely different failure surface (SIGTERM timing, PID-1 zombie
+reaping, no `systemctl --user is-active` equivalent to detect the
+supervisor). None of that problem exists here: the daemon's systemd unit,
+its `restart --drain` contract, and #5119's fix are completely untouched by
+this image, because this image never runs the daemon at all.
+
+**What this shape does not solve** (by design — tracked separately): making
+the worker *host* itself a reproducible artifact (the AMI, not the
+container) remains the 2AM umbrella repo's job. This image is one input to
+that host, not a replacement for it.
+
+## What this image guarantees (the `FROM` contract)
+
+A downstream image (e.g. klayout-tools' EDA sim overlay) that does
+`FROM ghcr.io/rjwalters/loom-worker:<version>` can rely on:
+
+| Guarantee | Detail |
+|---|---|
+| Base OS | Ubuntu 24.04 LTS, pinned (not `ubuntu:latest`) |
+| `loom-daemon` | The release binary for this exact version, on `PATH` at `/usr/local/bin/loom-daemon`, smoke-tested at build time (`loom-daemon --version`) |
+| Claude Code CLI | Installed via the same `curl -fsSL https://claude.ai/install.sh \| bash` installer the fleet `add_worker` plan uses, on `PATH` |
+| Core toolchain | `git`, `gh`, `jq`, `tmux`, `curl`, `ca-certificates`, `openssh-client`, plus the C toolchain (`build-essential`, `pkg-config`, `libssl-dev`, `libsqlite3-dev`) the fleet's `base-deps` step installs |
+| Default user | Non-root `loom` (uid/gid `1000`), `HOME=/home/loom` |
+| Default `WORKDIR` | `/workspace` — the expected repo-checkout mount point |
+| Secrets | **Zero.** No token, credential, PAT, or account file is copied, generated, or referenced anywhere in the build. Verified by `docker/worker/test-image.sh`'s `docker history` scan. |
+
+## What this image deliberately does NOT include
+
+- **No language/build toolchain beyond the C basics above** — no Rust, Node,
+  Python, or domain-specific compiler/simulator. Per-repo build-gate
+  toolchains are a downstream layer's job (this is the "generic worker
+  mechanism" the issue's owner decision describes; domain toolchains build
+  `FROM` this image, they do not live in it).
+- **No `loom-daemon` lifecycle.** No systemd, no supervisor, no `ENTRYPOINT`
+  that starts the daemon. See the shape decision above.
+- **No secrets, tokens, or identity of any kind.**
+
+## Bootstrap seams (mounts, not baked content)
+
+Everything host-specific arrives at `docker run` time:
+
+| Path | Contents | How it arrives |
+|---|---|---|
+| `/workspace` | A repo checkout / git worktree | Bind mount, e.g. `-v "$PWD:/workspace"` |
+| `/home/loom/.loom/tokens` | The token pool | Bind mount, read-only, e.g. `-v "$HOME/.loom/tokens:/home/loom/.loom/tokens:ro"` |
+| `gh`/git forge auth | A PAT or `gh auth login` state | Bind mount `~/.config/gh`, or `GH_TOKEN`/`GITHUB_TOKEN` env at `docker run` |
+
+Example dispatch, mirroring what a bare-metal fleet worker's `spawn-worker.sh`
+invocation already does:
+
+```bash
+docker run --rm \
+  -v "$PWD:/workspace" \
+  -v "$HOME/.loom/tokens:/home/loom/.loom/tokens:ro" \
+  -e CLAUDE_CODE_OAUTH_TOKEN \
+  ghcr.io/rjwalters/loom-worker:<version> \
+  .loom/scripts/spawn-worker.sh -p "/loom:sweep 123" --dangerously-skip-permissions
+```
+
+## Building and testing locally
+
+The Dockerfile expects a pre-built Linux `loom-daemon` release binary in the
+build context (the same `dist/loom-daemon-<target>` layout
+`.github/workflows/release.yml`'s `build-daemon` job already produces) rather
+than rebuilding it from source — this keeps the image build fast and makes
+the image ship the *exact, already-tested* release artifact instead of a
+second, divergent build of the same commit.
+
+```bash
+# From the repo root:
+cargo build --release -p loom-daemon --target x86_64-unknown-linux-gnu
+mkdir -p dist
+cp target/x86_64-unknown-linux-gnu/release/loom-daemon dist/loom-daemon-x86_64-unknown-linux-gnu
+
+docker build -f docker/worker/Dockerfile -t loom-worker:dev .
+./docker/worker/test-image.sh loom-worker:dev
+```
+
+## Versioning and publishing
+
+`.github/workflows/release.yml` builds and pushes
+`ghcr.io/rjwalters/loom-worker:<version>` and `:latest` on every GitHub
+Release, using the `x86_64-unknown-linux-gnu` binary its own `build-daemon`
+job already built and checksummed for that release — `<version>` is read
+from `scripts/version.sh` at the released commit, so it is always exactly
+the loom version the image's `loom-daemon` binary reports via `--version`.
+
+Only `linux/amd64` is published today (the platform every observed fleet
+worker host runs, including the loom-worker-2 provisioning incident this
+issue was filed from). Multi-arch (`linux/arm64`, matching the
+`aarch64-unknown-linux-gnu` binary the release workflow already builds) is a
+reasonable follow-up but is out of scope here — it needs a buildx/QEMU cross
+-build leg this change does not add.

--- a/docker/worker/test-image.sh
+++ b/docker/worker/test-image.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# test-image.sh — smoke-test a built `loom-worker` image (#5325).
+#
+# Deliberately NOT a build step: it takes an already-built image tag and
+# asserts the contract docker/worker/README.md documents — the checks a
+# `docker build` alone cannot catch (a Dockerfile with no `RUN false` still
+# builds "successfully" even if the resulting image is missing a binary on
+# PATH, runs as root, or has a stray secret baked in).
+#
+# Usage:
+#   docker build -f docker/worker/Dockerfile -t loom-worker:test .
+#   ./docker/worker/test-image.sh loom-worker:test
+#
+# Exit 0 = every check passed. Exit 1 = at least one check failed (each
+# failure is printed with which assertion broke, not just a generic diff).
+
+set -euo pipefail
+
+IMAGE="${1:?usage: test-image.sh <image-tag>}"
+
+FAILURES=0
+fail() {
+    echo "FAIL: $1" >&2
+    FAILURES=$((FAILURES + 1))
+}
+pass() {
+    echo "PASS: $1"
+}
+
+run() {
+    # Run a command inside the image as the image's default user, capturing
+    # stdout+stderr together so a failure's own diagnostic is visible in CI logs.
+    docker run --rm "$IMAGE" bash -lc "$1"
+}
+
+echo "== Testing image: $IMAGE =="
+
+# 1. loom-daemon is on PATH and runs.
+if OUT=$(run "loom-daemon --version" 2>&1); then
+    pass "loom-daemon --version: $OUT"
+else
+    fail "loom-daemon --version did not exit 0"
+fi
+
+# 2. Claude Code CLI is on PATH.
+if run "command -v claude >/dev/null 2>&1"; then
+    pass "claude CLI present on PATH"
+else
+    fail "claude CLI not found on PATH"
+fi
+
+# 3. Core toolchain the loom scripts assume is present.
+for bin in git gh jq tmux curl; do
+    if run "command -v $bin >/dev/null 2>&1"; then
+        pass "$bin present on PATH"
+    else
+        fail "$bin missing from PATH"
+    fi
+done
+
+# 4. Runs as a non-root user by default.
+ACTUAL_USER=$(run "id -un")
+ACTUAL_UID=$(run "id -u")
+if [[ "$ACTUAL_USER" != "root" && "$ACTUAL_UID" != "0" ]]; then
+    pass "default user is non-root ($ACTUAL_USER, uid=$ACTUAL_UID)"
+else
+    fail "default user is root (expected a non-root default user)"
+fi
+
+# 5. /workspace exists, is the default cwd, and is writable by the default user.
+WORKDIR_CHECK=$(run 'pwd && touch /workspace/.loom-test-write && rm -f /workspace/.loom-test-write && echo WRITABLE')
+if [[ "$WORKDIR_CHECK" == *"/workspace"* && "$WORKDIR_CHECK" == *"WRITABLE"* ]]; then
+    pass "/workspace is the default cwd and writable by the default user"
+else
+    fail "/workspace is not the default cwd or not writable: $WORKDIR_CHECK"
+fi
+
+# 6. No secrets baked in. This is a best-effort scan, not a proof: it greps
+# the image's history/env for the token/credential env vars and file paths
+# loom's own token-pool and forge-auth mechanisms use, so a regression that
+# accidentally bakes a real secret into a layer fails loudly here instead of
+# shipping silently.
+HISTORY=$(docker history --no-trunc "$IMAGE" 2>&1 || true)
+SECRET_HIT=0
+for pattern in CLAUDE_CODE_OAUTH_TOKEN GITHUB_TOKEN GH_TOKEN 'accounts\.env' '\.loom/tokens/.*\.token'; do
+    if echo "$HISTORY" | grep -qE "$pattern"; then
+        fail "docker history matched a secret-shaped pattern: $pattern"
+        SECRET_HIT=1
+    fi
+done
+if [[ "$SECRET_HIT" -eq 0 ]]; then
+    pass "no secret-shaped strings found in docker history"
+fi
+
+# Token pool dir exists but is empty (mount point, not baked content).
+TOKENS_CONTENTS=$(run 'ls -A /home/*/.loom/tokens 2>/dev/null || true')
+if [[ -z "$TOKENS_CONTENTS" ]]; then
+    pass "token pool mount point is empty (no baked tokens)"
+else
+    fail "token pool mount point is NOT empty: $TOKENS_CONTENTS"
+fi
+
+echo "== $FAILURES failure(s) =="
+exit $((FAILURES > 0 ? 1 : 0))


### PR DESCRIPTION
## Summary

- Adds `docker/worker/Dockerfile` — a pinned Ubuntu 24.04 base image (loom-daemon release binary + Claude Code CLI + git/gh/jq/tmux/build-essential + a non-root `loom` user), plus `docker/worker/test-image.sh` (a smoke test asserting the contract) and `docker/worker/README.md` (the shape decision + `FROM` contract for downstream consumers, e.g. klayout-tools' EDA sim overlay).
- `.github/workflows/release.yml` gains a `build-worker-image` job that reuses the existing `build-daemon` job's already-built `x86_64-unknown-linux-gnu` binary (never rebuilds it), smoke-tests the image, and — only from the canonical repo on a real `release` event — pushes `ghcr.io/rjwalters/loom-worker:<version>` and `:latest` to GHCR. `<version>` is `scripts/version.sh`'s output, so the image always matches the loom version its `loom-daemon` binary reports.
- `.github/workflows/ci.yml` gains a path-filtered `worker-image-smoke` job (only runs on PRs touching `docker/**`) that builds `loom-daemon` natively, builds the image, and runs the same smoke test — so a broken Dockerfile fails CI instead of being discovered only at release time.
- `.dockerignore` added at repo root (the image build context is the repo root, to reuse `build-daemon`'s exact `dist/loom-daemon-<target>` artifact path) with a deny-all-then-allowlist policy so the large `target/`/worktree tree never gets sent to the docker daemon.
- `CLAUDE.md` gets one pointer line to `docker/worker/README.md` under "Releasing" (budget check still passes: 301/320 lines).

## Shape decision (recorded in docker/worker/README.md)

Followed the issue's own recommendation: **sweep-execution environment, not daemon-as-PID-1**. `loom-daemon` stays on the host; the image is the pinned environment `spawn-worker.sh` dispatches a sweep/build-gate *into* (same runtime-adapter seam a bare-metal fleet worker already uses — no change needed to admit it).

This sidesteps #5119 (systemd `KillMode=mixed` reaping in-flight sweep children when the daemon's own service cgroup is torn down on restart) **entirely**, rather than reintroducing an equivalent problem: there is no daemon lifecycle inside this container at all, so the host's existing systemd unit, its `restart --drain` contract, and #5119's fix are completely untouched. A daemon-as-PID-1 shape would have had no cgroup boundary "for free" the way the host unit does, and would have needed an equivalent drain-before-teardown mechanism reinvented from scratch for whatever container-restart semantics apply (`docker restart`, a pod eviction, …) — this shape avoids that class of problem by construction instead of solving it.

Explicitly out of scope (per the issue): making the worker *host* itself reproducible (the AMI) remains the 2AM umbrella repo's job — this image is one input to that host, not a replacement.

## Acceptance Criteria Verification

- [x] Recorded decision on shape (1) vs (2), #5119 addressed explicitly — `docker/worker/README.md` "Shape decision" section.
- [x] `docker/worker/Dockerfile` building Ubuntu LTS + build deps + `loom-daemon` release binary + Claude Code CLI + non-root user + bootstrap seams as mounts, no secrets baked.
- [x] Release workflow publishes `ghcr.io/rjwalters/loom-worker:<version>` + `:latest` alongside existing release artifacts; image version = loom version (`scripts/version.sh`).
- [x] Zero secrets/identity in the image — verified structurally (no COPY/RUN references any token/credential file) and mechanically by `test-image.sh`'s `docker history` scan for secret-shaped env/path patterns, wired into both CI and the release job.
- [x] Documented `FROM` contract for downstream consumers — `docker/worker/README.md` "What this image guarantees" / "What this image deliberately does NOT include".

## Test Plan

- [x] YAML syntax validated for both modified workflow files via `python3 -c "import yaml; yaml.safe_load(...)"`.
- [x] `shellcheck docker/worker/test-image.sh` — clean, no warnings.
- [x] `bash -n docker/worker/test-image.sh` — syntax OK.
- [x] `bash scripts/check-docs-defaults-parity.sh` — OK (no `.loom/docs/` links broken by the new README's cross-references).
- [x] `bash scripts/check-claude-md-budget.sh` — OK, 301/320 lines.
- [x] `./scripts/version.sh` confirmed to return `0.18.0` (no `v` prefix), matching the tagging scheme documented in the README.
- [ ] **Not run in this environment**: an actual `docker build` — Docker is not available in this sandbox (`docker: command not found`). The new `worker-image-smoke` CI job (gated on `docker/**` changes, so it runs on this PR) is the first real `docker build` + `docker run` exercise of the Dockerfile; please confirm it passes before merging. Manual local repro instructions are in `docker/worker/README.md` "Building and testing locally".
- [ ] Multi-arch (`linux/arm64`) is explicitly deferred — documented as a follow-up in the README, not implemented here (only `linux/amd64` is published, matching every fleet worker host observed so far, including the loom-worker-2 incident that motivated this issue).

Closes #5325