### PR TITLE
chore: resync installed Loom surfaces (restores two stale guard hooks, incl. the #4767 confinement fix)

### DIFF
--- a/.loom/docs/guardrail-parity-codex.md
+++ b/.loom/docs/guardrail-parity-codex.md
@@ -192,6 +192,42 @@ hole for shell-derived writes.
 Untrusted JSON values are **never interpolated into a shell command**: paths and
 commands are passed to `jq`/`awk`/`python3` on stdin or as `--arg` values.
 
+### `workdir` anchor validation (issue #4767)
+
+`tool_input.workdir` on the `shell` tool is a **model-chosen** field — unlike
+the event's top-level `cwd`, which is runtime-supplied and never reachable
+from the model (the same distinction "Runtime discrimination" above draws for
+the payload shape). The bridge merges `workdir` into `GUARD_CWD`, which becomes
+the `cwd` of the normalized guard request `guard-destructive-generic.sh`
+consumes for its #4178 Bash write-confinement block.
+
+That block derives its main-checkout anchor (`_WT_MAIN_ROOT`) from `cwd` via
+`git rev-parse --git-common-dir`, falling back to `REPO_ROOT` (itself resolved
+from the same `cwd` via `git rev-parse --show-toplevel`) when that resolution
+is unavailable. A `cwd` that is not inside a git repo at all makes **both**
+come up empty, and the block's containment test **silently `continue`s past
+every write** when the anchor is empty — it has nothing to compare against. Because `workdir` is model-controlled, a Codex worker could
+therefore choose `workdir: "/tmp"` (or `"/"`, or any other out-of-repo path) to
+turn off managed-worktree write confinement for every subsequent redirect/
+`tee`/`sed -i`/`cp`/`mv` in the same call — while `rm -rf /`, protected-branch
+force-push, and the Loom workflow denials (all cwd-independent pattern
+matches) stayed correctly enforced throughout, so the gap was narrow but real.
+
+**Resolution.** After `GUARD_CWD` is computed, the bridge requires it to
+resolve to the same `git-common-dir/..` main-checkout root as the trusted
+anchor — the event's own `cwd`, falling back to the provisioned
+`--project-root` if the event `cwd` is not itself a repo (`main_root_of()` in
+`guard-codex-bridge.sh`, the identical idiom `guard-destructive-generic.sh`
+already uses for the same comparison). A `workdir` that fails this — not
+inside a git repo, nonexistent, or a *different* repo than the acting
+session's — `fail_closed`s instead of handing the sub-guards a rootless `cwd`.
+A `workdir` that resolves into the SAME repo (absolute or relative, including
+the common `"."` no-op) is unaffected. Covered by the `workdir anchor
+validation` section of `test-guard-codex-bridge.sh`: `/tmp`, `/`, a
+foreign/non-repo absolute path, a nonexistent directory, and a relative
+`workdir` that walks out of both the worktree and the repo, each asserted
+against `>` redirect, `tee`, `cp`, `mv`, and `sed -i`.
+
 ### Provisioning and trust
 
 `defaults/scripts/provision-codex-hooks.sh install|verify|remove` owns the
@@ -462,6 +498,11 @@ Known, documented, and accepted for tier-2. None is silent.
    Making Codex stricter here would fork the policy table, which this phase
    explicitly does not do. Closing the fallback case is a shared-policy change
    for both runtimes, and is out of scope for #4495.
+
+   **~~A model-chosen `workdir` could defeat this entirely.~~ CLOSED (issue
+   #4767).** See "`workdir` anchor validation" above — the bridge now requires
+   `workdir` to resolve into the same repo as the acting session before
+   trusting it, instead of handing the sub-guards a rootless `cwd`.
 3. **Command-pattern blocking now comes from Loom, not Codex.** With the managed
    hook in place, `DROP DATABASE`, `DELETE` without `WHERE`, `git push --force
    origin main`, fork bombs, and `curl … | sh` are matched by

--- a/.loom/docs/safehouse.md
+++ b/.loom/docs/safehouse.md
@@ -68,8 +68,68 @@ Env overrides (each wins over config for that key):
 | `LOOM_SAFEHOUSE_ROOMS_BY_REPO` | `rooms.byRepo`, as `repo=room[,repo=room…]` (#4225) |
 | `LOOM_SAFEHOUSE_ROOM_CLAIMS` | `rooms.claims` — dedicated peer-claim coordination room (#4713) |
 
-**Socket resolution**: configured `socket` → `$LOOM_SAFEHOUSE_SOCKET` →
-`$SAFEHOUSED_SOCKET`. If none resolves, narration logs one `warn!` and stays off.
+**Socket resolution** (precedence **env > config**, `resolve_socket` in
+`loom-daemon/src/safehouse.rs`; the bash-side worker-injection path
+(`defaults/scripts/lib/mcp-config.sh`'s `loom_mcp_safehouse_socket()`) mirrors
+the same chain): `$LOOM_SAFEHOUSE_SOCKET` → `$SAFEHOUSED_SOCKET` (the
+unprefixed convention `safehoused` clients also read) → the configured
+`socket` value. If none resolves, narration logs one `warn!` and stays off — no
+built-in `$HOME`-relative default, since safehouse is opt-in per-host.
+
+**`socket` must never be committed to the shared `.loom/config.json`** — like
+`observability.ingestKeyFile` (`observability.md`), it is host-specific by
+definition (every host's `safehoused` binds a different, unshareable path). Leave
+it unset in the committed file and either install `safehoused` at the
+conventional path each host's `$SAFEHOUSED_SOCKET` already points at, or set a
+per-host override in the gitignored `.loom-local/local.json` tier
+(`config_resolver.rs`, highest precedence) or via `$LOOM_SAFEHOUSE_SOCKET` —
+never in the committed file. #5457 is exactly the failure mode this avoids: a
+macOS `safehouse.socket` path was committed to this repo's own shared
+`.loom/config.json`, and — because `resolve_socket` checked the configured
+value *before* env at the time — every other host that `git pull`ed `main`
+inherited a path to a socket that did not exist on it, with no env override able
+to take effect while that stale path stayed committed.
+
+**Why there is still no built-in default, even after #5523.** #5457's fix left
+a gap: with the committed default gone and nothing installed in its place, an
+affected host's `safehouse.enabled: true` silently resolved to no socket at
+all, and the only signal was a `log_warn` inside each sweep's own per-role log
+— nobody was tailing those, so a real host ran with **zero** safehouse
+narration for 11 hours before a human noticed the public 2amlogic.com fleet
+pulse had gone stale (#5523). The tempting fix — teach the resolver a
+conventional-path fallback (e.g. `~/.loom/safehoused/state/safehoused.sock`) —
+was deliberately **rejected** for #5523: a code-level default *would* avoid
+re-triggering #5457's exact mechanism (it can't go stale via `git pull` the
+way a committed value can), but it would reintroduce the same underlying risk
+in a different shape — "resolves to *something*" would quietly stop meaning
+"actually reaches a live `safehoused`", which is precisely the gap that let
+#5523 run unnoticed. #5523's fix instead makes the **absence** loud and cheap
+to detect, in two ways, without touching this resolution chain at all:
+
+- `spawn-claude.sh`'s warning, when `safehouse.enabled` is true and no socket
+  resolves, now names the consequence ("no safehouse narration will be
+  recorded... the 2amlogic.com public fleet pulse is fed exclusively from
+  safehouse narration") instead of only the mechanism ("skipping safehouse MCP
+  injection") — still a `log_warn`, never a failed spawn (the degradation
+  contract above is unchanged: `safehouse.enabled: false`/absent stays a
+  byte-for-byte no-op, and `enabled: true` never blocks a sweep).
+- **`defaults/scripts/check-safehouse-socket.sh`** (installed as
+  `.loom/scripts/check-safehouse-socket.sh`) is a new standalone, on-demand
+  check that reports — per managed repo, without reading a single sweep log —
+  whether `safehouse.enabled` is set and, if so, whether a socket resolves AND
+  is present on disk. With no arguments it walks this host's machine-level
+  workspace registry (`~/.loom/workspaces.json`, the same registry
+  `loom-daemon workspace add/list` manages) and checks every registered repo
+  in one pass; pass explicit repo roots to check a subset. `--json` emits a
+  parseable array (`{repo, enabled, socket, present, status}` per repo) for
+  scripting/cron. It exits `0` when every repo is either not configured or
+  resolved-and-present, and `1` the moment any repo is enabled with an
+  unreachable socket — the exact condition #5523 needed surfaced. Unlike the
+  pre-existing static `Safehouse:` line in `loom-daemon-start.sh`'s startup
+  banner (below), this check has **no dependency on the daemon
+  (re)starting** — it can be run any time, which is what the incident
+  actually needed: the affected daemon never restarted across the 11-hour
+  window, so its own start-time check never re-ran.
 
 ### Room routing by attention class (`safehouse.rooms`, #4225)
 
@@ -312,8 +372,10 @@ hand is still documented as the debug fallback.
    controls this) for the next step.
 4. **Socket env or config.** Either export `SAFEHOUSED_SOCKET=<path>` (the
    convention safehoused's own clients read) machine-wide, or set
-   `safehouse.socket` explicitly in this host's `.loom/config.json` — see
-   [Socket resolution](#configuration) above for the full precedence.
+   `safehouse.socket` in this host's gitignored `.loom-local/local.json`
+   override (never in the shared, committed `.loom/config.json` — see the
+   callout above) — see [Socket resolution](#configuration) above for the
+   full precedence.
 5. **Enable the `safehouse` config block** in `.loom/config.json` (per
    workspace, since it lives in the per-repo config tier) or export
    `LOOM_SAFEHOUSE_ENABLED=1` machine-wide:
@@ -364,8 +426,8 @@ reboot — the interactive-host counterpart to the cloud-host provisioning path
 Parameters (precedence **flag > env > config > default**): `--bin`
 (`SAFEHOUSED_BIN`, else `command -v safehoused`); `--exec "<argv>"`
 (`SAFEHOUSED_EXEC`) for a full ExecStart override when safehoused needs flags;
-`--socket` (else the shared `safehouse.socket` → `$LOOM_SAFEHOUSE_SOCKET` →
-`$SAFEHOUSED_SOCKET` chain the daemon resolves); `--config`
+`--socket` (else the `$LOOM_SAFEHOUSE_SOCKET` → `$SAFEHOUSED_SOCKET` →
+`safehouse.socket` chain the daemon resolves); `--config`
 (`SAFEHOUSED_CONFIG`); `--log` (default `~/.loom/logs/safehoused.log`);
 `--label` / `--unit` for the launchd label / systemd unit name.
 
@@ -824,10 +886,17 @@ what feeds the public fleet feed on 2amlogic.com. Loom is the producer:
 - `defaults/scripts/cli/loom-daemon-start.sh` — (#4345) the static
   pre-connect `Safehouse:` line, via `lib/mcp-config.sh`'s existing
   `loom_mcp_safehouse_enabled`/`loom_mcp_safehouse_socket` resolvers.
+- `defaults/scripts/check-safehouse-socket.sh` — (#5523) the standalone,
+  daemon-restart-independent per-repo socket-resolution drift check described
+  above under "Socket resolution".
 - Tests: `safehouse.rs`'s `mod tests` (state-cell + wire-rendering cases),
   `workspace_pool.rs`'s `mod tests` (pool wiring), `ipc.rs`'s
   `test_build_daemon_status_reports_halt_and_in_flight` (report field),
-  `defaults/scripts/tests/test-loom-daemon-start.sh` (start-wrapper line).
+  `defaults/scripts/tests/test-loom-daemon-start.sh` (start-wrapper line),
+  `defaults/scripts/tests/test-mcp-config.sh` §13 (#5523: the loudened
+  spawn-claude.sh warning text + check-safehouse-socket.sh's not-configured /
+  resolved / unreachable-no-socket / unreachable-missing-file / multi-repo /
+  `--json` behavior).
 
 ## Peer-claim coordination: cross-host soft claim (#4028)
 

--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -415,7 +415,9 @@ and forecasts, and the pool-level "capacity returns at" aggregate.
 
 ## Bad-token tracking (`loom-daemon tokens mark-bad`)
 
-When a token returns `TOKEN_EXPIRED` or `TOKEN_EXHAUSTED`, callers append an entry
+When a token returns `TOKEN_EXPIRED`, `TOKEN_EXHAUSTED`, or
+`MODEL_CREDITS_EXHAUSTED` (#5687 — treated exactly like `TOKEN_EXHAUSTED` here),
+callers append an entry
 to `.loom/tokens/.bad_tokens` via `loom-daemon tokens mark-bad <name> --reason
 <text>` (native Rust, `loom-daemon/src/tokens_pool/bad_tokens.rs`, exposed as a
 CLI subcommand in #4228 — the historical Python `loom_tools.tokens.bad_tokens`
@@ -435,10 +437,21 @@ below.
 ## Error classification (`.loom/scripts/lib/classify-error.sh`)
 
 The `classify_error <output> <exit_code>` function returns one of `SUCCESS`,
-`TIMEOUT`, `CWD_DELETED`, `TOKEN_EXPIRED`, `TOKEN_EXHAUSTED`, `RECOVERABLE`.
+`TIMEOUT`, `CWD_DELETED`, `TOKEN_EXPIRED`, `TOKEN_EXHAUSTED`,
+`MODEL_CREDITS_EXHAUSTED`, `SESSION_LIMIT`, `MODEL_REFUSAL`, `RECOVERABLE`,
+`FATAL`.
 Critical fix from #3233: exit code is checked **before** output substring
 matching — clean exits (`exit_code == 0`) always return `SUCCESS` regardless of
 stdout content.
+
+`MODEL_CREDITS_EXHAUSTED` (#5687, "You're out of usage credits") is a
+per-model-**tier** credit exhaustion, not an account death. **Every pool
+mechanism treats it exactly like `TOKEN_EXHAUSTED`** — same rotation, same
+`.bad_tokens` entry, same cooldown, same retryability — because the pool tracks
+account health, not per-model account state. The distinct name exists for the
+in-session `/loom:sweep` orchestrator, which has no pool to rotate through and
+instead re-dispatches one model rung down (`sweep.md` → "Credit-exhaustion
+fallback").
 
 ## Worktree handling
 
@@ -781,8 +794,9 @@ Terminal policy is intentionally conservative:
 
 - `TOKEN_EXPIRED` requires an explicit verified-reauth clear and never expires
   merely because time passed or an ordinary success was observed.
-- `TOKEN_EXHAUSTED` cools down for
-  `LOOM_CODEX_EXHAUSTED_COOLDOWN_SECS` (default five hours).
+- `TOKEN_EXHAUSTED` and `MODEL_CREDITS_EXHAUSTED` cool down for
+  `LOOM_CODEX_EXHAUSTED_COOLDOWN_SECS` (default five hours) — the same arm, by
+  design (#5687).
 - `RECOVERABLE` and `SESSION_LIMIT` apply short temporary backoffs.
 - Success records freshness and clears transient counters.
 - Timeouts, fatal/configuration failures, refusals, and deleted-cwd outcomes do

--- a/.loom/hooks/guard-codex-bridge.sh
+++ b/.loom/hooks/guard-codex-bridge.sh
@@ -525,6 +525,35 @@ extract_workdir() {
 }
 
 # ---------------------------------------------------------------------------
+# `workdir` anchor validation (issue #4767)
+# ---------------------------------------------------------------------------
+#
+# `tool_input.workdir` is a MODEL-CHOSEN field of the Codex shell tool — unlike
+# the top-level `.cwd` on the event, which is runtime-supplied and never
+# reachable from the model (see the header's "RUNTIME DISCRIMINATION" note).
+# When it merges into GUARD_CWD below, a `workdir` that is simply not inside a
+# git repo (e.g. `/tmp` or `/`) leaves GUARD_CWD rootless. Rootless is not
+# neutral: guard-destructive-generic.sh's #4178 worktree-write-confinement
+# block derives its main-checkout anchor from that same cwd, finds nothing,
+# and silently `continue`s past its containment test — the model can pick an
+# out-of-repo workdir to make writes that must be denied hit that gap instead.
+#
+# main_root_of() resolves the true main-checkout root the SAME way
+# guard-destructive-generic.sh's #4178 block does (`git-common-dir/..`, which
+# is always the main checkout even from a linked worktree), so "resolves to
+# the same git common dir" here means exactly what the sub-guard means by it.
+# Empty output on any non-repo / nonexistent / unreadable path — never a
+# fatal error, always a value the caller can compare against.
+main_root_of() {
+    local dir="$1" common root
+    [[ -n "$dir" && -d "$dir" ]] || return 0
+    common=$(cd "$dir" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || return 0
+    [[ -n "$common" ]] || return 0
+    root=$(cd "$dir" 2>/dev/null && cd "$common/.." 2>/dev/null && pwd -P) || return 0
+    printf '%s' "$root"
+}
+
+# ---------------------------------------------------------------------------
 # PATCH normalization
 # ---------------------------------------------------------------------------
 #
@@ -599,8 +628,35 @@ if [[ "$TOOL_CLASS" == "shell" ]]; then
         elif [[ -n "$EVENT_CWD" ]]; then
             GUARD_CWD="${EVENT_CWD%/}/$WORKDIR"
         fi
-        if declare -F loom_canonical_path >/dev/null 2>&1; then
-            GUARD_CWD="$(loom_canonical_path "$GUARD_CWD" "$EVENT_CWD")"
+        # Deliberately NOT run through loom_canonical_path here (unlike the
+        # PATCH path's target-path canonicalization below): GUARD_CWD is a
+        # `cd` target for the sub-guards, not a path comparison operand, and
+        # guard-destructive-generic.sh's own #4178 write-confinement block
+        # already does its own symlink-aware resolution — it compares a
+        # write target against BOTH the physical (`pwd -P`) and logical
+        # (`pwd`) spelling of the main-checkout root specifically so a
+        # symlinked ancestor (e.g. macOS's `/tmp` -> `/private/tmp`) still
+        # matches. Pre-resolving GUARD_CWD to its physical form here would
+        # collapse that logical spelling before the sub-guard ever sees it,
+        # silently reopening the same symlinked-ancestor hole for any call
+        # that sets `workdir` at all (#4767 review finding).
+
+        # #4767: workdir is model-chosen and just merged into GUARD_CWD above.
+        # Require it to resolve into the SAME repository as the runtime-trusted
+        # anchor (the event's own cwd, falling back to the provisioned
+        # --project-root when the event cwd is not itself a repo) before it is
+        # handed to the sub-guards. Anything else — not inside a git repo,
+        # nonexistent, or a different repo entirely — fails closed rather than
+        # emitting the rootless cwd guard-destructive-generic.sh's #4178 block
+        # would silently skip its containment test on. main_root_of() resolves
+        # through `cd`/`git rev-parse`, which follow symlinks on their own, so
+        # this comparison needs no pre-canonicalized input either.
+        GUARD_MAIN_ROOT="$(main_root_of "$GUARD_CWD")"
+        ANCHOR_MAIN_ROOT="$(main_root_of "$EVENT_CWD")"
+        [[ -z "$ANCHOR_MAIN_ROOT" ]] && ANCHOR_MAIN_ROOT="$(main_root_of "$PROJECT_ROOT")"
+
+        if [[ -z "$GUARD_MAIN_ROOT" || -z "$ANCHOR_MAIN_ROOT" || "$GUARD_MAIN_ROOT" != "$ANCHOR_MAIN_ROOT" ]]; then
+            fail_closed "tool '$TOOL_NAME' set workdir '$WORKDIR', which does not resolve to the same git repository as the acting session (cwd '$EVENT_CWD'). A model-chosen workdir outside the session's own repository cannot be trusted as a write-confinement anchor."
         fi
     fi
 

--- a/.loom/hooks/guard-destructive-generic.sh
+++ b/.loom/hooks/guard-destructive-generic.sh
@@ -1476,7 +1476,7 @@ function strip_cd_quoting(tok,   out, n, i, c, in_s, in_d, sq, dq) {
 '
 
 # =============================================================================
-# QUOTE-AWARE REDIRECTION MASKING (#4245)
+# QUOTE- AND ARITHMETIC/TEST-CONTEXT-AWARE REDIRECTION MASKING (#4245, #5515)
 #
 # extract_write_targets() (below) recognizes `>`/`>>` redirection by splitting
 # a qsplit()-segmented command on whitespace and pattern-matching each token —
@@ -1497,6 +1497,37 @@ function strip_cd_quoting(tok,   out, n, i, c, in_s, in_d, sq, dq) {
 # DECIDE whether a token is a real (unquoted) redirection operator; the
 # ORIGINAL tokens are still used to extract the actual target text.
 #
+# ARITHMETIC/TEST CONTEXT (#5515): an unquoted `>`/`>=`/`<`/`<=` is ALSO not a
+# redirection operator when it is a comparison inside a `(( ... ))` arithmetic
+# command/expansion or a `[[ ... ]]` conditional expression — a routine bash
+# idiom (`if (( x > 0 )); then`, `(( ${#ARR[@]} > 0 ))`, `[[ "$a" > "$b" ]]`).
+# Before #5515, mask_gt() left those bytes unmasked (they are unquoted), so
+# extract_write_targets()'s bare-operator branch read the token immediately
+# after a bare `>` as a write target (`(( x > 0 ))` -> phantom target `0`), and
+# its attached-form branch matched the `>=` token shape (never a valid
+# redirection operator in POSIX/bash) and stripped its leading `>`, leaving a
+# phantom target of literal `=` (`(( x >= y ))` -> phantom target `=`). Both
+# resolve inside curcwd and can trigger a worktree-write-confinement DENY on a
+# command that writes nothing.
+#
+# mask_gt() now ALSO tracks `((`/`))` and `[[`/`]]` span depth (adepth/tdepth
+# below) the same way it tracks quote state, and masks `>`/`<` bytes found
+# while depth > 0 exactly like a quoted `>` — same MASK byte, same
+# byte-for-byte-length-identical contract. A span opens only on the LITERAL
+# adjacent two-character sequence `((`/`[[` (consumed as one step, so a
+# subsequent stray third paren/bracket is not itself misread as another open)
+# and closes on the literal adjacent `))`/`]]` while its own depth is > 0 —
+# nested single parens inside an arithmetic span (`(( (a) > 0 ))`) do not
+# perturb depth, matching the common case this fix targets. A `>` OUTSIDE any
+# such span — including one following a closed arithmetic span on the SAME
+# segment, e.g. `echo $(( x > 0 )) > file` — is untouched and still flows
+# through as a real operator, so the genuinely dangerous cases (`cp`/`mv`/
+# `tee`/`sed -i`/actual redirection writing into the main checkout) keep
+# denying. This span tracking only ever runs in unquoted mode (mode == 0
+# below): a literal `((`/`[[` appearing as DATA inside a quoted string is
+# never treated as entering a span, matching how such a string's `>` is
+# already unconditionally masked as quoted data regardless of context.
+#
 # Deliberately does NOT model backslash-escaped quotes -- same simplification
 # qsplit() (above) and strip_literal_text() already accept for this file's
 # other quote-tracking scans, and for good reason beyond just consistency: the
@@ -1514,22 +1545,57 @@ function strip_cd_quoting(tok,   out, n, i, c, in_s, in_d, sq, dq) {
 # best-effort risk this file already accepts for `;|&` segmentation -- never a
 # NEW risk introduced here. An unterminated quote (no matching close before
 # end-of-string) just runs to the end of the string in that quote state --
-# never crashes, never mis-indexes.
+# never crashes, never mis-indexes. Same acceptance for an unbalanced
+# `((`/`[[` span: depth simply never returns to 0 for the rest of the buffer,
+# masking any LATER unquoted `>`/`<` too -- the same "never widen a deny into
+# an allow" fallback direction every other best-effort scan in this file takes
+# (a masked-away `>` can only DROP a write target, never invent a new deny).
 # =============================================================================
 _MASKGT_AWK='
-function mask_gt(s,   out, n, i, c, mode, SQ, DQ, MASK) {
+function mask_gt(s,   out, n, i, c, mode, SQ, DQ, MASK, adepth, tdepth) {
     SQ = sprintf("%c", 39)    # single quote
     DQ = sprintf("%c", 34)    # double quote
-    MASK = sprintf("%c", 1)   # SOH -- placeholder for a quoted ">" (never a real char)
+    MASK = sprintf("%c", 1)   # SOH -- placeholder for a quoted/arith-context ">"/"<" (never a real char)
     out = ""
     n = length(s)
     i = 1
-    mode = 0   # 0 = unquoted, 1 = single-quoted, 2 = double-quoted
+    mode = 0     # 0 = unquoted, 1 = single-quoted, 2 = double-quoted
+    adepth = 0   # `((...))` arithmetic-context nesting depth (unquoted only)
+    tdepth = 0   # `[[...]]` test-context nesting depth (unquoted only)
     while (i <= n) {
         c = substr(s, i, 1)
         if (mode == 0) {
             if (c == SQ) { mode = 1; out = out c; i++; continue }
             if (c == DQ) { mode = 2; out = out c; i++; continue }
+            if (c == "(" && i < n && substr(s, i + 1, 1) == "(") {
+                adepth++
+                out = out "(("
+                i += 2
+                continue
+            }
+            if (c == ")" && i < n && substr(s, i + 1, 1) == ")" && adepth > 0) {
+                adepth--
+                out = out "))"
+                i += 2
+                continue
+            }
+            if (c == "[" && i < n && substr(s, i + 1, 1) == "[") {
+                tdepth++
+                out = out "[["
+                i += 2
+                continue
+            }
+            if (c == "]" && i < n && substr(s, i + 1, 1) == "]" && tdepth > 0) {
+                tdepth--
+                out = out "]]"
+                i += 2
+                continue
+            }
+            if ((adepth > 0 || tdepth > 0) && (c == ">" || c == "<")) {
+                out = out MASK
+                i++
+                continue
+            }
             out = out c
             i++
             continue
@@ -3626,18 +3692,33 @@ extract_write_targets() {
             #   `</tmp/in`  (attached, optionally fd-prefixed) consumes only
             #               itself.
             #
-            # QUOTE AWARENESS COMES FREE, no mask_gt()-style parallel
-            # tokenization needed: qsplit() preserves quote characters
-            # VERBATIM in toks[] and mask_ws() guarantees a quoted span never
-            # spans two tokens, so a quoted/escaped literal filename that
-            # merely BEGINS with `<` (single-quoted, double-quoted, or
-            # backslash-escaped) starts its token with the quote/backslash
-            # byte and can never match the anchored patterns here -- it stays
-            # a scanned write target, opening no new escape vector, which is
-            # the fail-closed direction this file requires.
-            # (mask_gt() exists because a `>` can appear
-            # MID-token inside a quoted span; these patterns only ever look at
-            # the first bytes of a token, so that case cannot arise.)
+            # QUOTE AWARENESS COMES FREE for a quoted/escaped literal
+            # filename that merely BEGINS with `<`: qsplit() preserves quote
+            # characters VERBATIM in toks[] and mask_ws() guarantees a quoted
+            # span never spans two tokens, so such a token starts with the
+            # quote/backslash byte and can never match the anchored patterns
+            # here -- it stays a scanned write target, opening no new escape
+            # vector, which is the fail-closed direction this file requires.
+            #
+            # ARITHMETIC/TEST-CONTEXT AWARENESS (#5515) is why this now reads
+            # mtoks[] (mask_gt() output) rather than the raw toks[]: a bare
+            # `<`/`<=` used as a comparison inside `(( ... ))`/`[[ ... ]]`
+            # (e.g. `(( x <= y ))`) is not a redirection operator either, and
+            # mask_gt() (see its own header above) now masks such a byte the
+            # same way it masks one found inside quotes. Without this, the
+            # comparisons own `<` token wrongly marked itself (and the
+            # following token) as "read from stdin", which cannot itself
+            # manufacture a phantom write target here but could silently
+            # suppress a real one later in the SAME segment. mtoks[] is
+            # byte-for-byte token-aligned with toks[] (mask_gt()/mask_ws()
+            # only ever substitute one byte for one byte), so switching the
+            # PATTERN test from toks[] to mtoks[] changes nothing about which
+            # token INDEX gets marked -- only whether a masked (quoted or
+            # arith/test-context) `<` can still match.
+            # (mask_gt() exists because a `>`/`<` can appear MID-token inside
+            # a quoted or arith/test-context span; these patterns only ever
+            # look at the first bytes of a token, so that case cannot arise
+            # here either way.)
             #
             # Deliberately NOT matched: `<<`, `<<-`, `<<<`. Those are heredoc
             # /herestring operators handled separately by the pre-tokenization
@@ -3647,14 +3728,14 @@ extract_write_targets() {
             delete stdin_redir
             for (j = 1; j <= m; j++) {
                 if (toks[j] == "") continue
-                if (toks[j] ~ /^[0-9]*<$/) {
+                if (mtoks[j] ~ /^[0-9]*<$/) {
                     stdin_redir[j] = 1
                     for (k = j + 1; k <= m; k++) {
                         if (toks[k] == "") continue
                         stdin_redir[k] = 1
                         break
                     }
-                } else if (toks[j] ~ /^[0-9]*<[^<]/) {
+                } else if (mtoks[j] ~ /^[0-9]*<[^<]/) {
                     stdin_redir[j] = 1
                 }
             }
@@ -3663,6 +3744,28 @@ extract_write_targets() {
                 for (j = 2; j <= m; j++) {
                     if (j in stdin_redir) continue
                     if (toks[j] == "" || toks[j] ~ /^-/) continue
+                    # Heredoc/herestring redirection (attached or quoted
+                    # delimiter, or the bare double-angle-bracket / dashed
+                    # form, plus the triple-angle-bracket herestring) is a
+                    # REDIRECTION OPERATOR feeding the tee commands stdin,
+                    # never a write-target argument -- but it is still just
+                    # another whitespace-bounded non-flag token to this
+                    # scanner, so without this exclusion the delimiter (or the
+                    # operator itself, in the space-separated bare spelling)
+                    # was misread as an extra file target and resolved against
+                    # curcwd, producing a bogus "<repo>/<<EOF" write that the
+                    # worktree-isolation check below then falsely denied
+                    # (#5232). A BARE operator token (`<<`, `<<-`, `<<<` with
+                    # no attached delimiter/content) also consumes the ONE
+                    # following word -- the heredoc delimiter, or the
+                    # herestring content. Consuming exactly one word is
+                    # shell-accurate for both: a herestring takes a single
+                    # word, so in `tee f <<< a b` the `b` really IS a tee
+                    # operand and must still be scanned.
+                    if (toks[j] ~ /^<<-?/) {
+                        if (toks[j] == "<<" || toks[j] == "<<-" || toks[j] == "<<<") j++
+                        continue
+                    }
                     print curcwd SEP resolve_var(toks[j])
                 }
             } else if (toks[1] == "sed") {
@@ -3674,6 +3777,15 @@ extract_write_targets() {
                     if (toks[j] ~ /^-i/) has_i = 1
                     if (toks[j] ~ /^-/) continue
                     if (toks[j] == "") continue
+                    # Same heredoc/herestring exclusion as the `tee` branch
+                    # above (#5232) -- a trailing `sed -i ... file <<EOF` (or
+                    # `... <<< word`) must not misread the redirection
+                    # operator, its delimiter, or the herestring content as an
+                    # extra file operand.
+                    if (toks[j] ~ /^<<-?/) {
+                        if (toks[j] == "<<" || toks[j] == "<<-" || toks[j] == "<<<") j++
+                        continue
+                    }
                     nf++
                     nfargs[nf] = toks[j]
                 }
@@ -3687,6 +3799,16 @@ extract_write_targets() {
                     if (j in stdin_redir) continue
                     if (toks[j] ~ /^-/) continue
                     if (toks[j] == "") continue
+                    # Same heredoc/herestring exclusion as the `tee` branch
+                    # above (#5232) -- without it a trailing `<<EOF` (or
+                    # `<<< word`) after the real cp/mv operands was misread as
+                    # the LAST non-flag token (the field this branch treats as
+                    # the destination), so it would win over the real
+                    # destination entirely.
+                    if (toks[j] ~ /^<<-?/) {
+                        if (toks[j] == "<<" || toks[j] == "<<-" || toks[j] == "<<<") j++
+                        continue
+                    }
                     nf++
                     nfargs[nf] = toks[j]
                 }

--- a/.loom/install-metadata.json
+++ b/.loom/install-metadata.json
@@ -1,6 +1,6 @@
 {
   "loom_version": "0.18.0",
-  "loom_commit": "72ef7b72",
+  "loom_commit": "4c4a3cb2",
   "install_date": "2026-04-21",
   "loom_source": "/Users/rwalters/GitHub/loom",
   "installed_files": [
@@ -37,5 +37,5 @@
     ".loom/README.md",
     "CLAUDE.md"
   ],
-  "last_resync": "2026-08-05"
+  "last_resync": "2026-08-07"
 }


### PR DESCRIPTION
## What

Mechanical output of `./.loom/scripts/resync-installed.sh` — the designed remediation for #3777 installed-surface drift. No hand-authored content: every changed byte comes from the already-reviewed `defaults/` tree on `main`.

```
[resync] 5 file(s) updated, 320 unchanged, 27 skipped.
```

## Why it matters

This checkout was executing **guard hooks missing merged fixes**. Seven of the last eight commits touching `defaults/hooks/` never updated the installed copy:

| commit | touched `defaults/hooks/` | touched `.loom/hooks/` |
|---|---|---|
| `a0679165` guard: arithmetic/test `>` `>=` `<` `<=` | 1 | **0** |
| `2eb81bd0` guard: heredoc redirection tokens | 1 | **0** |
| `16457853` codex-bridge: validate model-chosen workdir | 1 | **0** |
| `e5813606` hooks: exclude `<` stdin redirects | 1 | **0** |
| `6a81c291` guard: strip_cd_quoting() | 1 | **0** |
| `9748deb3` guard: quote-strip cd argument | 1 | **0** |
| `fb1b9b7f` guard: mask `git commit -F -` heredoc | 1 | 1 |
| `200d5187` guard: interpreter-aware heredoc masking | 1 | **0** |

Two of those gaps were live in the installed hooks until this PR:

**`guard-codex-bridge.sh` — missing #4767 (`16457853`).** The model-chosen `tool_input.workdir` was merged into `GUARD_CWD` without anchor validation. A `workdir` outside any git repo leaves `GUARD_CWD` rootless; `guard-destructive-generic.sh`'s #4178 worktree-write-confinement block then derives its main-checkout anchor from that same cwd, finds nothing, and silently `continue`s past its containment test. That is a **confinement bypass a model can steer into** by picking an out-of-repo workdir — precisely what the fix exists to close.

**`guard-destructive-generic.sh` — missing #5515 (`a0679165`).** Without arithmetic/test-context masking, `(( x > 0 ))` yields a phantom write target `0` and `(( x >= y ))` a phantom `=`, both of which resolve inside cwd and can trigger a worktree-write-confinement **DENY on a command that writes nothing**.

So the drift was costing correctness in both directions: a real bypass open, and false denials firing.

## Also included

`.loom/docs/{guardrail-parity-codex,safehouse,token-pool}.md` refreshed, and `install-metadata.json` re-stamped (`loom_version=0.18.0`, `loom_commit=4c4a3cb2`, `last_resync=2026-08-07`).

## Verification

```
$ ./.loom/scripts/resync-installed.sh --dry-run
[resync] DRY RUN: 0 file(s) would be updated, 325 unchanged, 27 skipped.
```

(run post-merge; the script is idempotent and a no-op once in sync)

## Notes

Surfaced by a `/repo:all` hygiene pass. The resync script prints the exact `git add … && git commit` invocation used here, specifically so the main-health gate does not skip on a dirty tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCYYxpVxH9dPQCtY1f1peJ
