### PR TITLE
fix: revert the codeowners-enforcement probe line from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,5 +380,3 @@ jobs:
         run: docker build -f docker/worker/Dockerfile -t loom-worker:ci-smoke .
       - name: Run the smoke test
         run: ./docker/worker/test-image.sh loom-worker:ci-smoke
-
-# codeowners-enforcement probe — this line is removed before merge


### PR DESCRIPTION
Reverts the probe line merged by #5471.

The probe was an enforcement test for `require_code_owner_review` on ruleset 8809610. It produced a clear negative result — the App merged a `.github/workflows/` change with zero approvals — and in doing so landed a stray comment line in `ci.yml`. This removes it.

No functional change: the reverted line was a comment.

Full findings on #4607.
