### PR TITLE
fix(guide): exclude the doc-maintenance phase's own PRs from the WORK_LOG diff

### DIFF
--- a/defaults/.claude/commands/loom/guide.md
+++ b/defaults/.claude/commands/loom/guide.md
@@ -1104,14 +1104,37 @@ If a docs PR is already open, **skip the entire document maintenance phase** to 
 Append entries for newly merged PRs and closed issues since the last high-water mark.
 
 ```bash
+# #5454 BUG, DO NOT REINTRODUCE: this phase's OWN merged PRs must never count as
+# "new content". Every `docs: Guide document maintenance update` PR is itself a
+# merged PR, so if it is allowed into `new_prs`, merging PR N manufactures the
+# very "there is something to append" signal that justifies PR N+1 — the skip
+# branch below can never be true two ticks in a row and the phase emits a PR
+# forever (observed: 23 self-referential PRs, one every ~15-30 min, all carrying
+# zero-information WORK_LOG lines about themselves).
+#
+# Excluded by BOTH identifying marks the phase controls: the head-branch prefix
+# `docs-worktree.sh` creates (`docs/guide-update-<timestamp>` — the same prefix
+# Step 1's open-docs-PR guard matches on) and the exact title `create_docs_pr`
+# passes to `gh pr create` in Step 5. Either one alone is enough; requiring only
+# one to match keeps the filter working if a docs PR is ever retitled or lands
+# from a differently-named branch.
+#
+# Keep this expression a single line assigned exactly as written: the regression
+# suite (defaults/scripts/tests/test-guide-work-log-self-loop.sh) extracts THIS
+# line out of THIS file and runs it against fixtures, so the prompt and the test
+# can never drift apart.
+GUIDE_DOCS_PR_EXCLUDE='((.headRefName // "") | startswith("docs/guide-update")) or (.title == "docs: Guide document maintenance update")'
+
 update_work_log() {
   # High-water marks come from the committed WORK_LOG.md (survives fresh checkout)
   local last_pr=$(work_log_max_pr)
   local last_issue=$(work_log_max_issue)
 
-  # Get newly merged PRs (after high-water mark)
-  local new_prs=$("$GH_READ" pr list --state merged --limit 50 --json number,title,mergedAt \
-    --jq "[.[] | select(.number > $last_pr)] | sort_by(.mergedAt) | reverse")
+  # Get newly merged PRs (after high-water mark), minus this phase's own docs PRs.
+  # `headRefName` MUST stay in the --json field list — jq cannot filter on a field
+  # gh was not asked to return, and `.headRefName` would silently be null.
+  local new_prs=$("$GH_READ" pr list --state merged --limit 50 --json number,title,mergedAt,headRefName \
+    --jq "[.[] | select(.number > $last_pr) | select(($GUIDE_DOCS_PR_EXCLUDE) | not)] | sort_by(.mergedAt) | reverse")
 
   # Get newly closed issues (after high-water mark)
   local new_issues=$("$GH_READ" issue list --state closed --limit 50 --json number,title,closedAt \
@@ -1120,6 +1143,10 @@ update_work_log() {
   # If nothing new, skip. NOTE: `printf '%s\n' "$VAR" | jq`, never `echo "$VAR"
   # | jq` — zsh's `echo` builtin reinterprets `\n`/`\t` escapes by default,
   # corrupting captured `gh --json` output before jq ever parses it (#5094).
+  # A tick whose only merged PRs above the watermark are this phase's own docs
+  # PRs lands HERE — `new_prs` is empty after the exclusion, so the phase reports
+  # "current" and returns 1, and (with WORK_PLAN/README also unchanged) Step 5's
+  # `git diff --cached --quiet` finds nothing to commit and creates no PR.
   if [ "$(printf '%s\n' "$new_prs" | jq 'length')" -eq 0 ] && [ "$(printf '%s\n' "$new_issues" | jq 'length')" -eq 0 ]; then
     echo "No new merged PRs or closed issues. WORK_LOG.md is current."
     return 1
@@ -1131,13 +1158,18 @@ update_work_log() {
   #         - **PR #N**: Title
   #         - **Issue #N** (closed): Title
   #
+  # Append ONLY what is in `$new_prs` / `$new_issues` — never hand-add a docs
+  # PR the filter above removed, and never "helpfully" log this tick's own PR.
+  #
   # Write with the Edit/Write tool against the ABSOLUTE "$DOCS_WT/WORK_LOG.md"
   # path — a repo-relative `WORK_LOG.md` resolves to the main checkout and is
   # denied by the worktree-isolation guards (see "Where This Phase Writes").
   #
   # No side-car watermark to update: the newly-written PR/issue numbers ARE the
   # new watermark the next tick reads back from WORK_LOG.md via work_log_max_pr /
-  # work_log_max_issue.
+  # work_log_max_issue. Excluded docs PRs therefore never advance the watermark
+  # either — harmless: they are re-queried every tick and re-filtered every tick,
+  # so they can never be appended no matter how far the watermark lags them.
 
   return 0
 }
@@ -1372,7 +1404,8 @@ Document Maintenance Phase
   ├─ DOCS_WT=$(./.loom/scripts/docs-worktree.sh | tail -1)
   │    └─ managed worktree on docs/guide-update-<timestamp>; the ONLY place
   │       this phase may write (guards deny the main checkout)
-  ├─ Update "$DOCS_WT/WORK_LOG.md" (append new entries)
+  ├─ Update "$DOCS_WT/WORK_LOG.md" (append new entries; this phase's OWN
+  │    docs PRs are filtered out — see the #5454 note in Step 2)
   ├─ Update "$DOCS_WT/WORK_PLAN.md" (regenerate if labels changed)
   ├─ Check "$DOCS_WT/README.md" staleness (only if architecture changed)
   ├─ If any changes:
@@ -1395,6 +1428,11 @@ Document Maintenance Phase
 - High-water marks are derived from the committed WORK_LOG.md itself (not a
   gitignored side-car that resets every fresh cron checkout), so they survive
   across ticks and prevent duplicate WORK_LOG entries
+- **This phase's own merged docs PRs are excluded from `new_prs`** (#5454) — by
+  the `docs/guide-update` head-branch prefix *or* the exact
+  `docs: Guide document maintenance update` title. Without that exclusion the
+  phase is self-perpetuating: its own merged PR is "new content" for the next
+  tick, so merging PR N always justifies PR N+1 and the loop never terminates
 - WORK_PLAN is only regenerated when label state actually changes — which
   requires `render_plan_body`'s output and the committed marker region to be
   comparable byte-for-byte (see the #5413 bug note in Step 3)

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -59,6 +59,7 @@ test-github-app-token.sh
 test-gitignore-guard.sh
 test-guard-codex-bridge.sh
 test-guard-hook-schema.sh
+test-guide-work-log-self-loop.sh
 test-install-active-session.sh
 test-install-full-reinstall-no-target-mutation.sh
 test-install-pr-markers.sh

--- a/defaults/scripts/tests/test-guide-work-log-self-loop.sh
+++ b/defaults/scripts/tests/test-guide-work-log-self-loop.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# test-guide-work-log-self-loop.sh - Regression test for issue #5454
+#
+# The Guide role's Document Maintenance phase self-perpetuated: `update_work_log()`
+# built its "new merged PRs" set from `gh pr list --state merged` with NO exclusion
+# for the phase's own `docs: Guide document maintenance update` PRs. Since every
+# docs-maintenance PR is itself a merged PR, merging PR N always produced "new
+# content above the watermark" for tick N+1 — the "nothing new, skip" branch could
+# never be true two ticks in a row, and the phase emitted a fresh PR forever
+# (observed: 23 self-referential PRs, one every ~15-30 min).
+#
+# The fix is a jq exclusion applied BEFORE `new_prs` is computed, matching either
+# the `docs/guide-update` head-branch prefix (the branch docs-worktree.sh creates,
+# and the same prefix Step 1's open-docs-PR guard searches on) or the exact title
+# `create_docs_pr` passes to `gh pr create`.
+#
+# Verifies that:
+#   1. guide.md still defines the single-line GUIDE_DOCS_PR_EXCLUDE expression
+#      and applies it inside update_work_log()'s `new_prs` query, with
+#      `headRefName` requested from `gh --json` (jq cannot filter a field gh was
+#      not asked to return).
+#   2. THE REGRESSION, executed rather than grepped: the expression extracted
+#      verbatim FROM guide.md, run through the real jq pipeline, drops docs PRs
+#      (by branch and by title) and keeps genuine work PRs.
+#   3. Two consecutive ticks whose only merged PR above the watermark is a prior
+#      docs PR both yield an empty `new_prs` — i.e. the second tick produces no
+#      PR, which is the loop-termination property #5454 is about.
+#   4. A tick with BOTH a genuine PR and a prior docs PR still logs the genuine
+#      one (the filter excludes docs PRs, not everything).
+#   5. The watermark helper `work_log_max_pr` reads back only what was written,
+#      so an excluded docs PR never advances it — and is re-filtered next tick.
+#
+# Hermetic: pure jq/grep against a temp dir. No forge, network, or `gh` calls.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+GUIDE_MD="$REPO_ROOT/defaults/.claude/commands/loom/guide.md"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" == "$expected" ]]; then pass "$msg"; else fail "$msg (got '$actual', expected '$expected')"; fi
+}
+
+assert_grep() {
+    local pattern="$1" file="$2" msg="$3"
+    if grep -qE "$pattern" "$file"; then pass "$msg"; else fail "$msg (missing pattern: $pattern)"; fi
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "SKIP: jq not available"
+    exit 0
+fi
+
+if [[ ! -f "$GUIDE_MD" ]]; then
+    echo -e "${RED}FATAL${NC}: guide.md not found at $GUIDE_MD"
+    exit 1
+fi
+
+SANDBOX="$(mktemp -d)"
+cleanup() { rm -rf "$SANDBOX"; }
+trap cleanup EXIT
+
+DOCS_TITLE='docs: Guide document maintenance update'
+
+# ---------------------------------------------------------------------------
+# Test 1: the prompt still carries the exclusion, wired into the real query
+# ---------------------------------------------------------------------------
+echo "Test 1: guide.md defines and applies the docs-PR exclusion"
+
+assert_grep '^GUIDE_DOCS_PR_EXCLUDE=' "$GUIDE_MD" \
+    "GUIDE_DOCS_PR_EXCLUDE is defined as a single-line assignment"
+assert_grep 'select\(\(\$GUIDE_DOCS_PR_EXCLUDE\) \| not\)' "$GUIDE_MD" \
+    "update_work_log()'s new_prs query applies the exclusion"
+# Bracket the leading dash so grep does not read the pattern as an option.
+assert_grep '[-]-json number,title,mergedAt,headRefName' "$GUIDE_MD" \
+    "headRefName is requested from gh --json (jq cannot filter an absent field)"
+assert_grep 'docs/guide-update' "$GUIDE_MD" \
+    "exclusion matches the docs-worktree branch prefix"
+
+# ---------------------------------------------------------------------------
+# Extract the expression VERBATIM from guide.md and reconstruct the exact jq
+# pipeline update_work_log() builds. Everything below executes the prompt's own
+# filter, so a prompt edit that breaks it fails this suite.
+# ---------------------------------------------------------------------------
+EXCLUDE_LINE="$(grep -m1 '^GUIDE_DOCS_PR_EXCLUDE=' "$GUIDE_MD")"
+# The assignment is `GUIDE_DOCS_PR_EXCLUDE='<expr>'` — a single-quoted literal.
+GUIDE_DOCS_PR_EXCLUDE="${EXCLUDE_LINE#GUIDE_DOCS_PR_EXCLUDE=}"
+GUIDE_DOCS_PR_EXCLUDE="${GUIDE_DOCS_PR_EXCLUDE#\'}"
+GUIDE_DOCS_PR_EXCLUDE="${GUIDE_DOCS_PR_EXCLUDE%\'}"
+
+if [[ -n "$GUIDE_DOCS_PR_EXCLUDE" ]]; then
+    pass "extracted exclusion expression from guide.md"
+else
+    fail "could not extract exclusion expression from guide.md"
+    echo "================================"
+    echo "Tests run:    $TESTS_RUN"
+    exit 1
+fi
+
+# Mirror of update_work_log()'s query, minus the `gh pr list` fetch: $1 = the
+# merged-PR JSON gh would have returned, $2 = the watermark.
+new_prs() {
+    printf '%s\n' "$1" | jq -c \
+        "[.[] | select(.number > $2) | select(($GUIDE_DOCS_PR_EXCLUDE) | not)] | sort_by(.mergedAt) | reverse"
+}
+
+# work_log_max_pr(), verbatim in behavior: highest `PR #N` recorded in the file.
+work_log_max_pr() {
+    { grep -oE 'PR #[0-9]+' "$1" 2>/dev/null | grep -oE '[0-9]+'; echo 0; } | sort -rn | head -1
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: the extracted expression drops docs PRs and keeps genuine ones
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 2: the exclusion drops docs PRs by branch AND by title"
+
+MIXED_JSON=$(jq -n --arg t "$DOCS_TITLE" '[
+  {number: 5410, title: "fix(daemon): mint a per-owner App token", mergedAt: "2026-08-05T10:00:00Z", headRefName: "feature/issue-5400"},
+  {number: 5420, title: $t,                                        mergedAt: "2026-08-05T10:20:00Z", headRefName: "docs/guide-update-20260805-102000"},
+  {number: 5430, title: "docs: update WORK_LOG, WORK_PLAN",        mergedAt: "2026-08-05T10:40:00Z", headRefName: "docs/guide-update-20260805-104000"},
+  {number: 5440, title: $t,                                        mergedAt: "2026-08-05T11:00:00Z", headRefName: "chore/hand-renamed-branch"},
+  {number: 5450, title: "feat(cli): add tokens check --ranking",   mergedAt: "2026-08-05T11:20:00Z", headRefName: "feature/issue-5445"}
+]')
+
+KEPT="$(new_prs "$MIXED_JSON" 0 | jq -c '[.[].number] | sort')"
+assert_eq "$KEPT" "[5410,5450]" \
+    "only the two genuine PRs survive (branch-matched 5420/5430 and title-matched 5440 dropped)"
+
+TITLES="$(new_prs "$MIXED_JSON" 0 | jq -r "[.[] | select(.title == \"$DOCS_TITLE\")] | length")"
+assert_eq "$TITLES" "0" "no surviving entry carries the docs-maintenance title"
+
+BRANCHES="$(new_prs "$MIXED_JSON" 0 | jq -r '[.[] | select(.headRefName | startswith("docs/guide-update"))] | length')"
+assert_eq "$BRANCHES" "0" "no surviving entry sits on a docs/guide-update-* branch"
+
+ORDER="$(new_prs "$MIXED_JSON" 0 | jq -c '[.[].number]')"
+assert_eq "$ORDER" "[5450,5410]" "surviving entries stay sorted newest-merged-first"
+
+# ---------------------------------------------------------------------------
+# Test 3: THE LOOP — two consecutive ticks whose only new PR is a docs PR
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 3: two consecutive ticks with only a prior docs PR produce nothing"
+
+WORK_LOG="$SANDBOX/WORK_LOG.md"
+cat > "$WORK_LOG" <<'EOF'
+# Work Log
+
+### 2026-08-05
+
+- **PR #5410**: fix(daemon): mint a per-owner App token
+EOF
+
+# --- Tick 1: PR #5420 (a docs PR) merged since the watermark.
+WM1="$(work_log_max_pr "$WORK_LOG")"
+assert_eq "$WM1" "5410" "tick 1 watermark read back from the committed WORK_LOG.md"
+
+TICK1_JSON=$(jq -n --arg t "$DOCS_TITLE" '[
+  {number: 5410, title: "fix(daemon): mint a per-owner App token", mergedAt: "2026-08-05T10:00:00Z", headRefName: "feature/issue-5400"},
+  {number: 5420, title: $t,                                        mergedAt: "2026-08-05T10:20:00Z", headRefName: "docs/guide-update-20260805-102000"}
+]')
+TICK1_LEN="$(new_prs "$TICK1_JSON" "$WM1" | jq 'length')"
+assert_eq "$TICK1_LEN" "0" "tick 1: new_prs is empty -> update_work_log returns 1, no WORK_LOG entry"
+
+# Nothing was appended, so the file is byte-identical and the watermark is unmoved.
+# (Under the pre-#5454 behavior tick 1 would have appended `- **PR #5420**: docs:
+# Guide document maintenance update` here, which is precisely what fed tick 2.)
+WM2="$(work_log_max_pr "$WORK_LOG")"
+assert_eq "$WM2" "5410" "tick 1 wrote nothing: watermark unchanged (docs PR never becomes a WORK_LOG line)"
+
+# --- Tick 2: the docs PR from tick 1 would have merged by now. Under the bug
+# this is where PR N+1 was born. It must still be empty.
+TICK2_JSON=$(jq -n --arg t "$DOCS_TITLE" '[
+  {number: 5410, title: "fix(daemon): mint a per-owner App token", mergedAt: "2026-08-05T10:00:00Z", headRefName: "feature/issue-5400"},
+  {number: 5420, title: $t,                                        mergedAt: "2026-08-05T10:20:00Z", headRefName: "docs/guide-update-20260805-102000"},
+  {number: 5432, title: $t,                                        mergedAt: "2026-08-05T10:50:00Z", headRefName: "docs/guide-update-20260805-105000"}
+]')
+TICK2_LEN="$(new_prs "$TICK2_JSON" "$WM2" | jq 'length')"
+assert_eq "$TICK2_LEN" "0" "tick 2: still empty -> the self-perpetuating cycle terminates (no PR)"
+
+# ...and it stays terminated however many docs PRs pile up above the watermark.
+TICK_N_JSON=$(jq -n --arg t "$DOCS_TITLE" '[range(5420; 5460; 4) | {
+  number: .,
+  title: $t,
+  mergedAt: "2026-08-05T12:00:00Z",
+  headRefName: "docs/guide-update-20260805-120000"
+}]')
+TICKN_LEN="$(new_prs "$TICK_N_JSON" "$WM2" | jq 'length')"
+assert_eq "$TICKN_LEN" "0" "N accumulated docs PRs above the watermark still yield no new content"
+
+# ---------------------------------------------------------------------------
+# Test 4: a genuine PR alongside a docs PR is still logged
+# ---------------------------------------------------------------------------
+echo ""
+echo "Test 4: a genuine merged PR still counts when a docs PR is also pending"
+
+TICK3_JSON=$(jq -n --arg t "$DOCS_TITLE" '[
+  {number: 5420, title: $t,                                      mergedAt: "2026-08-05T10:20:00Z", headRefName: "docs/guide-update-20260805-102000"},
+  {number: 5435, title: "fix(daemon): state confirmed FLAGS-OFF", mergedAt: "2026-08-05T11:30:00Z", headRefName: "feature/issue-5433"}
+]')
+TICK3="$(new_prs "$TICK3_JSON" 5410)"
+assert_eq "$(printf '%s' "$TICK3" | jq 'length')" "1" "exactly one entry survives"
+assert_eq "$(printf '%s' "$TICK3" | jq -r '.[0].number')" "5435" "the surviving entry is the genuine PR"
+
+# Simulate the append the Guide would perform, then confirm the watermark
+# advances to the genuine PR only — the docs PR is never recorded.
+{
+    printf '\n### 2026-08-05\n\n'
+    printf '%s\n' "$TICK3" | jq -r '.[] | "- **PR #\(.number)**: \(.title)"'
+} >> "$WORK_LOG"
+
+assert_eq "$(work_log_max_pr "$WORK_LOG")" "5435" \
+    "watermark advances to the genuine PR after the append"
+if grep -q "PR #5420" "$WORK_LOG"; then
+    fail "the docs PR leaked into WORK_LOG.md"
+else
+    pass "no docs PR line was written to WORK_LOG.md"
+fi
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "================================"
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+    exit 1
+fi
+echo "All tests passed"
+exit 0


### PR DESCRIPTION
## Summary

The Guide role's Document Maintenance phase was self-perpetuating: `update_work_log()` built its "new merged PRs" set from every merged PR above the WORK_LOG watermark, with **no exclusion for the phase's own `docs: Guide document maintenance update` PRs**. Since each of those is itself a merged PR, merging PR N manufactured the "there is new content to append" signal that justified PR N+1 — the no-new-PRs skip branch could never be true two ticks in a row, so the phase emitted a docs PR every ~15-30 minutes indefinitely (23 self-referential PRs observed), each carrying a zero-information WORK_LOG line about itself.

The fix is a jq exclusion applied **before** `new_prs` is computed, matching either identifying mark the phase controls:

- the `docs/guide-update` head-branch prefix — the branch `docs-worktree.sh` creates, and the same prefix Step 1's open-docs-PR guard already searches on (reuses an existing convention rather than inventing one), **or**
- the exact title `create_docs_pr` passes to `gh pr create` in Step 5.

Either match alone is enough, so the filter keeps working if a docs PR is ever retitled or lands from a differently-named branch.

## Changes

- `defaults/.claude/commands/loom/guide.md` — Step 2 "Update WORK_LOG.md":
  - New single-line `GUIDE_DOCS_PR_EXCLUDE` jq expression with a `#5454 BUG, DO NOT REINTRODUCE` rationale block (matching the file's existing `#5413` convention).
  - `update_work_log()`'s `new_prs` query now applies `select((...) | not)`, and requests `headRefName` from `gh --json` (jq cannot filter on a field `gh` was not asked to return — it would silently be `null`).
  - Comments state that the append step must use only `$new_prs`/`$new_issues`, and that excluded docs PRs never advance the watermark (harmless — they are re-queried and re-filtered every tick, so they can never be appended however far the watermark lags).
  - Document Maintenance Summary flow diagram + constraints list updated.
- `defaults/scripts/tests/test-guide-work-log-self-loop.sh` — **new** regression suite (18 assertions). It **extracts the exclusion expression verbatim from `guide.md`** and runs it through the real jq pipeline, so the prompt and the test cannot drift apart. Hermetic: pure jq/grep in a `mktemp -d`, no forge/network/`gh` calls.
- `defaults/scripts/tests/ci-wired.txt` — wires the new suite into CI (`check-ci-suite-manifest.sh` passes: 124 suites, 117 wired, 7 excluded).

**Note on affected files**: `.loom/roles/guide.md` and `defaults/roles/guide.md` are both symlinks resolving to the single tracked file `defaults/.claude/commands/loom/guide.md` (confirmed with `readlink -f`), so there is exactly one place to make this fix — as the Curator's affected-files correction noted.

## Acceptance Criteria Verification

- [x] **`update_work_log()` excludes PRs whose title is exactly `docs: Guide document maintenance update` or whose head branch matches `docs/guide-update-*`, from both the "new PRs" set used for the skip check and from the appended entries.** The exclusion is applied inside the `new_prs` query itself, so the same filtered set feeds both the skip check and the appended entries (the append step draws only from `$new_prs`; a comment now says so explicitly). Verified executably by Test 2: a fixture with 5 merged PRs (one genuine, two branch-matched docs PRs, one title-matched docs PR on a hand-renamed branch, one genuine) yields exactly `[5410, 5450]`.
- [x] **A cycle where the only merged PRs since the watermark are prior doc-maintenance PRs is treated as "no new PRs" and the whole phase is skipped (no PR created).** Test 3 runs two consecutive ticks off a real WORK_LOG.md fixture: tick 1 (`new_prs` length 0 → `update_work_log` returns 1, nothing appended, watermark unmoved at 5410) and tick 2 with the tick-1 docs PR now merged (`new_prs` length 0 again). With WORK_PLAN/README also unchanged, Step 5's existing `git diff --cached --quiet` then finds nothing to commit and creates no PR. A fourth case pushes 10 accumulated docs PRs above the watermark and still yields 0.
- [x] **Existing doc-maintenance lines already in WORK_LOG.md are left alone.** No retroactive cleanup: `WORK_LOG.md` is untouched by this PR. Because the filter runs on the *query* rather than the watermark, already-committed lines are inert — they can only raise `work_log_max_pr`, which is safe.
- [x] **Regression test / manual verification: two consecutive cycles whose only "new" merged PR is a prior doc-maintenance PR produce no PR on the second cycle.** Covered by Test 3 above (automated, CI-wired). Manually confirmed the *pre-fix* pipeline on the same fixture returns `2` "new" PRs (both docs PRs) where the post-fix pipeline returns `0` — i.e. the test fails against the old behavior.
- [x] **Edge case from the Curator test plan: a cycle with both a genuine new PR and a prior docs PR still logs the genuine one.** Test 4: the surviving entry is #5435 (the genuine PR), the simulated append advances the watermark to 5435, and `grep` confirms no `PR #5420` (docs) line reached WORK_LOG.md.

## Test Plan

```
$ bash defaults/scripts/tests/test-guide-work-log-self-loop.sh
Tests run:    18
Tests passed: 18
All tests passed

$ bash defaults/scripts/tests/check-ci-suite-manifest.sh
OK: 124 suites (117 wired, 7 excluded) — every test-*.sh is accounted for.

$ bash defaults/scripts/tests/test-docs-worktree.sh     # existing guide.md suite, unaffected
Tests run:    24
Tests passed: 24
All tests passed

$ bash scripts/check-docs-defaults-parity.sh   # OK
$ bash scripts/check-agents-md-sync.sh         # OK
$ ./.loom/scripts/check-main-clean.sh          # main worktree clean
```

`shellcheck -x` on the new suite reports only two info-level notes (SC2317 on the `trap`-invoked cleanup, SC2016 on a single-quoted grep pattern that is intentionally literal); both are expected for this file shape and CI does not run shellcheck.

Closes #5454