### PR TITLE
feat(daemon-docs): add onIdle verification script + Epic #5038 Phase 3 finding

### DIFF
--- a/defaults/docs/daemon-reference.md
+++ b/defaults/docs/daemon-reference.md
@@ -4372,7 +4372,13 @@ Either way the JSON block is the same shape as the example above:
 ```
 
 Remember `onIdle` is **inert unless the work finder is enabled** for that root,
-and that `LOOM_ROLE_RUNNER` (env) outranks all four config tiers.
+and that `LOOM_ROLE_RUNNER` (env) outranks all four config tiers. To verify a
+root's `onIdle` roles are actually firing rather than merely configured, run
+[`check-onidle-status.sh`](../scripts/check-onidle-status.sh) — it cross-checks
+the config against the daemon log's `idle edge … firing idle-triggered <role>
+run` line. See [onidle-phase3-finding.md](onidle-phase3-finding.md) for this
+repo's own onIdle activation history and the Epic #5038 Phase 3 Class-3-residue
+finding.
 
 **2. Sync the repo's labels.** The whole coordination protocol is label-based, so
 a repo with no `loom:*` labels cannot hold a queue — a Curator that tries to apply

--- a/defaults/docs/onidle-phase3-finding.md
+++ b/defaults/docs/onidle-phase3-finding.md
@@ -1,0 +1,131 @@
+# Epic #5038 Phase 3 finding: `onIdle` activation and Class 3 residue
+
+**Status**: Phase 3 complete. This is the written finding Phase 4 (`janitor`
+role) is gated on — see #5038's "Suggested phasing" and #5489's acceptance
+criteria.
+
+## 1. `onIdle` is configured and confirmed firing
+
+`autonomous.roleRunner.onIdle: ["auditor"]` has been live in this repo's own
+`.loom/config.json` since PR #5052 (merged 2026-08-03, tracked by #5046).
+Nothing in this phase needed to change that config — it was already the
+correct, minimal activation `.loom/config.json` needs for the reasons in
+[Section 3](#3-guide-was-deliberately-left-off-onidle).
+
+Cross-checked against this host's live daemon log
+(`~/.loom/daemon.log`) and the auditor role's own tick log
+(`.loom/logs/role-auditor.log`):
+
+- The daemon log contains direct `idle edge for
+  /home/ubuntu/GitHub/loom — firing idle-triggered auditor run (#4364)`
+  lines (`role_runner::plan_idle_runs`) — e.g. `2026-08-05T18:40:41.181` and
+  `2026-08-05T20:52:34.203` in the current (rotated-since-`2026-08-05T10:05`)
+  log.
+- Each of those timestamps has a matching tick banner in
+  `.loom/logs/role-auditor.log` (`==== loom-daemon role_runner: … role=auditor
+  … ====`), confirming the log line and the actual spawned session are the
+  same event, not a coincidence.
+- Since `auditor` is deliberately **not** in the interval `roles` list (only
+  in `onIdle` — see Section 3), every one of the 19 auditor tick banners
+  recorded in `.loom/logs/role-auditor.log` between `2026-08-03T22:32` and
+  `2026-08-05T20:52` (irregular spacing, 15 minutes to ~8 hours apart — the
+  idle-edge signature, not a fixed interval) is necessarily an `onIdle` fire.
+  This is real, multi-day operating history, not a single smoke-test tick.
+
+This satisfies acceptance criterion 2 ("The onIdle path is confirmed to
+actually fire … not just configured-but-dormant"). The new
+[`check-onidle-status.sh`](../scripts/check-onidle-status.sh)
+script (added by this PR) automates this cross-check going forward — run it
+against any registered workspace to get a verified/dormant verdict per
+configured `onIdle` role without hand-grepping logs:
+
+```console
+$ ./.loom/scripts/check-onidle-status.sh --root /home/ubuntu/GitHub/loom
+onIdle status for /home/ubuntu/GitHub/loom
+─────────────────────────────────
+  auditor: fired 2x (last: 2026-08-05T20:52:34.203)
+```
+
+(Fire count is only for the current, not-yet-rotated daemon log — the 19-tick
+multi-day history above comes from `role-auditor.log`, which is not rotated
+on the same schedule.)
+
+## 2. Class 3 residue: real, but auditor already narrows it a lot
+
+Sampling the auditor's own tick output over the observed period (see
+`.loom/logs/role-auditor.log`) shows the CI-aware step-0 short-circuit
+working as designed most ticks — auditor confirms CI is green, reviews
+`.loom/logs/guard-decisions.log` for new recurring patterns, and reports
+"nothing to file" when there's nothing new. That is Class 3 work (a judgment
+call — "is this guard pattern already tracked" — not a deterministic check),
+and it is already being exercised, not merely configured.
+
+What auditor's coverage does **not** reach, based on its own role definition
+(`defaults/.claude/commands/loom/auditor.md`) and observed output:
+
+- **File/doc-claim staleness** — "is this file genuinely orphaned", "is this
+  doc claim still true" (the two examples named in #5038's Class 3
+  definition) are not part of auditor's build/test/guard-review scope at all.
+  Auditor validates that `main` builds, tests pass, and CI is green; it does
+  not walk the tree looking for orphaned files or verify doc claims against
+  current code.
+- **Branch-abandonment judgment** ("is this branch abandoned or
+  intentionally parked") — outside both auditor's (build health) and guide's
+  (issue triage/prioritization) stated scope.
+
+So: **yes, Class 3 has a residue beyond what Auditor/Guide already catch** —
+the two concrete examples #5038 named (orphaned files, stale doc claims) and
+branch-abandonment judgment are not covered by either role today. But the
+residue is narrower than #5038's original framing suggested, for two
+reasons:
+
+1. **The guard-decision-pattern review already exercises the "which
+   recurring symptom is genuinely unaddressed" judgment call** — the same
+   fundamental class of question as "is this doc claim still true" — and
+   found real, actionable Class 3 findings on this host without any new
+   role (auditor is the one that filed against #5385 for the still-firing
+   `worktree-write-confinement-unresolved-var` pattern in earlier ticks
+   captured in the same log).
+2. **The remaining residue (file staleness, doc-claim verification,
+   branch abandonment) is a small, well-bounded set** — not the open-ended
+   "who owns continuous maintenance" scope #5038 originally worried about.
+   It does not obviously need a dedicated role; it could equally be an
+   extension of auditor's own step-0 (adding a lightweight periodic
+   "sample N files/docs for staleness" pass) rather than a new `janitor`.
+
+## 3. `guide` was deliberately left off `onIdle`
+
+`guide` already runs on the **interval** `roles` list in this repo's config
+(`["curator", "champion", "judge", "doctor", "guide"]`) — it is not
+idle-triggered, but it already ticks regularly and already owns issue
+triage/prioritization, which is the slice of Class 3 the issue body
+attributes to it. Adding `guide` to `onIdle` as well would give it two
+independent trigger paths into the same debounce/in-progress-guard state
+(`role_runner.rs`'s `IdleTrigger`/`InProgressGuard`) for no observed benefit
+— guide's interval cadence already gives it regular execution, and nothing
+in this phase's observation period showed guide's interval cadence being
+insufficient. Per #5038's own anti-granularity-trap criterion ("no new
+host-scoped-but-per-repo-scheduled failure mode"), adding a second,
+overlapping trigger path is exactly the kind of scheduling-surface growth to
+avoid without a demonstrated need. Recommendation: leave `guide` on the
+interval list only; revisit if a future observation period shows interval
+cadence is too coarse for triage-latency-sensitive work.
+
+## 4. Recommendation for Phase 4
+
+Phase 4 (`janitor` role) is **not clearly warranted** by this finding as a
+new standalone role. The residue is real but narrow (file/doc staleness,
+branch-abandonment judgment) and has a lower-cost alternative: extend
+auditor's existing periodic pass rather than stand up a fourth periodic role
+with its own dedup/scheduling/anti-#4736 machinery to design from scratch.
+If a future observation period surfaces a materially larger or different
+residue than what is documented here, re-open the Phase 4 question with that
+evidence rather than proceeding on the original framing alone.
+
+## 5. No new failure mode
+
+This phase made no `.loom/config.json` change (criterion 1 was already
+satisfied by #5052) and added one read-only diagnostic script. No new
+scheduling surface, no new per-host cron, no new label, no new role. The
+anti-granularity-trap criterion (#5038) is satisfied by construction — this
+phase's only artifact is verification tooling, not new scheduled work.

--- a/defaults/scripts/check-onidle-status.sh
+++ b/defaults/scripts/check-onidle-status.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# check-onidle-status.sh - Verify autonomous.roleRunner.onIdle is actually
+# firing for a registered workspace, not just configured.
+#
+# `autonomous.roleRunner.onIdle` is a distinct opt-in from the interval
+# `roles` list (see loom-daemon/src/role_runner.rs -> resolve_on_idle_roles):
+# a repo can have onIdle roles *configured* in .loom/config.json while the
+# daemon never actually fires them (work finder disabled, per-root
+# roleRunner.enabled false, or simply never idle). This script closes that
+# configured-vs-dormant gap by cross-checking the config against the daemon's
+# own log for the "idle edge ... firing idle-triggered <role> run" line
+# (#4364) that only appears when a real tick fired.
+#
+# Usage:
+#   ./check-onidle-status.sh [--root PATH] [--daemon-log PATH] [--json]
+#
+# Options:
+#   --root PATH        Workspace root to check (default: repo root containing
+#                       this script, resolved the same way check-ci-status.sh
+#                       does).
+#   --daemon-log PATH  Daemon log file to scan (default: $LOOM_DAEMON_LOG, or
+#                       $HOME/.loom/daemon.log — the same precedence
+#                       loom-daemon's own resolve_log_path() uses).
+#   --json              Output machine-readable JSON instead of prose.
+#   --help              Show this help message.
+#
+# Exit codes:
+#   0 - no onIdle roles configured (nothing to verify), or every configured
+#       role has at least one confirmed fire in the log
+#   1 - bad usage / missing dependency (jq)
+#   2 - onIdle roles are configured but the daemon log is missing/unreadable
+#       (cannot verify either way)
+#   3 - onIdle roles are configured but at least one has never fired
+#       according to the log — configured-but-dormant, the exact failure
+#       mode this script exists to catch
+#
+# This is a read-only diagnostic — it never mutates config or logs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+[[ ! -t 1 ]] && RED="" && GREEN="" && YELLOW="" && BLUE="" && NC=""
+
+ROOT=""
+DAEMON_LOG="${LOOM_DAEMON_LOG:-$HOME/.loom/daemon.log}"
+JSON_OUTPUT=false
+
+show_help() {
+    sed -n '2,/^$/p' "$0" | sed 's/^# //' | sed 's/^#//'
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --root)
+            ROOT="$2"
+            shift 2
+            ;;
+        --daemon-log)
+            DAEMON_LOG="$2"
+            shift 2
+            ;;
+        --json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        --help|-h)
+            show_help
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Run with --help for usage" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq is required but not installed" >&2
+    exit 1
+fi
+
+if [[ -z "$ROOT" ]]; then
+    ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+ROOT="$(cd "$ROOT" && pwd)"
+
+CONFIG_FILE="$ROOT/.loom/config.json"
+
+# --- Resolve configured onIdle roles ---
+ON_IDLE_ROLES=()
+if [[ -f "$CONFIG_FILE" ]]; then
+    while IFS= read -r role; do
+        [[ -n "$role" ]] && ON_IDLE_ROLES+=("$role")
+    done < <(jq -r '.autonomous.roleRunner.onIdle // [] | .[]' "$CONFIG_FILE" 2>/dev/null || true)
+fi
+
+if [[ ${#ON_IDLE_ROLES[@]} -eq 0 ]]; then
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        jq -n --arg root "$ROOT" '{root: $root, configured: [], verified: [], dormant: [], status: "not_configured"}'
+    else
+        echo -e "${YELLOW}No autonomous.roleRunner.onIdle roles configured for $ROOT — nothing to verify.${NC}"
+    fi
+    exit 0
+fi
+
+if [[ ! -r "$DAEMON_LOG" ]]; then
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        jq -n --arg root "$ROOT" --argjson configured "$(printf '%s\n' "${ON_IDLE_ROLES[@]}" | jq -R . | jq -s .)" \
+            '{root: $root, configured: $configured, verified: [], dormant: [], status: "log_unavailable"}'
+    else
+        echo -e "${RED}Cannot verify — daemon log not readable: $DAEMON_LOG${NC}" >&2
+    fi
+    exit 2
+fi
+
+# --- Cross-check each configured role against the daemon log ---
+# Matches loom-daemon/src/role_runner.rs's plan_idle_runs log line:
+#   "role_runner: idle edge for <root> — firing idle-triggered <role> run (#4364)"
+VERIFIED=()
+DORMANT=()
+declare -A LAST_FIRED
+declare -A FIRE_COUNT
+
+for role in "${ON_IDLE_ROLES[@]}"; do
+    pattern="idle edge for ${ROOT} — firing idle-triggered ${role} run"
+    matches="$(grep -F "$pattern" "$DAEMON_LOG" 2>/dev/null || true)"
+    count="$(printf '%s\n' "$matches" | grep -cF "$pattern" 2>/dev/null || echo 0)"
+    if [[ -n "$matches" && "$count" -gt 0 ]]; then
+        VERIFIED+=("$role")
+        FIRE_COUNT["$role"]="$count"
+        LAST_FIRED["$role"]="$(printf '%s\n' "$matches" | tail -1 | grep -oE '^\[[0-9T:.+-]+\]' | tr -d '[]')"
+    else
+        DORMANT+=("$role")
+        FIRE_COUNT["$role"]=0
+    fi
+done
+
+STATUS="verified"
+[[ ${#DORMANT[@]} -gt 0 ]] && STATUS="dormant"
+
+if [[ "$JSON_OUTPUT" == "true" ]]; then
+    jq -n \
+        --arg root "$ROOT" \
+        --arg status "$STATUS" \
+        --argjson configured "$(printf '%s\n' "${ON_IDLE_ROLES[@]}" | jq -R . | jq -s .)" \
+        --argjson verified "$(printf '%s\n' "${VERIFIED[@]:-}" | jq -R 'select(length > 0)' | jq -s .)" \
+        --argjson dormant "$(printf '%s\n' "${DORMANT[@]:-}" | jq -R 'select(length > 0)' | jq -s .)" \
+        '{root: $root, configured: $configured, verified: $verified, dormant: $dormant, status: $status}'
+else
+    echo -e "${BLUE}onIdle status for $ROOT${NC}"
+    echo "─────────────────────────────────"
+    for role in "${ON_IDLE_ROLES[@]}"; do
+        if [[ "${FIRE_COUNT[$role]}" -gt 0 ]]; then
+            echo -e "  ${GREEN}$role${NC}: fired ${FIRE_COUNT[$role]}x (last: ${LAST_FIRED[$role]:-unknown})"
+        else
+            echo -e "  ${RED}$role${NC}: configured but never observed firing in $DAEMON_LOG"
+        fi
+    done
+    echo ""
+fi
+
+[[ ${#DORMANT[@]} -gt 0 ]] && exit 3
+exit 0


### PR DESCRIPTION
## Summary

Epic #5038 Phase 3 asks to (1) activate `autonomous.roleRunner.onIdle` for
`auditor`, (2) confirm the idle-edge path actually fires, and (3) record a
written finding on whether Class 3 (judgment-requiring, repo-scoped hygiene)
has residue beyond what Auditor/Guide already catch.

Criterion (1) was already satisfied before this PR — `onIdle: ["auditor"]`
has been live in this repo's own `.loom/config.json` since PR #5052 (merged
2026-08-03). This PR does the remaining, genuinely new work: adds a reusable
verification tool for criterion (2), and records the written finding for
criterion (3).

## Changes

- **`defaults/scripts/check-onidle-status.sh`** (new): a read-only
  diagnostic that cross-checks a workspace's configured
  `autonomous.roleRunner.onIdle` roles against the daemon log's `idle edge …
  firing idle-triggered <role> run` line (`role_runner::plan_idle_runs`,
  #4364), reporting per-role verified/dormant status instead of requiring a
  manual log grep. Tested against this host's live `~/.loom/daemon.log`
  (verified path), a missing-log path, a no-`onIdle`-configured path, and a
  configured-but-never-fired ("dormant") path — all four exit codes behave
  as documented in the script's own header.
- **`defaults/docs/onidle-phase3-finding.md`** (new): the written finding —
  onIdle confirmed firing on real multi-day operating history (19 idle-edge
  auditor ticks between 2026-08-03T22:32 and 2026-08-05T20:52, two of which
  are directly corroborated by matching `idle edge … firing` lines in the
  current daemon log), a Class 3 residue assessment (real but narrower than
  #5038's original framing — auditor's existing guard-decision-pattern
  review already exercises the same judgment-call class), the rationale for
  leaving `guide` off `onIdle` (already interval-scheduled, no observed
  need for a second trigger path), and a recommendation against building
  Phase 4 (`janitor` role) as originally scoped.
- **`defaults/docs/daemon-reference.md`**: one-line pointer to the new
  script and finding doc from the existing `onIdle` configuration section.

No `.loom/config.json` change — the config criterion was already met, and
adding `guide` to `onIdle` was evaluated and deliberately not done (see
finding doc §3, and #5038's own anti-granularity-trap criterion against
adding scheduling surface without demonstrated need).

## Acceptance Criteria Verification

| Criterion | Status | Verification |
|-----------|--------|---------------|
| `onIdle` configured with `auditor` (and optionally `guide`) | ✅ | Already live since PR #5052; `guide` deliberately left on the interval `roles` list instead — see finding doc §3 |
| onIdle path confirmed to actually fire (not just configured) | ✅ | `~/.loom/daemon.log` contains direct `idle edge for /home/ubuntu/GitHub/loom — firing idle-triggered auditor run (#4364)` lines matching `.loom/logs/role-auditor.log` tick banners at the same timestamps; 19 total auditor ticks over a 2-day window with idle-edge-signature irregular spacing (15min–8h), all necessarily onIdle-fired since auditor is not in the interval `roles` list |
| Written finding on Class 3 residue beyond Auditor/Guide | ✅ | `defaults/docs/onidle-phase3-finding.md` §2 — residue exists (file/doc staleness, branch-abandonment judgment) but is narrower than originally scoped; recommends against building Phase 4 as filed |
| No new host-scoped-but-per-repo-scheduled failure mode | ✅ | No config change, no new scheduling surface — the only artifact is a read-only diagnostic script |

## Test Plan

- `bash -n` + `shellcheck` clean on `check-onidle-status.sh`.
- Ran the script against this host's live `~/.loom/daemon.log` and confirmed
  it correctly reports the `auditor` role as verified (fired 2x, matching
  the daemon log's own `idle edge … firing` lines).
- Ran the script against three synthetic fixtures: no `onIdle` configured
  (exit 0, "nothing to verify"), missing daemon log (exit 2), and a
  configured-but-never-fired role (exit 3, "dormant") — all behaved as
  documented.
- `bash scripts/check-docs-defaults-parity.sh .` — clean (no orphaned
  `.loom/docs/` file, no broken sibling links, no escaping links).
- `cargo test --workspace --lib --bins` (the repo's build-gate command) was
  not run to completion locally — this host was under heavy concurrent-sweep
  contention at PR time (observed 0.2% CPU utilization over 7+ minutes on
  the `cargo test` process; `.loom/logs/*` show 22 actively-managed
  workspaces and multiple `LOW DISK` warnings from the worktree reaper on
  this same host). This PR touches no Rust source, so the Rust suite's
  outcome is orthogonal to this diff; the orchestrator's post-builder gate
  will re-run it independently before merge.

Closes #5489