### PR TITLE
docs(readme): correct ADR range to 0001–0014

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ as `.loom/docs/`).
 
 | Path | Contents |
 |------|----------|
-| [`adr/`](adr/) | Architecture Decision Records (0001–0013) plus a [template](adr/template.md). Start at the [ADR index](adr/README.md). |
+| [`adr/`](adr/) | Architecture Decision Records (0001–0014) plus a [template](adr/template.md). Start at the [ADR index](adr/README.md). |
 | [`api/`](api/) | API surface reference. |
 | [`design/`](design/) | Design notes for specific subsystems — config resolution tiers, the label state machine, the supervised restart primitive, Architect/Hermit cadence. |
 | [`guides/`](guides/) | How-to guides: getting started, quickstart tutorial, development, dev workflow, git workflow, testing, code quality, CI/CD setup, CLI reference, daemon dev mode, fork drift, troubleshooting, styling, TypeScript conventions, common tasks. |


### PR DESCRIPTION
Closes #5347

## Summary

`docs/README.md`'s Directories table described `adr/` as holding "Architecture
Decision Records (0001–0013)". ADR-0014 (forge coordination decoupling) landed
in 5fb6e9cb (#5295) and is already listed in `docs/adr/README.md:63`, so the
directory index was one ADR behind the index it links to.

## Change

One line — the range in the `adr/` row now reads `0001–0014`. No other content
touched.

## Verification

- `docs/adr/` contains 0001, 0003, 0004, 0006, 0008–0014 (highest = 0014)
- `scripts/check-docs-defaults-parity.sh` — OK
- `scripts/check-claude-md-budget.sh` — OK (301/320 lines, unaffected)

## Provenance

Surfaced by a `/repo:all` hygiene pass on 2026-08-04. The same pass found no
broken links (223 tracked `.md` files scanned), no gitignore issues, and no
orphaned files.

## Follow-up (not in scope)

A hardcoded numeric range drifts silently every time an ADR lands. Dropping the
range from `docs/README.md` and letting `docs/adr/README.md` be the sole source
of truth would remove the failure mode entirely — worth a separate issue if the
pattern recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014a2bVjUnR58K8TJ6CbYB7G
