### PR TITLE
fix(guide): close TOCTOU race in doc-maintenance Step 1 open-PR check

### DIFF
--- a/defaults/.claude/commands/loom/guide.md
+++ b/defaults/.claude/commands/loom/guide.md
@@ -1121,26 +1121,63 @@ These are idempotent across a fresh checkout: whatever is already in the
 committed WORK_LOG.md defines the watermark, so the same PR is never appended
 twice even though no gitignored state persists between cron ticks.
 
-### Step 1: Check for Existing Docs PR
+### Step 1: Acquire the Docs-Guide Lock, Then Check for an Existing Docs PR
 
-Before creating any changes, check if a previous docs PR is still open:
+**#5573 BUG, DO NOT REINTRODUCE:** this used to be a plain check-then-act — query
+for an open docs PR, and if none, proceed. Two Guide ticks starting within the
+same short window (a role-runner tick overlapping a manual `/loom:guide`
+session, or two role-runner ticks overlapping each other) could both see "no
+open PR" before either had pushed a branch, both call `docs-worktree.sh`
+(clobbering the shared worktree slot — see "Where This Phase Writes" above),
+and both end up creating their own docs PR (observed: #5571 and #5572, opened
+49 seconds apart with an identical diff shape). The check and the create were
+not atomic.
+
+The fix is a non-blocking mkdir-based lock (`docs-guide-lock.sh`) that must be
+held across the **entire** window from this check through Step 5's
+`gh pr create` — not just around the check itself:
 
 ```bash
+# Non-blocking: a busy lock means another tick is already mid-flight through
+# this same phase, so this tick skips outright rather than waiting (waiting
+# would just shift the identical race to a later timestamp, not close it).
+if ! ./.loom/scripts/docs-guide-lock.sh acquire; then
+  echo "Another Guide tick already holds the docs-guide lock. Skipping document maintenance this tick."
+  return
+fi
+
+# From this point on, EVERY exit path from the Document Maintenance phase —
+# every early `return` below, the end of Step 5 (create_docs_pr, both its
+# "no changes" and its success paths), and any error path — MUST call
+# `./.loom/scripts/docs-guide-lock.sh release` before ending the turn. There
+# is no shell `trap` that can cover this automatically: Steps 1-5 run as
+# separate Bash tool invocations (interleaved with Edit tool calls to write
+# the docs) within one Guide turn, not one continuous process. If a tick
+# crashes without releasing, the NEXT tick's `acquire` reaps the lock
+# automatically once it is older than LOOM_DOCS_GUIDE_LOCK_STALE_SECS
+# (default 1800s / 30 min) — see docs-guide-lock.sh's header comment for why
+# staleness is age-based rather than PID-liveness here.
+
 # Match on the branch-name PREFIX, not an exact head. Docs branches are named
 # `docs/guide-update-<timestamp>` (see Step 5), so `--head "docs/guide-update"`
 # (an exact-match filter) never matched and the "only one docs PR open" guard
 # never fired — PRs accumulated. `--search "head:docs/guide-update"` matches the
-# prefix.
+# prefix. This check runs INSIDE the lock now, but it is not redundant with
+# it: the lock closes the race between two CONCURRENT ticks, while this check
+# is what makes a docs PR left open from a PRIOR (non-racing) tick — whose
+# lock was already released once its `gh pr create` succeeded — still cause
+# the next tick to skip.
 OPEN_DOCS_PR=$("$GH_READ" pr list --state open --search "head:docs/guide-update" --json number --jq '.[0].number // empty')
 
 if [ -n "$OPEN_DOCS_PR" ]; then
   echo "Docs PR #$OPEN_DOCS_PR is still open. Skipping document maintenance."
   # Optionally: check if it's stale and comment
+  ./.loom/scripts/docs-guide-lock.sh release
   return
 fi
 ```
 
-If a docs PR is already open, **skip the entire document maintenance phase** to prevent PR accumulation.
+If a docs PR is already open, **skip the entire document maintenance phase** to prevent PR accumulation (and release the lock — there is nothing left for this tick to do).
 
 ### Step 2: Update WORK_LOG.md
 
@@ -1472,6 +1509,9 @@ create_docs_pr() {
   # Check if there are actual changes to commit
   if git -C "$DOCS_WT" diff --cached --quiet; then
     echo "No document changes to commit."
+    # Release the docs-guide lock (see Step 1) — nothing left for this tick
+    # to do, and a held lock would needlessly block the next one.
+    ./.loom/scripts/docs-guide-lock.sh release
     return
   fi
 
@@ -1506,6 +1546,12 @@ See issue #1784 for the feature specification.
 PRBODY
 )")
 
+  # Release the docs-guide lock (see Step 1) now that the PR exists. Step 1's
+  # open-docs-PR check — not this lock — is what prevents the NEXT tick from
+  # creating another one while this PR is still open; this lock's only job
+  # was to keep concurrent ticks from racing each other to this point.
+  ./.loom/scripts/docs-guide-lock.sh release
+
   # No side-car state to update — the committed WORK_LOG.md / WORK_PLAN.md carried
   # in this PR ARE the durable state the next tick reads back.
   #
@@ -1520,7 +1566,8 @@ The full document maintenance flow runs at the end of each triage cycle:
 
 ```
 Document Maintenance Phase
-  ├─ Check for open docs PR → skip if one exists
+  ├─ Acquire the docs-guide lock (non-blocking) → skip if another tick holds it
+  ├─ Check for open docs PR → skip (and release the lock) if one exists
   ├─ DOCS_WT=$(./.loom/scripts/docs-worktree.sh | tail -1)
   │    └─ managed worktree on docs/guide-update-<timestamp>; the ONLY place
   │       this phase may write (guards deny the main checkout)
@@ -1531,8 +1578,9 @@ Document Maintenance Phase
   ├─ If any changes:
   │    ├─ Commit all document changes (git -C "$DOCS_WT")
   │    ├─ Push and create PR with loom:review-requested
+  │    ├─ Release the docs-guide lock
   │    └─ (committed WORK_LOG.md / WORK_PLAN.md ARE the durable state)
-  └─ If no changes: skip (no PR created)
+  └─ If no changes: release the docs-guide lock, skip (no PR created)
 ```
 
 **Important constraints:**
@@ -1542,9 +1590,20 @@ Document Maintenance Phase
   denial by disabling a guard or switching write tool
 - The main checkout is never `git checkout`-ed onto another branch — concurrent
   sweeps and `check-main-clean.sh` assume it stays on the default branch
+- **The docs-guide lock (`docs-guide-lock.sh`) serializes concurrent ticks**
+  (#5573) — held from Step 1's acquire through Step 5's release, so two ticks
+  starting within the same short window can never both pass the open-PR check
+  and race each other into `docs-worktree.sh` / `gh pr create`. Non-blocking
+  (a busy tick just skips) and self-healing (a lock older than
+  `LOOM_DOCS_GUIDE_LOCK_STALE_SECS`, default 30 min, is reaped by the next
+  `acquire` — see the script's header comment for why staleness is age-based,
+  not PID-based, in this context)
 - Only one docs PR open at a time (prevents accumulation) — the open-PR check
   matches the `docs/guide-update` branch **prefix** (`head:` search), so it
-  catches the timestamped branches `docs-worktree.sh` creates
+  catches the timestamped branches `docs-worktree.sh` creates. This is
+  distinct from the lock above: the lock stops concurrent ticks from racing
+  each other, this check stops a later tick from piling a second PR onto a
+  still-open one from an earlier, non-racing tick
 - High-water marks are derived from the committed WORK_LOG.md itself (not a
   gitignored side-car that resets every fresh cron checkout), so they survive
   across ticks and prevent duplicate WORK_LOG entries

--- a/defaults/scripts/docs-guide-lock.sh
+++ b/defaults/scripts/docs-guide-lock.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Loom Docs Guide Lock - atomic guard around the Guide role's Document
+# Maintenance phase, from Step 1's open-docs-PR check through Step 5's
+# `gh pr create` (issue #5573).
+#
+# Usage:
+#   ./.loom/scripts/docs-guide-lock.sh acquire   # exit 0 = acquired, 1 = busy
+#   ./.loom/scripts/docs-guide-lock.sh release   # always exits 0 (idempotent)
+#   ./.loom/scripts/docs-guide-lock.sh status    # exit 0 = held (not stale), 1 = free
+#
+# Why this exists
+# ----------------
+# guide.md's Document Maintenance Step 1 used to be a plain check-then-act:
+# query for an open `docs/guide-update*` PR, and if none is open, proceed
+# through docs-worktree.sh (which resets a SINGLE shared worktree slot),
+# write the docs, and `gh pr create`. Two Guide ticks starting within the same
+# short window (a role-runner tick overlapping a manual `/loom:guide` session,
+# or two role-runner ticks overlapping each other) could both see "no open
+# PR" before either had pushed a branch, both call docs-worktree.sh (the
+# second clobbering the first's in-progress worktree state), and both end up
+# creating their own docs PR. This happened: #5571 and #5572, opened 49
+# seconds apart with an identical diff shape.
+#
+# This lock closes the gap: the phase acquires it BEFORE the open-PR check
+# and releases it only after `gh pr create` succeeds (or the phase decides
+# there is nothing to do). A second tick that arrives while the lock is held
+# fails to acquire and skips outright — it never reaches docs-worktree.sh or
+# `gh pr create`, so the race is structurally impossible, not just narrowed.
+#
+# Concurrency primitive: POSIX-atomic `mkdir` under
+# .loom/locks/docs-guide-lock/ — the same primitive worktree.sh's
+# worktree-add lock and lib/build-slot.sh use (`flock` is not available on
+# stock macOS, so `mkdir` is the only portable atomic filesystem op we can
+# rely on).
+#
+# Staleness is AGE-based only, deliberately NOT PID-liveness (unlike
+# worktree.sh's lock). worktree.sh's lock is held by one continuously running
+# `worktree.sh` process for the duration of a single `git worktree add`, so
+# checking whether that PID is still alive is a meaningful staleness signal.
+# This lock is different: the Guide's Document Maintenance phase is a role
+# PROMPT (defaults/.claude/commands/loom/guide.md) that an agent executes as a
+# sequence of separate Bash tool-call subprocesses (interleaved with Edit tool
+# calls to write the docs) across one turn — there is no single process alive
+# for the whole Step-1-through-Step-5 window. The PID recorded by the
+# `acquire` subcommand exits the instant that one command returns, long
+# before Step 5 runs, so a PID-liveness check would misclassify every
+# legitimate in-flight lock as stale within seconds. Age is the only signal
+# available here — the same tradeoff lib/build-slot.sh made for the same
+# reason (a build-gate stage is not one continuously running shell either).
+#
+# Crash recovery: if a tick dies mid-phase without releasing (agent crash,
+# host restart, cancelled sweep), the lock is reaped automatically the next
+# time `acquire` is attempted, once it is older than
+# LOOM_DOCS_GUIDE_LOCK_STALE_SECS (default 1800s / 30 min — generous headroom
+# over the phase's normal one-to-few-minute runtime, so a crashed tick can
+# never permanently block future ticks, and a live tick is never reaped out
+# from under itself).
+#
+# Exit codes:
+#   acquire: 0 = lock acquired, 1 = busy (another tick holds a live lock)
+#   release: always 0 (idempotent; safe to call even if never acquired)
+#   status:  0 = held and not stale, 1 = free (absent or stale)
+#   invalid usage: 2
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+print_error() { echo -e "${RED}ERROR: $1${NC}" >&2; }
+print_info() { echo -e "${BLUE}ℹ $1${NC}" >&2; }
+print_success() { echo -e "${GREEN}✓ $1${NC}" >&2; }
+
+show_help() {
+    cat <<'EOF'
+Loom Docs Guide Lock
+
+Usage: ./.loom/scripts/docs-guide-lock.sh <acquire|release|status>
+
+Atomic mkdir-based lock serializing the Guide role's Document Maintenance
+phase (Step 1's open-docs-PR check through Step 5's `gh pr create`) across
+concurrent Guide ticks. See the header comment in this file for the full
+rationale (issue #5573).
+
+Commands:
+  acquire   Non-blocking. Exit 0 if the lock was acquired, 1 if another tick
+            already holds a live (non-stale) lock.
+  release   Release the lock. Idempotent -- exit 0 even if not held.
+  status    Exit 0 if the lock is currently held and not stale, 1 otherwise.
+
+Tunables (env vars):
+  LOOM_DOCS_GUIDE_LOCK_STALE_SECS   Age in seconds after which a held lock is
+                                    treated as abandoned and reaped on the
+                                    next acquire attempt (default 1800 = 30m).
+EOF
+}
+
+CMD="${1:-}"
+if [[ "$CMD" == "--help" ]] || [[ "$CMD" == "-h" ]]; then
+    show_help
+    exit 0
+fi
+if [[ "$CMD" != "acquire" ]] && [[ "$CMD" != "release" ]] && [[ "$CMD" != "status" ]]; then
+    print_error "Unknown or missing command: '${CMD}'"
+    show_help >&2
+    exit 2
+fi
+
+LOOM_DOCS_GUIDE_LOCK_STALE_SECS="${LOOM_DOCS_GUIDE_LOCK_STALE_SECS:-1800}"
+if ! [[ "$LOOM_DOCS_GUIDE_LOCK_STALE_SECS" =~ ^[0-9]+$ ]]; then
+    print_error "LOOM_DOCS_GUIDE_LOCK_STALE_SECS must be a non-negative integer (got: '$LOOM_DOCS_GUIDE_LOCK_STALE_SECS')"
+    exit 2
+fi
+
+# Resolve the locks directory the same way worktree.sh's worktree-add lock
+# does: relative to the canonical git-common-dir, so the main workspace and
+# every worktree share the same lock namespace regardless of cwd.
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) || {
+    print_error "Not in a git repository"
+    exit 1
+}
+REPO_ROOT=$(cd "$(dirname "$GIT_COMMON_DIR")" && pwd -P)
+LOCKS_DIR="$REPO_ROOT/.loom/locks"
+LOCK_PATH="$LOCKS_DIR/docs-guide-lock"
+
+# Age of a path in whole seconds. An unreadable mtime echoes 0 (= "brand
+# new"), so a lock we cannot age is NEVER reaped -- the conservative
+# direction (mirrors lib/build-slot.sh's _loom_build_slot_age_secs).
+_lock_age_secs() {
+    local path="$1" mtime now
+    mtime="$(stat -c %Y "$path" 2>/dev/null || true)"
+    if [[ ! "$mtime" =~ ^[0-9]+$ ]]; then
+        mtime="$(stat -f %m "$path" 2>/dev/null || true)"
+    fi
+    [[ "$mtime" =~ ^[0-9]+$ ]] || { echo 0; return 0; }
+    now="$(date +%s)"
+    if (( now > mtime )); then echo $(( now - mtime )); else echo 0; fi
+}
+
+_lock_is_stale() {
+    [[ -d "$LOCK_PATH" ]] || return 1
+    (( $(_lock_age_secs "$LOCK_PATH") > LOOM_DOCS_GUIDE_LOCK_STALE_SECS ))
+}
+
+case "$CMD" in
+    acquire)
+        mkdir -p "$LOCKS_DIR" 2>/dev/null || true
+
+        if mkdir "$LOCK_PATH" 2>/dev/null; then
+            : # acquired on the first try
+        elif _lock_is_stale; then
+            print_info "Reaping stale docs-guide lock (age > ${LOOM_DOCS_GUIDE_LOCK_STALE_SECS}s) — a prior tick likely crashed mid-phase"
+            rm -rf "$LOCK_PATH" 2>/dev/null || true
+            if ! mkdir "$LOCK_PATH" 2>/dev/null; then
+                print_info "Lost the race to re-acquire after reaping — another tick got there first"
+                exit 1
+            fi
+        else
+            print_info "docs-guide lock is held by another (non-stale) tick — skipping"
+            exit 1
+        fi
+
+        cat > "$LOCK_PATH/owner.json" <<EOF
+{
+  "acquired_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "acquired_by_pid": $$,
+  "note": "PID is informational only -- staleness is age-based, see header comment"
+}
+EOF
+        print_success "docs-guide lock acquired"
+        exit 0
+        ;;
+    release)
+        rm -rf "$LOCK_PATH" 2>/dev/null || true
+        print_success "docs-guide lock released"
+        exit 0
+        ;;
+    status)
+        if [[ -d "$LOCK_PATH" ]] && ! _lock_is_stale; then
+            exit 0
+        fi
+        exit 1
+        ;;
+esac

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -50,6 +50,7 @@ test-default-branch.sh
 test-dependency-parse.sh
 test-detect-dependency-cycle.sh
 test-disk-headroom.sh
+test-docs-guide-lock.sh
 test-docs-worktree.sh
 test-fleet-check.sh
 test-fleet-send.sh

--- a/defaults/scripts/tests/test-docs-guide-lock.sh
+++ b/defaults/scripts/tests/test-docs-guide-lock.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# test-docs-guide-lock.sh - Regression test for issue #5573
+#
+# The Guide role's Document Maintenance Step 1 used to be a plain
+# check-then-act: query for an open docs PR, and if none, proceed through
+# docs-worktree.sh (a single shared worktree slot) to `gh pr create`. Two
+# Guide ticks starting within the same short window could both see "no open
+# PR" before either had pushed a branch, race each other into
+# docs-worktree.sh (the second clobbering the first's in-progress state), and
+# both end up creating their own docs PR (observed: #5571 and #5572, opened
+# 49 seconds apart with an identical diff shape).
+#
+# docs-guide-lock.sh closes the gap with a non-blocking mkdir-based lock held
+# across the whole Step-1-through-Step-5 window. This suite verifies:
+#
+#   1. acquire/release round-trip, and `status` reflects held/free correctly.
+#   2. serialization — a second concurrent acquire is refused (busy) while
+#      the first holds the lock; only one of two truly concurrent,
+#      backgrounded acquire attempts wins (the actual race scenario, not
+#      just a sequential simulation of it).
+#   3. release is idempotent (safe even when the lock was never acquired).
+#   4. stale-lock recovery — a lock older than LOOM_DOCS_GUIDE_LOCK_STALE_SECS
+#      is reaped by the next acquire attempt, so a crashed tick can never
+#      permanently block future ticks.
+#   5. argument validation (unknown command, bad stale-secs value).
+#   6. guide.md's Document Maintenance phase actually acquires the lock in
+#      Step 1 before the open-PR check, and releases it on every exit path
+#      out of Step 1 and Step 5 (both the "no changes" and success paths of
+#      create_docs_pr()) — and the pre-existing #5454 self-referential-PR
+#      exclusion is still intact (this fix must not reintroduce that bug).
+#
+# Hermetic: throwaway git repo under mktemp -d, no forge/network calls.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPTS_DIR/../.." && pwd)"
+
+LOCK_SH="$SCRIPTS_DIR/docs-guide-lock.sh"
+GUIDE_MD="$REPO_ROOT/defaults/.claude/commands/loom/guide.md"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1)); echo -e "  ${GREEN}PASS${NC}: $1"; }
+fail() { TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1)); echo -e "  ${RED}FAIL${NC}: $1"; }
+
+assert_grep() {
+    local pattern="$1" file="$2" msg="$3"
+    if grep -qE "$pattern" "$file"; then pass "$msg"; else fail "$msg (missing pattern: $pattern)"; fi
+}
+
+if [[ ! -x "$LOCK_SH" ]]; then
+    fail "docs-guide-lock.sh missing or not executable at $LOCK_SH"
+    echo ""
+    echo "================================"
+    echo "Tests run:    1"
+    echo -e "Tests failed: ${RED}1${NC}"
+    exit 1
+fi
+
+SANDBOX="$(mktemp -d)"
+cleanup() { rm -rf "$SANDBOX"; }
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Sandbox repo: docs-guide-lock.sh resolves its lock dir off `git
+# rev-parse --git-common-dir`, so it needs to run inside a real git repo.
+# ---------------------------------------------------------------------------
+SANDBOX_REPO="$SANDBOX/repo"
+mkdir -p "$SANDBOX_REPO"
+git init --quiet "$SANDBOX_REPO"
+git -C "$SANDBOX_REPO" config user.email "test@loom.local"
+git -C "$SANDBOX_REPO" config user.name "Loom Test"
+
+LOCK_DIR_EXPECTED="$SANDBOX_REPO/.loom/locks/docs-guide-lock"
+
+# --- Test 1: acquire / status / release round-trip -------------------------
+echo "Test 1: acquire / status / release round-trip"
+
+RC=0
+(cd "$SANDBOX_REPO" && "$LOCK_SH" status >/dev/null 2>&1) || RC=$?
+if [[ "$RC" != "0" ]]; then pass "status is 'free' before any acquire"; else fail "status reported held before any acquire"; fi
+
+RC=0
+(cd "$SANDBOX_REPO" && "$LOCK_SH" acquire >/dev/null 2>&1) || RC=$?
+if [[ "$RC" == "0" ]]; then pass "first acquire succeeds"; else fail "first acquire failed (rc=$RC)"; fi
+
+if [[ -d "$LOCK_DIR_EXPECTED" ]]; then
+    pass "lock directory created at .loom/locks/docs-guide-lock"
+else
+    fail "lock directory missing at $LOCK_DIR_EXPECTED"
+fi
+
+if [[ -f "$LOCK_DIR_EXPECTED/owner.json" ]]; then
+    pass "owner.json metadata written"
+else
+    fail "owner.json missing"
+fi
+
+RC=0
+(cd "$SANDBOX_REPO" && "$LOCK_SH" status >/dev/null 2>&1) || RC=$?
+if [[ "$RC" == "0" ]]; then pass "status is 'held' after acquire"; else fail "status did not report held after acquire"; fi
+
+RC=0
+(cd "$SANDBOX_REPO" && "$LOCK_SH" release >/dev/null 2>&1) || RC=$?
+if [[ "$RC" == "0" ]]; then pass "release succeeds"; else fail "release failed (rc=$RC)"; fi
+
+if [[ ! -d "$LOCK_DIR_EXPECTED" ]]; then
+    pass "lock directory removed after release"
+else
+    fail "lock directory survived release"
+fi
+
+# --- Test 2: idempotent release ---------------------------------------------
+echo ""
+echo "Test 2: release is idempotent"
+RC=0
+(cd "$SANDBOX_REPO" && "$LOCK_SH" release >/dev/null 2>&1) || RC=$?
+if [[ "$RC" == "0" ]]; then pass "release on an already-free lock still exits 0"; else fail "release on a free lock failed (rc=$RC)"; fi
+
+# --- Test 3: serialization (sequential) -------------------------------------
+echo ""
+echo "Test 3: a second acquire is refused while the first is held"
+(cd "$SANDBOX_REPO" && "$LOCK_SH" acquire >/dev/null 2>&1)
+RC=0
+(cd "$SANDBOX_REPO" && "$LOCK_SH" acquire >/dev/null 2>&1) || RC=$?
+if [[ "$RC" == "1" ]]; then pass "second acquire while held returns busy (exit 1)"; else fail "second acquire returned $RC, expected 1 (busy)"; fi
+(cd "$SANDBOX_REPO" && "$LOCK_SH" release >/dev/null 2>&1)
+
+# --- Test 4: THE REGRESSION — true concurrent race --------------------------
+# This is the actual failure mode from #5571/#5572: two ticks starting within
+# the same short window. Launch two acquire attempts as truly-concurrent
+# backgrounded processes (not a sequential simulation) and verify exactly one
+# wins.
+echo ""
+echo "Test 4: two concurrent acquire attempts — exactly one wins (THE #5573 RACE)"
+
+RESULTS_DIR="$SANDBOX/race-results"
+mkdir -p "$RESULTS_DIR"
+
+race_attempt() {
+    local id="$1"
+    local rc=0
+    (cd "$SANDBOX_REPO" && "$LOCK_SH" acquire >/dev/null 2>&1) || rc=$?
+    echo "$rc" > "$RESULTS_DIR/attempt-$id.rc"
+}
+
+race_attempt 1 &
+PID1=$!
+race_attempt 2 &
+PID2=$!
+wait "$PID1"
+wait "$PID2"
+
+RC1="$(cat "$RESULTS_DIR/attempt-1.rc" 2>/dev/null || echo "MISSING")"
+RC2="$(cat "$RESULTS_DIR/attempt-2.rc" 2>/dev/null || echo "MISSING")"
+
+WINS=0
+[[ "$RC1" == "0" ]] && WINS=$((WINS + 1))
+[[ "$RC2" == "0" ]] && WINS=$((WINS + 1))
+
+if [[ "$WINS" == "1" ]]; then
+    pass "exactly one of two truly-concurrent acquire attempts wins (rc1=$RC1, rc2=$RC2)"
+else
+    fail "expected exactly one winner, got $WINS winners (rc1=$RC1, rc2=$RC2) — the race is NOT closed"
+fi
+
+if [[ -d "$LOCK_DIR_EXPECTED" ]]; then
+    pass "lock directory left held by the winner (as expected — release is a separate, explicit step)"
+else
+    fail "lock directory missing after the race — a winner must hold it until released"
+fi
+(cd "$SANDBOX_REPO" && "$LOCK_SH" release >/dev/null 2>&1)
+
+# --- Test 5: stale-lock recovery (crashed tick never permanently blocks) ---
+echo ""
+echo "Test 5: a lock older than LOOM_DOCS_GUIDE_LOCK_STALE_SECS is reaped"
+(cd "$SANDBOX_REPO" && "$LOCK_SH" acquire >/dev/null 2>&1)
+sleep 2
+RC=0
+(cd "$SANDBOX_REPO" && LOOM_DOCS_GUIDE_LOCK_STALE_SECS=1 "$LOCK_SH" acquire >/dev/null 2>&1) || RC=$?
+if [[ "$RC" == "0" ]]; then
+    pass "a stale (crashed-tick) lock is reaped and re-acquired automatically"
+else
+    fail "expected the stale lock to be reaped and re-acquired, got rc=$RC"
+fi
+(cd "$SANDBOX_REPO" && "$LOCK_SH" release >/dev/null 2>&1)
+
+# A lock that is NOT yet stale (default 30-minute threshold, well above this
+# test's runtime) must NOT be reaped by a fresh acquire.
+(cd "$SANDBOX_REPO" && "$LOCK_SH" acquire >/dev/null 2>&1)
+RC=0
+(cd "$SANDBOX_REPO" && "$LOCK_SH" acquire >/dev/null 2>&1) || RC=$?
+if [[ "$RC" == "1" ]]; then
+    pass "a fresh (non-stale) lock is NOT reaped by a contending acquire"
+else
+    fail "a fresh lock was incorrectly reaped/re-acquired (rc=$RC)"
+fi
+(cd "$SANDBOX_REPO" && "$LOCK_SH" release >/dev/null 2>&1)
+
+# --- Test 6: argument validation --------------------------------------------
+echo ""
+echo "Test 6: argument validation"
+
+RC=0
+(cd "$SANDBOX_REPO" && "$LOCK_SH" >/dev/null 2>&1) || RC=$?
+if [[ "$RC" == "2" ]]; then pass "missing command -> exit 2"; else fail "expected exit 2 for missing command, got $RC"; fi
+
+RC=0
+(cd "$SANDBOX_REPO" && "$LOCK_SH" bogus >/dev/null 2>&1) || RC=$?
+if [[ "$RC" == "2" ]]; then pass "unknown command -> exit 2"; else fail "expected exit 2 for an unknown command, got $RC"; fi
+
+RC=0
+(cd "$SANDBOX_REPO" && "$LOCK_SH" --help >/dev/null 2>&1) || RC=$?
+if [[ "$RC" == "0" ]]; then pass "--help -> exit 0"; else fail "expected exit 0 for --help, got $RC"; fi
+
+RC=0
+(cd "$SANDBOX_REPO" && LOOM_DOCS_GUIDE_LOCK_STALE_SECS=notanumber "$LOCK_SH" acquire >/dev/null 2>&1) || RC=$?
+if [[ "$RC" == "2" ]]; then pass "non-numeric LOOM_DOCS_GUIDE_LOCK_STALE_SECS -> exit 2"; else fail "expected exit 2 for a bad stale-secs value, got $RC"; fi
+(cd "$SANDBOX_REPO" && "$LOCK_SH" release >/dev/null 2>&1)
+
+# --- Test 7: guide.md wiring -------------------------------------------------
+echo ""
+echo "Test 7: guide.md acquires/releases the lock around Steps 1-5"
+
+assert_grep 'docs-guide-lock\.sh acquire' "$GUIDE_MD" \
+    "Step 1 acquires the docs-guide lock"
+assert_grep 'docs-guide-lock\.sh release' "$GUIDE_MD" \
+    "at least one exit path releases the docs-guide lock"
+
+# Every exit path must release: Step 1's open-PR skip, create_docs_pr()'s
+# "no changes" return, and create_docs_pr()'s success path. That's 3 distinct
+# release call sites (plus the wiring-check above already covers >=1).
+RELEASE_COUNT="$(grep -c 'docs-guide-lock\.sh release' "$GUIDE_MD")"
+if [[ "$RELEASE_COUNT" -ge 3 ]]; then
+    pass "the lock is released on every known exit path ($RELEASE_COUNT release call sites)"
+else
+    fail "expected >=3 release call sites (Step 1 skip, create_docs_pr no-op, create_docs_pr success), found $RELEASE_COUNT"
+fi
+
+# The acquire must run BEFORE the open-PR check, not after -- an acquire
+# positioned after the check would just reintroduce the original TOCTOU gap.
+ACQUIRE_LINE="$(grep -n 'docs-guide-lock\.sh acquire' "$GUIDE_MD" | head -1 | cut -d: -f1)"
+OPEN_PR_LINE="$(grep -n 'OPEN_DOCS_PR=' "$GUIDE_MD" | head -1 | cut -d: -f1)"
+if [[ -n "$ACQUIRE_LINE" && -n "$OPEN_PR_LINE" && "$ACQUIRE_LINE" -lt "$OPEN_PR_LINE" ]]; then
+    pass "the lock is acquired BEFORE the open-docs-PR check (closes the TOCTOU gap)"
+else
+    fail "lock acquire (line ${ACQUIRE_LINE:-?}) must precede the open-PR check (line ${OPEN_PR_LINE:-?})"
+fi
+
+# --- Test 8: #5454 self-referential-PR exclusion is still intact -----------
+echo ""
+echo "Test 8: the #5454 fix (own-docs-PR exclusion) was not disturbed"
+assert_grep 'GUIDE_DOCS_PR_EXCLUDE=' "$GUIDE_MD" \
+    "GUIDE_DOCS_PR_EXCLUDE is still defined"
+assert_grep 'startswith\("docs/guide-update"\)' "$GUIDE_MD" \
+    "GUIDE_DOCS_PR_EXCLUDE still excludes by head-branch prefix"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "================================"
+echo "Tests run:    $TESTS_RUN"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
+    exit 1
+fi
+echo "All tests passed"
+exit 0


### PR DESCRIPTION
## Summary

Fixes #5573 — the Guide role's Document Maintenance Step 1 open-docs-PR check
was a plain check-then-act with no atomicity. Two Guide ticks starting within
the same short window (a role-runner tick overlapping a manual `/loom:guide`
session, or two role-runner ticks overlapping each other) could both see "no
open PR" before either had pushed a branch, both call `docs-worktree.sh`
(clobbering the shared, single worktree slot), and both end up on
independently-branched, independently-pushed docs PRs. This actually
happened: #5571 and #5572, opened 49 seconds apart with an identical diff
shape.

### Fix

Added `.loom/scripts/docs-guide-lock.sh` (a non-blocking, mkdir-based lock —
the same portable atomic primitive `worktree.sh`'s worktree-add lock and
`lib/build-slot.sh` already use in this repo; `flock` isn't available on
stock macOS) and wired it into `defaults/.claude/commands/loom/guide.md`
(which `.loom/roles/guide.md` and `defaults/roles/guide.md` both symlink to
— a single edit covers all three paths named in the issue):

- **Step 1** now `acquire`s the lock *before* the open-docs-PR check. A busy
  lock (another tick mid-flight) makes this tick skip outright — non-blocking,
  since waiting would just shift the identical race to a later timestamp
  instead of closing it.
- **Step 5**'s `create_docs_pr()` releases the lock on both of its exit paths
  (the "no changes to commit" early return, and after `gh pr create`
  succeeds). Step 1's early-return-on-open-PR path releases it too.
- Staleness is **age-based** (default 1800s / 30 min), not PID-liveness like
  `worktree.sh`'s lock: the "holder" here is a sequence of separate Bash
  tool-call subprocesses within one Guide agent turn (interleaved with Edit
  tool calls), not one continuously running process — a PID recorded at
  `acquire` time has already exited long before Step 5 runs, so PID-liveness
  would misclassify every legitimate in-flight lock as stale within seconds.
  A crashed tick's lock is reaped automatically by the next `acquire` once it
  ages past the threshold, so it can never permanently block future ticks.
- The pre-existing open-docs-PR check (Step 1) is unchanged in intent and
  still needed — it is what prevents a *later, non-racing* tick from piling a
  second PR onto one left open by an earlier tick, which is a distinct
  concern from the lock (which only stops *concurrent* ticks from racing each
  other).
- The #5454 self-referential-PR exclusion (`GUIDE_DOCS_PR_EXCLUDE`) was left
  untouched and is verified intact by the new test suite.

### Verification

Added `defaults/scripts/tests/test-docs-guide-lock.sh` (wired into
`ci-wired.txt`), hermetic, no forge/network calls:

- acquire/release/status round-trip
- release is idempotent
- sequential serialization (second acquire while held returns busy)
- **the actual #5571/#5572 failure mode, executed rather than simulated**:
  two truly concurrent, backgrounded `acquire` attempts race on the same
  lock — verified exactly one wins, every run (ran the suite 5x locally with
  no flakiness)
- stale-lock recovery (a lock older than `LOOM_DOCS_GUIDE_LOCK_STALE_SECS` is
  reaped by the next acquire; a fresh lock is not)
- argument validation
- guide.md wiring: the lock is acquired before the open-PR check (not after,
  which would just reintroduce the same TOCTOU gap), and released on every
  known exit path (>=3 release call sites)
- the #5454 exclusion is still present and unmodified

All pre-existing related suites still pass unchanged:
`test-docs-worktree.sh`, `test-guide-work-log-self-loop.sh`,
`test-guide-work-log-issue-out-of-order.sh`,
`test-guide-work-log-out-of-order-merge.sh`, `test-sweep-auto-stack.sh`,
`test-warn-out-of-set-deps.sh`.

### Files changed
- `defaults/.claude/commands/loom/guide.md` (canonical target of the
  `.loom/roles/guide.md` / `defaults/roles/guide.md` symlinks)
- `defaults/scripts/docs-guide-lock.sh` (new)
- `defaults/scripts/tests/test-docs-guide-lock.sh` (new)
- `defaults/scripts/tests/ci-wired.txt`

Closes #5573