### PR TITLE
chore(deps): label Dependabot PRs into the Loom workflow (#5455)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,33 @@
 version: 2
+
+# Every ecosystem below applies `loom:review-requested` in addition to its own
+# labels. That is not cosmetic — it is what keeps a Dependabot PR OUT of the
+# Judge's fallback queue (#5455).
+#
+# The fallback queue is defined as "open PRs carrying no `loom:` label", and the
+# fallback path deliberately applies no labels, so evaluating an unlabeled PR
+# cannot remove it from the queue. PR #4972 (a 2-line `libc` lockfile bump) took
+# 199 fallback evaluations over 37 hours — roughly half of them approvals — and
+# still did not merge. Labeling on creation makes that livelock structurally
+# impossible rather than merely less likely.
+#
+# The label is applied here rather than by a workflow because Dependabot sets it
+# at PR-creation time; a labeler workflow races the first Judge tick and only
+# narrows the window instead of closing it.
+#
+# `loom:review-requested` routes these into the normal review queue. It does not
+# make them auto-merge — the Champion's safety criteria still reject the class
+# (#4765). Bounding the wasted review loop and deciding the merge policy are
+# separate fixes; this file is only the first.
 updates:
   # NPM dependencies
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "loom:review-requested"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -16,6 +39,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "loom:review-requested"
     groups:
       all-dependencies:
         patterns:
@@ -26,3 +52,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "loom:review-requested"


### PR DESCRIPTION
## What

Adds `labels: [dependencies, loom:review-requested]` to all three ecosystems in `.github/dependabot.yml`.

Part of #5455 (fixes the Dependabot half; see "What this does NOT do" below for remaining scope).

## Why

The Judge's fallback queue is defined as *"open PRs carrying no `loom:` label"*, and the fallback path deliberately applies no labels — every fallback comment says so in its own words: *"no `loom:` labels present, so labels are left unchanged."*

So evaluating an unlabeled PR **cannot remove it from the queue**. There is no state transition and therefore no termination condition.

**PR #4972** — a 2-line `libc` `Cargo.lock` bump — has taken **199 fallback evaluations over 37 hours** (5.4/hour), roughly half of them approvals, and still has not merged. Every other open PR in this repo, all of them labeled, sits at 7–18 comments:

| PR | labels | comments |
|---|---|---|
| **#4972** | `dependencies, rust` — **no `loom:`** | **199** |
| #5397 | `loom:blocked, loom:changes-requested` | 18 |
| #4918 | `loom:pr` | 15 |
| #4770 | `loom:pr` | 7 |

The distinguishing feature is not size, age, or author — it is the absence of a `loom:` label.

**`vibesql` is the natural control.** Its Dependabot PRs carry `loom:review-requested` and have **0** Judge comments, with 10 of 14 merged. Same Judge, same fallback-queue code, opposite behaviour, one variable.

## Why in `dependabot.yml` rather than a labeler workflow

Dependabot applies these labels at **PR-creation time**. A labeler workflow fires after the PR opens and races the first Judge tick — it narrows the window rather than closing it. This makes the livelock structurally impossible for this class instead of merely less likely.

## Notes for review

- **`dependencies` is listed explicitly on purpose.** Dependabot's `labels:` **replaces** its defaults rather than adding to them; omitting it would silently drop the existing label.
- **Both labels were verified to exist on this repo** before committing (`dependencies` `#0366d6`, `loom:review-requested` `#10B981`). Dependabot silently ignores labels that don't exist, which would fail open into exactly the current behaviour.
- No workflow, script, or Judge logic changes — configuration only.

## What this does NOT do

Stated plainly so it isn't oversold:

1. **It does not make these PRs merge.** The Champion's safety criteria still reject the whole Dependabot class (#4765) — `vibesql`'s were ultimately merged by a human, and still carried `loom:review-requested` at merge time. This bounds the wasted review loop; #4765 supplies the merge decision.
2. **It does not fix #4972**, which already exists and needs a label applied directly to stop its loop.
3. **It only protects the Dependabot class.** Any future PR that reaches the fallback queue and cannot be advanced hits the same unbounded loop. The per-PR evaluation cap proposed in #5455 is what makes that case bounded, and is still worth doing.

## Test plan

- [x] `.github/dependabot.yml` parses as valid YAML; all three ecosystems carry both labels
- [x] Both label names verified present on `rjwalters/loom`
- [ ] On the next Dependabot PR: confirm it opens carrying `loom:review-requested`, and that it does **not** accumulate fallback-mode comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

