### PR TITLE
fix(champion): thread expected head SHA into merge API calls (#5579)

### DIFF
--- a/defaults/.claude/commands/loom/champion-pr-merge.md
+++ b/defaults/.claude/commands/loom/champion-pr-merge.md
@@ -857,10 +857,28 @@ git checkout main 2>/dev/null || true
 
 # Use merge-pr.sh for worktree-safe merge via GitHub API
 # --auto enables auto-merge if ruleset requires wait
-./.loom/scripts/merge-pr.sh "$PR_NUMBER" --auto || {
+#
+# merge-pr.sh reads the PR's head SHA itself (a fresh, uncached read — see
+# "Cached forge reads" above) immediately before merging, and passes it
+# through to the forge's merge API as an optimistic-concurrency precondition
+# (#5579). Capture the exit code rather than using a bare `||`: exit 3 is a
+# DISTINCT outcome from exit 1 and must not be handled as a failure (below).
+MERGE_RC=0
+./.loom/scripts/merge-pr.sh "$PR_NUMBER" --auto || MERGE_RC=$?
+
+if [ "$MERGE_RC" -eq 3 ]; then
+  # #5579: the PR's head branch moved past the SHA this merge attempt gated
+  # on — most commonly a session pushing new commits to an open, loom:pr
+  # branch while Champion was running. This is NOT a merge failure: the PR
+  # is still Judge-approved, its diff just changed underneath it.
+  #
+  # Do NOT follow the failure steps below for this outcome — see the "Exit
+  # code 3" exception in "Error Handling".
+  echo "PR #$PR_NUMBER head moved during merge attempt — re-queuing for a fresh pass instead of failing"
+elif [ "$MERGE_RC" -ne 0 ]; then
   echo "Merge failed for PR #$PR_NUMBER"
   # Post failure comment (see Error Handling section)
-}
+fi
 ```
 
 **Merge strategy**:
@@ -868,6 +886,9 @@ git checkout main 2>/dev/null || true
 - **Squash merge**: Combines all commits into single commit (clean history)
 - **`--auto`**: Enables GitHub's auto-merge if ruleset requires wait
 - Branch deleted automatically after merge
+- **Head-moved guard (#5579)**: `merge-pr.sh` refuses to merge (exit 3, not a
+  failure) if the PR's head branch advanced past the SHA it read immediately
+  before merging — see "Exit code 3" in "Error Handling" below
 
 ### Step 4: Verify Issue Auto-Close
 
@@ -1707,6 +1728,33 @@ This PR met all safety criteria but the merge operation failed. A human will nee
 ---
 *Automated by Champion role*"
 ```
+
+### Exception: exit code 3 — head moved, re-queue, not a failure (#5579)
+
+`merge-pr.sh` exits **3** (distinct from the generic failure exit **1**) when
+the PR's head branch changed between the fresh head-SHA read it took
+immediately before merging and the actual merge call — most commonly because
+a session pushed new commits to an open, `loom:pr`-labeled branch while
+Champion was running. **Do not follow the 5 failure steps above for this
+outcome:**
+
+- Do **not** post the "Merge Failed" comment — the PR is still Judge-approved,
+  its diff just moved out from under the merge attempt.
+- Do **not** count it as an error in the completion summary.
+- Leave `loom:pr` in place and move on to the next PR in the queue. A later
+  Champion pass will pick this PR up fresh — its safety criteria (including
+  `updatedAt` and CI status) will naturally re-evaluate the new head before
+  merging it.
+
+**Squash-merge detection trap.** If you ever need to manually verify whether a
+re-queued (or, worse, an already-merged-before-this-fix) PR's commits actually
+landed vs. were silently stranded, `git merge-base --is-ancestor <commit>
+origin/main` is **not reliable evidence either way**: a squash merge produces
+a brand-new commit SHA on `main` that is not a git-ancestry descendant of any
+commit on the original PR branch, regardless of whether that commit's content
+made it into the squash or was left behind. There is no cheap ancestry check
+for "squashed-and-landed" vs. "stranded" — verification requires diffing the
+actual file content on `main` against the branch/commit in question.
 
 ---
 

--- a/defaults/scripts/lib/forge-helpers.sh
+++ b/defaults/scripts/lib/forge-helpers.sh
@@ -305,21 +305,58 @@ forge_split_nwo() {
 # --- Forge-Dispatched Operations ---
 
 # Merge a PR via the forge API.
-# Usage: forge_merge_pr NWO PR_NUMBER
+# Usage: forge_merge_pr NWO PR_NUMBER [EXPECTED_HEAD_SHA]
 # GitHub: PUT /repos/{nwo}/pulls/{n}/merge with merge_method=squash
 # Gitea: POST /repos/{owner}/{repo}/pulls/{n}/merge with Do=squash
+#
+# EXPECTED_HEAD_SHA (optional, #5579): an optimistic-concurrency precondition —
+# the SHA the PR's head branch must currently match for the merge to proceed.
+# Without it, both forges will happily squash-merge whatever the CURRENT head
+# is at the moment the request lands, even if it has commits the caller never
+# saw approved (silently stranding them — squash-merge makes this invisible to
+# an ancestry check afterward, since the new squash commit is not a descendant
+# of the stranded commits either way). Pass the freshest possible head-SHA read
+# (never a cached one) immediately before calling this.
+#
+# GitHub: REST's optional `sha` field. Verified (GitHub's public OpenAPI spec,
+# 2026-08-07) to fail with HTTP 409 and message "Head branch was modified.
+# Review and try the merge again." on a mismatch — a DIFFERENT string from the
+# existing "Base branch was modified" retry case handled elsewhere in
+# merge-pr.sh; callers must not conflate the two (that one means "rebase onto
+# base and retry"; this one means "the approved diff moved out from under us,
+# do not retry-and-merge-anyway").
+#
+# Gitea: the `head_commit_id` field on MergePullRequestOption (confirmed
+# present via Gitea/Forgejo's published swagger.v1.json and upstream
+# services/pull/merge_prepare.go, 2026-08-07). A mismatch raises
+# ErrSHADoesNotMatch, which routers/api/v1/repo/pull.go maps to HTTP 409 with
+# message "head out of date".
 forge_merge_pr() {
   local nwo="$1"
   local pr_number="$2"
+  local expected_head_sha="${3:-}"
 
   if [[ "$FORGE_TYPE" == "gitea" ]]; then
     forge_split_nwo "$nwo"
-    gitea_api POST "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number/merge" \
-      -d '{"Do":"squash","delete_branch_after_merge":false}'
+    if [[ -n "$expected_head_sha" ]]; then
+      gitea_api POST "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number/merge" \
+        -d "$(jq -nc --arg sha "$expected_head_sha" \
+          '{"Do":"squash","delete_branch_after_merge":false,"head_commit_id":$sha}')"
+    else
+      gitea_api POST "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number/merge" \
+        -d '{"Do":"squash","delete_branch_after_merge":false}'
+    fi
   else
-    gh api "repos/$nwo/pulls/$pr_number/merge" \
-      -X PUT \
-      -f merge_method=squash 2>&1
+    if [[ -n "$expected_head_sha" ]]; then
+      gh api "repos/$nwo/pulls/$pr_number/merge" \
+        -X PUT \
+        -f merge_method=squash \
+        -f sha="$expected_head_sha" 2>&1
+    else
+      gh api "repos/$nwo/pulls/$pr_number/merge" \
+        -X PUT \
+        -f merge_method=squash 2>&1
+    fi
   fi
 }
 
@@ -489,31 +526,62 @@ forge_delete_branch() {
 }
 
 # Enable auto-merge on a PR.
-# Usage: forge_auto_merge NWO PR_NUMBER
+# Usage: forge_auto_merge NWO PR_NUMBER [EXPECTED_HEAD_SHA]
 # GitHub: GraphQL enablePullRequestAutoMerge mutation (pure API, no
 #         working-tree dependency — `gh pr merge --auto` does a local
 #         checkout that collides with worktrees owning the head branch).
 # Gitea: POST /repos/{owner}/{repo}/pulls/{n}/merge with merge_when_checks_succeed
+#
+# EXPECTED_HEAD_SHA (optional, #5579): same optimistic-concurrency precondition
+# as forge_merge_pr's — see that function's comment for the general rationale
+# and the Gitea `head_commit_id` citation (identical here; Gitea's `/merge`
+# endpoint carries both the auto-merge poll flags and the mismatch guard).
+#
+# GitHub: the GraphQL mutation's `expectedHeadOid: GitObjectID` input field
+# (confirmed present in GitHub's public GraphQL schema, 2026-08-07). The exact
+# error string GitHub returns on a mismatch could NOT be verified against a
+# live incident or public documentation as of this writing (GraphQL validation
+# error text is not part of the published schema) — merge-pr.sh's classifier
+# for this path therefore matches a best-effort pattern and should be
+# tightened against the first real occurrence, the same way the CLEAN/UNSTABLE
+# classifiers elsewhere in this file were derived from live incident text.
 forge_auto_merge() {
   local nwo="$1"
   local pr_number="$2"
+  local expected_head_sha="${3:-}"
 
   if [[ "$FORGE_TYPE" == "gitea" ]]; then
     forge_split_nwo "$nwo"
-    gitea_api POST "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number/merge" \
-      -d '{"Do":"squash","merge_when_checks_succeed":true,"delete_branch_after_merge":true}'
+    if [[ -n "$expected_head_sha" ]]; then
+      gitea_api POST "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number/merge" \
+        -d "$(jq -nc --arg sha "$expected_head_sha" \
+          '{"Do":"squash","merge_when_checks_succeed":true,"delete_branch_after_merge":true,"head_commit_id":$sha}')"
+    else
+      gitea_api POST "repos/$FORGE_OWNER/$FORGE_REPO/pulls/$pr_number/merge" \
+        -d '{"Do":"squash","merge_when_checks_succeed":true,"delete_branch_after_merge":true}'
+    fi
   else
     # Resolve PR node_id (required by GraphQL mutation).
     local node_id
     node_id=$(gh api "repos/$nwo/pulls/$pr_number" --jq '.node_id' 2>/dev/null) || return 1
     [[ -z "$node_id" ]] && return 1
 
-    local mutation='mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) { enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId, mergeMethod: $mergeMethod}) { pullRequest { number autoMergeRequest { enabledAt } } } }'
+    if [[ -n "$expected_head_sha" ]]; then
+      local mutation_with_oid='mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!, $expectedHeadOid: GitObjectID) { enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId, mergeMethod: $mergeMethod, expectedHeadOid: $expectedHeadOid}) { pullRequest { number autoMergeRequest { enabledAt } } } }'
 
-    gh api graphql \
-      -f "query=$mutation" \
-      -F "pullRequestId=$node_id" \
-      -F "mergeMethod=SQUASH" 2>/dev/null
+      gh api graphql \
+        -f "query=$mutation_with_oid" \
+        -F "pullRequestId=$node_id" \
+        -F "mergeMethod=SQUASH" \
+        -F "expectedHeadOid=$expected_head_sha" 2>/dev/null
+    else
+      local mutation='mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) { enablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId, mergeMethod: $mergeMethod}) { pullRequest { number autoMergeRequest { enabledAt } } } }'
+
+      gh api graphql \
+        -f "query=$mutation" \
+        -F "pullRequestId=$node_id" \
+        -F "mergeMethod=SQUASH" 2>/dev/null
+    fi
   fi
 }
 

--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -83,6 +83,15 @@
 # Exit codes:
 #   0 = merged (or auto-merge enabled)
 #   1 = failed
+#   3 = PR head moved past the SHA this merge attempt gated on (#5579) — a
+#       session pushed new commits to the branch after the approving review
+#       (or after this run's own head-SHA read). NOT a merge failure: the PR
+#       is still Judge-approved, its diff just changed underneath it. Callers
+#       (notably champion-pr-merge.md Step 3) must treat this distinctly from
+#       exit 1 — re-queue the PR for a fresh pass rather than posting a
+#       failure comment. See "Squash-merge detection trap" in that file's
+#       Error Handling section for why ancestry checks can't verify this
+#       state after the fact.
 
 set -euo pipefail
 
@@ -97,6 +106,23 @@ error() { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
 info() { echo -e "${BLUE}$*${NC}"; }
 success() { echo -e "${GREEN}$*${NC}"; }
 warning() { echo -e "${YELLOW}$*${NC}"; }
+# #5579: distinct from error() (exit 1) — see "Exit codes" above. Emits to
+# stderr like error() so it is visible in logs, but exits 3 so the caller can
+# tell "re-queue" from "genuinely failed" without parsing message text.
+error_head_moved() { echo -e "${YELLOW}PR head moved during merge attempt (stale approval, not a failure): $*${NC}" >&2; exit 3; }
+
+# #5579: detect a head-SHA-mismatch response from either forge's merge API.
+# Distinct from the existing "Base branch was modified" matcher below (that
+# one means the PR's BASE fell behind and a rebase-and-retry is correct;
+# this one means the PR's OWN head moved, so retrying would either fail again
+# or silently merge a different diff than the one that was approved). String
+# provenance is documented on forge_merge_pr / forge_auto_merge in
+# lib/forge-helpers.sh — GitHub REST and Gitea are verified against each
+# forge's own source/spec; the GitHub GraphQL (auto-merge) string is
+# best-effort pending a live-incident confirmation.
+_is_head_mismatch_response() {
+  echo "$1" | grep -Eiq 'Head branch was modified\.|head out of date|expectedHeadOid'
+}
 
 # Function to show help
 show_help() {
@@ -1179,6 +1205,24 @@ _wait_for_checks_then_sync_merge() {
 #     loom-clean handle it.
 #
 # See issue #3279.
+
+# Freshest possible head-SHA read for the merge's optimistic-concurrency
+# precondition (#5579). $PR_HEAD_SHA (set above from the initial $PR_JSON
+# fetch) may have gone through the gh-cached wrapper via $GH — fine for the
+# branch-cleanup safety check it also feeds, but a merge-gating precondition
+# must observe current state as closely as possible: a stale value here only
+# ever produces a spurious "head moved" re-queue (fail-safe — it can never
+# cause a stale-but-accepted merge, since the forge itself does the real
+# comparison against its own current head), but staleness still costs an
+# unneeded round trip, so read it live via the uncached helper immediately
+# before either merge path runs. A lookup failure falls back to the
+# already-known $PR_HEAD_SHA rather than merging with no precondition at all.
+MERGE_PRECONDITION_SHA="$PR_HEAD_SHA"
+_MPS_JSON="$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')"
+_MPS_FRESH_SHA="$(echo "$_MPS_JSON" | jq -r '.head.sha // empty' 2>/dev/null || echo '')"
+[[ -n "$_MPS_FRESH_SHA" ]] && MERGE_PRECONDITION_SHA="$_MPS_FRESH_SHA"
+unset _MPS_JSON _MPS_FRESH_SHA
+
 if [[ "$AUTO_MERGE" == "true" ]]; then
   # Bounded poll window for the UNSTABLE-because-checks-are-still-running case
   # (#3664). Reuses the same env-var names/semantics as the shell Gitea
@@ -1232,6 +1276,17 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
     # curl poll-and-merge). A native GitHub *failure* (exit 1) is NOT a decline:
     # its gh error is left in AUTO_MERGE_OUTPUT so the disabled/clean/unstable
     # detection further down fires exactly as it did for loom-auto-merge.
+    #
+    # KNOWN GAP (#5579, noted not fixed here — out of scope per the issue's own
+    # curation): this native path has no `--expected-head-sha`/`--match-head-
+    # commit` flag equivalent to the `sha`/`expectedHeadOid` precondition this
+    # commit adds to the shell forge_auto_merge/forge_merge_pr below. Since
+    # this native path is preferred whenever `loom-daemon` is on PATH (the
+    # common case), the head-moved guard added below only actually protects
+    # the Gitea-decline and loom-daemon-absent fallback through shell
+    # forge_auto_merge, plus the always-shell synchronous forge_merge_pr path.
+    # A GitHub merge routed through this native call can still silently
+    # squash whatever the current head is. Tracked separately in #5589.
     _AM_DECLINED=true
     if command -v loom-daemon &>/dev/null; then
       [[ $MERGE_ATTEMPT -eq 1 ]] && info "Using loom-daemon forge auto-merge (native forge-agnostic auto-merge)"
@@ -1251,7 +1306,7 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
     if [[ "$_AM_DECLINED" == true ]]; then
       # loom-daemon absent, or it declined (e.g. Gitea) — shell-based
       # forge_auto_merge carries the poll-and-merge for both forges.
-      if AUTO_MERGE_OUTPUT=$(forge_auto_merge "$REPO_NWO" "$PR_NUMBER" 2>&1); then
+      if AUTO_MERGE_OUTPUT=$(forge_auto_merge "$REPO_NWO" "$PR_NUMBER" "$MERGE_PRECONDITION_SHA" 2>&1); then
         AUTO_MERGE_OK=true
         break
       fi
@@ -1264,6 +1319,16 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
       warning "Auto-merge reported error but PR is already merged (race condition)"
       AUTO_MERGE_OK=true
       break
+    fi
+
+    # Head-SHA-mismatch (#5579): the PR's OWN head branch moved past
+    # $MERGE_PRECONDITION_SHA — distinct from "Base branch was modified"
+    # below (that means the BASE fell behind; this means the branch we're
+    # trying to merge changed). Do NOT retry-and-merge: exit 3 so the caller
+    # (Champion) re-queues this PR for a fresh pass instead of treating it as
+    # a failure. See error_head_moved()/_is_head_mismatch_response() above.
+    if _is_head_mismatch_response "$AUTO_MERGE_OUTPUT"; then
+      error_head_moved "PR #$PR_NUMBER: $AUTO_MERGE_OUTPUT"
     fi
 
     # Retry on stale-branch race ("Base branch was modified")
@@ -1653,7 +1718,7 @@ MAX_MERGE_RETRIES=3
 MERGE_RETRY_DELAY=5
 
 for MERGE_ATTEMPT in $(seq 1 $MAX_MERGE_RETRIES); do
-  MERGE_RESPONSE=$(forge_merge_pr "$REPO_NWO" "$PR_NUMBER" 2>&1) && break  # Success, exit loop
+  MERGE_RESPONSE=$(forge_merge_pr "$REPO_NWO" "$PR_NUMBER" "$MERGE_PRECONDITION_SHA" 2>&1) && break  # Success, exit loop
 
   # Check if it merged despite error (race condition)
   RECHECK_JSON=$(forge_get_pr_nocache "$REPO_NWO" "$PR_NUMBER" "$GH" 2>/dev/null || echo '{}')
@@ -1677,6 +1742,18 @@ for MERGE_ATTEMPT in $(seq 1 $MAX_MERGE_RETRIES); do
     # Still not merged after wait - continue retry loop
     warning "Concurrent merge not yet complete, retrying..."
     continue
+  fi
+
+  # Head-SHA-mismatch (#5579): the PR's OWN head branch moved past
+  # $MERGE_PRECONDITION_SHA — distinct from "Base branch was modified" below
+  # (that means the BASE fell behind; this means the branch we're trying to
+  # merge changed, most commonly a session pushing new commits mid-merge). Do
+  # NOT retry-and-merge: retrying would either fail again (session still
+  # pushing) or silently squash a different diff than the one Judge approved.
+  # Exit 3 so the caller (Champion) re-queues instead of treating this as a
+  # failure. See error_head_moved()/_is_head_mismatch_response() above.
+  if _is_head_mismatch_response "$MERGE_RESPONSE"; then
+    error_head_moved "PR #$PR_NUMBER: $MERGE_RESPONSE"
   fi
 
   # Check for stale branch error (base branch was modified)

--- a/defaults/scripts/tests/ci-wired.txt
+++ b/defaults/scripts/tests/ci-wired.txt
@@ -86,6 +86,7 @@ test-mcp-config.sh
 test-merge-pr-auto-merge-disabled-fallback.sh
 test-merge-pr-auto-reconcile.sh
 test-merge-pr-dirty-worktree-guard.sh
+test-merge-pr-head-mismatch.sh
 test-merge-pr-help.sh
 test-merge-pr-local-branch-cleanup.sh
 test-merge-pr-merge-ordering-guard.sh

--- a/defaults/scripts/tests/test-merge-pr-head-mismatch.sh
+++ b/defaults/scripts/tests/test-merge-pr-head-mismatch.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+# test-merge-pr-head-mismatch.sh - Unit tests for the merge head-SHA
+# optimistic-concurrency precondition (#5579).
+#
+# Root cause: neither forge_merge_pr() nor forge_auto_merge()
+# (lib/forge-helpers.sh) passed the forge's optional head-SHA precondition
+# (GitHub REST's `sha` field / GraphQL's `expectedHeadOid` input / Gitea's
+# `head_commit_id` field) to the merge API, so Champion (or merge-pr.sh
+# directly) could squash-merge a PR whose branch received new commits after
+# the approving review — silently stranding those commits (squash-merge makes
+# this invisible to an ancestry check afterward).
+#
+# This suite exercises three layers:
+#   1. forge_merge_pr / forge_auto_merge (lib/forge-helpers.sh): the optional
+#      3rd EXPECTED_HEAD_SHA argument is threaded into the right API call
+#      shape for both GitHub (REST `sha` / GraphQL `expectedHeadOid`) and
+#      Gitea (`head_commit_id`), and omitted entirely when not supplied
+#      (backward compatibility for any other caller).
+#   2. The merge-pr.sh classifier (_is_head_mismatch_response) and exit-code
+#      helper (error_head_moved): extracted and unit-tested directly, the
+#      same "extract from source" strategy test-merge-pr-auto-reconcile.sh
+#      uses, so the test stays in lockstep with the script. Confirms the
+#      classifier fires on the verified GitHub REST / Gitea strings, a
+#      best-effort GraphQL pattern, and does NOT fire on the pre-existing,
+#      semantically distinct "Base branch was modified" string (that one
+#      means "rebase onto base and retry" — conflating the two would either
+#      retry forever against a moving target or silently merge a different
+#      diff than the one Judge approved).
+#   3. Source-wiring: merge-pr.sh threads $MERGE_PRECONDITION_SHA into both
+#      merge calls, and both retry loops check the new classifier BEFORE the
+#      existing "Base branch was modified" retry branch (ordering matters:
+#      the two matchers must stay mutually exclusive, but a future edit that
+#      accidentally reorders them could still cause the "Base branch was
+#      modified" retry to eat a head-mismatch case first).
+#
+# Usage:
+#   ./.loom/scripts/tests/test-merge-pr-head-mismatch.sh
+
+# SC2034: FORGE_TYPE (read by the sourced forge_merge_pr/forge_auto_merge) and
+# YELLOW (read by error_head_moved, extracted+sourced below) are only
+# consumed by code shellcheck can't see is a reader — both look "unused" to
+# the linter.
+# shellcheck disable=SC2034
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPERS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MERGE_PR_SRC="$HELPERS_DIR/merge-pr.sh"
+FORGE_HELPERS_SRC="$HELPERS_DIR/lib/forge-helpers.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: $msg"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: $msg"
+        echo "    Expected: '$expected'"
+        echo "    Actual:   '$actual'"
+    fi
+}
+
+# ============================================================================
+# Part 1: forge_merge_pr / forge_auto_merge thread the expected head SHA
+# ============================================================================
+echo "Testing forge_merge_pr / forge_auto_merge head-SHA threading..."
+
+# shellcheck source=../lib/forge-helpers.sh
+source "$FORGE_HELPERS_SRC"
+
+STUB_DIR="$(mktemp -d)"
+GH_ARGS_FILE="$(mktemp)"
+trap 'rm -rf "$STUB_DIR"; rm -f "$GH_ARGS_FILE"' EXIT
+
+cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_ARGS_FILE"
+if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+  echo '{"data":{}}'
+  exit 0
+fi
+# PUT .../merge
+echo '{"merged":true}'
+exit 0
+STUB
+chmod +x "$STUB_DIR/gh"
+
+FORGE_TYPE="github"
+
+# --- forge_merge_pr: GitHub REST ---
+: > "$GH_ARGS_FILE"
+GH_ARGS_FILE="$GH_ARGS_FILE" PATH="$STUB_DIR:$PATH" \
+  forge_merge_pr "owner/repo" "42" "deadbeef123" >/dev/null
+if grep -q -- "-f sha=deadbeef123" "$GH_ARGS_FILE"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_merge_pr (GitHub) passes -f sha=<EXPECTED_HEAD_SHA> when supplied"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_merge_pr (GitHub) did not pass sha= (argv: $(cat "$GH_ARGS_FILE"))"
+fi
+
+: > "$GH_ARGS_FILE"
+GH_ARGS_FILE="$GH_ARGS_FILE" PATH="$STUB_DIR:$PATH" \
+  forge_merge_pr "owner/repo" "42" >/dev/null
+if grep -q -- "sha=" "$GH_ARGS_FILE"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_merge_pr (GitHub) passed sha= even though no EXPECTED_HEAD_SHA was given"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_merge_pr (GitHub) omits sha= when EXPECTED_HEAD_SHA is not supplied (backward compatible)"
+fi
+
+# --- forge_auto_merge: GitHub GraphQL ---
+: > "$GH_ARGS_FILE"
+GH_ARGS_FILE="$GH_ARGS_FILE" PATH="$STUB_DIR:$PATH" \
+  forge_auto_merge "owner/repo" "42" "feedface456" >/dev/null
+if grep -q -- "expectedHeadOid=feedface456" "$GH_ARGS_FILE"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_auto_merge (GitHub) passes -F expectedHeadOid=<EXPECTED_HEAD_SHA> when supplied"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_auto_merge (GitHub) did not pass expectedHeadOid= (argv: $(cat "$GH_ARGS_FILE"))"
+fi
+
+: > "$GH_ARGS_FILE"
+GH_ARGS_FILE="$GH_ARGS_FILE" PATH="$STUB_DIR:$PATH" \
+  forge_auto_merge "owner/repo" "42" >/dev/null
+if grep -q -- "expectedHeadOid=" "$GH_ARGS_FILE"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_auto_merge (GitHub) passed expectedHeadOid= even though no EXPECTED_HEAD_SHA was given"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_auto_merge (GitHub) omits expectedHeadOid= when EXPECTED_HEAD_SHA is not supplied"
+fi
+
+# --- forge_merge_pr / forge_auto_merge: Gitea ---
+echo ""
+echo "Testing Gitea head_commit_id threading..."
+
+CURL_ARGS_FILE="$(mktemp)"
+cat > "$STUB_DIR/curl" <<'SHIM'
+#!/usr/bin/env bash
+: > "$CURL_ARGS_FILE"
+for a in "$@"; do
+  printf '%s\n' "$a" >> "$CURL_ARGS_FILE"
+done
+printf '{"ok":true}\n200\n'
+SHIM
+chmod +x "$STUB_DIR/curl"
+
+FORGE_TYPE="gitea"
+_GITEA_BASE_URL="https://gitea.example.com"
+_GITEA_TOKEN="tok-abc"
+_GITEA_USERNAME=""
+
+CURL_ARGS_FILE="$CURL_ARGS_FILE" PATH="$STUB_DIR:$PATH" \
+  forge_merge_pr "owner/repo" "42" "gitea-sha-1" >/dev/null
+if grep -q '"head_commit_id":"gitea-sha-1"' "$CURL_ARGS_FILE"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_merge_pr (Gitea) includes head_commit_id in the POST body when supplied"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_merge_pr (Gitea) missing head_commit_id (body: $(tr '\n' ' ' < "$CURL_ARGS_FILE"))"
+fi
+
+CURL_ARGS_FILE="$CURL_ARGS_FILE" PATH="$STUB_DIR:$PATH" \
+  forge_merge_pr "owner/repo" "42" >/dev/null
+if grep -q 'head_commit_id' "$CURL_ARGS_FILE"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_merge_pr (Gitea) included head_commit_id even though no EXPECTED_HEAD_SHA was given"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_merge_pr (Gitea) omits head_commit_id when EXPECTED_HEAD_SHA is not supplied"
+fi
+
+CURL_ARGS_FILE="$CURL_ARGS_FILE" PATH="$STUB_DIR:$PATH" \
+  forge_auto_merge "owner/repo" "42" "gitea-sha-2" >/dev/null
+if grep -q '"head_commit_id":"gitea-sha-2"' "$CURL_ARGS_FILE"; then
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: forge_auto_merge (Gitea) includes head_commit_id in the POST body when supplied"
+else
+    TESTS_RUN=$((TESTS_RUN + 1)); TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: forge_auto_merge (Gitea) missing head_commit_id (body: $(tr '\n' ' ' < "$CURL_ARGS_FILE"))"
+fi
+
+rm -f "$CURL_ARGS_FILE"
+
+# ============================================================================
+# Part 2: the merge-pr.sh classifier + exit-code helper, extracted and
+# unit-tested directly (same strategy as test-merge-pr-auto-reconcile.sh).
+# ============================================================================
+echo ""
+echo "Testing _is_head_mismatch_response / error_head_moved (extracted)..."
+
+CLASSIFIER_FILE="$(mktemp)"
+awk '
+  /^error_head_moved\(\) \{/       { print; next }
+  /^_is_head_mismatch_response\(\) \{/ { capture=1 }
+  capture { print }
+  /^}/ && capture { capture=0 }
+' "$MERGE_PR_SRC" > "$CLASSIFIER_FILE"
+
+if ! grep -q '_is_head_mismatch_response()' "$CLASSIFIER_FILE"; then
+    echo -e "${RED}FATAL${NC}: could not extract _is_head_mismatch_response from $MERGE_PR_SRC" >&2
+    exit 2
+fi
+if ! grep -q 'error_head_moved()' "$CLASSIFIER_FILE"; then
+    echo -e "${RED}FATAL${NC}: could not extract error_head_moved from $MERGE_PR_SRC" >&2
+    exit 2
+fi
+# error_head_moved() references $YELLOW/$NC (merge-pr.sh's own color globals,
+# not captured by the extraction above); this test runs under `set -u`, so an
+# unset reference would abort the function before reaching its `exit 3` and
+# masquerade as a wrong-exit-code failure. $YELLOW is unused by the rest of
+# this test file, so define it once, permanently, as an empty string (output
+# is discarded at every call site below anyway) — cheaper and less fragile
+# than saving/restoring it around each error_head_moved call.
+YELLOW=''
+# shellcheck disable=SC1090
+source "$CLASSIFIER_FILE"
+
+# Positive fixtures: MUST fire.
+positive_fixtures=(
+    "github_rest:Error: Head branch was modified. Review and try the merge again. (HTTP 409)"
+    "gitea:{\"message\":\"head out of date\",\"url\":\"https://gitea.example.com/api/v1/...\"}"
+    "graphql_best_effort:could not enable auto-merge: expectedHeadOid does not match current head"
+)
+for entry in "${positive_fixtures[@]}"; do
+    name="${entry%%:*}"
+    value="${entry#*:}"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if _is_head_mismatch_response "$value"; then
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: _is_head_mismatch_response fires on $name"
+    else
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: _is_head_mismatch_response missed $name ('$value')"
+    fi
+done
+
+# Negative fixtures: MUST NOT fire — especially the pre-existing "Base branch
+# was modified" string, which triggers the OLD retry-and-update-branch path.
+# Conflating the two would either retry forever against a moving head or
+# silently merge a diff different from the one Judge approved.
+negative_fixtures=(
+    "base_modified:Error: Base branch was modified. Review and try the merge again. (HTTP 409)"
+    "merge_in_progress:Merge already in progress"
+    "clean_status:Pull request Pull request is in clean status (enablePullRequestAutoMerge)"
+    "unstable_status:Pull request Pull request is in unstable status (enablePullRequestAutoMerge)"
+)
+for entry in "${negative_fixtures[@]}"; do
+    name="${entry%%:*}"
+    value="${entry#*:}"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if _is_head_mismatch_response "$value"; then
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        echo -e "  ${RED}FAIL${NC}: _is_head_mismatch_response false-fired on $name (would misroute the pre-existing retry path)"
+    else
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        echo -e "  ${GREEN}PASS${NC}: _is_head_mismatch_response correctly ignores $name"
+    fi
+done
+
+# error_head_moved must exit 3 (distinct from error()'s exit 1), per the
+# script's own documented exit-code contract. Guarded with `|| head_moved_rc=$?`
+# so the nonzero exit doesn't trip this test script's own `set -e`.
+head_moved_rc=0
+( error_head_moved "test" >/dev/null 2>&1 ) || head_moved_rc=$?
+assert_eq "3" "$head_moved_rc" "error_head_moved exits 3 (distinct from error()'s exit 1)"
+
+rm -f "$CLASSIFIER_FILE"
+
+# ============================================================================
+# Part 3: source-wiring — merge-pr.sh threads MERGE_PRECONDITION_SHA into
+# both merge calls, and both retry loops check the classifier BEFORE the
+# pre-existing "Base branch was modified" branch.
+# ============================================================================
+echo ""
+echo "Testing merge-pr.sh source wiring..."
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q 'forge_merge_pr "\$REPO_NWO" "\$PR_NUMBER" "\$MERGE_PRECONDITION_SHA"' "$MERGE_PR_SRC"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: merge-pr.sh threads \$MERGE_PRECONDITION_SHA into the synchronous forge_merge_pr call"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: synchronous forge_merge_pr call does not pass \$MERGE_PRECONDITION_SHA"
+fi
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q 'forge_auto_merge "\$REPO_NWO" "\$PR_NUMBER" "\$MERGE_PRECONDITION_SHA"' "$MERGE_PR_SRC"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: merge-pr.sh threads \$MERGE_PRECONDITION_SHA into the shell forge_auto_merge call"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: shell forge_auto_merge call does not pass \$MERGE_PRECONDITION_SHA"
+fi
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q 'MERGE_PRECONDITION_SHA="\$PR_HEAD_SHA"' "$MERGE_PR_SRC" \
+   && grep -q 'forge_get_pr_nocache "\$REPO_NWO" "\$PR_NUMBER" "\$GH"' "$MERGE_PR_SRC"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: MERGE_PRECONDITION_SHA is derived from a fresh (uncached) PR read, not the cached \$GH read alone"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: could not confirm MERGE_PRECONDITION_SHA's uncached-read derivation"
+fi
+
+# Ordering: in BOTH loops, the new classifier must appear BEFORE the existing
+# "Base branch was modified" grep, so a future accidental reorder can't let
+# the base-modified retry path eat a head-mismatch response first.
+sync_loop_order=$(awk '
+  /^for MERGE_ATTEMPT in \$\(seq 1 \$MAX_MERGE_RETRIES\); do/ { infor=1 }
+  infor && /_is_head_mismatch_response "\$MERGE_RESPONSE"/ { print "mismatch"; exit }
+  infor && /grep -q "Base branch was modified"/ { print "base_modified"; exit }
+' "$MERGE_PR_SRC")
+assert_eq "mismatch" "$sync_loop_order" "synchronous retry loop checks the head-mismatch classifier before 'Base branch was modified'"
+
+auto_loop_order=$(awk '
+  /^  for MERGE_ATTEMPT in \$\(seq 1 \$MAX_MERGE_RETRIES\); do/ { infor=1 }
+  infor && /_is_head_mismatch_response "\$AUTO_MERGE_OUTPUT"/ { print "mismatch"; exit }
+  infor && /grep -q "Base branch was modified"/ { print "base_modified"; exit }
+' "$MERGE_PR_SRC")
+assert_eq "mismatch" "$auto_loop_order" "auto-merge retry loop checks the head-mismatch classifier before 'Base branch was modified'"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q '^#   3 = PR head moved' "$MERGE_PR_SRC"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: merge-pr.sh's header 'Exit codes' comment documents exit 3"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: header 'Exit codes' comment does not document exit 3"
+fi
+
+# ============================================================================
+# Part 4: champion-pr-merge.md wires the exit-3 re-queue outcome distinctly
+# from the failure path, and documents the squash-merge detection trap.
+# ============================================================================
+echo ""
+echo "Testing champion-pr-merge.md wiring..."
+
+CHAMPION_MD="$HELPERS_DIR/../.claude/commands/loom/champion-pr-merge.md"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$CHAMPION_MD" ]] && grep -q 'MERGE_RC' "$CHAMPION_MD" && grep -q '"\$MERGE_RC" -eq 3' "$CHAMPION_MD"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: champion-pr-merge.md Step 3 captures merge-pr.sh's exit code and branches on 3 (re-queue)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: champion-pr-merge.md does not branch on exit code 3"
+fi
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$CHAMPION_MD" ]] && grep -qi 'squash-merge detection trap' "$CHAMPION_MD"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: champion-pr-merge.md documents the squash-merge detection trap"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: champion-pr-merge.md is missing the squash-merge detection trap note"
+fi
+
+# --- Summary ---
+echo ""
+echo "────────────────────────────────"
+echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Champion could squash-merge a PR while a session was still pushing new commits
to its branch, silently stranding those commits — squash-merge makes this
invisible to the obvious `git merge-base --is-ancestor` check, since the new
squash commit is never a descendant of the stranded commits either way.

## Root cause

Neither `forge_merge_pr()` nor `forge_auto_merge()`
(`defaults/scripts/lib/forge-helpers.sh`) passed a head-SHA optimistic-concurrency
precondition to the forge's merge API, even though `merge-pr.sh` already
computed `$PR_HEAD_SHA` for an unrelated purpose (local branch cleanup safety).

## Changes

- **`defaults/scripts/lib/forge-helpers.sh`**: `forge_merge_pr()` and
  `forge_auto_merge()` accept an optional 3rd `EXPECTED_HEAD_SHA` argument,
  threaded into GitHub's `sha` (REST) / `expectedHeadOid` (GraphQL) fields and
  Gitea's `head_commit_id` field. Backward compatible — omitted entirely when
  not supplied.
- **`defaults/scripts/merge-pr.sh`**:
  - Reads the freshest possible head SHA (`MERGE_PRECONDITION_SHA`, via an
    uncached `forge_get_pr_nocache` call) immediately before either merge path
    runs, falling back to the already-known `$PR_HEAD_SHA` on lookup failure
    (fail-safe: a stale value only ever produces a spurious re-queue, never a
    stale-but-accepted merge — the forge itself does the real comparison).
  - New `_is_head_mismatch_response()` classifier + `error_head_moved()` helper:
    a head-SHA-mismatch response is now a **distinct exit code (3, not 1)**,
    checked *before* the existing "Base branch was modified" retry branch in
    both the synchronous and `--auto` retry loops, so a future edit can't
    accidentally let the base-modified retry eat a head-mismatch case.
    Exit 3 must NOT retry-and-merge (that would defeat the guard) — it
    surfaces a distinct condition for the caller to recognize as "re-queue,
    don't fail loudly."
  - Documented in the script's "Exit codes" header comment.
- **`defaults/.claude/commands/loom/champion-pr-merge.md`**: Step 3 captures
  `merge-pr.sh`'s exit code and branches on 3 — re-queues the PR (leaves
  `loom:pr` in place, does not post a failure comment, does not count it as an
  error) instead of following the existing failure path. New "Exception: exit
  code 3" subsection in Error Handling documents this, plus the **squash-merge
  detection trap**: ancestry checks can't distinguish "squashed-and-landed"
  from "stranded" after the fact — verification requires diffing actual file
  content on `main`, not `git merge-base --is-ancestor`.
- **`defaults/scripts/tests/test-merge-pr-head-mismatch.sh`** (new, wired into
  `ci-wired.txt`): 23 assertions across 4 layers — SHA threading for both
  forges (GitHub REST/GraphQL, Gitea), the classifier/exit-code helper against
  positive/negative string fixtures (including the pre-existing "Base branch
  was modified" string, to confirm the two stay mutually exclusive), source
  wiring + branch ordering in both retry loops, and `champion-pr-merge.md`'s
  exit-3 handling + squash-merge-trap documentation.

## Verified against live API specs (documented in code comments)

- GitHub REST `sha` field / 409 "Head branch was modified. Review and try the
  merge again." — verified against GitHub's public OpenAPI spec.
- Gitea `head_commit_id` field / `ErrSHADoesNotMatch` → 409 "head out of date"
  — verified against Gitea/Forgejo's published swagger + upstream source.
- GitHub GraphQL `expectedHeadOid` input field — confirmed present in GitHub's
  public GraphQL schema; the exact mismatch error text could **not** be
  verified against a live incident or published docs (GraphQL validation
  error text isn't part of the schema) — the classifier's GraphQL pattern is
  best-effort, flagged in comments for tightening against the first real
  occurrence.

## Known gap (documented, tracked separately)

The `loom-daemon` native `forge auto-merge` path (preferred whenever
`loom-daemon` is on `PATH` — the common case) has no equivalent
`expectedHeadOid`/`sha` precondition flag. This means the head-moved guard
added here fully protects the always-shell synchronous `forge_merge_pr` path
and the Gitea/loom-daemon-absent `forge_auto_merge` fallback, but a GitHub
merge routed through the native `loom-daemon` auto-merge call can still
silently squash whatever the current head is. Documented inline in
`merge-pr.sh` and tracked in #5589.

## Test plan

- [x] New `test-merge-pr-head-mismatch.sh`: 23/23 passing.
- [x] All 15 pre-existing `test-merge-pr-*.sh` suites still pass (no
      regressions in the retry-loop/classifier ordering change).
- [x] `test-forge-helpers.sh` and `test-forge-helpers-rate-limit-fallback.sh`
      still pass.
- [x] `check-ci-suite-manifest.sh`: new suite correctly wired into
      `ci-wired.txt`.
- [x] `shellcheck` on all modified/new shell files: no new errors (pre-existing
      style-only SC2016/SC2015/SC2002 infos, none introduced by this change).
- [x] `bash -n` syntax check on all modified/new shell files.
- Manual end-to-end verification against a live GitHub race (push mid-merge)
  is not practical in CI — per the issue's own test plan, favored testing the
  shell logic/parsing in isolation instead, matching the existing
  `test-merge-pr-auto-reconcile.sh` "extract from source" strategy.

## Edge cases from the issue's test plan

- (a) Benign/identical-content head moves still conservatively re-queue — the
  guard doesn't attempt to distinguish "safe" moves; any head-SHA mismatch is
  exit 3.
- (b) Gitea: confirmed the equivalent precondition (`head_commit_id`) exists
  and is wired — not a documented gap after all (the curated issue's
  "suspected cause" was more pessimistic than the actual Gitea API surface).
- (c) `--auto` GitHub auto-merge-queue path: `expectedHeadOid` is an input to
  `enablePullRequestAutoMerge` itself (enable-time), not the eventual queued
  merge execution. Whether it's re-checked at actual-merge time (which can
  happen well after the mutation returns) could not be confirmed against
  public docs — flagged inline as a residual risk on that specific path,
  distinct from the documented `loom-daemon` native-path gap above.

Closes #5579