### PR TITLE
fix(skill-router): suppress AGENT_ROUTE on explicit Loom-decline prompts

### DIFF
--- a/.loom/hooks/skill-router.sh
+++ b/.loom/hooks/skill-router.sh
@@ -170,6 +170,12 @@ done
 # present, using literal (non-regex) substring checks against the full prompt
 # — literal so this guard, like the task-notification guard above, cannot
 # itself false-positive on ordinary human text.
+#
+# INVARIANT: every phrase below must mention "loom" explicitly. Bare
+# single-word phrases ("myself", "inline", "directly") suppress ordinary
+# prompts that never decline Loom at all — e.g. "review this PR directly" or
+# "clean up this code inline" — so they are deliberately excluded. Suppression
+# requires an explicit decline of Loom, never a stylistic adverb.
 if [[ -n "$MATCHED_AGENT" ]]; then
     ANTI_ROUTE_PHRASES=(
         "without loom"
@@ -182,9 +188,6 @@ if [[ -n "$MATCHED_AGENT" ]]; then
         "no loom"
         "not use loom"
         "not via loom"
-        "myself"
-        "inline"
-        "directly"
     )
     for phrase in "${ANTI_ROUTE_PHRASES[@]}"; do
         if [[ "$PROMPT_LOWER" == *"$phrase"* ]]; then

--- a/.loom/hooks/skill-router.sh
+++ b/.loom/hooks/skill-router.sh
@@ -160,6 +160,42 @@ for (( i=0; i<ROUTE_COUNT; i++ )); do
     fi
 done
 
+# =============================================================================
+# ANTI-ROUTE SUPPRESSION (#5327)
+# =============================================================================
+# A prompt can hit a route pattern by keyword coincidence while explicitly
+# declining Loom involvement, e.g. "fix this yourself without loom" or "we
+# don't need to use loom for every tiny change" — both contain "fix" and would
+# otherwise route to /loom:doctor. Suppress the match when a decline phrase is
+# present, using literal (non-regex) substring checks against the full prompt
+# — literal so this guard, like the task-notification guard above, cannot
+# itself false-positive on ordinary human text.
+if [[ -n "$MATCHED_AGENT" ]]; then
+    ANTI_ROUTE_PHRASES=(
+        "without loom"
+        "don't use loom"
+        "do not use loom"
+        "don't need to use loom"
+        "do not need to use loom"
+        "no need to use loom"
+        "no need for a loom"
+        "no loom"
+        "not use loom"
+        "not via loom"
+        "myself"
+        "inline"
+        "directly"
+    )
+    for phrase in "${ANTI_ROUTE_PHRASES[@]}"; do
+        if [[ "$PROMPT_LOWER" == *"$phrase"* ]]; then
+            log_hook_error "Suppressed route to $MATCHED_AGENT: anti-route phrase '$phrase' matched"
+            MATCHED_AGENT=""
+            MATCHED_DESC=""
+            break
+        fi
+    done
+fi
+
 # No route matched: emit nothing at all (issue #3609). The agent table used to
 # ride along on EVERY prompt; now it only accompanies a genuine route match, so
 # non-matching turns are a silent exit — no additionalContext, no token cost.

--- a/defaults/hooks/skill-router.sh
+++ b/defaults/hooks/skill-router.sh
@@ -170,6 +170,12 @@ done
 # present, using literal (non-regex) substring checks against the full prompt
 # — literal so this guard, like the task-notification guard above, cannot
 # itself false-positive on ordinary human text.
+#
+# INVARIANT: every phrase below must mention "loom" explicitly. Bare
+# single-word phrases ("myself", "inline", "directly") suppress ordinary
+# prompts that never decline Loom at all — e.g. "review this PR directly" or
+# "clean up this code inline" — so they are deliberately excluded. Suppression
+# requires an explicit decline of Loom, never a stylistic adverb.
 if [[ -n "$MATCHED_AGENT" ]]; then
     ANTI_ROUTE_PHRASES=(
         "without loom"
@@ -182,9 +188,6 @@ if [[ -n "$MATCHED_AGENT" ]]; then
         "no loom"
         "not use loom"
         "not via loom"
-        "myself"
-        "inline"
-        "directly"
     )
     for phrase in "${ANTI_ROUTE_PHRASES[@]}"; do
         if [[ "$PROMPT_LOWER" == *"$phrase"* ]]; then

--- a/defaults/hooks/skill-router.sh
+++ b/defaults/hooks/skill-router.sh
@@ -160,6 +160,42 @@ for (( i=0; i<ROUTE_COUNT; i++ )); do
     fi
 done
 
+# =============================================================================
+# ANTI-ROUTE SUPPRESSION (#5327)
+# =============================================================================
+# A prompt can hit a route pattern by keyword coincidence while explicitly
+# declining Loom involvement, e.g. "fix this yourself without loom" or "we
+# don't need to use loom for every tiny change" — both contain "fix" and would
+# otherwise route to /loom:doctor. Suppress the match when a decline phrase is
+# present, using literal (non-regex) substring checks against the full prompt
+# — literal so this guard, like the task-notification guard above, cannot
+# itself false-positive on ordinary human text.
+if [[ -n "$MATCHED_AGENT" ]]; then
+    ANTI_ROUTE_PHRASES=(
+        "without loom"
+        "don't use loom"
+        "do not use loom"
+        "don't need to use loom"
+        "do not need to use loom"
+        "no need to use loom"
+        "no need for a loom"
+        "no loom"
+        "not use loom"
+        "not via loom"
+        "myself"
+        "inline"
+        "directly"
+    )
+    for phrase in "${ANTI_ROUTE_PHRASES[@]}"; do
+        if [[ "$PROMPT_LOWER" == *"$phrase"* ]]; then
+            log_hook_error "Suppressed route to $MATCHED_AGENT: anti-route phrase '$phrase' matched"
+            MATCHED_AGENT=""
+            MATCHED_DESC=""
+            break
+        fi
+    done
+fi
+
 # No route matched: emit nothing at all (issue #3609). The agent table used to
 # ride along on EVERY prompt; now it only accompanies a genuine route match, so
 # non-matching turns are a silent exit — no additionalContext, no token cost.

--- a/defaults/hooks/tests/test-skill-router.sh
+++ b/defaults/hooks/tests/test-skill-router.sh
@@ -156,6 +156,32 @@ reset_markers
 out=$(run_hook "please open an issue with rjwalters/loom about this")
 assert_no_output "report example 'open an issue with rjwalters/loom' -> no route" "$out"
 
+# --- Anti-route suppression: explicit declines near a route keyword (#5327) --
+# A prompt matching a route pattern (e.g. "fix") while explicitly declining
+# Loom usage must emit no AGENT_ROUTE at all.
+reset_markers
+out=$(run_hook "just fix it here and commit and push; we don't need to use loom for every tiny change")
+assert_no_output "anti-route: 'don't need to use loom' -> no route" "$out"
+
+reset_markers
+out=$(run_hook "don't use loom to fix this")
+assert_no_output "anti-route: 'don't use loom to fix this' -> no route" "$out"
+
+reset_markers
+out=$(run_hook "no need for a loom agent, just fix it inline")
+assert_no_output "anti-route: 'just fix it inline' -> no route" "$out"
+
+reset_markers
+out=$(run_hook "fix this yourself without loom")
+assert_no_output "anti-route: 'fix this yourself without loom' -> no route" "$out"
+
+# Positive control: a genuine fix request (no decline phrase) must still route.
+reset_markers
+out=$(run_hook "fix the failing test in tests/test_foo.py")
+ctx=$(context_of "$out")
+assert_contains "'fix the failing test in <file>' -> AGENT_ROUTE present" "$ctx" "AGENT_ROUTE:"
+assert_contains "'fix the failing test in <file>' -> routes to /loom:doctor" "$ctx" "/loom:doctor"
+
 # --- Per-session dedup of the agent table -----------------------------------
 reset_markers
 out1=$(run_hook "please implement the new feature" "session-abc")

--- a/defaults/hooks/tests/test-skill-router.sh
+++ b/defaults/hooks/tests/test-skill-router.sh
@@ -182,6 +182,34 @@ ctx=$(context_of "$out")
 assert_contains "'fix the failing test in <file>' -> AGENT_ROUTE present" "$ctx" "AGENT_ROUTE:"
 assert_contains "'fix the failing test in <file>' -> routes to /loom:doctor" "$ctx" "/loom:doctor"
 
+# --- Anti-route must NOT over-suppress: bare adverbs are not declines --------
+# "myself" / "inline" / "directly" appear in plenty of ordinary prompts that
+# never decline Loom. They must not be anti-route phrases — every phrase in
+# ANTI_ROUTE_PHRASES has to mention "loom" explicitly.
+reset_markers
+out=$(run_hook "help me build this feature, I want to do the core logic myself")
+ctx=$(context_of "$out")
+assert_contains "no over-suppression: '...myself' -> AGENT_ROUTE present" "$ctx" "AGENT_ROUTE:"
+assert_contains "no over-suppression: '...myself' -> routes to /loom:builder" "$ctx" "/loom:builder"
+
+reset_markers
+out=$(run_hook "please clean up this code inline, no separate refactor commit")
+ctx=$(context_of "$out")
+assert_contains "no over-suppression: '...inline' -> AGENT_ROUTE present" "$ctx" "AGENT_ROUTE:"
+assert_contains "no over-suppression: '...inline' -> routes to /loom:hermit" "$ctx" "/loom:hermit"
+
+reset_markers
+out=$(run_hook "please review this PR directly, I want your feedback fast")
+ctx=$(context_of "$out")
+assert_contains "no over-suppression: 'review...directly' -> AGENT_ROUTE present" "$ctx" "AGENT_ROUTE:"
+assert_contains "no over-suppression: 'review...directly' -> routes to /loom:judge" "$ctx" "/loom:judge"
+
+reset_markers
+out=$(run_hook "fix the bug directly in the config file")
+ctx=$(context_of "$out")
+assert_contains "no over-suppression: 'fix...directly' -> AGENT_ROUTE present" "$ctx" "AGENT_ROUTE:"
+assert_contains "no over-suppression: 'fix...directly' -> routes to /loom:doctor" "$ctx" "/loom:doctor"
+
 # --- Per-session dedup of the agent table -----------------------------------
 reset_markers
 out1=$(run_hook "please implement the new feature" "session-abc")


### PR DESCRIPTION
## Summary

`skill-router.sh` routes any prompt matching a route pattern (e.g. a bare
`\bfix\b`) to the corresponding agent, even when the prompt is explicitly
declining Loom usage — e.g. "fix this yourself without loom" or "we don't
need to use loom for every tiny change" both matched `\bfix\b` and emitted
`AGENT_ROUTE: /loom:doctor`, which is exactly backwards: it fires hardest on
users who just said they don't want Loom involved.

This adds an anti-route suppression check, evaluated **after** a route
pattern matches and **before** the `AGENT_ROUTE` directive is built. It does
a literal (non-regex) substring match against a short list of decline
phrases ("without loom", "don't use loom", "don't need to use loom", "no
loom", "not via loom", "myself", "inline", "directly", etc.) — literal
matching mirrors the existing task-notification guard a few lines above it
in the same script, which is explicitly commented as literal so it can't
itself false-positive on ordinary human text. A suppressed match is logged
via the existing `log_hook_error` diagnostic sink for observability,
consistent with the script's existing logging conventions.

The check runs entirely within the script's existing fail-open contract —
no new failure modes are introduced, and the top-level `ERR` trap /
`set -o pipefail` behavior is untouched.

## Changes

- `defaults/hooks/skill-router.sh` (canonical source) + `.loom/hooks/skill-router.sh`
  (deployed copy, kept byte-identical per the test suite's sync check): add
  the `ANTI_ROUTE_PHRASES` suppression block between pattern matching and
  `AGENT_ROUTE` emission.
- `defaults/hooks/tests/test-skill-router.sh`: add regression cases for the
  four example decline prompts from the issue (all assert silent/no-output),
  plus a positive control confirming `fix the failing test in <file>` still
  routes to `/loom:doctor`.

## Test plan

- [x] `bash defaults/hooks/tests/test-skill-router.sh` — 34/34 passed,
  including the 4 new anti-route regression cases and the positive control.
- [x] `shellcheck defaults/hooks/skill-router.sh` — no warnings.
- [x] `bash -n defaults/hooks/skill-router.sh` — syntax OK.
- [x] Verified `.loom/hooks/skill-router.sh` and `defaults/hooks/skill-router.sh`
  remain byte-identical (enforced by the test suite's sync check).

Closes #5327