### PR TITLE
test: probe code-owner review enforcement (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,3 +380,5 @@ jobs:
         run: docker build -f docker/worker/Dockerfile -t loom-worker:ci-smoke .
       - name: Run the smoke test
         run: ./docker/worker/test-image.sh loom-worker:ci-smoke
+
+# codeowners-enforcement probe — this line is removed before merge


### PR DESCRIPTION
Temporary probe PR — do not merge.

Appends one comment line to `.github/workflows/ci.yml` so the new `require_code_owner_review` rule on ruleset 8809610 can be **observed** rather than assumed. GitHub does not document whether code-owner review enforces when `required_approving_review_count` is 0, and rjwalters/loom#4607 depends on the answer.

Will be closed without merging and the branch deleted.
