### PR TITLE
fix(daemon): scope the autonomy teardown like the kill it accompanies (#5131)

### DIFF
--- a/defaults/scripts/cli/loom-daemon-stop.sh
+++ b/defaults/scripts/cli/loom-daemon-stop.sh
@@ -353,8 +353,34 @@ if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
     warn "No running loom-daemon found (nothing to stop)."
     rm -f "$PID_FILE"
     launchd_bootout_if_loaded
+    # #5131: apply the SAME scoping to the teardown that already protects the
+    # kill. The pid resolver's last-resort  tier is deliberately skipped
+    # for a non-default LOOM_LAUNCHD_LABEL (#4078) — "stop THAT daemon, not
+    # whatever else is named loom-daemon". But the marker and watchdog are
+    # HOST-GLOBAL ($LOOM_DIR/autonomy-desired), while PID_FILE is per-workspace,
+    # so a label-scoped stop that legitimately finds nothing would still disarm
+    # the whole host and exit 0 — silently, since "nothing to stop" reads like a
+    # correct no-op.
+    #
+    # An invocation that scoped its label but NOT its marker is asking to stop
+    # one specific daemon; it is not asking to revoke host-wide autonomy. Only
+    # tear down when this stop owns that state: the default label (the
+    # operator's real daemon), or an explicit LOOM_AUTONOMY_MARKER (the caller
+    # scoped the marker too — what the test suites do via
+    # live_state_sandbox_init).
+    _teardown_is_in_scope=true
+    if [[ "$LAUNCHD_LABEL" != "$DEFAULT_LAUNCHD_LABEL" && -z "${LOOM_AUTONOMY_MARKER:-}" ]]; then
+        _teardown_is_in_scope=false
+    fi
     if [[ "$KEEP_INTENT" != "true" ]]; then
-        teardown_autonomy_intent
+        if [[ "$_teardown_is_in_scope" == "true" ]]; then
+            teardown_autonomy_intent
+        else
+            warn "Label-scoped stop (LOOM_LAUNCHD_LABEL=$LAUNCHD_LABEL) found no daemon;"
+            warn "  leaving the host-global autonomy marker and watchdog untouched (#5131)."
+            warn "  Set LOOM_AUTONOMY_MARKER to scope the marker too, or use the default"
+            warn "  label, if this stop is meant to disarm the host."
+        fi
     fi
     exit 0
 fi

--- a/defaults/scripts/tests/test-loom-daemon-stop.sh
+++ b/defaults/scripts/tests/test-loom-daemon-stop.sh
@@ -590,6 +590,50 @@ else
 fi
 
 # ============================================================
+# ============================================================
+# #5131: a label-scoped stop that finds NO daemon must not tear down the
+# HOST-GLOBAL autonomy marker.
+#
+# The pid resolver's last-resort  tier is skipped for a non-default
+# LOOM_LAUNCHD_LABEL (#4078), so such an invocation reaches the "nothing to
+# stop" path whenever its own per-workspace PID_FILE is absent. Before this
+# fix it still ran teardown_autonomy_intent, deleting
+# $LOOM_DIR/autonomy-desired and booting the watchdog for the WHOLE host --
+# then exited 0, so it read as a correct no-op.
+#
+# Scoping rule under test: tear down only when this stop owns that state --
+# the default label, or an explicit LOOM_AUTONOMY_MARKER (what
+# live_state_sandbox_init sets, which is why the suites were never bitten).
+# ============================================================
+scope_dir="$(mktemp -d)"
+mkdir -p "$scope_dir/loomdir"
+
+# (a) non-default label, marker NOT scoped -> marker must survive
+: > "$scope_dir/loomdir/autonomy-desired"
+( LOOM_SOCKET_PATH="$scope_dir/loomdir/loom-daemon.sock"   LOOM_PID_FILE="$scope_dir/absent.pid"   LOOM_LAUNCHD_LABEL="com.example.scratch-5131"   bash "$STOP_SCRIPT" ) >/dev/null 2>&1
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$scope_dir/loomdir/autonomy-desired" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} #5131: label-scoped stop with nothing to stop preserves the host-global marker"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} #5131: label-scoped stop with nothing to stop preserves the host-global marker"
+fi
+
+# (b) non-default label WITH an explicit marker -> teardown still happens
+#     (the sandboxed-suite path must keep working)
+: > "$scope_dir/loomdir/autonomy-desired"
+( LOOM_SOCKET_PATH="$scope_dir/loomdir/loom-daemon.sock"   LOOM_PID_FILE="$scope_dir/absent.pid"   LOOM_LAUNCHD_LABEL="com.example.scratch-5131"   LOOM_AUTONOMY_MARKER="$scope_dir/loomdir/autonomy-desired"   bash "$STOP_SCRIPT" ) >/dev/null 2>&1
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ ! -f "$scope_dir/loomdir/autonomy-desired" ]]; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "${GREEN}✓${NC} #5131: an explicitly-scoped marker is still torn down (sandboxed suites unaffected)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "${RED}✗${NC} #5131: an explicitly-scoped marker is still torn down (sandboxed suites unaffected)"
+fi
+rm -rf "$scope_dir"
+
 # Live daemon state guard (#5179, adopted here per #5191): every live `.loom`
 # state path reachable from the ambient environment (the real $HOME/.loom, the
 # live checkout's .loom, an ambient LOOM_PID_FILE / LOOM_WORKSPACE /


### PR DESCRIPTION
Addresses the structural half of #5131.

## The gap

`loom-daemon-stop.sh` scopes its **kill** but not its **teardown**.

The pid resolver's last-resort `pgrep` tier is deliberately skipped when `LOOM_LAUNCHD_LABEL` is non-default (#4078) — *"stop THAT daemon, not whatever else happens to be named loom-daemon"*. Good. But the two pieces of state have different scopes:

| | scope |
|---|---|
| `PID_FILE` | **per-workspace** (`$DAEMON_STATE_HOME/.daemon.pid`) |
| kill target | **label-scoped**, deliberately (#4078) |
| intent marker + watchdog teardown | **host-global** (`${LOOM_AUTONOMY_MARKER:-$LOOM_DIR/autonomy-desired}`) |

So a label-scoped stop whose own per-workspace pid file is absent falls through to the "nothing to stop" branch — and that branch still ran `teardown_autonomy_intent`, deleting the host's marker and booting its watchdog, then `exit 0`.

The exit code and message are what made it silent: `No running loom-daemon found (nothing to stop)` reads as a correct no-op, not as *"this host is now unprotected."*

## The fix

Tear down only when this invocation owns that state:

- the **default label** — the operator's real daemon, unchanged behaviour, or
- an explicit **`LOOM_AUTONOMY_MARKER`** — the caller scoped the marker too

Otherwise warn and leave the marker and watchdog alone.

That second clause is also why the test suites never caught this: `live_state_sandbox_init` sets `LOOM_AUTONOMY_MARKER`, which is precisely the in-scope case, so the suites exercise the teardown path safely and always will.

## Verification

Same sandbox, before and after:

```
UNPATCHED  non-default label, no marker override   -> marker REMOVED   <- the bug
PATCHED    non-default label, no marker override   -> marker PRESERVED
PATCHED    non-default label, WITH marker override -> marker REMOVED   <- suites unaffected
PATCHED    default label (operator's real stop)    -> marker REMOVED   <- unchanged
```

Two regression cases added to `test-loom-daemon-stop.sh` covering rows 2 and 3.

**Full suite: 40 tests, 40 passed**, including the #5191 live-state guard confirming no real `.loom` path was written during the run.

## Scope

Unchanged for every existing path — the default-label operator stop, `--restarting` (`KEEP_INTENT`), and sandboxed suites all behave exactly as before.

This does **not** claim to explain the original 2026-08-03 incident. That had no reproduction, and the vector it most resembled (tests under scratch labels) was already sandboxed before I looked. This closes the structural gap that remained after that correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
