### PR TITLE
fix(daemon): replace pgrep -f loom-daemon liveness checks with exact process-name matching

### DIFF
--- a/defaults/scripts/build-gate.sh
+++ b/defaults/scripts/build-gate.sh
@@ -34,6 +34,11 @@
 #   - bash scripts/test-migrate-consumer.sh (#5276) covers scripts/install/
 #     migrate-consumer.sh (Epic #3835 Phase 6) against throwaway git fixtures
 #     -- no network, no real daemon, sub-second.
+#   - bash scripts/test-daemon-liveness.sh (#5548) regression-tests
+#     scripts/stop-daemon.sh's and scripts/start-daemon.sh's daemon-liveness
+#     pgrep matcher against a decoy fixture literally named `loom-daemon` --
+#     no real daemon build, PATH-stubs `pgrep` for the one case that would
+#     otherwise touch the live process table, sub-second.
 #   - mcp-loom (TypeScript) is intentionally EXCLUDED: it needs npm install/ci
 #     in a fresh worktree (no guaranteed warm node_modules), which adds
 #     unpredictable latency to a gate that also runs once per PR. CI still
@@ -163,6 +168,9 @@ bash scripts/test-installer.sh
 
 echo "[build-gate] bash changelog generator suite"
 bash scripts/test-changelog.sh
+
+echo "[build-gate] bash daemon-liveness pgrep suite (#5548)"
+bash scripts/test-daemon-liveness.sh
 
 echo "[build-gate] bash install --local/--gitignore mode suite"
 bash scripts/test-install-local-mode.sh

--- a/defaults/scripts/cli/loom-daemon-stop.sh
+++ b/defaults/scripts/cli/loom-daemon-stop.sh
@@ -404,6 +404,15 @@ if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
     # label-blind kill would violate that scoping and contradict the #4054
     # label-scoped-stop discipline. With the default label we keep the fallback
     # as a genuine lost-PID-file recovery path.
+    # #5548 cross-reference: this tier's `pgrep -f` is still forgeable by a
+    # leaked test fixture whose path literally ends in `/loom-daemon` (the
+    # exact shape #5548 hit) -- the `(^|/)...$` anchor narrows it versus a
+    # bare substring match, but does not close that gap. No code change here:
+    # this is the intentionally-last-resort tier, already gated behind the
+    # default-label check above and already covered by a decoy regression
+    # test (test-loom-daemon-update.sh's suite-level decoy, #4078). #5548's
+    # actual fixes are in scripts/stop-daemon.sh, scripts/start-daemon.sh, and
+    # the renamed `loom-daemon-mock` test fixtures elsewhere in this repo.
     if [[ "$LAUNCHD_LABEL" == "$DEFAULT_LAUNCHD_LABEL" ]] && command -v pgrep >/dev/null 2>&1; then
         pid=$(pgrep -f '(^|/)loom-daemon$' 2>/dev/null | head -n1 || true)
     fi

--- a/defaults/scripts/tests/ci-excluded.txt
+++ b/defaults/scripts/tests/ci-excluded.txt
@@ -23,3 +23,4 @@ scripts/test-changelog.sh  Already wired directly in build-gate.sh (bash scripts
 scripts/test-install-local-mode.sh  Already wired directly in ci.yml's "Installer local/gitignore mode" step and build-gate.sh; excluded here to avoid double-running it.
 scripts/test-installer.sh  Already wired directly in ci.yml's "Installer Integration Tests" job and build-gate.sh; excluded here to avoid double-running it.
 scripts/test-migrate-consumer.sh  Already wired directly in ci.yml's "migrate-consumer" step and build-gate.sh; excluded here to avoid double-running it.
+scripts/test-daemon-liveness.sh  Already wired directly in build-gate.sh (bash scripts/test-daemon-liveness.sh, #5548); excluded here to avoid double-running it.

--- a/defaults/scripts/tests/test-check-duplicate.sh
+++ b/defaults/scripts/tests/test-check-duplicate.sh
@@ -100,7 +100,18 @@ trap 'rm -rf "$STUB_DIR" 2>/dev/null || true' EXIT
 # check-duplicate.sh's `loom-daemon --version` probe fails and it falls back
 # to the `gh` stub below (byte-for-byte the documented fallback path,
 # defaults/scripts/check-duplicate.sh). Keeps this test independent of
-# whether a real loom-daemon happens to be installed on the host. ---
+# whether a real loom-daemon happens to be installed on the host.
+#
+# NOT renamed per #5548's "test fixtures should not be named `loom-daemon`"
+# fix, unlike the fixtures in test-loom-status.sh / test-gh-cached.sh /
+# test-loom-daemon-watchdog.sh: check-duplicate.sh resolves this binary via a
+# bare `command -v loom-daemon` PATH lookup with no LOOM_DAEMON_BIN-style
+# override, so the literal name is load-bearing here -- renaming it would
+# stop check-duplicate.sh from finding it at all, defeating the test. This
+# poses no #5548-shaped liveness-check risk in practice: the stub is invoked
+# synchronously (`exit 1`, no backgrounding, no loop), so even a leaked copy
+# left on disk after a failed trap can never appear as a running process for
+# a `pgrep`-style liveness check to match. ---
 cat > "$STUB_DIR/loom-daemon" <<'STUB'
 #!/usr/bin/env bash
 exit 1

--- a/defaults/scripts/tests/test-gh-cached.sh
+++ b/defaults/scripts/tests/test-gh-cached.sh
@@ -281,7 +281,14 @@ FAKE_DAEMON_DIR="$TMP_ROOT/daemon"
 mkdir -p "$FAKE_DAEMON_DIR"
 # A fake loom-daemon: `forge <e> list --cached` with --json succeeds and emits a
 # sentinel; any shape without --json exits 3 (decline), mirroring the real one.
-cat > "$FAKE_DAEMON_DIR/loom-daemon" <<'FAKE'
+#
+# Named `loom-daemon-mock`, NOT `loom-daemon` (#5548): gh-cached's
+# locate_loom_daemon() checks $LOOM_DAEMON_BIN (set explicitly below) BEFORE
+# falling back to a bare `which("loom-daemon")` PATH lookup, so this fixture
+# never needs the literal name to be resolved. A distinct name means a leaked
+# fixture can never forge a production `pgrep -f loom-daemon`-style liveness
+# check the way the incident describes.
+cat > "$FAKE_DAEMON_DIR/loom-daemon-mock" <<'FAKE'
 #!/usr/bin/env bash
 if [[ "$1" == "forge" && "$3" == "list" ]]; then
     if printf '%s\n' "$@" | grep -q -- '--json'; then
@@ -292,13 +299,16 @@ if [[ "$1" == "forge" && "$3" == "list" ]]; then
 fi
 exit 3
 FAKE
-chmod +x "$FAKE_DAEMON_DIR/loom-daemon"
+chmod +x "$FAKE_DAEMON_DIR/loom-daemon-mock"
 
-# Runner with the fake daemon on PATH and the ETag layer ENABLED.
+# Runner with the fake daemon pinned via LOOM_DAEMON_BIN and the ETag layer
+# ENABLED. FAKE_DAEMON_DIR is still added to PATH as a belt-and-suspenders
+# safety net for any code path that falls through to a PATH search, but
+# LOOM_DAEMON_BIN is what locate_loom_daemon() actually resolves first.
 ghc_etag() {
     PATH="$STUB_DIR:$FAKE_DAEMON_DIR:$PATH" \
     GH_CACHE_DIR="$CACHE_DIR" \
-    LOOM_DAEMON_BIN="$FAKE_DAEMON_DIR/loom-daemon" \
+    LOOM_DAEMON_BIN="$FAKE_DAEMON_DIR/loom-daemon-mock" \
       "$GH_CACHED" "$@"
 }
 

--- a/defaults/scripts/tests/test-loom-daemon-update.sh
+++ b/defaults/scripts/tests/test-loom-daemon-update.sh
@@ -1009,6 +1009,16 @@ export LOOM_PROVISION_ALLOW_SCRIPT=1
 # any test regresses into one, this decoy dies and the final assertion fails.
 # Spawned OUTSIDE $BASE_WORKDIR's path so the trap's `pkill -f "$BASE_WORKDIR"`
 # does not sweep it; killed explicitly below.
+#
+# Deliberately NOT renamed per #5548's "test fixtures should not be named
+# `loom-daemon`" fix: the whole point of this fixture is to BE a process
+# named `loom-daemon` so the label-blind pgrep tier it decoys has something
+# to (not) match -- renaming it would defeat the test. It is tracked via
+# bg_proc_track/bg_proc_reap (EXIT/INT/TERM traps) like every other
+# background fixture in this suite, so it does not additionally widen
+# #5548's "orphaned past all cleanup" risk beyond what SIGKILL of the test
+# runner already allows for any tracked fixture (a hard, documented
+# bash/POSIX limit -- see lib/bg-proc-trap.sh).
 DECOY_DIR="$(mktemp -d)"
 cat > "$DECOY_DIR/loom-daemon" <<'EOF'
 #!/usr/bin/env bash

--- a/defaults/scripts/tests/test-loom-daemon-watchdog.sh
+++ b/defaults/scripts/tests/test-loom-daemon-watchdog.sh
@@ -188,7 +188,13 @@ EOF
 # The watchdog shells out to the resolved `loom-daemon` binary for its bounded
 # in-band probe, so the probe is driven entirely by a stub binary pinned via
 # LOOM_DAEMON_BIN — no real daemon, no real socket, no `timeout` dependency on
-# the outcome. Each mode reproduces one shape the classifier must handle:
+# the outcome. The stub is named `loom-daemon-mock`, NOT `loom-daemon` (#5548):
+# it is resolved solely via LOOM_DAEMON_BIN (never a PATH lookup by name), and
+# the `hang` mode below backgrounds an infinite loop that is the exact process
+# shape (`bash <path ending in loom-daemon>`, orphaned) a leaked #5548-style
+# fixture takes — a distinct name means a leak of this fixture, past this
+# suite's traps, could never forge a production `pgrep -f loom-daemon`-style
+# liveness check. Each mode reproduces one shape the classifier must handle:
 #
 #   ok          successful IPC round-trip (exit 0)
 #   slow-ok     eventually-responsive round-trip (the #4279 under-load case):
@@ -204,20 +210,20 @@ make_daemon_stub() { # <mode> [sleep_secs]
     dir="$(mktemp -d)"
     case "$mode" in
         ok)
-            printf '#!/usr/bin/env bash\necho "no active quarantines"\nexit 0\n' > "$dir/loom-daemon" ;;
+            printf '#!/usr/bin/env bash\necho "no active quarantines"\nexit 0\n' > "$dir/loom-daemon-mock" ;;
         slow-ok)
-            printf '#!/usr/bin/env bash\nsleep %s\necho "no active quarantines"\nexit 0\n' "$secs" > "$dir/loom-daemon" ;;
+            printf '#!/usr/bin/env bash\nsleep %s\necho "no active quarantines"\nexit 0\n' "$secs" > "$dir/loom-daemon-mock" ;;
         hang)
-            printf '#!/usr/bin/env bash\nwhile true; do sleep 1; done\n' > "$dir/loom-daemon" ;;
+            printf '#!/usr/bin/env bash\nwhile true; do sleep 1; done\n' > "$dir/loom-daemon-mock" ;;
         unreachable)
-            printf '#!/usr/bin/env bash\necho "Could not reach loom-daemon at /tmp/x.sock: round-trip timed out after 5s" >&2\nexit 1\n' > "$dir/loom-daemon" ;;
+            printf '#!/usr/bin/env bash\necho "Could not reach loom-daemon at /tmp/x.sock: round-trip timed out after 5s" >&2\nexit 1\n' > "$dir/loom-daemon-mock" ;;
         usage)
-            printf '#!/usr/bin/env bash\necho "error: unrecognized subcommand" >&2\nexit 2\n' > "$dir/loom-daemon" ;;
+            printf '#!/usr/bin/env bash\necho "error: unrecognized subcommand" >&2\nexit 2\n' > "$dir/loom-daemon-mock" ;;
         daemon-err)
-            printf '#!/usr/bin/env bash\necho "Daemon error: workspace not registered" >&2\nexit 1\n' > "$dir/loom-daemon" ;;
+            printf '#!/usr/bin/env bash\necho "Daemon error: workspace not registered" >&2\nexit 1\n' > "$dir/loom-daemon-mock" ;;
         *) echo "unknown stub mode $mode" >&2; return 1 ;;
     esac
-    chmod +x "$dir/loom-daemon"
+    chmod +x "$dir/loom-daemon-mock"
     echo "$dir"
 }
 
@@ -738,7 +744,7 @@ fi
 STUB12="$(make_daemon_stub ok)"
 start_alive_and_fresh 12
 run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
-    LOOM_DAEMON_BIN="$STUB12/loom-daemon"
+    LOOM_DAEMON_BIN="$STUB12/loom-daemon-mock"
 kill "$LIVE_PID" 2>/dev/null || true
 assert_rc 0 "$RC" "probe succeeds: exits 0 (healthy, unchanged behavior)"
 if log_has DIVERGENCE; then
@@ -763,7 +769,7 @@ STUB13="$(make_daemon_stub hang)"
 start_alive_and_fresh 13
 t0=$(date +%s)
 run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
-    LOOM_DAEMON_BIN="$STUB13/loom-daemon" \
+    LOOM_DAEMON_BIN="$STUB13/loom-daemon-mock" \
     LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=2 \
     LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=3
 elapsed=$(( $(date +%s) - t0 ))
@@ -797,7 +803,7 @@ rm -rf "$PS_STUB_DIR" "$STUB13"
 STUB14="$(make_daemon_stub hang)"
 start_alive_and_fresh 14
 probe_env=(PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1
-    LOOM_DAEMON_BIN="$STUB14/loom-daemon"
+    LOOM_DAEMON_BIN="$STUB14/loom-daemon-mock"
     LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=2
     LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=2)
 run_watchdog "${probe_env[@]}"            # tick 1 -> failure 1 of 2
@@ -835,7 +841,7 @@ start_alive_and_fresh 15
 rm -rf "$PS_STUB_DIR"
 PS_STUB_DIR="$(make_ps_stub "00:00:10")"   # 10s old ⇒ inside the 90s default grace
 run_watchdog_verbose PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
-    LOOM_DAEMON_BIN="$STUB15/loom-daemon" \
+    LOOM_DAEMON_BIN="$STUB15/loom-daemon-mock" \
     LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=2 \
     LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=2
 kill "$LIVE_PID" 2>/dev/null || true
@@ -898,7 +904,7 @@ rm -rf "$STUB16_PS"
 STUB17="$(make_daemon_stub slow-ok 2)"
 start_alive_and_fresh 17
 run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
-    LOOM_DAEMON_BIN="$STUB17/loom-daemon" \
+    LOOM_DAEMON_BIN="$STUB17/loom-daemon-mock" \
     LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=15
 kill "$LIVE_PID" 2>/dev/null || true
 assert_rc 0 "$RC" "slow-but-responsive probe (2s < 15s budget): exits 0, not flagged as hung"
@@ -917,7 +923,7 @@ rm -rf "$PS_STUB_DIR" "$STUB17"
 STUB18="$(make_daemon_stub daemon-err)"
 start_alive_and_fresh 18
 run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
-    LOOM_DAEMON_BIN="$STUB18/loom-daemon" LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=1
+    LOOM_DAEMON_BIN="$STUB18/loom-daemon-mock" LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=1
 kill "$LIVE_PID" 2>/dev/null || true
 assert_rc 0 "$RC" "daemon answered with an application error: exits 0 (IPC demonstrably works)"
 if log_has DIVERGENCE; then
@@ -930,7 +936,7 @@ rm -rf "$PS_STUB_DIR" "$STUB18"
 STUB18B="$(make_daemon_stub usage)"
 start_alive_and_fresh 18b
 run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
-    LOOM_DAEMON_BIN="$STUB18B/loom-daemon" LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=1
+    LOOM_DAEMON_BIN="$STUB18B/loom-daemon-mock" LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=1
 kill "$LIVE_PID" 2>/dev/null || true
 assert_rc 0 "$RC" "probe subcommand unsupported by this build: exits 0 (graceful degrade)"
 if log_has DIVERGENCE; then
@@ -951,7 +957,7 @@ STUB19="$(make_daemon_stub ok)"
 start_alive_and_fresh 19
 printf '%s 5\n' "$LIVE_PID" > "$PROBE_STATE"
 run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
-    LOOM_DAEMON_BIN="$STUB19/loom-daemon"
+    LOOM_DAEMON_BIN="$STUB19/loom-daemon-mock"
 kill "$LIVE_PID" 2>/dev/null || true
 assert_rc 0 "$RC" "successful probe after a streak: exits 0"
 if [[ -f "$PROBE_STATE" ]]; then
@@ -965,7 +971,7 @@ STUB19B="$(make_daemon_stub unreachable)"
 start_alive_and_fresh 19b
 printf '999999 9\n' > "$PROBE_STATE"    # a streak owned by a DIFFERENT (dead) pid
 run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
-    LOOM_DAEMON_BIN="$STUB19B/loom-daemon" LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=2
+    LOOM_DAEMON_BIN="$STUB19B/loom-daemon-mock" LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=2
 kill "$LIVE_PID" 2>/dev/null || true
 assert_rc 1 "$RC" "failed probe after a relaunch: exits 1 (reported)"
 if log_hasi 'consecutive failure 1 of 2'; then
@@ -988,7 +994,7 @@ STUB20="$(make_daemon_stub hang)"
 start_alive_and_fresh 20
 t0=$(date +%s)
 run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=0 \
-    LOOM_DAEMON_BIN="$STUB20/loom-daemon" \
+    LOOM_DAEMON_BIN="$STUB20/loom-daemon-mock" \
     LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=2
 elapsed=$(( $(date +%s) - t0 ))
 kill "$LIVE_PID" 2>/dev/null || true
@@ -1012,7 +1018,7 @@ start_alive_and_fresh 21
 t0=$(date +%s)
 run_watchdog PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
     LOOM_FORCE_PORTABLE_TIMEOUT=1 \
-    LOOM_DAEMON_BIN="$STUB21/loom-daemon" \
+    LOOM_DAEMON_BIN="$STUB21/loom-daemon-mock" \
     LOOM_WATCHDOG_STATUS_PROBE_TIMEOUT_SECS=2 \
     LOOM_WATCHDOG_IPC_PROBE_FAIL_THRESHOLD=3
 elapsed=$(( $(date +%s) - t0 ))
@@ -1043,7 +1049,7 @@ mv "$BOUNDED_RUN_LIB" "$BOUNDED_RUN_LIB_BAK"
 STUB22="$(make_daemon_stub unreachable)"
 start_alive_and_fresh 22
 run_watchdog_verbose PATH="$PS_STUB_DIR:$PATH" LOOM_WATCHDOG_IPC_PROBE=1 \
-    LOOM_DAEMON_BIN="$STUB22/loom-daemon"
+    LOOM_DAEMON_BIN="$STUB22/loom-daemon-mock"
 kill "$LIVE_PID" 2>/dev/null || true
 mv "$BOUNDED_RUN_LIB_BAK" "$BOUNDED_RUN_LIB"
 assert_rc 0 "$RC" "missing lib/bounded-run.sh: degrades to a skip, not a hard failure (exit 0)"
@@ -1078,7 +1084,7 @@ rm -f "$WORKDIR/pid23"
 write_marker "$WORKDIR/pid23" 60            # marker names a pid file that does not exist
 printf '%s pid=x ts=now\n' "$(date +%s)" > "$HEARTBEAT"
 : > "$WDLOG"
-run_watchdog_verbose LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB23/loom-daemon"
+run_watchdog_verbose LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB23/loom-daemon-mock"
 assert_rc 0 "$RC" "#5118 pid file ABSENT but socket answers: exits 0 (healthy via the IPC round-trip)"
 if log_has DIVERGENCE; then
     fail "#5118 pid file absent + socket answers: reported a DIVERGENCE ($(cat "$WDLOG"))"
@@ -1101,7 +1107,7 @@ echo "$dead24" > "$WORKDIR/pid24"
 write_marker "$WORKDIR/pid24" 60
 printf '%s pid=x ts=now\n' "$(date +%s)" > "$HEARTBEAT"
 : > "$WDLOG"
-run_watchdog_verbose LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB24/loom-daemon"
+run_watchdog_verbose LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB24/loom-daemon-mock"
 assert_rc 0 "$RC" "#5118 STALE pid file (dead pid) but socket answers: exits 0 (healthy)"
 if log_has DIVERGENCE; then
     fail "#5118 stale pid file + socket answers: reported a DIVERGENCE ($(cat "$WDLOG"))"
@@ -1116,7 +1122,7 @@ STUB25="$(make_daemon_stub unreachable)"
 rm -f "$WORKDIR/pid25"
 write_marker "$WORKDIR/pid25" 60
 : > "$WDLOG"
-run_watchdog LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB25/loom-daemon"
+run_watchdog LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB25/loom-daemon-mock"
 assert_rc 1 "$RC" "#5118 daemon genuinely down (socket unreachable): exits 1 on the FIRST tick"
 if log_has DIVERGENCE && log_hasi 'in-band probe confirms it'; then
     pass "#5118 daemon down: DIVERGENCE cites BOTH the out-of-band and in-band signals"
@@ -1200,7 +1206,7 @@ EOF
     env PATH="$STUB28:$PATH" LOOM_PID_FILE= LOOM_WORKSPACE= LOOM_MACHINE_CHECKOUT= \
         LOOM_SOCKET_PATH="$WORKDIR/loom-daemon.sock" \
         LOOM_AUTONOMY_MARKER="$MARKER" LOOM_WATCHDOG_LOG="$WDLOG" \
-        LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB28D/loom-daemon" \
+        LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$STUB28D/loom-daemon-mock" \
         bash "$WATCHDOG" > "$OUT" 2>&1
     rc28=$?
     assert_rc 1 "$rc28" "#5118 supervisor down + socket answers: exits 1 (state mismatch)"
@@ -1295,7 +1301,7 @@ start_confirmed_down() { # <pid_file_suffix>
 recover_env() { # <recover-cmd> [extra KEY=VAL...]
     local cmd="$1"; shift
     echo LOOM_WATCHDOG_IPC_PROBE=1 \
-         LOOM_DAEMON_BIN="$DOWN_STUB/loom-daemon" \
+         LOOM_DAEMON_BIN="$DOWN_STUB/loom-daemon-mock" \
          LOOM_WATCHDOG_AUTO_RECOVER=1 \
          LOOM_WATCHDOG_RECOVER_CMD="$cmd" \
          LOOM_WATCHDOG_KICKSTART_RECHECK_ATTEMPTS=1 \
@@ -1596,7 +1602,7 @@ rm -rf "$(dirname "$REC35")"
 #          "self-healing host". This is the report-only half of the AC.
 start_confirmed_down 36
 : > "$WDLOG"
-run_watchdog LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$DOWN_STUB/loom-daemon" \
+run_watchdog LOOM_WATCHDOG_IPC_PROBE=1 LOOM_DAEMON_BIN="$DOWN_STUB/loom-daemon-mock" \
     LOOM_WATCHDOG_AUTO_RECOVER=0
 assert_rc 1 "$RC" "#5391 recovery disabled: still reports the outage (exit 1)"
 if log_hasi 'REPORT-ONLY' && log_hasi 'DETECTION, not self-healing'; then

--- a/defaults/scripts/tests/test-loom-status.sh
+++ b/defaults/scripts/tests/test-loom-status.sh
@@ -100,15 +100,24 @@ FAKEGH
 chmod +x "$FAKE_BIN/gh"
 
 # ---- Fake `loom-daemon` stub factory -------------------------------------------
-# Writes a `loom-daemon` binary at $WORKDIR/daemon-<mode>/loom-daemon that
-# answers `status --json` per the named scenario. Echoes the stub's path.
+# Writes a stub binary at $WORKDIR/daemon-<mode>/loom-daemon-mock that answers
+# `status --json` per the named scenario. Echoes the stub's path.
+#
+# Named `loom-daemon-mock`, NOT `loom-daemon` (#5548): this stub is invoked
+# solely via its full path (pinned into LOOM_DAEMON_BIN below, never looked
+# up by name on PATH), so the name has no bearing on what loom-status.sh
+# resolves. A fixture literally named `loom-daemon` that leaked past this
+# suite's cleanup would be indistinguishable, to a production `pgrep -f
+# loom-daemon`-style liveness check, from the real daemon -- exactly the
+# failure mode #5548 describes. A distinct name means a leak can never forge
+# that check.
 make_daemon_stub() { # <mode>
     local mode="$1"
     local dir="$WORKDIR/daemon-$mode"
     mkdir -p "$dir"
     case "$mode" in
         managed)
-            cat > "$dir/loom-daemon" <<EOF
+            cat > "$dir/loom-daemon-mock" <<EOF
 #!/usr/bin/env bash
 if [[ "\$1" == "status" && "\$2" == "--json" ]]; then
   cat <<JSON
@@ -122,7 +131,7 @@ exit 1
 EOF
             ;;
         managed-halted)
-            cat > "$dir/loom-daemon" <<EOF
+            cat > "$dir/loom-daemon-mock" <<EOF
 #!/usr/bin/env bash
 if [[ "\$1" == "status" && "\$2" == "--json" ]]; then
   cat <<JSON
@@ -135,7 +144,7 @@ exit 1
 EOF
             ;;
         unmanaged)
-            cat > "$dir/loom-daemon" <<'EOF'
+            cat > "$dir/loom-daemon-mock" <<'EOF'
 #!/usr/bin/env bash
 if [[ "$1" == "status" && "$2" == "--json" ]]; then
   echo '{"per_repo":[{"root":"/some/other/repo","priority":100,"in_flight_count":0,"health_gate_halted":false}],"role_tick_records":[],"work_finder_enabled":true}'
@@ -145,7 +154,7 @@ exit 1
 EOF
             ;;
         unreachable)
-            cat > "$dir/loom-daemon" <<'EOF'
+            cat > "$dir/loom-daemon-mock" <<'EOF'
 #!/usr/bin/env bash
 if [[ "$1" == "status" && "$2" == "--json" ]]; then
   echo '{"error":"could not reach loom-daemon at /tmp/x.sock: connect failed","install_state":{"state":"ExpectedButDead","started_at":"2026-07-30T00:00:00Z","pid":null,"liveness_detail":"no live pid file"}}'
@@ -156,8 +165,8 @@ EOF
             ;;
         *) echo "unknown stub mode $mode" >&2; return 1 ;;
     esac
-    chmod +x "$dir/loom-daemon"
-    echo "$dir/loom-daemon"
+    chmod +x "$dir/loom-daemon-mock"
+    echo "$dir/loom-daemon-mock"
 }
 
 # Run loom-status.sh from $REPO with the given extra env assignments (as

--- a/scripts/start-daemon.sh
+++ b/scripts/start-daemon.sh
@@ -29,8 +29,19 @@ CARGO_PID=$!
 # Wait for the actual daemon process to spawn (cargo spawns it as a child)
 sleep 2
 
-# Find the actual loom-daemon process (not cargo)
-DAEMON_PID=$(pgrep -P "$CARGO_PID" -f "target/debug/loom-daemon" || pgrep -f "target/debug/loom-daemon" | head -1)
+# Find the actual loom-daemon process (not cargo). The first branch is
+# scoped to CARGO_PID's own children, so it cannot match an unrelated
+# process regardless of matcher. The bare fallback (used if `cargo run`
+# already reparented the daemon away from CARGO_PID by the time we look) used
+# to be `pgrep -f "target/debug/loom-daemon"` -- a full-command-line
+# substring match that any leaked test fixture path containing that string
+# would satisfy forever. `pgrep -x` matches the kernel-reported process
+# *name* (comm) exactly instead: a leaked bash script is invoked as `bash
+# /path/to/loom-daemon` and reports comm "bash", not "loom-daemon", so it can
+# never satisfy this check (#5548). The real compiled binary's comm is
+# "loom-daemon", so this narrowing does not change behavior for the real
+# target.
+DAEMON_PID=$(pgrep -P "$CARGO_PID" -f "target/debug/loom-daemon" || pgrep -x "loom-daemon" | head -1)
 
 if [ -z "$DAEMON_PID" ]; then
   echo "ERROR: Daemon process not found"

--- a/scripts/stop-daemon.sh
+++ b/scripts/stop-daemon.sh
@@ -8,8 +8,17 @@ DAEMON_PID_FILE=".loom/.daemon.pid"
 if [ ! -f "$DAEMON_PID_FILE" ]; then
   echo "No daemon PID file found"
 
-  # Try to find daemon process anyway
-  DAEMON_PID=$(pgrep -f "loom-daemon" | head -1 || true)
+  # Try to find daemon process anyway. `pgrep -x` matches the kernel-reported
+  # process *name* (argv[0]/comm) exactly -- NOT `pgrep -f`, which substring-
+  # matches the full command line of every process on the box. A leaked test
+  # fixture (a bash script literally named `loom-daemon`, e.g. under
+  # $TMPDIR) is invoked as `bash /path/to/loom-daemon`; its comm is "bash",
+  # so `-x "loom-daemon"` will never match it, while `-f "loom-daemon"` would
+  # match it forever, making a dead daemon look alive (#5548 -- a leaked
+  # fixture kept a real daemon looking healthy for 66 minutes on this exact
+  # shape). The real, compiled `loom-daemon` binary's comm IS "loom-daemon",
+  # so this narrowing does not change behavior for the real target.
+  DAEMON_PID=$(pgrep -x "loom-daemon" | head -1 || true)
   if [ -n "$DAEMON_PID" ]; then
     echo "Found daemon process (PID: $DAEMON_PID)"
     kill "$DAEMON_PID" || true

--- a/scripts/test-daemon-liveness.sh
+++ b/scripts/test-daemon-liveness.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# test-daemon-liveness.sh — regression test for #5548 ("pgrep -f loom-daemon
+# is not a liveness check — leaked test fixtures named loom-daemon kept a
+# dead daemon looking healthy for 66 minutes").
+#
+# Reproduces the incident's exact shape: a bash script literally named
+# `loom-daemon`, running as `bash /path/to/loom-daemon`. `pgrep -f` matches
+# it forever (a full-command-line substring match); `pgrep -x` never does
+# (its kernel-reported process *name*/comm is "bash", not "loom-daemon" —
+# only the real, compiled binary's comm is "loom-daemon"). This asserts
+# scripts/stop-daemon.sh and scripts/start-daemon.sh use the narrower `-x`
+# matcher and that a leaked decoy fixture cannot be mistaken for the real
+# daemon.
+#
+# SAFETY: this host may be running a REAL loom-daemon (e.g. the operator's
+# production daemon, comm exactly "loom-daemon" — verified present on the
+# box this suite was authored on). Test 3 below therefore NEVER lets
+# scripts/stop-daemon.sh's own `pgrep` call reach the live process table —
+# it shadows `pgrep` on PATH with a stub that only knows about this test's
+# scratch decoy, so the exercised kill-or-not decision is real but can never
+# touch a process this test does not own. Tests 1/2 use the real `pgrep`
+# read-only (never `kill`), and assert only on the presence/absence of this
+# suite's own DECOY_PID in the output — never "no match at all" — so they
+# stay correct even on a host with its own real loom-daemon already running.
+#
+# Usage: bash scripts/test-daemon-liveness.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STOP_SCRIPT="$REPO_ROOT/scripts/stop-daemon.sh"
+START_SCRIPT="$REPO_ROOT/scripts/start-daemon.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+passed=0
+failed=0
+pass() { echo -e "${GREEN}✓${NC} $1"; passed=$((passed + 1)); }
+fail() { echo -e "${RED}✗${NC} $1"; failed=$((failed + 1)); }
+
+if ! command -v pgrep >/dev/null 2>&1; then
+    echo "pgrep not found on PATH -- skipping (this suite tests pgrep-based liveness checks)"
+    exit 0
+fi
+
+WORKDIR="$(mktemp -d)"
+DECOY_PID=""
+cleanup() {
+    [[ -n "$DECOY_PID" ]] && kill "$DECOY_PID" 2>/dev/null
+    rm -rf "$WORKDIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+trap 'cleanup; exit 1' INT TERM
+
+# The exact incident shape (#5548): a bash script literally named
+# `loom-daemon`, backgrounded. We do not need to orphan it (re-parent to
+# PID 1) to reproduce the bug -- pgrep matches on process attributes
+# (name/cmdline), not parentage; the incident's "orphaned 2 days" detail
+# just explains why it was still around to be matched, not why it matched.
+DECOY_DIR="$WORKDIR/decoy"
+mkdir -p "$DECOY_DIR"
+cat > "$DECOY_DIR/loom-daemon" <<'EOF'
+#!/usr/bin/env bash
+while true; do sleep 1; done
+EOF
+chmod +x "$DECOY_DIR/loom-daemon"
+"$DECOY_DIR/loom-daemon" >/dev/null 2>&1 &
+DECOY_PID=$!
+# Give the decoy a moment to actually be running before probing for it.
+for _ in $(seq 1 20); do
+    kill -0 "$DECOY_PID" 2>/dev/null && break
+    sleep 0.1
+done
+
+echo "Test 1: a leaked fixture literally named 'loom-daemon' does not satisfy pgrep -x"
+match_pids="$(pgrep -x "loom-daemon" 2>/dev/null || true)"
+if printf '%s\n' "$match_pids" | grep -qx "$DECOY_PID"; then
+    fail "pgrep -x 'loom-daemon' matched the bash-script decoy PID $DECOY_PID (its comm should be 'bash', not 'loom-daemon')"
+else
+    pass "pgrep -x 'loom-daemon' does not match the decoy PID $DECOY_PID"
+fi
+
+echo "Test 2: the OLD (broken) pgrep -f WOULD have matched it (proves the decoy reproduces the incident)"
+match_pids_f="$(pgrep -f "loom-daemon" 2>/dev/null || true)"
+if printf '%s\n' "$match_pids_f" | grep -qx "$DECOY_PID"; then
+    pass "pgrep -f 'loom-daemon' (the pre-fix matcher) matches the decoy PID $DECOY_PID, confirming the bug shape is real"
+else
+    fail "pgrep -f 'loom-daemon' unexpectedly did NOT match the decoy -- test setup may be broken"
+fi
+
+echo "Test 3: scripts/stop-daemon.sh's no-PID-file fallback leaves the decoy alone (pgrep stubbed for safety -- see file header)"
+STUB_BIN_DIR="$WORKDIR/stubbin"
+mkdir -p "$STUB_BIN_DIR"
+# A pgrep stub scoped ONLY to this test's own decoy -- never touches the
+# live process table. Mirrors the real pgrep contract just enough for
+# stop-daemon.sh's call shape (`pgrep -x "loom-daemon" | head -1` and, for
+# comparison, `pgrep -f "loom-daemon"`): `-x` never matches (the decoy's
+# real comm is "bash"); `-f` matches the decoy's PID (proving the pre-fix
+# shape), consistent with Tests 1/2 above.
+cat > "$STUB_BIN_DIR/pgrep" <<STUBEOF
+#!/usr/bin/env bash
+if [[ "\$1" == "-x" && "\$2" == "loom-daemon" ]]; then
+    exit 1
+fi
+if [[ "\$1" == "-f" && "\$2" == "loom-daemon" ]]; then
+    echo "$DECOY_PID"
+    exit 0
+fi
+exit 1
+STUBEOF
+chmod +x "$STUB_BIN_DIR/pgrep"
+
+STOP_WORKDIR="$WORKDIR/stopcwd"
+mkdir -p "$STOP_WORKDIR/.loom"
+out="$(cd "$STOP_WORKDIR" && PATH="$STUB_BIN_DIR:$PATH" bash "$STOP_SCRIPT" 2>&1)"
+if printf '%s\n' "$out" | grep -q "Daemon not running"; then
+    pass "stop-daemon.sh (no PID file, decoy present) reports 'Daemon not running'"
+else
+    fail "stop-daemon.sh did not report 'Daemon not running' (got: $out)"
+fi
+if kill -0 "$DECOY_PID" 2>/dev/null; then
+    pass "stop-daemon.sh left the decoy process alone"
+else
+    fail "stop-daemon.sh killed the decoy process -- the #5548 regression is back"
+fi
+
+echo "Test 4: scripts/start-daemon.sh's bare pgrep fallback resolves via -x (exact process-name match), not -f"
+if grep -q 'pgrep -x "loom-daemon" | head -1' "$START_SCRIPT"; then
+    pass "start-daemon.sh's bare fallback uses 'pgrep -x' (exact process-name match)"
+else
+    fail "start-daemon.sh's bare fallback no longer matches the expected 'pgrep -x' pattern -- check for regressions"
+fi
+
+echo ""
+echo "Results: $passed passed, $failed failed"
+[[ "$failed" -eq 0 ]]


### PR DESCRIPTION
## Summary

`pgrep -f loom-daemon` is a full-command-line substring match, not a liveness
check: any process whose command line contains the string `loom-daemon` —
including a leaked test fixture bash script literally named `loom-daemon`
under `$TMPDIR` — satisfies it forever. Per the incident in #5548, this kept
a real daemon looking healthy for 66 minutes after it actually died.

`pgrep -x` matches the kernel-reported process *name* (comm) exactly instead.
A fixture invoked as `bash /path/to/loom-daemon` reports comm `bash`, not
`loom-daemon`, so `-x "loom-daemon"` never matches it — while the real,
compiled `loom-daemon` binary's comm still is `loom-daemon`, so the
narrowing is behavior-preserving for the real target.

## Changes

- **`scripts/stop-daemon.sh`** — the unscoped `pgrep -f "loom-daemon"`
  no-PID-file fallback now uses `pgrep -x "loom-daemon"`.
- **`scripts/start-daemon.sh`** — the bare `pgrep -f "target/debug/loom-daemon"`
  fallback (used when `cargo run`'s child has already reparented away from
  `$CARGO_PID` by the time we look) now uses `pgrep -x "loom-daemon"`. The
  `pgrep -P "$CARGO_PID" -f ...` primary branch is unchanged — it's already
  scoped to `$CARGO_PID`'s own children and cannot match an unrelated
  process regardless of matcher.
- **Test fixture renames** (`loom-daemon` → `loom-daemon-mock`) in
  `test-loom-status.sh`, `test-gh-cached.sh`, and
  `test-loom-daemon-watchdog.sh` — all three resolve their mock daemon
  binary via `LOOM_DAEMON_BIN` (an explicit path), never a bare PATH-name
  lookup, so the rename is behavior-preserving. `test-loom-daemon-watchdog.sh`
  was not in the curator's original verified list (its stub uses
  `printf ... > file`, not `cat > file`, so the curator's grep missed it) but
  is arguably the closest match to the incident's actual process shape: its
  `hang` mode backgrounds an infinite `while true; do sleep 1; done` loop
  under the literal name `loom-daemon`.
- **`scripts/test-daemon-liveness.sh`** (new, wired into `build-gate.sh`) —
  spawns a decoy `loom-daemon` bash script and asserts the fixed matchers do
  not mistake it for the real daemon. Test 3 (which exercises
  `stop-daemon.sh`'s real kill-or-not decision) stubs `pgrep` on `PATH` so it
  can never reach the live process table — this dev host runs a real
  production `loom-daemon` (PID with comm exactly `loom-daemon`), so
  invoking the unstubbed script directly would have risked killing it.
- **`defaults/scripts/cli/loom-daemon-stop.sh`** — added a cross-reference
  comment (no code change) to its already-gated, already-narrowed
  `pgrep -f '(^|/)loom-daemon$'` last-resort tier, noting the residual
  #5548-shaped gap and pointing at where the actual fixes live.

## Scope items evaluated and deliberately left unchanged

- **`test-check-duplicate.sh`'s `loom-daemon` fixture** — NOT renamed.
  `check-duplicate.sh` resolves it via a bare `command -v loom-daemon` PATH
  lookup with no `LOOM_DAEMON_BIN`-style override, so the literal name is
  load-bearing; renaming it would break the test. It poses no #5548-shaped
  risk in practice since it's invoked synchronously (`exit 1`, never
  backgrounded) — even a leaked copy on disk can never appear as a running
  process for a `pgrep`-style check to match.
- **`test-loom-daemon-update.sh`'s `DECOY_DIR/loom-daemon` fixture** — NOT
  renamed, per the curator's own suggestion: it exists specifically to test
  `loom-daemon-stop.sh`'s label-blind pgrep fallback, so it must be named
  `loom-daemon` to have anything to (not) match. It's already reaped via
  `bg_proc_track`/`bg_proc_reap` (EXIT/INT/TERM traps).
- **AC #2's `pgrep -f safehoused` claim** — confirmed incorrect, matching
  the curator's scope correction. `loom-daemon/src/fleet/status.rs:344` uses
  `pgrep -x safehoused` (exact match, not `-f`) as a last-resort fallback
  *after* a socket check. Grepped the whole tree for `exec -a` (a fixture
  renaming its own process to fake a `comm` match) — no hits — so no fixture
  could forge this narrower check either. No code change made here.
- **`loom-daemon-stop.sh:408`'s gated `pgrep -f '(^|/)loom-daemon$'` tier** —
  left as a comment-only cross-reference. It's already gated behind a
  default-launchd-label check and already covered by
  `test-loom-daemon-update.sh`'s decoy regression test (#4078). It does have
  a residual gap (a leaked fixture whose full path ends in `/loom-daemon`
  still satisfies the anchored regex) but this repo's own #5131 analysis
  already treats it as an intentional, narrowly-scoped last resort — not an
  unaddressed instance of this bug.
- **Fixture cleanup/teardown hardening (AC #6)** — investigated but not
  refactored. `lib/bg-proc-trap.sh` (from #4773) already provides
  `bg_proc_track`/`bg_proc_reap` with EXIT/INT/TERM traps across the
  higher-risk suites (`test-loom-daemon-stop.sh`, `test-loom-daemon-update.sh`,
  `test-loom-daemon-watchdog.sh`) and already documents its own residual gap:
  a `SIGKILL` of the test runner (or a host crash/sleep) bypasses every trap,
  which is a hard bash/POSIX limitation, not a fixable code gap. That's the
  most plausible root cause of the incident's 3 long-orphaned processes. The
  fixture renames above are the actual mitigation for that residual case:
  even a fixture that survives every trap can no longer forge a production
  liveness check once it isn't named `loom-daemon`.
- **AC #5 (watchdog job liveness)** — per the curator's scope correction,
  `loom-daemon-watchdog.sh` already resolves liveness via `LOOM_PID_FILE` /
  `launchctl print` / the systemd unit, never `pgrep -f loom-daemon`.
  Confirmed via `grep -n pgrep defaults/scripts/cli/loom-daemon-watchdog.sh`
  (no hits). "Why did the watchdog job itself die" routes to the linked
  external issue (2AMLogic/2am#15), out of scope here.

## Test plan

- `bash scripts/test-daemon-liveness.sh` — new suite, 5/5 passing.
- `bash defaults/scripts/tests/test-loom-status.sh` — 49/49 passing.
- `bash defaults/scripts/tests/test-gh-cached.sh` — 33/33 passing.
- `bash defaults/scripts/tests/test-check-duplicate.sh` — 133/133 passing
  (unchanged, confirms the fixture-kept-as-is decision doesn't regress it).
- `bash defaults/scripts/tests/test-loom-daemon-watchdog.sh` — 114/114
  passing.
- `bash defaults/scripts/tests/test-loom-daemon-stop.sh` — 38/38 passing
  (unchanged, confirms the comment-only edit doesn't regress it).
- `bash defaults/scripts/tests/test-loom-daemon-update.sh` — 254/254 passing
  (unchanged, confirms the comment-only edit doesn't regress it).
- `bash defaults/scripts/tests/check-ci-suite-manifest.sh` — confirms the
  new suite is correctly excluded (wired directly in `build-gate.sh`
  instead) with no manifest violation.
- Manually confirmed no leaked `loom-daemon`/`loom-daemon-mock` processes
  survive any of the above runs (`pgrep -af`).

Closes #5548