### PR TITLE
feat(labels,champion): add loom:operator state, wire into merge-risk hold

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -141,6 +141,21 @@
   description: "Requires human action or ruling outside automation (creds, infra, hardware); sweep skips"
   color: "F97316"  # orange-500 - operator-action signal (matches loom:abort)
 
+# loom:operator is the first-class "a human is needed" pipeline state (#5502):
+# the engine (any role, plus sweep/shepherd dispatch) will not act on this
+# item further until a human does. It differs from BOTH neighbors above:
+# vs. loom:operator-only — operator-only tells sweep/shepherd to SKIP the item
+# entirely; loom:operator does not — the item stays in the normal
+# re-evaluation queue so a role's own exit rule (e.g. Champion's head-SHA
+# precheck, an explicit human comment, or a new artifact) can still clear it
+# automatically. vs. loom:blocked — blocked means "waiting on a dependency,
+# still automatable"; loom:operator means "the engine has stopped and only a
+# human moves it forward." See .loom/docs/label-state-machine.md for the full
+# entry/exit model.
+- name: loom:operator
+  description: "Engine stops work on this item; human is the only transition out. Sweep/shepherd do not skip it."
+  color: "EA580C"  # orange-600 - operator-action signal, one shade darker than operator-only
+
 # Epic Labels
 - name: loom:epic
   description: Multi-phase epic proposal (decomposes into implementation issues)

--- a/.loom/docs/label-state-machine.md
+++ b/.loom/docs/label-state-machine.md
@@ -1,0 +1,1 @@
+../../defaults/docs/label-state-machine.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,10 @@ label documents its own `Applied by:` owner). State transitions:
 - **Epic**: `loom:epic` → Champion creates phased `loom:architect` +
   `loom:epic-phase` issues.
 
+`loom:operator` is the first-class "a human is needed" state (engine stops
+acting, re-evaluable, unlike `loom:operator-only`) — wired at Champion's
+merge-risk hold only so far: [`.loom/docs/label-state-machine.md`](.loom/docs/label-state-machine.md).
+
 > **Note on label cleanup**: Loom intentionally does **not** remove labels from
 > closed issues or merged PRs (harmless — all agents filter by open state — and it
 > saves gh API calls). Do not implement label cleanup on merge/close (see #2838).

--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -448,6 +448,15 @@ else
 fi
 ```
 
+`$HOLD_REVERSAL_BLOCK` non-empty is also the exact signal that gates the
+`loom:operator` label removal (#5502) — this precheck already distinguishes
+"never held", "held and still bound" (which bails out at the STICKY HOLD
+branch above and never reaches here with a merge decision), and "held and
+genuinely released", so the label reuses that same computation instead of a
+second state-tracking mechanism. The actual `gh pr edit --remove-label` call
+lives in Step 2 below, in the same pass that posts this block's text — see
+"Step 2: Add Pre-Merge Comment".
+
 "Seems fine now", "re-evaluated, looks OK", or any restatement that would read
 the same against the original diff is **not** an acceptable flip rationale — if
 you cannot name what changed, the precheck should not have released the hold.
@@ -499,6 +508,17 @@ Keeping \`loom:pr\`. This PR stays in the queue and is re-checked each tick agai
 ---
 *Automated by Champion role*"
 fi
+
+# loom:operator (#5502): the first-class "engine will not act further, a
+# human is the only transition out" pipeline state, applied alongside the
+# marker above (whether freshly posted this tick or already standing from an
+# earlier one — `--add-label` is idempotent, so it is safe to reassert every
+# tick the hold binds). UNLIKE loom:operator-only, this must NOT make
+# sweep/shepherd skip the PR — loom:pr is kept (see above) and the PR stays
+# in the normal re-evaluation queue precisely so the release precheck
+# (loom:auto-merge-ok / operator comment / new push / new Judge review, all
+# above) can still fire and clear it. Never applied in place of loom:pr.
+gh pr edit "$PR_NUMBER" --add-label "loom:operator" 2>/dev/null || true
 # Skip this PR for this pass — do not merge.
 ```
 
@@ -803,6 +823,16 @@ EOF
   echo "Pre-merge comment failed for #$PR_NUMBER — NOT merging this pass"
   exit 1
 }
+
+# loom:operator removal (#5502) — the reversal companion to the hold-post
+# label add in criterion #2's "Hold behavior". Gated on the SAME
+# $HOLD_REVERSAL_BLOCK the comment above just posted (non-empty only when
+# PRIOR_HOLD=true AND the precheck found a genuine release — see "Reversal is
+# one mandatory comment" above), so this never fires on the never-held path
+# and always fires in the same pass as the reversal comment.
+if [ -n "$HOLD_REVERSAL_BLOCK" ]; then
+  gh pr edit "$PR_NUMBER" --remove-label "loom:operator" 2>/dev/null || true
+fi
 "$GH_READ" --clear-cache   # your own write must not be masked by your own cache
 ```
 
@@ -1325,7 +1355,7 @@ fi
 
 If ANY safety criterion fails, do NOT merge. How the failure is handled depends on whether it is **transient** (clears on its own or on the next push — pending CI, conflicts being resolved, `UNKNOWN` mergeability), **terminal** (the PR has gone stale and cannot clear without a rebase), or a **merge-risk hold** (criterion #2 judged the PR to need a human merge).
 
-**Merge-risk holds** keep `loom:pr` like a transient failure, but comment **once** behind the `<!-- champion:merge-risk-hold -->` idempotency marker because the condition does not clear on its own. Unlike a transient failure, the hold is **sticky**: later ticks re-check it against the release conditions (`loom:auto-merge-ok`, an explicit operator clearing comment, a new push, a new Judge review) rather than re-deriving it from a fresh axis read, and any merge that reverses one carries a mandatory reversal comment (#4742). The exact commands live with the criterion itself — see "Safety Criteria → 2. Merge-Risk Judgment → Sticky holds / Hold behavior"; do not duplicate them here.
+**Merge-risk holds** keep `loom:pr` like a transient failure, but comment **once** behind the `<!-- champion:merge-risk-hold -->` idempotency marker because the condition does not clear on its own, and additionally carry `loom:operator` (#5502) — the first-class "engine will not act further, a human is the only transition out" state, added alongside the marker and removed alongside its reversal, kept **filterable** without making sweep/shepherd skip the PR (see [`.loom/docs/label-state-machine.md`](../../../.loom/docs/label-state-machine.md)). Unlike a transient failure, the hold is **sticky**: later ticks re-check it against the release conditions (`loom:auto-merge-ok`, an explicit operator clearing comment, a new push, a new Judge review) rather than re-deriving it from a fresh axis read, and any merge that reverses one carries a mandatory reversal comment (#4742). The exact commands live with the criterion itself — see "Safety Criteria → 2. Merge-Risk Judgment → Sticky holds / Hold behavior"; do not duplicate them here.
 
 ### Transient failures — keep `loom:pr`, retry next tick
 

--- a/defaults/.github/labels.yml
+++ b/defaults/.github/labels.yml
@@ -141,6 +141,21 @@
   description: "Requires human action or ruling outside automation (creds, infra, hardware); sweep skips"
   color: "F97316"  # orange-500 - operator-action signal (matches loom:abort)
 
+# loom:operator is the first-class "a human is needed" pipeline state (#5502):
+# the engine (any role, plus sweep/shepherd dispatch) will not act on this
+# item further until a human does. It differs from BOTH neighbors above:
+# vs. loom:operator-only — operator-only tells sweep/shepherd to SKIP the item
+# entirely; loom:operator does not — the item stays in the normal
+# re-evaluation queue so a role's own exit rule (e.g. Champion's head-SHA
+# precheck, an explicit human comment, or a new artifact) can still clear it
+# automatically. vs. loom:blocked — blocked means "waiting on a dependency,
+# still automatable"; loom:operator means "the engine has stopped and only a
+# human moves it forward." See .loom/docs/label-state-machine.md for the full
+# entry/exit model.
+- name: loom:operator
+  description: "Engine stops work on this item; human is the only transition out. Sweep/shepherd do not skip it."
+  color: "EA580C"  # orange-600 - operator-action signal, one shade darker than operator-only
+
 # Epic Labels
 - name: loom:epic
   description: Multi-phase epic proposal (decomposes into implementation issues)

--- a/defaults/docs/label-state-machine.md
+++ b/defaults/docs/label-state-machine.md
@@ -1,0 +1,108 @@
+# The `loom:operator` state — "a human is needed"
+
+Loom's coordination substrate is labels (see `CLAUDE.md` § "Label-Based
+Workflow") — every pipeline transition (`loom:triage` → `loom:curated` →
+`loom:issue` → `loom:building`, `loom:review-requested` → `loom:pr`, etc.) is
+a label change on an issue or PR. Before `loom:operator` existed, one state
+was the exception: "the engine has stopped and a human is the only way
+forward." Champion's merge-risk hold expressed that state as an HTML comment
+marker (`<!-- champion:merge-risk-hold -->`) buried inside a PR comment —
+invisible to `gh pr list`, the dashboard, or any label-filtered query. See
+[#5502](https://github.com/rjwalters/loom/issues/5502) for the incident that
+prompted this (four Judge-approved PRs sat held-but-invisible for up to 126
+hours).
+
+`loom:operator` moves that state onto the label substrate, where every other
+pipeline state already lives.
+
+## Definition
+
+> `loom:operator`: the engine will not work this item further; a human is the
+> only transition out.
+
+## Relationship to `loom:blocked` and `loom:operator-only`
+
+Three labels now sit in similar territory. They are **not** consolidated into
+one — each answers a different question, and the differences are load-bearing
+enough to keep separate (see `.github/labels.yml` inline comments, next to
+each definition, for the terse version of this same table):
+
+| Label | Question it answers | Does sweep/shepherd skip it? |
+|---|---|---|
+| `loom:blocked` | Waiting on a dependency, but still automatable once that clears | No |
+| `loom:operator-only` | Requires human action or ruling *outside* automation entirely (credentials, infra, hardware, an owner-gated decision) | **Yes** — sweep/shepherd skip it |
+| `loom:operator` | The engine has stopped on this specific artifact and a human must act, but the item stays live in its normal queue so the engine's own release conditions can still fire | **No** — stays in the normal re-evaluation queue |
+
+The distinguishing property of `loom:operator` is that it is **re-evaluable**:
+unlike `loom:operator-only`, applying it must never cause sweep/shepherd
+dispatch to skip the item. That is what makes it safe to apply to a PR that
+still needs to pass through its normal Champion tick — the hold that put the
+label on can also be the mechanism that takes it back off, without a human
+having to remember to remove it.
+
+## Entry points
+
+| Role | Trigger | Status |
+|---|---|---|
+| Champion (PR merge) | Posts a merge-risk hold (`champion:merge-risk-hold`) because a safety axis is red | **Wired** — `defaults/.claude/commands/loom/champion-pr-merge.md`, "Hold behavior" |
+| Builder / Doctor | Encounters work that needs credentials, infra, or a policy ruling outside automation (today's `loom:operator-only` use case) | Not yet wired — follow-up work |
+| Judge | A review surfaces a question only a human can answer | Not yet wired — follow-up work |
+| Human | Applies the label directly to any issue or PR | Always available (labels are always human-writable) |
+
+**Scope note**: this first pass (#5502) wires only the Champion merge-risk
+hold entry point end-to-end. `curator.md`, `builder.md`, `doctor.md`,
+`judge.md`, `champion.md`, `champion-common.md`, `champion-issue-promo.md`,
+`champion-reference.md`, `loom.md`, `sweep.md`, and `watch.md` all reference
+`loom:operator-only` and/or `loom:blocked` today; none of them assume that set
+is exhaustive in a way that required editing for this PR, but none of them
+have been migrated to *use* `loom:operator` yet either. Extending
+`loom:operator` to the Builder/Doctor/Judge entry points above is explicitly
+out of scope here — file a follow-up issue per entry point once the Champion
+wiring has run in production.
+
+## Exit rule
+
+`loom:operator` is cleared when the artifact the engine judged **materially
+changes** — never merely because a role re-read the same artifact and changed
+its mind. For the Champion hold, this reuses the *existing* release precheck
+(`champion-pr-merge.md`, "Sticky holds" / criterion #2), which already
+computes exactly this distinction for the hold marker itself. `loom:operator`
+does not add a second, independent state-tracking mechanism — it piggybacks
+on the same four precheck outcomes:
+
+| Precheck outcome | `loom:operator` |
+|---|---|
+| Never held (`PRIOR_HOLD=false`) | Never applied |
+| Held, no release signal yet | Stays applied (label add is idempotent — re-asserted, not re-added, each tick the hold stands) |
+| Held, released by `loom:auto-merge-ok` override | Removed in the same pass as the reversal comment |
+| Held, released by an explicit operator-comment, a new push (head SHA changed), or a new Judge review | Removed in the same pass as the reversal comment |
+
+A human can also clear `loom:operator` directly at any time by removing the
+label — the automated exit rule above is the *default* path, not the only
+one.
+
+## Current implementation
+
+Only the Champion merge-risk-hold entry/exit pair is wired today:
+
+- **Entry** — `defaults/.claude/commands/loom/champion-pr-merge.md`, criterion
+  #2's "Hold behavior" block (`gh pr edit ... --add-label loom:operator`,
+  posted alongside the `champion:merge-risk-hold` marker).
+- **Exit** — the same file's Step 2 ("Add Pre-Merge Comment"), gated on the
+  non-empty `$HOLD_REVERSAL_BLOCK` built by the release precheck (`gh pr edit
+  ... --remove-label loom:operator`, posted alongside the
+  `champion:merge-risk-hold-cleared` marker).
+
+Both reuse the single release precheck at `champion-pr-merge.md` ("Sticky
+holds — a hold does NOT clear on a re-read alone") rather than re-deriving
+release state independently.
+
+## Follow-up work
+
+- Wire `loom:operator` into Builder/Doctor's credential-or-policy stop path
+  (today's `loom:operator-only` usage).
+- Wire `loom:operator` into Judge's unanswerable-question path.
+- Decide whether `loom:operator-only` should eventually be subsumed by
+  `loom:operator` + a separate "skip dispatch" signal, or remain a distinct
+  label permanently — the #5502 issue thread leaves this open pending
+  experience with the Champion-only rollout.


### PR DESCRIPTION
## Summary

Models "a human is needed" as a first-class, re-evaluable pipeline state (`loom:operator`) instead of an HTML comment marker invisible outside the PR body (#5502). Per the issue's curated Acceptance Criteria and Implementation Guidance, this PR is **scoped to the Champion merge-risk-hold entry point only** — Builder/Doctor/Judge entry points are explicitly deferred to follow-up issues.

- **`.github/labels.yml` / `defaults/.github/labels.yml`**: adds `loom:operator`, documented inline against `loom:blocked`/`loom:operator-only` (following the mutual-exclusion comment convention already at `labels.yml:39-40`). The two files stay byte-identical (`defaults/scripts/check-labels-drift.sh` passes). I also created the label live on the forge (`gh label create`) so Champion's `--add-label` call works immediately once this merges, without waiting on a manual `gh label sync`.
- **`defaults/.claude/commands/loom/champion-pr-merge.md`**:
  - The hold-post block ("Hold behavior", criterion #2) now adds `loom:operator` alongside the `<!-- champion:merge-risk-hold -->` marker, in the same pass, idempotently (`--add-label` no-ops if already present).
  - The reversal in Step 2 ("Add Pre-Merge Comment") removes `loom:operator` alongside the `<!-- champion:merge-risk-hold-cleared -->` reversal text, gated on the same `$HOLD_REVERSAL_BLOCK` the *existing* release precheck already computes (head-SHA comparison, explicit operator-comment parsing, `loom:auto-merge-ok` override, new Judge review) — no new state-tracking mechanism, per the issue's guidance to reuse the precheck rather than reinvent it.
  - Unlike `loom:operator-only`, `loom:operator` never causes sweep/shepherd to skip the PR — `loom:pr` is kept throughout, so the PR stays in the normal re-evaluation queue.
- **`defaults/docs/label-state-machine.md`** (+ `.loom/docs/label-state-machine.md` symlink, matching this repo's existing docs-symlink convention): documents the state's definition, entry points per role (only Champion wired here; Builder/Doctor/Judge flagged as follow-up work), the exit rule (artifact-changed, not re-read), and its relationship to `loom:blocked`/`loom:operator-only`.
- **`CLAUDE.md`**: a one-line pointer to the new doc in the "Label-Based Workflow" section (315/320 lines, still within `check-claude-md-budget.sh`'s budget).

### Light audit (per issue's Affected Files list — no edits expected or made)

Read `curator.md`, `builder.md`, `doctor.md`, `judge.md`, `champion.md`, `champion-common.md`, `champion-issue-promo.md`, `champion-reference.md`, `loom.md`, `sweep.md`, `watch.md` for any assumption that `loom:operator-only`/`loom:blocked` are an exhaustive "human needed" set. None found that needs updating for this PR's scope:

- `sweep.md`'s hard-skip rule checks specifically for the `loom:operator-only` **label**, not "any human-needed label" — a PR carrying `loom:operator` (which also keeps `loom:pr`) is *not* skipped by that rule, which is exactly the desired behavior.
- `champion.md`'s issue-promotion candidate queries exclude `loom:operator-only`/`loom:blocked` for **issues** being evaluated for promotion — unrelated to the PR-only merge-risk hold this PR wires up.
- `champion-issue-promo.md`'s escalation-to-`loom:operator-only` (stuck proposal cycles) is a distinct mechanism (Curator-side proposal evaluation, not Champion's PR-merge hold) and remains correct as-is.

## Test plan

- [x] `./defaults/scripts/check-labels-drift.sh .` — passes (files byte-identical).
- [x] `./defaults/scripts/check-label-descriptions.sh .` — passes (new description is 96/100 chars).
- [x] `./defaults/scripts/check-phantom-labels.sh .` — passes.
- [x] `./scripts/check-claude-md-budget.sh` — passes (315/320 lines).
- [x] `bash .loom/scripts/tests/test-install-sync-labels.sh` — 24/24 passed (unaffected generic label-sync tests).
- [x] Manual code-read verification: the hold-post block adds `loom:operator`, the reversal block removes it, and both reuse `$HOLD_REVERSAL_BLOCK` / the existing precheck's four outcomes rather than a new mechanism (see diff in `champion-pr-merge.md`).
- [ ] **Requires a live Champion run — not verifiable in this PR**: a fresh `champion:merge-risk-hold` actually results in a `loom:operator`-labeled PR findable via `gh pr list --label=loom:operator`; a sweep/shepherd pass does not skip it; a push that changes `headRefOid` clears it on the next tick; the legacy no-`hold-state`-line fallback path also clears it correctly. These are the issue's Test Plan items 1-5, all of which depend on an actual Champion tick observing a held PR in production — flagging per the issue's own note that this PR should state which checklist items are static-verifiable vs. requiring a live run.

Closes #5502