### PR TITLE
chore(security): require code-owner review for .github/workflows/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# Code owners — path-scoped review requirements.
+#
+# This file exists for one reason: `.github/workflows/` is executable
+# configuration with access to repository secrets, and as of 2026-08-05 the
+# `loom-fleet-dispatch` GitHub App carries `workflows: write` so agents can
+# edit it (rjwalters/loom#4607).
+#
+# Before that grant, a workflow change was blocked twice over — the Champion's
+# Critical File Exclusion Check declines to auto-merge one, AND the credential
+# could not push it. The grant removed the second, leaving a single
+# prompt-enforced control with a documented false-negative mode (#4613: a
+# 117-file PR whose workflow deletion was missed because `gh pr view --json
+# files` truncates at 100 entries).
+#
+# Requiring code-owner review on this path restores a second control, enforced
+# by the forge rather than by a role prompt. It is deliberately narrow: this is
+# the only entry, so every other path merges exactly as it did before and
+# autonomous operation is unaffected.
+#
+# Paired with `require_code_owner_review: true` on the `main` ruleset (8809610).
+# The entry and the rule are load-bearing together — neither works alone.
+
+/.github/workflows/  @rjwalters


### PR DESCRIPTION
## What

Adds `.github/CODEOWNERS` with a single entry:

```
/.github/workflows/  @rjwalters
```

Paired with `require_code_owner_review: true` on the `main` ruleset (8809610), which is being set alongside this. **Neither works alone** — the file is inert without the rule, and the rule has nothing to match without the file.

## Why

The `loom-fleet-dispatch` App gained `workflows: write` on 2026-08-05 so agents could do the work parked in #4607, #5329, and #4767 — three issues blocked for that one reason under two different labels.

That grant removed one of two controls. Before it, a workflow change was blocked twice over:

1. The Champion's **Critical File Exclusion Check** declines to auto-merge any PR touching `.github/workflows/*`
2. The App credential **could not push one at all**

Only (1) remains, and it is **prompt-enforced, not forge-enforced** — with a documented false negative (#4613, PR #4611): a Champion asserted "no critical-file changes" on a 117-file PR that removed a workflow file, because `gh pr view --json files` silently truncates at 100 entries.

Meanwhile `main`'s ruleset requires a PR but sets `required_approving_review_count: 0`, so there is no forge-level human gate:

```
rules: deletion, non_fast_forward, pull_request, required_linear_history
pull_request:
  required_approving_review_count : 0
  require_code_owner_review       : false
```

## Why this shape and not the alternatives

- **Requiring approvals on all PRs** would end autonomous merging entirely — the Champion could never auto-merge anything again. Non-starter for this repo's posture.
- **Blocking the path outright** (`file_path_restriction` + bypass actor) works, but means bypassing a rule on every legitimate change rather than approving one.
- **CODEOWNERS is path-scoped by design**: only PRs modifying owned content need the owner's approval. Every other path merges exactly as it does today. Per GitHub's docs — *"any pull request that modifies content with a code owner must be approved by that code owner before the pull request can be merged"*.

## Verification

GitHub's documentation does not state whether code-owner review enforces when `required_approving_review_count` is `0`. Rather than assume, this is being **tested with a real PR touching a workflow file** to confirm the merge is actually blocked. Result will be reported on #4607 — and if it does not enforce at count 0, that will be said plainly rather than leaving a control that looks active but is not.

## Scope

One file, one line of policy. No workflow, script, or role changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
