### PR TITLE
fix(gitignore): converge the managed block on .loom/.install.lock (#4940)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ Thumbs.db
 .loom/*.sock
 .loom/*.tmp
 .loom/*.bak
+.loom/.install.lock
 .loom/logs/
 # <<< loom-managed <<<
 .loom-test-failure-context.json


### PR DESCRIPTION
Fixes a red `main`.

`.gitignore Convergence Check` went red on `main` at `2eb81bd0`. Cause: **#4940** added `.loom/.install.lock` to `EPHEMERAL_PATTERNS` in `loom-daemon/src/init/post_init.rs` (the per-target install lock from #4928) but did not regenerate the committed `.gitignore`, so the managed block drifted from the pattern set the moment it merged.

This PR is the one missing line, produced by running the prescribed command with a binary built from current `main`:

```
+.loom/.install.lock
```

## Verified

```
$ bash scripts/check-gitignore-convergence.sh . target/debug/loom-daemon
check-gitignore-convergence: OK — .gitignore's Loom-managed block matches the current EPHEMERAL_PATTERNS set.
exit=0
```

## Note on how this got in

#4940 predates the convergence gate (#5493), so nothing flagged it pre-merge — its own CI was green because the check did not exist on that branch yet. The gate caught it on `main` within minutes of the merge.

That is Epic #5038 Phase 2 working on its first day, and worth recording: *"deterministic, repo-scoped, verifiable pre-merge -> CI gates, where a violation blocks a PR instead of generating an issue."* #5014 found this exact class by hand, well after the fact. This time the window was minutes and the fix is one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
