### PR TITLE
ci: wire check-cas-recheck-consistency.sh into installer-tests (#4607)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,8 @@ jobs:
         run: bash defaults/scripts/check-labels-drift.sh
       - name: Check label descriptions fit GitHub's 100-char limit (#4335)
         run: bash defaults/scripts/check-label-descriptions.sh
+      - name: Check Verdict-Time CAS Recheck sections are intact (#4570)
+        run: bash defaults/scripts/check-cas-recheck-consistency.sh
       - name: Run installer tests
         run: bash scripts/test-installer.sh
       - name: Run installer reinstall-safety tests (#4188)


### PR DESCRIPTION
Closes #4607.

Adds one step to the `installer-tests` job:

```yaml
- name: Check Verdict-Time CAS Recheck sections are intact (#4570)
  run: bash defaults/scripts/check-cas-recheck-consistency.sh
```

## Why it could not be done before

PR #4606 (closing #4570) added the guard script but could not wire it in. That was **not** a Builder shortcoming — the `loom-fleet-dispatch` App had no `workflows` permission, so GitHub refused any agent push touching `.github/workflows/` regardless of the diff. The permission was granted and approved on both installations (`rjwalters` 151241341, `2AMLogic` 151241294) on 2026-08-05, which is what makes this possible.

This PR is also the practical confirmation that the grant works end to end.

## Placement

Alongside the other `defaults/scripts/check-*.sh` guards, after `check-label-descriptions` — cheap assertion scripts before the heavier installer suites, matching the existing ordering.

The job is already gated on `needs.changes.outputs.scripts == 'true'` (or a push), so this adds no cost to PRs that do not touch scripts.

## Verification

Ran locally against current `main` before wiring:

```
check-cas-recheck-consistency: OK — Verdict-Time CAS Recheck (Judge + Doctor),
Champion's Verdict-State Janitor, criterion 1's fix, and the labels.yml
mutual-exclusion invariant are all present.
```

`ci.yml` re-parsed as valid YAML after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
