### PR TITLE
fix(safehouse): loudify unresolved-socket failure + add drift check (#5523)

### DIFF
--- a/defaults/docs/safehouse.md
+++ b/defaults/docs/safehouse.md
@@ -69,8 +69,10 @@ Env overrides (each wins over config for that key):
 | `LOOM_SAFEHOUSE_ROOM_CLAIMS` | `rooms.claims` — dedicated peer-claim coordination room (#4713) |
 
 **Socket resolution** (precedence **env > config**, `resolve_socket` in
-`loom-daemon/src/safehouse.rs`): `$LOOM_SAFEHOUSE_SOCKET` → `$SAFEHOUSED_SOCKET`
-(the unprefixed convention `safehoused` clients also read) → the configured
+`loom-daemon/src/safehouse.rs`; the bash-side worker-injection path
+(`defaults/scripts/lib/mcp-config.sh`'s `loom_mcp_safehouse_socket()`) mirrors
+the same chain): `$LOOM_SAFEHOUSE_SOCKET` → `$SAFEHOUSED_SOCKET` (the
+unprefixed convention `safehoused` clients also read) → the configured
 `socket` value. If none resolves, narration logs one `warn!` and stays off — no
 built-in `$HOME`-relative default, since safehouse is opt-in per-host.
 
@@ -87,6 +89,47 @@ macOS `safehouse.socket` path was committed to this repo's own shared
 value *before* env at the time — every other host that `git pull`ed `main`
 inherited a path to a socket that did not exist on it, with no env override able
 to take effect while that stale path stayed committed.
+
+**Why there is still no built-in default, even after #5523.** #5457's fix left
+a gap: with the committed default gone and nothing installed in its place, an
+affected host's `safehouse.enabled: true` silently resolved to no socket at
+all, and the only signal was a `log_warn` inside each sweep's own per-role log
+— nobody was tailing those, so a real host ran with **zero** safehouse
+narration for 11 hours before a human noticed the public 2amlogic.com fleet
+pulse had gone stale (#5523). The tempting fix — teach the resolver a
+conventional-path fallback (e.g. `~/.loom/safehoused/state/safehoused.sock`) —
+was deliberately **rejected** for #5523: a code-level default *would* avoid
+re-triggering #5457's exact mechanism (it can't go stale via `git pull` the
+way a committed value can), but it would reintroduce the same underlying risk
+in a different shape — "resolves to *something*" would quietly stop meaning
+"actually reaches a live `safehoused`", which is precisely the gap that let
+#5523 run unnoticed. #5523's fix instead makes the **absence** loud and cheap
+to detect, in two ways, without touching this resolution chain at all:
+
+- `spawn-claude.sh`'s warning, when `safehouse.enabled` is true and no socket
+  resolves, now names the consequence ("no safehouse narration will be
+  recorded... the 2amlogic.com public fleet pulse is fed exclusively from
+  safehouse narration") instead of only the mechanism ("skipping safehouse MCP
+  injection") — still a `log_warn`, never a failed spawn (the degradation
+  contract above is unchanged: `safehouse.enabled: false`/absent stays a
+  byte-for-byte no-op, and `enabled: true` never blocks a sweep).
+- **`defaults/scripts/check-safehouse-socket.sh`** (installed as
+  `.loom/scripts/check-safehouse-socket.sh`) is a new standalone, on-demand
+  check that reports — per managed repo, without reading a single sweep log —
+  whether `safehouse.enabled` is set and, if so, whether a socket resolves AND
+  is present on disk. With no arguments it walks this host's machine-level
+  workspace registry (`~/.loom/workspaces.json`, the same registry
+  `loom-daemon workspace add/list` manages) and checks every registered repo
+  in one pass; pass explicit repo roots to check a subset. `--json` emits a
+  parseable array (`{repo, enabled, socket, present, status}` per repo) for
+  scripting/cron. It exits `0` when every repo is either not configured or
+  resolved-and-present, and `1` the moment any repo is enabled with an
+  unreachable socket — the exact condition #5523 needed surfaced. Unlike the
+  pre-existing static `Safehouse:` line in `loom-daemon-start.sh`'s startup
+  banner (below), this check has **no dependency on the daemon
+  (re)starting** — it can be run any time, which is what the incident
+  actually needed: the affected daemon never restarted across the 11-hour
+  window, so its own start-time check never re-ran.
 
 ### Room routing by attention class (`safehouse.rooms`, #4225)
 
@@ -843,10 +886,17 @@ what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
 - `defaults/scripts/cli/loom-daemon-start.sh` — (#4345) the static
   pre-connect `Safehouse:` line, via `lib/mcp-config.sh`'s existing
   `loom_mcp_safehouse_enabled`/`loom_mcp_safehouse_socket` resolvers.
+- `defaults/scripts/check-safehouse-socket.sh` — (#5523) the standalone,
+  daemon-restart-independent per-repo socket-resolution drift check described
+  above under "Socket resolution".
 - Tests: `safehouse.rs`'s `mod tests` (state-cell + wire-rendering cases),
   `workspace_pool.rs`'s `mod tests` (pool wiring), `ipc.rs`'s
   `test_build_daemon_status_reports_halt_and_in_flight` (report field),
-  `defaults/scripts/tests/test-loom-daemon-start.sh` (start-wrapper line).
+  `defaults/scripts/tests/test-loom-daemon-start.sh` (start-wrapper line),
+  `defaults/scripts/tests/test-mcp-config.sh` §13 (#5523: the loudened
+  spawn-claude.sh warning text + check-safehouse-socket.sh's not-configured /
+  resolved / unreachable-no-socket / unreachable-missing-file / multi-repo /
+  `--json` behavior).
 
 ## Peer-claim coordination: cross-host soft claim (#4028)
 

--- a/defaults/scripts/check-safehouse-socket.sh
+++ b/defaults/scripts/check-safehouse-socket.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# check-safehouse-socket.sh — one-shot, per-host safehouse-socket resolution
+# report (issue #5523).
+#
+# Why: #5457 removed the only hardcoded `safehouse.socket` default — a path
+# that had been committed to the SHARED `.loom/config.json` and stranded
+# loom-worker-2 75 commits behind `git pull` (a correct fix). But nothing took
+# its place as a *check*: `loom_mcp_safehouse_socket()`
+# (defaults/scripts/lib/mcp-config.sh) has always silently returned an empty
+# string when nothing resolves, and every caller's only signal was a
+# `log_warn` buried inside that particular sweep's own log file. From the
+# moment #5457 merged, every sweep on an affected host silently stopped
+# narrating to safehouse — and the failure ran for 11 hours before a human
+# noticed the public 2amlogic.com fleet pulse had gone stale, because nothing
+# outside a sweep's own log was watching for it.
+#
+# This script is that "something watching": a standalone, on-demand check
+# that reports — per managed repo, without reading a single sweep log —
+# whether `safehouse.enabled` is set and, if so, whether a socket resolves
+# AND is actually present on disk. It reuses the exact resolvers
+# spawn-claude.sh / loom-daemon-start.sh already call
+# (`defaults/scripts/lib/mcp-config.sh`), so "drift" here means exactly what
+# it means to a spawning worker — no separate definition to keep in sync.
+#
+# Deliberately does NOT add a code-level conventional-path default to the
+# resolver (see mcp-config.sh's `loom_mcp_safehouse_socket` header and
+# defaults/docs/safehouse.md "Socket resolution" for the full writeup on
+# why): the fix for "silence went unnoticed for 11 hours" is making the
+# silence loud and cheap to check, independent of the daemon's own
+# start/restart lifecycle — not guessing a path. The pre-existing static
+# check in `loom-daemon-start.sh` (`print_safehouse_status`) only re-runs
+# when the daemon itself (re)starts, which is exactly the case that let this
+# incident run unnoticed on an already-running daemon; this script has no
+# such dependency.
+#
+# Usage:
+#   check-safehouse-socket.sh [--json] [REPO_ROOT ...]
+#
+#   With no REPO_ROOT arguments, checks every workspace registered in this
+#   host's machine-level daemon registry (~/.loom/workspaces.json, or
+#   $LOOM_WORKSPACES_PATH — see loom-daemon/src/workspace_registry.rs),
+#   falling back to the enclosing repo of the current directory when the
+#   registry is empty/absent/unreadable, so a lone interactive host still
+#   gets a useful answer.
+#
+# Exit codes:
+#   0 — every checked repo is either "not configured" (safehouse.enabled is
+#       false/absent — a byte-for-byte no-op, see the degradation contract in
+#       defaults/docs/safehouse.md) or "resolved" (a socket path resolved AND
+#       is present on disk).
+#   1 — at least one repo is "configured, enabled, unreachable": either
+#       safehouse.enabled is true with no socket resolving at all (the exact
+#       #5523 failure mode), or a socket path resolved but nothing exists
+#       there yet (safehoused not running / not yet started).
+#   2 — usage error (e.g. the sibling lib/mcp-config.sh is missing, a
+#       stale/partial install).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/lib/mcp-config.sh"
+
+if [[ ! -r "$LIB" ]]; then
+    echo "check-safehouse-socket: missing $LIB (stale/partial install) — cannot check." >&2
+    exit 2
+fi
+# shellcheck source=./lib/mcp-config.sh
+source "$LIB"
+
+JSON=false
+declare -a ROOTS=()
+for _arg in "$@"; do
+    case "$_arg" in
+        --json) JSON=true ;;
+        -h | --help)
+            sed -n '2,45p' "${BASH_SOURCE[0]}"
+            exit 0
+            ;;
+        *) ROOTS+=("$_arg") ;;
+    esac
+done
+
+# find_repo_root <start_dir> — walk up looking for a `.loom` directory
+# (mirrors loom-daemon-start.sh's find_repo_root, minimal subset: no worktree
+# .git-file resolution, since this is only used as a last-resort fallback).
+find_repo_root() {
+    local dir="$1"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.loom" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+if [[ ${#ROOTS[@]} -eq 0 ]]; then
+    _registry="${LOOM_WORKSPACES_PATH:-$HOME/.loom/workspaces.json}"
+    if [[ -f "$_registry" ]] && command -v jq >/dev/null 2>&1; then
+        while IFS= read -r _root; do
+            [[ -n "$_root" ]] && ROOTS+=("$_root")
+        done < <(jq -r '.workspaces[]?.root // empty' "$_registry" 2>/dev/null || true)
+    fi
+    if [[ ${#ROOTS[@]} -eq 0 ]]; then
+        # No registry (or unreadable/empty) — fall back to the repo enclosing
+        # the current directory, so a lone interactive host still gets an
+        # answer instead of silently checking nothing.
+        _fallback_root="$(find_repo_root "$PWD" || true)"
+        if [[ -n "$_fallback_root" ]]; then
+            ROOTS+=("$_fallback_root")
+        fi
+    fi
+fi
+
+if [[ ${#ROOTS[@]} -eq 0 ]]; then
+    echo "check-safehouse-socket: no managed workspaces found (no $HOME/.loom/workspaces.json entries, and no enclosing .loom/ from \$PWD) — nothing to check." >&2
+    exit 0
+fi
+
+_exit=0
+_tsv_file=""
+if $JSON; then
+    _tsv_file="$(mktemp)"
+    trap 'rm -f "$_tsv_file"' EXIT
+fi
+
+for _root in "${ROOTS[@]}"; do
+    _enabled="$(loom_mcp_safehouse_enabled "$_root" 2>/dev/null || echo false)"
+    _socket=""
+    _present="false"
+    if [[ "$_enabled" != "true" ]]; then
+        _status="not_configured"
+    else
+        _socket="$(loom_mcp_safehouse_socket "$_root" 2>/dev/null || true)"
+        if [[ -z "$_socket" ]]; then
+            _status="unreachable_no_socket"
+            _exit=1
+        elif [[ -S "$_socket" || -e "$_socket" ]]; then
+            _status="resolved"
+            _present="true"
+        else
+            _status="unreachable_missing_file"
+            _exit=1
+        fi
+    fi
+
+    if $JSON; then
+        printf '%s\t%s\t%s\t%s\t%s\n' "$_root" "$_enabled" "$_socket" "$_present" "$_status" >>"$_tsv_file"
+    else
+        case "$_status" in
+            not_configured)
+                echo "check-safehouse-socket: $_root -- not configured (safehouse.enabled is false/absent)"
+                ;;
+            resolved)
+                echo "check-safehouse-socket: $_root -- OK (socket resolved: $_socket)"
+                ;;
+            unreachable_no_socket)
+                echo "check-safehouse-socket: $_root -- DRIFT: safehouse.enabled is true but no socket resolves (safehouse.socket / \$LOOM_SAFEHOUSE_SOCKET / \$SAFEHOUSED_SOCKET) -- no safehouse narration will be recorded from this repo; the 2amlogic.com public fleet pulse is fed exclusively from safehouse narration (issue #5523)." >&2
+                ;;
+            unreachable_missing_file)
+                echo "check-safehouse-socket: $_root -- DRIFT: safehouse.enabled is true, socket resolved to '$_socket', but nothing exists there yet -- is safehoused running? (issue #5523)" >&2
+                ;;
+        esac
+    fi
+done
+
+if $JSON; then
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c '
+import json, sys
+rows = []
+for line in open(sys.argv[1], encoding="utf-8"):
+    repo, enabled, socket, present, status = line.rstrip("\n").split("\t")
+    rows.append({
+        "repo": repo,
+        "enabled": enabled == "true",
+        "socket": socket,
+        "present": present == "true",
+        "status": status,
+    })
+json.dump(rows, sys.stdout)
+print()
+' "$_tsv_file"
+    else
+        echo "check-safehouse-socket: --json requires python3 (not found) -- falling back to TSV" >&2
+        cat "$_tsv_file"
+    fi
+fi
+
+exit "$_exit"

--- a/defaults/scripts/lib/mcp-config.sh
+++ b/defaults/scripts/lib/mcp-config.sh
@@ -55,6 +55,21 @@ loom_mcp_safehouse_enabled() {
 # LOOM_SAFEHOUSE_SOCKET (env) > SAFEHOUSED_SOCKET (env) > safehouse.socket
 # (config). Env wins here so a host-specific env override always takes effect
 # over a committed/shared config value.
+#
+# DELIBERATELY no conventional-path fallback (issue #5523). #5457 removed a
+# hardcoded macOS socket path that had been committed to the SHARED
+# .loom/config.json — every host that `git pull`ed main inherited a path to a
+# socket that did not exist on it, with no env override able to win while
+# that stale committed value stayed in place. Adding a code-level default here
+# would not reintroduce that exact failure mode (a code default can't go
+# stale via `git pull`), but it does reintroduce the underlying risk this
+# function's callers must not paper over: "resolves to *something*" silently
+# stops meaning "actually reaches a live safehoused". #5523's incident was
+# caused by the RESULTING silence being invisible for 11 hours, not by the
+# absence of a default — so the fix there is to make "enabled but
+# unresolved/unreachable" LOUD (see spawn-claude.sh's safehouse warning and
+# check-safehouse-socket.sh), not to guess a path here. See
+# defaults/docs/safehouse.md "Socket resolution" for the full writeup.
 loom_mcp_safehouse_socket() {
     local repo_root="$1"
     if [[ -n "${LOOM_SAFEHOUSE_SOCKET:-}" ]]; then

--- a/defaults/scripts/spawn-claude.sh
+++ b/defaults/scripts/spawn-claude.sh
@@ -636,7 +636,16 @@ if [[ -f "$_mcp_config_lib" ]]; then
         fi
 
         if [[ -z "$_sh_socket" ]]; then
-            log_warn "spawn-claude: safehouse enabled but no socket resolves (safehouse.socket / \$LOOM_SAFEHOUSE_SOCKET / \$SAFEHOUSED_SOCKET); skipping safehouse MCP injection (loom MCP unaffected)."
+            # Loud on purpose (issue #5523): before this, the message named
+            # only the mechanism ("skipping safehouse MCP injection"), buried
+            # in a per-role sweep log nobody was tailing — every sweep on an
+            # affected host silently stopped narrating to safehouse for 11
+            # hours, unnoticed, because the ONLY consequence anyone could see
+            # from outside was the public 2amlogic.com fleet pulse going
+            # stale. Name that consequence here, and point at the standalone,
+            # on-demand check (independent of a daemon restart) that answers
+            # "is this drifted?" without reading any sweep log.
+            log_warn "spawn-claude: SAFEHOUSE DRIFT — safehouse.enabled is true but no socket resolves (safehouse.socket / \$LOOM_SAFEHOUSE_SOCKET / \$SAFEHOUSED_SOCKET); no safehouse narration will be recorded for this sweep — the 2amlogic.com public fleet pulse is fed exclusively from safehouse narration, so this host's activity will not appear there until the socket resolves. Run '.loom/scripts/check-safehouse-socket.sh' to check every managed repo on this host without reading sweep logs. Skipping safehouse MCP injection (loom MCP unaffected)."
         elif ! command -v "$_sh_command" >/dev/null 2>&1; then
             log_warn "spawn-claude: safehouse launch command '$_sh_command' not found in PATH; skipping safehouse MCP injection (loom MCP unaffected)."
         else

--- a/defaults/scripts/tests/test-mcp-config.sh
+++ b/defaults/scripts/tests/test-mcp-config.sh
@@ -129,7 +129,7 @@ fi
 echo "Testing loom_mcp_safehouse_socket..."
 
 assert_eq "" "$(loom_mcp_safehouse_socket "$_empty_repo")" \
-    "empty when nothing resolves"
+    "empty when nothing resolves (deliberately NO conventional-path fallback -- #5523)"
 assert_eq "/tmp/a.sock" \
     "$(LOOM_SAFEHOUSE_SOCKET=/tmp/a.sock loom_mcp_safehouse_socket "$_empty_repo")" \
     "LOOM_SAFEHOUSE_SOCKET is used"
@@ -956,6 +956,152 @@ JSON
     rm -rf "$_ws_dir"
 else
     echo -e "  ${YELLOW}SKIP${NC}: check_workspace_trust tests (python3 not installed)"
+fi
+
+# ============================================================
+# Section 13: safehouse-socket-unresolved LOUDNESS + check-safehouse-socket.sh
+# (issue #5523)
+#
+# #5457 removed the safehouse.socket default with nothing taking its place as
+# a *check*: an unresolved socket with safehouse.enabled=true degraded to a
+# `log_warn` buried in a per-role sweep log, unnoticed for 11 hours while the
+# public 2amlogic.com fleet pulse went stale. This section covers:
+#   13a. spawn-claude.sh's warning text names the consequence, not just the
+#        mechanism (a static source check -- exercising the live injection
+#        block needs a real loom-daemon binary for token selection, which
+#        test-spawn-claude.sh already covers elsewhere).
+#   13b/c/d. The new standalone drift-check script: not-configured / resolved
+#        / unreachable-no-socket / unreachable-missing-file, --json mode, and
+#        exit codes (0 = nothing wrong, 1 = drift detected).
+# ============================================================
+echo ""
+echo "Testing safehouse-socket-unresolved loudness + check-safehouse-socket.sh (#5523)..."
+
+# 13a. spawn-claude.sh's unresolved-socket warning names the consequence.
+_spawn_claude_src="$SCRIPTS_DIR/spawn-claude.sh"
+if [[ -f "$_spawn_claude_src" ]]; then
+    _warn_line="$(grep -A0 'SAFEHOUSE DRIFT' "$_spawn_claude_src" || true)"
+    assert_contains "SAFEHOUSE DRIFT" "$_warn_line" \
+        "spawn-claude.sh's unresolved-socket warning is visually loud (#5523)"
+    assert_contains "no safehouse narration" "$_warn_line" \
+        "spawn-claude.sh's warning names the narration consequence, not just the mechanism (#5523)"
+    assert_contains "2amlogic.com" "$_warn_line" \
+        "spawn-claude.sh's warning names the downstream public-pulse consequence (#5523)"
+    assert_contains "check-safehouse-socket.sh" "$_warn_line" \
+        "spawn-claude.sh's warning points at the standalone drift check (#5523)"
+else
+    echo -e "  ${YELLOW}SKIP${NC}: spawn-claude.sh warning text check (file not found at $_spawn_claude_src)"
+fi
+
+DRIFT_SCRIPT="$SCRIPTS_DIR/check-safehouse-socket.sh"
+if [[ -x "$DRIFT_SCRIPT" ]]; then
+    _drift_fixtures="$(mktemp -d)"
+
+    # not configured
+    mkdir -p "$_drift_fixtures/disabled/.loom"
+    cat >"$_drift_fixtures/disabled/.loom/config.json" <<'JSON'
+{ "safehouse": { "enabled": false } }
+JSON
+
+    # enabled, no socket resolves at all -- the exact #5523 failure mode
+    mkdir -p "$_drift_fixtures/no-socket/.loom"
+    cat >"$_drift_fixtures/no-socket/.loom/config.json" <<'JSON'
+{ "safehouse": { "enabled": true } }
+JSON
+
+    # enabled, socket resolves AND is present on disk
+    mkdir -p "$_drift_fixtures/resolved/.loom"
+    cat >"$_drift_fixtures/resolved/.loom/config.json" <<JSON
+{ "safehouse": { "enabled": true, "socket": "$_drift_fixtures/resolved/sh.sock" } }
+JSON
+    : >"$_drift_fixtures/resolved/sh.sock"
+
+    # enabled, socket resolves but nothing is there
+    mkdir -p "$_drift_fixtures/missing-file/.loom"
+    cat >"$_drift_fixtures/missing-file/.loom/config.json" <<JSON
+{ "safehouse": { "enabled": true, "socket": "$_drift_fixtures/missing-file/nope.sock" } }
+JSON
+
+    # Isolate from any ambient safehouse env (a builder sweep session sets
+    # SAFEHOUSED_SOCKET/SAFEHOUSE_PERSONA for its own fleet-comms narration --
+    # #5523's own dev/test loop hit exactly this).
+    _drift_env=(env -u SAFEHOUSED_SOCKET -u SAFEHOUSE_PERSONA -u LOOM_SAFEHOUSE_SOCKET)
+
+    if $HAVE_JQ; then
+        # 13b. Explicit REPO_ROOT args, text mode: one exit code per drift class.
+        # NOTE: capture via `|| _rc=$?` (never a bare `|| true` + later `$?`,
+        # which would clobber `$?` back to 0) -- both to survive `set -e` on a
+        # deliberately-nonzero exit AND to record the real exit code.
+        _rc_disabled=0
+        _out_disabled="$("${_drift_env[@]}" "$DRIFT_SCRIPT" "$_drift_fixtures/disabled" 2>&1)" || _rc_disabled=$?
+        assert_contains "not configured" "$_out_disabled" \
+            "check-safehouse-socket.sh: disabled repo reports not configured"
+        assert_eq "0" "$_rc_disabled" "check-safehouse-socket.sh: disabled repo exits 0"
+
+        _rc_resolved=0
+        _out_resolved="$("${_drift_env[@]}" "$DRIFT_SCRIPT" "$_drift_fixtures/resolved" 2>&1)" || _rc_resolved=$?
+        assert_contains "OK (socket resolved" "$_out_resolved" \
+            "check-safehouse-socket.sh: resolved+present repo reports OK"
+        assert_eq "0" "$_rc_resolved" "check-safehouse-socket.sh: resolved+present repo exits 0"
+
+        _rc_no_socket=0
+        _out_no_socket="$("${_drift_env[@]}" "$DRIFT_SCRIPT" "$_drift_fixtures/no-socket" 2>&1)" || _rc_no_socket=$?
+        assert_contains "DRIFT" "$_out_no_socket" \
+            "check-safehouse-socket.sh: unresolved socket reports DRIFT (#5523's own failure mode)"
+        assert_eq "1" "$_rc_no_socket" \
+            "check-safehouse-socket.sh: unresolved socket exits 1 (non-zero = detectable without reading logs)"
+
+        _rc_missing_file=0
+        _out_missing_file="$("${_drift_env[@]}" "$DRIFT_SCRIPT" "$_drift_fixtures/missing-file" 2>&1)" || _rc_missing_file=$?
+        assert_contains "DRIFT" "$_out_missing_file" \
+            "check-safehouse-socket.sh: resolved-but-absent socket reports DRIFT"
+        assert_eq "1" "$_rc_missing_file" \
+            "check-safehouse-socket.sh: resolved-but-absent socket exits 1"
+
+        # 13c. Multiple REPO_ROOT args in one invocation: exit reflects the union.
+        _rc_multi=0
+        _out_multi="$("${_drift_env[@]}" "$DRIFT_SCRIPT" \
+            "$_drift_fixtures/disabled" "$_drift_fixtures/resolved" "$_drift_fixtures/no-socket" 2>&1)" || _rc_multi=$?
+        assert_contains "not configured" "$_out_multi" \
+            "check-safehouse-socket.sh: multi-repo run still reports the disabled repo"
+        assert_contains "OK (socket resolved" "$_out_multi" \
+            "check-safehouse-socket.sh: multi-repo run still reports the resolved repo"
+        assert_contains "DRIFT" "$_out_multi" \
+            "check-safehouse-socket.sh: multi-repo run still reports the drifted repo"
+        assert_eq "1" "$_rc_multi" \
+            "check-safehouse-socket.sh: one drifted repo among several still exits 1 (union, not majority)"
+
+        # 13d. --json mode emits a parseable array with the expected shape.
+        if command -v python3 >/dev/null 2>&1; then
+            _json_out="$("${_drift_env[@]}" "$DRIFT_SCRIPT" --json \
+                "$_drift_fixtures/disabled" "$_drift_fixtures/no-socket" "$_drift_fixtures/resolved" 2>/dev/null)" || true
+            _json_status_no_socket="$(printf '%s' "$_json_out" | python3 -c "
+import json, sys
+rows = json.load(sys.stdin)
+by_status = {r['status'] for r in rows}
+print('unreachable_no_socket' in by_status and 'not_configured' in by_status and 'resolved' in by_status)
+" 2>/dev/null || echo "PARSE_FAILED")"
+            assert_eq "True" "$_json_status_no_socket" \
+                "check-safehouse-socket.sh --json: emits a parseable array covering all three states"
+        else
+            echo -e "  ${YELLOW}SKIP${NC}: check-safehouse-socket.sh --json parse check (python3 not installed)"
+        fi
+    else
+        echo -e "  ${YELLOW}SKIP${NC}: check-safehouse-socket.sh fixture-repo tests (jq not installed)"
+    fi
+
+    # 13e. No REPO_ROOT args, no workspace registry, cwd outside any repo:
+    # a clean no-op (exit 0), never a false DRIFT.
+    _no_registry_out="$(cd /tmp && "${_drift_env[@]}" LOOM_WORKSPACES_PATH=/nonexistent-registry.json "$DRIFT_SCRIPT" 2>&1)"
+    _rc_no_registry=$?
+    assert_contains "nothing to check" "$_no_registry_out" \
+        "check-safehouse-socket.sh: no registry + no enclosing repo is a clean no-op"
+    assert_eq "0" "$_rc_no_registry" \
+        "check-safehouse-socket.sh: no registry + no enclosing repo exits 0 (never a false DRIFT)"
+
+    rm -rf "$_drift_fixtures"
+else
+    echo -e "  ${YELLOW}SKIP${NC}: check-safehouse-socket.sh tests (script not found or not executable at $DRIFT_SCRIPT)"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary

#5457 removed the only hardcoded `safehouse.socket` default (correctly — it had
been committed to the shared `.loom/config.json` and stranded a host 75
commits behind `git pull`), but nothing replaced it as a *check*:
`loom_mcp_safehouse_socket()` has always silently returned empty when nothing
resolves, and the only signal was a `log_warn` buried inside each sweep's own
per-role log. Every sweep on an affected host silently stopped narrating to
safehouse for 11 hours before a human noticed the public 2amlogic.com fleet
pulse had gone stale.

## AC bullet 1 — deliberately NOT implemented as literally worded

The curator's own analysis flagged that AC bullet 1 ("fall back to the
conventional path... before giving up") conflicts with `defaults/docs/safehouse.md`'s
explicit, documented decision that there is **no built-in default** — because
that is exactly the class of failure #5457 fixed (a *committed* default socket
path silently going stale via `git pull` on every other host). The curator
recommended option (b): drop the fallback-default idea and rely on making the
failure loud (AC bullet 2) + fleet-wide drift detection (AC bullet 4) instead.
I went with (b) — a code-level default would avoid #5457's exact mechanism
(it can't go stale via `git pull`), but it reintroduces the same underlying
risk in a different shape: "resolves to *something*" would quietly stop
meaning "actually reaches a live `safehoused`", which is precisely the kind of
silent gap that let this incident run 11 hours unnoticed. `defaults/docs/safehouse.md`
now has an explicit "Why there is still no built-in default, even after #5523"
paragraph documenting this reasoning in lockstep with the code.

## What changed

- **`defaults/scripts/spawn-claude.sh`** — the unresolved-socket warning now
  names the consequence ("no safehouse narration will be recorded... the
  2amlogic.com public fleet pulse is fed exclusively from safehouse
  narration") instead of only the mechanism ("skipping safehouse MCP
  injection"), and points at the new check below. Still a `log_warn`, never a
  failed spawn — the degradation contract (`safehouse.enabled: false` stays a
  byte-for-byte no-op; `enabled: true` never blocks a sweep) is unchanged and
  covered by existing tests.
- **New `defaults/scripts/check-safehouse-socket.sh`** — a standalone,
  on-demand, per-repo drift check with **no dependency on a daemon restart**
  (the pre-existing `loom-daemon-start.sh` static `Safehouse:` line only
  re-runs when the daemon itself restarts — exactly the case that let this
  incident run unnoticed on an already-running daemon). With no arguments it
  walks the machine-level workspace registry (`~/.loom/workspaces.json`, the
  same one `loom-daemon workspace add/list` manages); explicit repo-root args
  check a subset. `--json` emits a parseable array for scripting/cron. Exits
  `0` when every repo is either not-configured or resolved+present, `1` the
  moment any repo is enabled with an unreachable socket (unresolved, or
  resolved-but-nothing-there).
- **`defaults/scripts/lib/mcp-config.sh`** — no functional change to
  `loom_mcp_safehouse_socket()`; added a comment documenting the "deliberately
  no fallback default" decision so a future reader doesn't mistake this for an
  oversight.
- **`defaults/docs/safehouse.md`** — updated in lockstep: the new "Why there
  is still no built-in default, even after #5523" writeup, and a pointer to
  the new check under "Socket resolution" and the Implementation file list.
- **`defaults/scripts/tests/test-mcp-config.sh`** — new §13 covering the
  loudened warning text (static source assertions) and every
  `check-safehouse-socket.sh` state: not-configured, resolved, unresolved (no
  socket), unresolved (socket resolved but missing on disk), multi-repo runs,
  `--json` output, and the no-registry/no-cwd-repo no-op path.

## Out of scope (per curator)

Fleet re-provisioning (visiting every host to confirm it now resolves) is an
operational follow-up, not a code change, and not done as part of this PR.

## Test plan

- `./defaults/scripts/tests/test-mcp-config.sh` — 120/120 passing (was 101
  before this PR's new §13 additions).
- `./defaults/scripts/tests/test-loom-daemon-start.sh` — 112/112 passing
  (unaffected, confirms the pre-existing static `Safehouse:` check still
  works).
- `./defaults/scripts/tests/test-spawn-claude.sh` — 180/189 passing; the 9
  failures are pre-existing and unrelated (niceness/taskpolicy/CPU-budget
  tests, `#4233`/`#5111`), reproduced identically against `origin/main`'s
  unmodified `spawn-claude.sh` in this sandboxed nested-sweep environment
  before restoring my changes.
- `shellcheck` clean on all new/modified shell files.
- Manually exercised `check-safehouse-socket.sh` against fixture repos for
  every state (not-configured / resolved / unreachable-no-socket /
  unreachable-missing-file / no-registry) in both text and `--json` modes.

Closes #5523