### PR TITLE
docs(champion): add a body-hash idempotency guard to the epic rejection path

### DIFF
--- a/defaults/.claude/commands/loom/champion-epic.md
+++ b/defaults/.claude/commands/loom/champion-epic.md
@@ -73,7 +73,209 @@ For each epic proposal, evaluate against these **6 criteria**. All must pass for
 
 ---
 
+## Idempotency Guard for Unrevised Epics (`champion:epic-verdict:body-*`)
+
+**Problem this section fixes (#5865)**: Step 4 below used to re-evaluate the 6
+criteria and post a fresh "Epic Needs Revision" comment on **every** Champion
+pass, with nothing checking whether the epic had actually changed since the last
+rejection. An epic that is never revised therefore accumulates one near-identical
+rejection comment per cycle, indefinitely, and no human is ever pulled in.
+Observed downstream on 2AMLogic/2am#184: three rejections inside three hours
+(16:40:55Z, 18:10:39Z, 19:17:50Z), the same finding each time, no edit to the
+body in between.
+
+This is the same failure `champion-issue-promo.md`'s "Concurrency Guard and
+Idempotency (`loom:evaluating`)" closes for proposals (#4954/#4966/#4967), ported
+here in the epic workflow's own terms. **Read that section for the full
+rationale** — the invariants under its "Bounding the silent skip" apply verbatim
+to this port, with `Champion Review: Epic Needs Revision` substituted for
+`Champion Review: NEEDS REVISION`. Only what differs is restated below.
+
+**What is deliberately NOT ported.**
+
+- **The `loom:evaluating` claim label.** Epic approvals are rate-limited to one
+  per iteration ("Epic Rate Limiting" below) and epic evaluation is not part of
+  the high-frequency proposal batch loop, so the concurrent-evaluation race the
+  claim closes is far less pressing here. If two Champion hosts ever do evaluate
+  the same epic at once, the body-hash marker still bounds the outcome to one
+  extra comment rather than an unbounded stream.
+- **The dependency-timing gate and Pass 0 self-healing un-escalation (#5664).**
+  Those exist because a *proposal* can be rejected for a finding that clears
+  itself when a blocker closes. None of the 6 epic criteria is a
+  blocker-state finding — they are all structural (phases, milestone, success
+  criteria, scope) and only a human editing the epic can clear them. An epic
+  whose *phase* names an external blocker is handled by Step 2.5, which holds
+  the phase without posting a verdict at all (see below).
+
+**What this guard must never suppress.** The marker is written by, and read for,
+**rejections only**. It keys on posted `Champion Review: Epic Needs Revision`
+comments, so:
+
+- An **approved** epic never carries the marker. Step 2.5's Epic-Aware Blocker
+  Check and everything under "Phase Progression" run on every pass exactly as
+  before. This mirrors the #5211 caveat in `champion-issue-promo.md`: a blocker's
+  state changes underneath an unchanged body, so a body hash can never be allowed
+  to gate it.
+- A phase **held** by Step 2.5 posts a hold comment, not a verdict — no marker is
+  written, and the blocker is re-checked on every later pass.
+
+### The check (run BEFORE Step 1, once per epic)
+
+Compute a marker keyed to a **hash of the epic's own text** (title + body), so a
+genuine revision always gets a fresh evaluation while an unchanged epic is never
+re-commented. The check is **three-way**, not two-way: no match → evaluate; match
+with skips left in the budget → skip silently; match with the budget exhausted →
+**escalate**.
+
+```bash
+EPIC_NUMBER=<number>
+
+# Cached (${GH_READ:-gh}) — this is a content check, not claim arbitration.
+# champion-epic.md does not set GH_READ itself, so default it like
+# champion-common.md does.
+EPIC_JSON=$(${GH_READ:-gh} issue view "$EPIC_NUMBER" --json title,body,labels,comments)
+
+# Portable sha256 (sha256sum on Linux, shasum on macOS) — the same fallback shape
+# the repo's own scripts use. 16 hex chars is plenty for change detection.
+_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum
+  elif command -v shasum >/dev/null 2>&1; then shasum -a 256
+  else cksum; fi
+}
+# NOTE: use `printf '%s\n' "$VAR" | jq`, never `echo "$VAR" | jq`, for any
+# variable holding captured `gh --json` output — zsh's `echo` builtin
+# reinterprets `\n`/`\t` escapes and corrupts the JSON before jq parses it
+# (#5094).
+BODY_HASH=$(printf '%s\n%s' \
+  "$(printf '%s\n' "$EPIC_JSON" | jq -r '.title // ""')" \
+  "$(printf '%s\n' "$EPIC_JSON" | jq -r '.body // ""')" \
+  | _sha256 | awk '{print substr($1, 1, 16)}')
+VERDICT_MARKER="<!-- champion:epic-verdict:body-$BODY_HASH -->"
+
+# Escalation inputs, computed HERE rather than in Step 4: the skip path below
+# must be able to decide "escalate instead of skipping again" without ever
+# reaching Step 4. Step 4 reuses these same variables.
+PRIOR_REJECTIONS=$(printf '%s\n' "$EPIC_JSON" | jq \
+  '[.comments[] | select(.body | contains("Champion Review: Epic Needs Revision"))] | length')
+ALREADY_ROUTED=$(printf '%s\n' "$EPIC_JSON" | jq -e '.labels[] | select(.name=="loom:operator-only")' >/dev/null && echo yes || echo no)
+SKIP_STREAK=0            # silent skips already recorded for THIS body revision
+ESCALATE_UNREVISED=no    # set to yes to bypass re-evaluation and go straight to Step 4's escalation
+
+if [ "$ALREADY_ROUTED" = "yes" ]; then
+  # Terminal state — a human owns this epic now. This short-circuit is what makes
+  # the escalation terminal: unlike Priorities 1-3, champion.md's Priority 4 epic
+  # discovery query does NOT filter loom:operator-only, so an escalated epic keeps
+  # being handed to this file and must be dropped here.
+  echo "#$EPIC_NUMBER already routed to loom:operator-only — skipping (no comment, no tally, no evaluation)"
+  # Continue to the next epic; do not read further.
+elif printf '%s\n' "$EPIC_JSON" | jq -e --arg m "$VERDICT_MARKER" \
+       '.comments[] | select(.body | contains($m))' >/dev/null; then
+  # This exact revision was already evaluated and rejected. Read the silent-skip
+  # tally carried by the matching verdict comment. REST, not `gh issue view`: only
+  # the REST payload has the numeric comment id that the PATCH below needs (the
+  # `id` from `gh issue view --json comments` is a GraphQL node id and cannot be
+  # PATCHed).
+  VERDICT_COMMENT=$(gh api "repos/{owner}/{repo}/issues/$EPIC_NUMBER/comments" --paginate \
+    --jq ".[] | select(.body | contains(\"$VERDICT_MARKER\"))" | jq -s 'last')
+  COMMENT_ID=$(printf '%s\n' "$VERDICT_COMMENT" | jq -r '.id // empty')
+  COMMENT_BODY=$(printf '%s\n' "$VERDICT_COMMENT" | jq -r '.body // ""')
+  SKIP_STREAK=$(printf '%s' "$COMMENT_BODY" \
+    | sed -n "s|.*<!-- champion:epic-unrevised-skips:$BODY_HASH:\([0-9]\{1,\}\) -->.*|\1|p" | tail -n 1)
+  SKIP_STREAK=${SKIP_STREAK:-0}
+  UNREVISED_EVALS=$(( PRIOR_REJECTIONS + SKIP_STREAK ))
+
+  if [ "$UNREVISED_EVALS" -ge "${LOOM_MAX_UNREVISED_EVALUATIONS:-2}" ]; then
+    # Silence is not free forever: the skip budget is spent, so this pass does NOT
+    # skip. Jump straight to Step 4's escalation branch — no re-evaluation, since
+    # the text is unchanged and therefore so is the verdict.
+    ESCALATE_UNREVISED=yes
+    echo "#$EPIC_NUMBER unrevised at $BODY_HASH across $UNREVISED_EVALS evaluations — escalating to the operator instead of skipping again"
+  else
+    # Record this cycle's skip IN PLACE by PATCHing the existing verdict comment.
+    # An edit posts no new comment and sends no notification, so the "1 comment,
+    # then silence" guarantee holds while the counter still advances.
+    NEXT_SKIPS=$(( SKIP_STREAK + 1 ))
+    if printf '%s' "$COMMENT_BODY" | grep -q "<!-- champion:epic-unrevised-skips:$BODY_HASH:"; then
+      NEW_BODY=$(printf '%s' "$COMMENT_BODY" \
+        | sed "s|<!-- champion:epic-unrevised-skips:$BODY_HASH:[0-9]\{1,\} -->|<!-- champion:epic-unrevised-skips:$BODY_HASH:$NEXT_SKIPS -->|")
+    else
+      # Verdict comment predates this tally — append it.
+      NEW_BODY=$(printf '%s\n\n%s' "$COMMENT_BODY" "<!-- champion:epic-unrevised-skips:$BODY_HASH:$NEXT_SKIPS -->")
+    fi
+    [ -n "$COMMENT_ID" ] && gh api --method PATCH \
+      "repos/{owner}/{repo}/issues/comments/$COMMENT_ID" -f body="$NEW_BODY" >/dev/null
+    echo "Already evaluated #$EPIC_NUMBER at body revision $BODY_HASH — skipping silently (skip $NEXT_SKIPS recorded; unrevised evaluations now $(( PRIOR_REJECTIONS + NEXT_SKIPS ))/${LOOM_MAX_UNREVISED_EVALUATIONS:-2}, escalates once it reaches the cap; no comment)"
+    # Continue to the next epic; do not read further.
+  fi
+fi
+```
+
+| Guard outcome | Next action |
+|---|---|
+| No marker match — a new epic, or one revised since its last rejection | Step 1 (Read) → Step 2 (Evaluate) → Step 2.5 → Step 3 or 4: a **full** re-evaluation, exactly as before this section existed |
+| Marker match, `UNREVISED_EVALS < ${LOOM_MAX_UNREVISED_EVALUATIONS:-2}` | Tally the skip in place (`PATCH` the existing verdict comment) and continue to the next epic. No new comment, no label change, no evaluation |
+| Marker match, budget exhausted (`ESCALATE_UNREVISED=yes`) | Go **straight to Step 4's escalation branch**, skipping Steps 1–3 — the text is byte-identical, so re-evaluating cannot change the verdict |
+| `ALREADY_ROUTED=yes` | Continue to the next epic — no tally, no re-escalation, no comment; a human already owns it |
+
+A silent skip is neither an approval nor a rejection, so it never counts against
+"Epic Rate Limiting" below. An escalation **is** a verdict.
+
+#### Why a hash of title + body, and NOT the epic's `updatedAt`
+
+`updatedAt` is **self-invalidating**: the marker baked into a verdict comment
+necessarily records the value read *before* that comment was posted, and posting
+the comment bumps `updatedAt` forward — so the marker can never match and every
+pass re-evaluates and re-comments, which is the exact loop this section closes.
+A hash of title + body changes if and only if the epic is actually edited;
+comments, label churn, and Champion's own verdict all leave it untouched. Full
+derivation, and the parallel with `loom:reviewing` claim staleness, in
+`champion-issue-promo.md` → "Why a body hash and NOT the issue's `updatedAt`
+(#4966)".
+
+#### The counters, and why the skip must cost something
+
+| Mechanism | Counts | Written by | Survives a silent skip? |
+|---|---|---|---|
+| `PRIOR_REJECTIONS` | posted `Champion Review: Epic Needs Revision` comments (any revision) | Step 4's reject branch | Yes, but **frozen** while skipping — it cannot advance on its own |
+| `SKIP_STREAK` | silent skips recorded for the **current** body hash | the skip path's in-place `PATCH` of the existing verdict comment | **Yes — this is the counter that keeps advancing** |
+| `UNREVISED_EVALS` = `PRIOR_REJECTIONS + SKIP_STREAK` | evaluation cycles spent on an unrevised epic | derived | Yes — the single escalation gate, used identically by the skip path and Step 4 |
+
+Suppressing duplicate comments must never suppress the escalation that eventually
+puts a stuck epic in front of a human — that regression already happened once on
+the proposal path (#4967). Traced against an epic that fails at body hash H1 and
+is never revised:
+
+| Cycle | Marker match? | `PRIOR_REJECTIONS` | `SKIP_STREAK` | `UNREVISED_EVALS` | Outcome | Comments posted |
+|---|---|---|---|---|---|---|
+| 1 | no (H1 unseen) | 0 | 0 | 0 | evaluate → reject → post "Epic Needs Revision" carrying `VERDICT_MARKER` + `epic-unrevised-skips:H1:0` | 1 |
+| 2 | yes (H1) | 1 | 0 | 1 < 2 | silent skip; `PATCH` the tally to `1` | 0 |
+| 3 | yes (H1) | 1 | 1 | 2 ≥ 2 | `ESCALATE_UNREVISED=yes` → Step 4 escalation → `loom:operator-only` | 1 (escalation) |
+| 4+ | — | — | — | — | `ALREADY_ROUTED=yes` drops it from every future pass | 0 |
+
+Invariants a future edit must preserve:
+
+- **Comment budget for an unrevised epic is exactly 2**: one "Epic Needs
+  Revision", one escalation. The skip path may only ever *edit* the existing
+  verdict comment (`gh api --method PATCH .../issues/comments/<id>` — no
+  notification, no new timeline entry), never post.
+- **A revision resets `SKIP_STREAK`, not `PRIOR_REJECTIONS`.** A new hash means a
+  new marker, so the tally restarts at 0 for the new revision — but the rejection
+  count keeps accumulating across revisions, so an epic revised-and-rejected twice
+  still escalates on its third cycle. Both paths stay bounded.
+- **`ALREADY_ROUTED=yes` short-circuits everything**, and here it is
+  unconditional: there is no epic analogue of the #5664 self-healing
+  un-escalation, because no epic criterion is a self-clearing dependency finding.
+
+`LOOM_MAX_UNREVISED_EVALUATIONS` (default **2**) is the same knob the proposal
+path reads — one threshold, both surfaces.
+
+---
+
 ## Epic Approval Workflow
+
+**Run the "Idempotency Guard for Unrevised Epics" above FIRST, before Step 1.**
+It has three outcomes (skip silently / escalate / evaluate), and only the third
+enters Step 1.
 
 ### Step 1: Read the Epic
 
@@ -181,10 +383,68 @@ Epic will progress to Phase 2 when all Phase 1 issues are closed.
 
 ### Step 4: Reject (One or More Criteria Fail)
 
-If any criteria fail, leave detailed feedback but keep the `loom:epic` label:
+If any criteria fail, first check whether this rejection should **escalate**
+instead of posting another comment — the mechanism that stops the duplicate
+"Epic Needs Revision" loop:
 
 ```bash
-gh issue comment <number> --body "**Champion Review: Epic Needs Revision**
+# All four were computed by the "Idempotency Guard for Unrevised Epics" above,
+# which always runs first — do NOT recompute them here:
+#   PRIOR_REJECTIONS   — posted "Champion Review: Epic Needs Revision" comments (any revision)
+#   SKIP_STREAK        — silent skips recorded for THIS body revision (0 if the marker did not match)
+#   ALREADY_ROUTED     — yes when loom:operator-only is already present
+#   ESCALATE_UNREVISED — yes when the guard sent you straight here without re-evaluating
+UNREVISED_EVALS=$(( PRIOR_REJECTIONS + SKIP_STREAK ))
+```
+
+**If `ESCALATE_UNREVISED=yes`, or `UNREVISED_EVALS >= ${LOOM_MAX_UNREVISED_EVALUATIONS:-2}`
+and `ALREADY_ROUTED=no`** — escalate to the operator instead of rejecting again.
+Keep `loom:epic` (the epic is parked for a human, not withdrawn), and use the
+`loom:operator-decision` sub-kind (#5671, `.loom/docs/label-state-machine.md`
+→ "operator-only sub-kinds"): an epic that keeps failing structural criteria is a
+judgement call about how the work should be shaped, never a self-clearing
+dependency wait, so `loom:operator-blocked` is never the right sub-kind here.
+
+```bash
+ESCALATE_MARKER="<!-- champion:epic-escalated -->"
+gh issue comment <number> --body "$ESCALATE_MARKER
+**Champion: Escalating to Operator — Epic Rejected Repeatedly Without Revision**
+
+This epic has been evaluated $UNREVISED_EVALS+ times with converging feedback ($PRIOR_REJECTIONS posted rejection(s) plus $SKIP_STREAK silent skip(s) of an unchanged epic), but has not been revised to address it. Re-running an identical evaluation each cycle changes nothing, and skipping it silently forever would leave it invisible; escalating is the only move that makes progress.
+
+**Recurring findings:**
+- [Criterion that failed, repeated across rejections]: [Specific reason]
+
+A human needs to decide whether to restructure this epic, close it, or take it
+out of the epic workflow entirely (for example by filing the work as ordinary
+issues instead of phases).
+
+---
+*Automated by Champion role*" \
+  && gh issue edit <number> --add-label "loom:operator-only,loom:operator-decision"
+```
+
+When you arrive here via `ESCALATE_UNREVISED=yes` you have **not** re-run the 6
+criteria, and must not: the epic's title and body are byte-identical to the
+revision the prior verdict was written against, so the verdict is unchanged by
+construction. Lift the **Recurring findings** verbatim from that prior "Epic
+Needs Revision" comment (`$COMMENT_BODY`, fetched by the guard) rather than
+re-deriving them.
+
+The guard's `ALREADY_ROUTED=yes` short-circuit is what keeps this comment to
+exactly one per epic — champion.md's Priority 4 discovery query does not filter
+`loom:operator-only` on its own.
+
+**Otherwise** (first or second evaluation, not yet routed): leave detailed
+feedback and keep the `loom:epic` label.
+
+```bash
+# Both markers are load-bearing: $VERDICT_MARKER makes the next cycle skip
+# silently; the skip tally (seeded at 0) is what that silent skip increments, so
+# the epic still escalates on schedule while staying quiet.
+gh issue comment <number> --body "$VERDICT_MARKER
+<!-- champion:epic-unrevised-skips:$BODY_HASH:0 -->
+**Champion Review: Epic Needs Revision**
 
 This epic requires additional work before approval:
 
@@ -200,6 +460,14 @@ Keeping \`loom:epic\` label. The Architect can revise and resubmit.
 ---
 *Automated by Champion role*"
 ```
+
+`$VERDICT_MARKER` and `$BODY_HASH` come from the guard above, keyed to a hash of
+this epic's title + body. Omitting the verdict marker — or substituting a
+timestamp-keyed one — reopens the duplicate-comment loop this mechanism exists to
+close; omitting the `champion:epic-unrevised-skips:$BODY_HASH:0` line beside it
+reopens the opposite failure, where skips are free, `UNREVISED_EVALS` never
+advances past `PRIOR_REJECTIONS`, and an unrevised epic is skipped quietly
+forever instead of escalating. **Both markers ship together or neither works.**
 
 ---
 


### PR DESCRIPTION
## Summary

`champion-epic.md`'s Step 2 → Step 4 re-evaluated the 6 epic criteria and posted
a fresh "Epic Needs Revision" comment on **every** Champion pass, with nothing
checking whether the epic had changed since the last rejection. An epic that is
never revised accumulates one near-identical rejection comment per cycle,
indefinitely, and no human is ever pulled in.

This is the same loop `champion-issue-promo.md` already closes for proposals
(#4954 / #4966 / #4967). This PR ports the idempotency + escalation half of that
mechanism to the epic path.

**Observed downstream** (the report this came from, 2AMLogic/2am#208):
2AMLogic/2am#184 was rejected by the epic workflow three times inside three
hours — 16:40:55Z, 18:10:39Z, 19:17:50Z — with materially identical findings and
no edit to the issue body in between. The fix has to land here because the
downstream `.claude/commands/loom/` copy is byte-identical to `defaults/` and a
hand-edit there is discarded by the next resync.

## Changes

`defaults/.claude/commands/loom/champion-epic.md` (single file):

- **New section "Idempotency Guard for Unrevised Epics
  (`champion:epic-verdict:body-*`)"**, between the evaluation criteria and the
  approval workflow. It computes a marker keyed to a hash of the epic's **title +
  body** and runs a three-way check before Step 1:
  | Outcome | Action |
  |---|---|
  | No marker match (new or revised) | Full re-evaluation, Steps 1 → 4 as before |
  | Match, `UNREVISED_EVALS < 2` | Silent skip; `PATCH` the tally into the existing verdict comment (no new comment, no notification) |
  | Match, budget spent | Straight to Step 4's escalation, skipping Steps 1–3 |
  | `ALREADY_ROUTED=yes` | Drop it — a human owns it |
- **Step 4 rewritten** into an escalation branch and a rejection branch. The
  rejection comment now carries both `$VERDICT_MARKER` and
  `<!-- champion:epic-unrevised-skips:$BODY_HASH:0 -->`; the escalation branch
  posts one rationale comment and adds `loom:operator-only` +
  `loom:operator-decision` (#5671) while keeping `loom:epic`.
- Counter table + a cycle-by-cycle trace, so the coupling between the silent skip
  and the N=2 escalation is explicit — the regression documented in #4967 (silent
  skips that were free, so escalation never fired) is the failure this port must
  not reintroduce.

**Epic-specific deviations from the proposal mechanism, documented inline:**

- **The `loom:evaluating` claim label is not ported.** Epic approvals are
  rate-limited to one per iteration and epic evaluation is not part of the
  high-frequency proposal batch loop, so the concurrent-evaluation race the claim
  closes is far less pressing; the body hash still bounds a concurrent double-pass
  to one extra comment.
- **No dependency-timing gate and no Pass 0 un-escalation (#5664).** None of the
  6 epic criteria is a self-clearing blocker finding — they are all structural —
  so `ALREADY_ROUTED` is an *unconditional* short-circuit here. It also has to be:
  unlike Priorities 1–3, `champion.md`'s Priority 4 epic discovery does **not**
  filter `loom:operator-only`, so this short-circuit is the only thing that makes
  the escalated state terminal. (Left as a short-circuit rather than changing
  Priority 4's query, to keep the diff to one file.)
- **The guard keys on posted rejection verdicts only**, so it can never suppress
  Step 2.5's Epic-Aware Blocker Check (#5211) or Phase Progression on an approved
  epic — an approved epic never carries the marker, and a Step 2.5 hold posts a
  hold comment rather than a verdict.

## Acceptance Criteria Verification

- [x] Idempotency check documented, keyed to a hash of title + body — with an
      explicit "why not `updatedAt`" subsection (it self-invalidates: posting the
      verdict bumps the field the marker recorded) pointing at
      `champion-issue-promo.md` → "Why a body hash and NOT the issue's
      `updatedAt` (#4966)".
- [x] An epic rejected twice without revision escalates to `loom:operator-only`
      with a rationale comment instead of a third rejection — traced in the
      cycle table: 1 rejection, 1 silent skip, escalation on cycle 3, then
      silence. Comment budget for an unrevised epic is exactly 2.
- [x] Epics that *are* revised between passes still get a full re-evaluation — a
      new body ⇒ new hash ⇒ no marker match ⇒ Steps 1–4 run unchanged.
      `SKIP_STREAK` resets on a revision; `PRIOR_REJECTIONS` does not, so a
      revised-and-rejected-twice epic still escalates on its third cycle.
- [x] Body-hash verdict marker embedded in the "Epic Needs Revision" comment,
      together with the skip-tally seed — both markers ship together or neither
      works (stated in the doc).

## Test Plan

Documentation-only change to a role-instruction file; no runtime code touched.
Ran the repo's doc/consistency gates in the worktree — all green:

- `bash scripts/check-dangling-links.sh` — OK (131 tracked markdown files)
- `bash scripts/check-docs-defaults-parity.sh` — OK
- `bash defaults/scripts/check-phantom-labels.sh` — OK (`loom:operator-only`,
  `loom:operator-decision`, `loom:epic` all exist in the registry)
- `bash defaults/scripts/check-cas-recheck-consistency.sh` — OK
- `bash scripts/check-agents-md-sync.sh` — OK
- `bash scripts/check-claude-md-budget.sh` — OK (320/320)
- The new guard's shell block extracted and run through `bash -n` — syntax OK

Installed copies under `.claude/commands/loom/` are intentionally **not** touched
— that is the periodic resync commit's job.

Closes #5865

🤖 Generated with [Claude Code](https://claude.com/claude-code)