### PR TITLE
feat(daemon): add --expected-head-sha precondition to forge auto-merge

### DIFF
--- a/defaults/scripts/merge-pr.sh
+++ b/defaults/scripts/merge-pr.sh
@@ -1277,26 +1277,32 @@ if [[ "$AUTO_MERGE" == "true" ]]; then
     # its gh error is left in AUTO_MERGE_OUTPUT so the disabled/clean/unstable
     # detection further down fires exactly as it did for loom-auto-merge.
     #
-    # KNOWN GAP (#5579, noted not fixed here — out of scope per the issue's own
-    # curation): this native path has no `--expected-head-sha`/`--match-head-
-    # commit` flag equivalent to the `sha`/`expectedHeadOid` precondition this
-    # commit adds to the shell forge_auto_merge/forge_merge_pr below. Since
-    # this native path is preferred whenever `loom-daemon` is on PATH (the
-    # common case), the head-moved guard added below only actually protects
-    # the Gitea-decline and loom-daemon-absent fallback through shell
-    # forge_auto_merge, plus the always-shell synchronous forge_merge_pr path.
-    # A GitHub merge routed through this native call can still silently
-    # squash whatever the current head is. Tracked separately in #5589.
+    # #5589 (closes the #5579 gap noted here previously): the native path now
+    # carries the same `expectedHeadOid` optimistic-concurrency precondition
+    # as the shell forge_auto_merge/forge_merge_pr below, via
+    # `--expected-head-sha`. A head-SHA mismatch on this path exits 4
+    # (EX_FORGE_HEAD_MISMATCH in loom-daemon/src/forge_cmd.rs) — distinct
+    # from both the Gitea-decline exit (3) and the generic failure exit (1) —
+    # and is routed straight to `error_head_moved()` below, the same
+    # "re-queue, not a failure" signal `_is_head_mismatch_response()` gives
+    # the shell path.
     _AM_DECLINED=true
     if command -v loom-daemon &>/dev/null; then
       [[ $MERGE_ATTEMPT -eq 1 ]] && info "Using loom-daemon forge auto-merge (native forge-agnostic auto-merge)"
       # `|| _AM_RC=$?` keeps the failing substitution from tripping `set -e`
-      # and captures the native exit code (0=merged, 3=Gitea decline, else fail).
+      # and captures the native exit code (0=merged, 3=Gitea decline,
+      # 4=head-SHA mismatch, else fail).
       _AM_RC=0
-      AUTO_MERGE_OUTPUT=$(loom-daemon forge auto-merge "$PR_NUMBER" --method squash 2>&1) || _AM_RC=$?
+      AUTO_MERGE_OUTPUT=$(loom-daemon forge auto-merge "$PR_NUMBER" --method squash --expected-head-sha "$MERGE_PRECONDITION_SHA" 2>&1) || _AM_RC=$?
       if [[ $_AM_RC -eq 0 ]]; then
         AUTO_MERGE_OK=true
         break
+      elif [[ $_AM_RC -eq 4 ]]; then
+        # Native path detected a head-SHA mismatch (#5589) — same "re-queue,
+        # stale approval" signal as the shell path's
+        # _is_head_mismatch_response() check further down; do not fall
+        # through to the generic failure/retry branch.
+        error_head_moved "PR #$PR_NUMBER: $AUTO_MERGE_OUTPUT"
       elif [[ $_AM_RC -ne 3 ]]; then
         # Native attempted and failed (not a Gitea decline) — keep the gh error
         # in AUTO_MERGE_OUTPUT and fall through to the recheck/retry logic.

--- a/defaults/scripts/tests/test-merge-pr-head-mismatch.sh
+++ b/defaults/scripts/tests/test-merge-pr-head-mismatch.sh
@@ -370,6 +370,52 @@ else
     echo -e "  ${RED}FAIL${NC}: champion-pr-merge.md is missing the squash-merge detection trap note"
 fi
 
+# ============================================================================
+# Part 5 (#5589): the native `loom-daemon forge auto-merge` call site passes
+# --expected-head-sha and its _AM_RC dispatch routes the new distinct
+# head-mismatch exit code (4) to error_head_moved(), not the generic
+# failure/retry branch. loom-daemon itself is Rust-tested separately
+# (loom-daemon/src/forge_cmd.rs); this only verifies merge-pr.sh's own
+# source-level wiring of the exit code it already knows about (matching this
+# file's existing "source-wiring" grep strategy, not an executable stub —
+# there is no `loom-daemon` binary available in this shell-only test harness).
+# ============================================================================
+echo ""
+echo "Testing native loom-daemon forge auto-merge wiring (#5589)..."
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -q 'loom-daemon forge auto-merge "\$PR_NUMBER" --method squash --expected-head-sha "\$MERGE_PRECONDITION_SHA"' "$MERGE_PR_SRC"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: merge-pr.sh passes --expected-head-sha \$MERGE_PRECONDITION_SHA to the native loom-daemon forge auto-merge call"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: native loom-daemon forge auto-merge call does not pass --expected-head-sha \$MERGE_PRECONDITION_SHA"
+fi
+
+# The native dispatch's `_AM_RC -eq 4` branch must call error_head_moved
+# BEFORE the `_AM_RC -ne 3` (Gitea-decline) check further down, so a 4 never
+# falls through and gets misclassified as a generic native failure.
+native_dispatch_order=$(awk '
+  /AUTO_MERGE_OUTPUT=\$\(loom-daemon forge auto-merge/ { indispatch=1 }
+  indispatch && /_AM_RC -eq 4/ { print "mismatch"; exit }
+  indispatch && /_AM_RC -ne 3/ { print "decline_check"; exit }
+' "$MERGE_PR_SRC")
+assert_eq "mismatch" "$native_dispatch_order" "native _AM_RC dispatch checks the head-mismatch exit code (4) before the Gitea-decline check (-ne 3)"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if awk '
+  /AUTO_MERGE_OUTPUT=\$\(loom-daemon forge auto-merge/ { indispatch=1; next }
+  indispatch && /_AM_RC -eq 4/ { found=1 }
+  found && /error_head_moved "PR #\$PR_NUMBER: \$AUTO_MERGE_OUTPUT"/ { print "ok"; exit }
+  indispatch && /^    fi$/ { exit }
+' "$MERGE_PR_SRC" | grep -q ok; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    echo -e "  ${GREEN}PASS${NC}: the native _AM_RC -eq 4 branch calls error_head_moved() (re-queue, not a generic failure)"
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+    echo -e "  ${RED}FAIL${NC}: could not confirm the native _AM_RC -eq 4 branch calls error_head_moved()"
+fi
+
 # --- Summary ---
 echo ""
 echo "────────────────────────────────"

--- a/loom-daemon/src/cli/tokens.rs
+++ b/loom-daemon/src/cli/tokens.rs
@@ -517,10 +517,14 @@ pub(crate) fn handle_forge_command(action: ForgeAction) -> Result<()> {
         ForgeAction::Pr { args } => ForgeCmd::Pr(args),
         ForgeAction::Auth { args } => ForgeCmd::Auth(args),
         ForgeAction::AutoMerge {
-            pr_number, method, ..
+            pr_number,
+            method,
+            expected_head_sha,
+            ..
         } => ForgeCmd::AutoMerge {
             pr: pr_number,
             method,
+            expected_head_sha,
         },
     };
     dispatch(cmd)

--- a/loom-daemon/src/forge_cmd.rs
+++ b/loom-daemon/src/forge_cmd.rs
@@ -75,6 +75,18 @@ use crate::config_resolver::{get_path, resolve_effective_config};
 /// error (which must flow into the disabled/clean/unstable detection).
 pub const EX_FORGE_DECLINED: i32 = 3;
 
+/// Exit code `forge auto-merge` uses to signal a GitHub head-SHA-mismatch
+/// response — the `expectedHeadOid` optimistic-concurrency precondition (see
+/// [`github_auto_merge`]) was violated, i.e. the PR's head branch moved past
+/// the caller-supplied `--expected-head-sha` between the caller's read and
+/// this call. Distinct from both [`EX_FORGE_DECLINED`] (3, the Gitea-decline
+/// signal) and the generic failure exit `1`, so `merge-pr.sh`'s `_AM_RC`
+/// dispatch can route this straight to `error_head_moved()` (a "re-queue,
+/// stale approval" signal, not a hard failure) the same way its own
+/// `_is_head_mismatch_response()` classifier does for the shell merge path
+/// (#5579 / #5589).
+pub const EX_FORGE_HEAD_MISMATCH: i32 = 4;
+
 /// The two forge backends Loom understands.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ForgeType {
@@ -420,9 +432,18 @@ fn gh_passthrough(entity: &str, args: &[String]) -> Result<()> {
 /// Enable GitHub auto-merge for `pr` via the `enablePullRequestAutoMerge`
 /// GraphQL mutation (ported from `common/github.py::auto_merge_pull_request`).
 /// The `poll_interval` / `timeout` args are accepted for CLI compatibility but
-/// ignored on GitHub (the server queues the merge). Returns the process exit
-/// code to use.
-fn github_auto_merge(pr: u32, method: &str) -> i32 {
+/// ignored on GitHub (the server queues the merge).
+///
+/// `expected_head_sha` (optional, #5589 — mirrors the shell
+/// `forge_auto_merge`'s `EXPECTED_HEAD_SHA` precondition added by #5579):
+/// when present, threaded into the mutation's `expectedHeadOid: GitObjectID`
+/// input field, GitHub's optimistic-concurrency guard against merging a head
+/// the caller never actually saw approved. A mismatch response is classified
+/// via [`is_head_mismatch_response`] and reported as
+/// [`EX_FORGE_HEAD_MISMATCH`] rather than the generic failure exit `1`.
+///
+/// Returns the process exit code to use.
+fn github_auto_merge(pr: u32, method: &str, expected_head_sha: Option<&str>) -> i32 {
     let gh = gh_bin();
 
     // Resolve the repo NWO (owner/repo).
@@ -471,27 +492,48 @@ fn github_auto_merge(pr: u32, method: &str) -> i32 {
     }
 
     // Step 2: enable auto-merge via GraphQL. mergeMethod must be uppercase.
+    // The $expectedHeadOid variable is only declared/bound when the caller
+    // supplied a precondition SHA, mirroring the shell forge_auto_merge's
+    // conditional field (lib/forge-helpers.sh) rather than always sending a
+    // null expectedHeadOid.
     let merge_method = method.to_ascii_uppercase();
-    let mutation = "mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {\
+    let mutation = if expected_head_sha.is_some() {
+        "mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!, $expectedHeadOid: GitObjectID) {\
+  enablePullRequestAutoMerge(input: {\
+    pullRequestId: $pullRequestId,\
+    mergeMethod: $mergeMethod,\
+    expectedHeadOid: $expectedHeadOid\
+  }) {\
+    pullRequest { number autoMergeRequest { enabledAt } }\
+  }\
+}"
+    } else {
+        "mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {\
   enablePullRequestAutoMerge(input: {\
     pullRequestId: $pullRequestId,\
     mergeMethod: $mergeMethod\
   }) {\
     pullRequest { number autoMergeRequest { enabledAt } }\
   }\
-}";
-    let result = Command::new(&gh)
-        .args([
-            "api",
-            "graphql",
-            "-f",
-            &format!("query={mutation}"),
-            "-F",
-            &format!("pullRequestId={node_id}"),
-            "-F",
-            &format!("mergeMethod={merge_method}"),
-        ])
-        .output();
+}"
+    };
+
+    let mut args = vec![
+        "api".to_string(),
+        "graphql".to_string(),
+        "-f".to_string(),
+        format!("query={mutation}"),
+        "-F".to_string(),
+        format!("pullRequestId={node_id}"),
+        "-F".to_string(),
+        format!("mergeMethod={merge_method}"),
+    ];
+    if let Some(sha) = expected_head_sha {
+        args.push("-F".to_string());
+        args.push(format!("expectedHeadOid={sha}"));
+    }
+
+    let result = Command::new(&gh).args(&args).output();
     match result {
         Ok(o) if o.status.success() => {
             println!("Auto-merge enabled for PR #{pr}");
@@ -508,13 +550,30 @@ fn github_auto_merge(pr: u32, method: &str) -> i32 {
                 err.trim()
             };
             eprintln!("Failed to enable auto-merge for PR #{pr}: {detail}");
-            1
+            if expected_head_sha.is_some() && is_head_mismatch_response(detail) {
+                EX_FORGE_HEAD_MISMATCH
+            } else {
+                1
+            }
         }
         Err(e) => {
             eprintln!("Failed to enable auto-merge for PR #{pr}: {e}");
             1
         }
     }
+}
+
+/// Detect a head-SHA-mismatch response from the `enablePullRequestAutoMerge`
+/// GraphQL mutation, mirroring `merge-pr.sh`'s own
+/// `_is_head_mismatch_response()` classifier (kept in sync deliberately —
+/// see that function's comment for the string-provenance caveat: the
+/// GraphQL `expectedHeadOid` mismatch text is best-effort, not verified
+/// against a live incident or the (unpublished) GraphQL error schema).
+fn is_head_mismatch_response(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("head branch was modified")
+        || lower.contains("head out of date")
+        || lower.contains("expectedheadoid")
 }
 
 /// Resolve `owner/repo`. Prefers `gh repo view --json nameWithOwner`
@@ -575,11 +634,15 @@ fn parse_nwo_from_remote_url(url: &str) -> Option<String> {
 
 /// Handle `loom-daemon forge auto-merge`. GitHub goes native (GraphQL); Gitea
 /// declines with [`EX_FORGE_DECLINED`] so the shell `forge_auto_merge` carries
-/// the poll-and-merge. Never returns (exits the process).
-pub fn handle_auto_merge(pr: u32, method: &str) -> Result<()> {
+/// the poll-and-merge. `expected_head_sha` is forwarded to
+/// [`github_auto_merge`] (ignored on the Gitea decline path — Gitea always
+/// falls back to the shell `forge_auto_merge`, which already carries its own
+/// `EXPECTED_HEAD_SHA` precondition, #5579). Never returns (exits the
+/// process).
+pub fn handle_auto_merge(pr: u32, method: &str, expected_head_sha: Option<&str>) -> Result<()> {
     let ft = detect_forge(None);
     match ft {
-        ForgeType::GitHub => std::process::exit(github_auto_merge(pr, method)),
+        ForgeType::GitHub => std::process::exit(github_auto_merge(pr, method, expected_head_sha)),
         ForgeType::Gitea => {
             eprintln!(
                 "loom-daemon forge auto-merge: gitea is not handled natively; falling \
@@ -609,8 +672,16 @@ pub enum ForgeCmd {
     Pr(Vec<String>),
     /// `forge auth <args…>` — passthrough to `gh auth` on GitHub.
     Auth(Vec<String>),
-    /// `forge auto-merge <pr> [--method M]`.
-    AutoMerge { pr: u32, method: String },
+    /// `forge auto-merge <pr> [--method M] [--expected-head-sha SHA]`.
+    AutoMerge {
+        pr: u32,
+        method: String,
+        /// Optimistic-concurrency precondition (#5589): the SHA the PR's head
+        /// branch must currently match, threaded into the GitHub
+        /// `expectedHeadOid` mutation input. `None` preserves prior
+        /// (unguarded) behavior.
+        expected_head_sha: Option<String>,
+    },
 }
 
 /// Dispatch a parsed `forge` subcommand. Handlers exit the process directly
@@ -631,7 +702,11 @@ pub fn dispatch(cmd: ForgeCmd) -> Result<()> {
         ForgeCmd::Issue(args) => gh_passthrough("issue", &args),
         ForgeCmd::Pr(args) => gh_passthrough("pr", &args),
         ForgeCmd::Auth(args) => gh_passthrough("auth", &args),
-        ForgeCmd::AutoMerge { pr, method } => handle_auto_merge(pr, &method),
+        ForgeCmd::AutoMerge {
+            pr,
+            method,
+            expected_head_sha,
+        } => handle_auto_merge(pr, &method, expected_head_sha.as_deref()),
     }
 }
 
@@ -1043,5 +1118,180 @@ mod tests {
             Some("acme/widgets")
         );
         assert_eq!(parse_nwo_from_remote_url("not-a-remote"), None);
+    }
+
+    // ===== #5589: is_head_mismatch_response() classifier =====
+
+    #[test]
+    fn is_head_mismatch_response_matches_known_patterns() {
+        assert!(is_head_mismatch_response(
+            "Head branch was modified. Review and try the merge again."
+        ));
+        assert!(is_head_mismatch_response("pull request head out of date"));
+        assert!(is_head_mismatch_response(
+            "gh: GraphQL: Variable $expectedHeadOid of type GitObjectID was invalid"
+        ));
+        // Case-insensitive.
+        assert!(is_head_mismatch_response("HEAD OUT OF DATE"));
+        // Unrelated failures do not match.
+        assert!(!is_head_mismatch_response("Pull request Review is in unstable status"));
+        assert!(!is_head_mismatch_response("Base branch was modified"));
+        assert!(!is_head_mismatch_response("connection refused"));
+    }
+
+    // ===== #5589: github_auto_merge() expectedHeadOid mutation wiring =====
+
+    /// Writes a fake `gh` that answers the three calls `github_auto_merge()`
+    /// makes (`repo view`, the node_id lookup, and the `graphql` mutation),
+    /// capturing the full `graphql` argv (one arg per line) to `$CAPTURE_FILE`
+    /// and replying to the mutation per `$MOCK_RESULT`
+    /// (`success` | `mismatch` | `other_fail`).
+    fn write_mock_gh_for_auto_merge(dir: &Path) -> PathBuf {
+        let path = dir.join("fake-gh-automerge.sh");
+        std::fs::write(
+            &path,
+            r#"#!/bin/sh
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  printf 'acme/widgets'
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" != "graphql" ]; then
+  printf 'NODEID123'
+  exit 0
+fi
+if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
+  shift
+  printf '%s\n' "$@" > "$CAPTURE_FILE"
+  case "$MOCK_RESULT" in
+    success)
+      echo '{"data":{"enablePullRequestAutoMerge":{"pullRequest":{"number":1}}}}'
+      exit 0
+      ;;
+    mismatch)
+      echo 'gh: GraphQL: Head branch was modified. Review and try the merge again. (enablePullRequestAutoMerge)' 1>&2
+      exit 1
+      ;;
+    other_fail)
+      echo 'gh: GraphQL: Pull Request is in unstable status' 1>&2
+      exit 1
+      ;;
+  esac
+  exit 1
+fi
+exit 1
+"#,
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+        path
+    }
+
+    /// Sets `LOOM_GH_BIN` / `CAPTURE_FILE` / `MOCK_RESULT`, runs
+    /// `github_auto_merge`, and clears the env vars again. Serialized (env
+    /// vars are process-global) like the other `#[serial]` tests in this
+    /// module.
+    fn run_github_auto_merge_with_mock(
+        gh: &Path,
+        capture_file: &Path,
+        mock_result: &str,
+        expected_head_sha: Option<&str>,
+    ) -> i32 {
+        std::env::set_var("LOOM_GH_BIN", gh);
+        std::env::set_var("CAPTURE_FILE", capture_file);
+        std::env::set_var("MOCK_RESULT", mock_result);
+        let rc = github_auto_merge(42, "squash", expected_head_sha);
+        std::env::remove_var("LOOM_GH_BIN");
+        std::env::remove_var("CAPTURE_FILE");
+        std::env::remove_var("MOCK_RESULT");
+        rc
+    }
+
+    #[test]
+    #[serial]
+    fn github_auto_merge_threads_expected_head_oid_into_mutation() {
+        let dir = tempdir().unwrap();
+        let gh = write_mock_gh_for_auto_merge(dir.path());
+        let capture = dir.path().join("capture.txt");
+
+        let rc = run_github_auto_merge_with_mock(&gh, &capture, "success", Some("deadbeef123"));
+        assert_eq!(rc, 0);
+
+        let captured = std::fs::read_to_string(&capture).unwrap();
+        assert!(
+            captured.contains("expectedHeadOid=deadbeef123"),
+            "expected -F expectedHeadOid=deadbeef123 in captured argv, got: {captured}"
+        );
+        assert!(
+            captured.contains("expectedHeadOid: $expectedHeadOid"),
+            "expected the mutation body to reference $expectedHeadOid, got: {captured}"
+        );
+        assert!(
+            captured.contains("$expectedHeadOid: GitObjectID"),
+            "expected the mutation to declare $expectedHeadOid: GitObjectID, got: {captured}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn github_auto_merge_omits_expected_head_oid_when_not_supplied() {
+        let dir = tempdir().unwrap();
+        let gh = write_mock_gh_for_auto_merge(dir.path());
+        let capture = dir.path().join("capture.txt");
+
+        let rc = run_github_auto_merge_with_mock(&gh, &capture, "success", None);
+        assert_eq!(rc, 0);
+
+        let captured = std::fs::read_to_string(&capture).unwrap();
+        assert!(
+            !captured.contains("expectedHeadOid"),
+            "expectedHeadOid must not appear when no precondition SHA was supplied, got: {captured}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn github_auto_merge_head_mismatch_exits_distinct_code() {
+        let dir = tempdir().unwrap();
+        let gh = write_mock_gh_for_auto_merge(dir.path());
+        let capture = dir.path().join("capture.txt");
+
+        let rc = run_github_auto_merge_with_mock(&gh, &capture, "mismatch", Some("deadbeef123"));
+        assert_eq!(rc, EX_FORGE_HEAD_MISMATCH);
+        assert_ne!(EX_FORGE_HEAD_MISMATCH, EX_FORGE_DECLINED);
+        assert_ne!(EX_FORGE_HEAD_MISMATCH, 1);
+        assert_ne!(EX_FORGE_HEAD_MISMATCH, 0);
+    }
+
+    #[test]
+    #[serial]
+    fn github_auto_merge_non_mismatch_failure_exits_generic_failure() {
+        let dir = tempdir().unwrap();
+        let gh = write_mock_gh_for_auto_merge(dir.path());
+        let capture = dir.path().join("capture.txt");
+
+        let rc = run_github_auto_merge_with_mock(&gh, &capture, "other_fail", Some("deadbeef123"));
+        assert_eq!(rc, 1);
+    }
+
+    #[test]
+    #[serial]
+    fn github_auto_merge_without_precondition_never_reports_head_mismatch() {
+        // Even if the (unlikely) response text happens to match the
+        // head-mismatch pattern, no precondition means no
+        // expectedHeadOid-mismatch classification is meaningful: the caller
+        // never asked for the guard, so this must fall through to the
+        // generic failure exit, not EX_FORGE_HEAD_MISMATCH.
+        let dir = tempdir().unwrap();
+        let gh = write_mock_gh_for_auto_merge(dir.path());
+        let capture = dir.path().join("capture.txt");
+
+        let rc = run_github_auto_merge_with_mock(&gh, &capture, "mismatch", None);
+        assert_eq!(rc, 1);
     }
 }

--- a/loom-daemon/src/main.rs
+++ b/loom-daemon/src/main.rs
@@ -1533,11 +1533,12 @@ enum ForgeAction {
         )]
         args: Vec<String>,
     },
-    /// `forge auto-merge <pr> [--method M]` — enable auto-merge for a PR
-    /// (formerly `loom-auto-merge`). GitHub: `enablePullRequestAutoMerge`
-    /// GraphQL mutation. Gitea: declines (exit 3) → shell `forge_auto_merge`.
-    /// `--poll-interval` / `--timeout` are accepted for CLI compatibility and
-    /// ignored on GitHub (the server queues the merge).
+    /// `forge auto-merge <pr> [--method M] [--expected-head-sha SHA]` —
+    /// enable auto-merge for a PR (formerly `loom-auto-merge`). GitHub:
+    /// `enablePullRequestAutoMerge` GraphQL mutation. Gitea: declines (exit
+    /// 3) → shell `forge_auto_merge`. `--poll-interval` / `--timeout` are
+    /// accepted for CLI compatibility and ignored on GitHub (the server
+    /// queues the merge).
     #[command(name = "auto-merge")]
     AutoMerge {
         /// Pull request number.
@@ -1547,6 +1548,15 @@ enum ForgeAction {
         /// Merge method (squash | merge | rebase). Default squash.
         #[arg(long, default_value = "squash")]
         method: String,
+
+        /// Optimistic-concurrency precondition (#5589, mirrors #5579's shell
+        /// `EXPECTED_HEAD_SHA`): the SHA the PR's head branch must currently
+        /// match. Threaded into the GitHub `expectedHeadOid` GraphQL mutation
+        /// input; a mismatch exits `EX_FORGE_HEAD_MISMATCH` (4) instead of
+        /// the generic failure exit `1`, distinguishable from a Gitea decline
+        /// (exit 3). Omit to preserve prior (unguarded) behavior.
+        #[arg(long, value_name = "SHA")]
+        expected_head_sha: Option<String>,
 
         /// Seconds between CI polls (Gitea shell path only). Accepted for
         /// compatibility; unused on the GitHub native path.


### PR DESCRIPTION
## Summary

`loom-daemon forge auto-merge` lacked the head-SHA optimistic-concurrency
precondition #5579 added to the shell merge path
(`forge_merge_pr()` / `forge_auto_merge()` in
`defaults/scripts/lib/forge-helpers.sh`). Since `merge-pr.sh` prefers the
native `loom-daemon` path whenever it is on `PATH`, this gap meant a
GitHub `--auto` merge on the most common path had no protection against
squash-merging a PR whose branch received new commits after the
approving review — reproducing #5579's original bug on the path most
fleets actually exercise.

## Changes

- `loom-daemon/src/main.rs`: add `--expected-head-sha <SHA>` to the
  `forge auto-merge` clap subcommand.
- `loom-daemon/src/cli/tokens.rs`: thread the new field through
  `ForgeAction::AutoMerge` → `ForgeCmd::AutoMerge`.
- `loom-daemon/src/forge_cmd.rs`:
  - `github_auto_merge()` now accepts an optional `expected_head_sha`
    and, when present, threads it into the `enablePullRequestAutoMerge`
    GraphQL mutation's `expectedHeadOid` input (the mutation's
    `$expectedHeadOid` variable is only declared when a precondition is
    supplied, mirroring the shell side's conditional field).
  - New `EX_FORGE_HEAD_MISMATCH = 4` exit code — distinct from
    `EX_FORGE_DECLINED = 3` (Gitea decline) and the generic failure exit
    `1` — returned when the GraphQL response matches a head-mismatch
    pattern (`is_head_mismatch_response()`, mirroring `merge-pr.sh`'s own
    `_is_head_mismatch_response()`).
  - `handle_auto_merge()` forwards `expected_head_sha` through; the
    Gitea decline path is unaffected (Gitea always falls back to the
    shell path, which already carries its own `EXPECTED_HEAD_SHA`
    precondition from #5579).
- `defaults/scripts/merge-pr.sh`: the native-path call site now passes
  `--expected-head-sha "$MERGE_PRECONDITION_SHA"`, and the `_AM_RC`
  dispatch routes exit `4` straight to `error_head_moved()` (a
  "re-queue, stale approval" signal, exit 3, not a hard failure) instead
  of falling into the generic native-failure branch.

## Acceptance Criteria Verification

1. ✅ `loom-daemon forge auto-merge <pr>` accepts `--expected-head-sha
   <SHA>` — added to the clap subcommand in `main.rs`.
2. ✅ When supplied, the value is threaded into the
   `enablePullRequestAutoMerge` mutation's `expectedHeadOid` input in
   `github_auto_merge()`.
3. ✅ A GitHub head-SHA mismatch is distinguishable via a new, distinct
   exit code (`EX_FORGE_HEAD_MISMATCH = 4`) that does not collide with
   `EX_FORGE_DECLINED = 3` or the generic failure exit `1` — verified in
   `github_auto_merge_head_mismatch_exits_distinct_code`.
4. ✅ `merge-pr.sh`'s native-path call site (`_AM_RC` dispatch,
   `defaults/scripts/merge-pr.sh:1296` at time of writing) passes
   `--expected-head-sha "$MERGE_PRECONDITION_SHA"` and routes exit 4 to
   `error_head_moved()` before the Gitea-decline check (`-ne 3`).
5. ✅ Gitea is unaffected — `handle_auto_merge()` still declines
   unconditionally for Gitea (`EX_FORGE_DECLINED`), no Gitea-side
   change.

## Test Plan

- `cargo check` / `cargo clippy --all-targets -- -D warnings` /
  `cargo fmt -- --check` — all clean in `loom-daemon`.
- `cargo nextest run --workspace --profile ci` (the same command CI's
  `backend-tests` job runs) — 3929/3929 tests passed (plain `cargo test`
  shows unrelated pre-existing flakiness from the daemon suite's
  environment-variable mutation racing with `Command::spawn`, a
  documented issue that's exactly why CI uses `nextest`'s
  process-per-test isolation instead — not caused by this change).
- New Rust tests in `loom-daemon/src/forge_cmd.rs` (all passing):
  - `is_head_mismatch_response_matches_known_patterns`
  - `github_auto_merge_threads_expected_head_oid_into_mutation`
  - `github_auto_merge_omits_expected_head_oid_when_not_supplied`
  - `github_auto_merge_head_mismatch_exits_distinct_code`
  - `github_auto_merge_non_mismatch_failure_exits_generic_failure`
  - `github_auto_merge_without_precondition_never_reports_head_mismatch`
- Extended `defaults/scripts/tests/test-merge-pr-head-mismatch.sh` with
  a new "Part 5" (source-wiring style, matching the file's existing
  strategy) verifying `merge-pr.sh` passes `--expected-head-sha` to the
  native call and that its `_AM_RC` dispatch checks exit code 4 before
  the Gitea-decline check and routes it to `error_head_moved()` — 26/26
  passed.
- `shellcheck defaults/scripts/merge-pr.sh
  defaults/scripts/tests/test-merge-pr-head-mismatch.sh` — no new
  findings (only pre-existing info-level SC2016/SC2015/SC2002 notices).
- Manual live-PR verification (stale SHA rejected / current SHA
  succeeds) from the issue's Test Plan was not runnable in this
  environment (no live PR to test against, as anticipated in the issue
  body); the automated Rust + shell coverage above is the primary
  verification.

Closes #5589