### PR TITLE
docs(readme): correct the daemon work-generation claim and installed-surface tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,10 @@ your-repo/
 ├── .loom/
 │   ├── config.json      # Terminal configuration
 │   ├── roles/           # Agent role definitions
-│   └── scripts/         # Helper scripts
+│   ├── scripts/         # Helper scripts
+│   ├── hooks/           # Guard hooks (PreToolUse)
+│   ├── docs/            # Reference documentation
+│   └── bin/             # CLI entry points (loom, loom-clean, …)
 ├── .claude/commands/loom/  # Slash commands
 ├── .github/labels.yml   # Workflow labels
 └── CLAUDE.md            # AI context document
@@ -278,7 +281,7 @@ mcp__loom__list_sweeps       # inspect running sweeps
 mcp__loom__cancel_sweep      # cancel a running sweep
 ```
 
-Each dispatched sweep runs in its own detached process and picks its own OAuth token via `spawn-claude.sh` for multi-account rotation. The daemon has no work-generation triggers — see the [GitHub Actions cron workflows](.github/workflows/) for periodic Champion / Curator / Judge / Auditor / Guide ticks (opt-in per workflow). See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the full MCP surface.
+Each dispatched sweep runs in its own detached process and picks its own OAuth token via `spawn-claude.sh` for multi-account rotation. By default the daemon is **not** a work generator — work arrives only via `dispatch_sweep` and the cron workflows. Three opt-in, default-off subsystems let it generate its own work when enabled: the autonomous work finder, the epic supervisor, and the role runner. Periodic support roles run either through that daemon-native role runner (`autonomous.roleRunner.enabled=true`, preferred — same rotated token pool as sweeps) or through the [GitHub Actions cron workflows](.github/workflows/) for Champion / Curator / Judge / Auditor / Guide (opt-in per workflow, single static key, no rotation). See [`.loom/docs/daemon-reference.md`](.loom/docs/daemon-reference.md) for the full MCP surface and the `autonomous` config block.
 
 > The legacy `spawn-loop.sh` was **removed in v0.11.0** — use `loom-daemon` + `mcp__loom__dispatch_sweep` instead. See the [migration guide](docs/migration/v0.10.0-shepherd-deprecation.md).
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ your-repo/
 │   ├── scripts/         # Helper scripts
 │   ├── hooks/           # Guard hooks (PreToolUse)
 │   ├── docs/            # Reference documentation
-│   └── bin/             # CLI entry points (loom, loom-clean, …)
+│   └── bin/             # CLI entry point (loom)
 ├── .claude/commands/loom/  # Slash commands
 ├── .github/labels.yml   # Workflow labels
 └── CLAUDE.md            # AI context document


### PR DESCRIPTION
Closes #5704

## What

Two `README.md` accuracy fixes surfaced by a `/repo:all` documentation pass.

### 1. The daemon *does* have work-generation triggers

README claimed:

> The daemon has no work-generation triggers

Contradicted by `CLAUDE.md`, `defaults/docs/daemon-reference.md:3226`, and this repo's own live config:

```
$ jq '.autonomous | {workFinder: .workFinder.enabled, roleRunner: .roleRunner.enabled}' .loom/config.json
{ "workFinder": true, "roleRunner": true }
```

Replaced with the accurate framing: default-off by design, with three opt-in generators (work finder, epic supervisor, role runner). The new text also names the **daemon-native role runner** as the preferred path for periodic support roles — it shares the rotated token pool, while the cron workflows use a single static key — which the old sentence omitted entirely.

### 2. "What Gets Installed" tree was missing three surfaces

Added `hooks/`, `docs/`, and `bin/`. `resync-installed.sh` refreshes all five `.loom/` subdirs and `install.sh` references `.loom/hooks` 17× and `.loom/bin` 6×; `.loom/bin/` is a live install-critical surface.

## Verification

```
$ grep -c "The daemon has no work-generation triggers" README.md
0
$ git diff --name-only origin/main...HEAD
README.md
```

## Scope

`README.md` only — 5 insertions, 2 deletions. Filed under the `CLAUDE.md` operator-session lane (command-verifiable criteria, `.md`-only diff), so Curator was skipped; Judge and Champion run unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCYYxpVxH9dPQCtY1f1peJ
