### PR TITLE
Raise token-exhaustion probe threshold 95% -> 99%

### DIFF
--- a/.loom/docs/token-pool.md
+++ b/.loom/docs/token-pool.md
@@ -242,8 +242,8 @@ and parses rate-limit response headers. The header parser matches by **suffix**
 `anthropic-ratelimit-tokens-*` prefix still work; the full header set is logged on
 the first probe of each run.
 
-Status assignment: `available` (utilizations < 95%), `exhausted`
-(`7d_utilization >= 0.95`), `rate_limited` (current 429), `blocked` (401 auth
+Status assignment: `available` (utilizations < 99%), `exhausted`
+(`7d_utilization >= 0.99`), `rate_limited` (current 429), `blocked` (401 auth
 failure or token listed in `.bad_tokens`). Probe failures (network, timeout, 5xx)
 are logged and skipped — one bad account does not abort the run.
 

--- a/defaults/docs/token-pool.md
+++ b/defaults/docs/token-pool.md
@@ -242,8 +242,8 @@ and parses rate-limit response headers. The header parser matches by **suffix**
 `anthropic-ratelimit-tokens-*` prefix still work; the full header set is logged on
 the first probe of each run.
 
-Status assignment: `available` (utilizations < 95%), `exhausted`
-(`7d_utilization >= 0.95`), `rate_limited` (current 429), `blocked` (401 auth
+Status assignment: `available` (utilizations < 99%), `exhausted`
+(`7d_utilization >= 0.99`), `rate_limited` (current 429), `blocked` (401 auth
 failure or token listed in `.bad_tokens`). Probe failures (network, timeout, 5xx)
 are logged and skipped — one bad account does not abort the run.
 

--- a/loom-daemon/src/tokens_pool/check.rs
+++ b/loom-daemon/src/tokens_pool/check.rs
@@ -61,7 +61,7 @@ pub const DEFAULT_PROBE_MODEL: &str = "claude-haiku-4-5-20251001";
 pub const DEFAULT_PROBE_PROMPT: &str = "hi";
 const DEFAULT_TIMEOUT_SECONDS: f64 = 15.0;
 /// 7d-utilization at or above which an account is `exhausted` (issue #3988).
-pub const EXHAUSTED_THRESHOLD: f64 = 0.95;
+pub const EXHAUSTED_THRESHOLD: f64 = 0.99;
 
 const HEADER_SUFFIX_5H_UTIL: &str = "-5h-utilization";
 const HEADER_SUFFIX_7D_UTIL: &str = "-7d-utilization";
@@ -1010,13 +1010,13 @@ mod tests {
 
     #[test]
     fn status_200_exhausted_above_threshold() {
-        let r = probe_with(resp(200, &[("anthropic-ratelimit-tokens-7d-utilization", "0.97")]));
+        let r = probe_with(resp(200, &[("anthropic-ratelimit-tokens-7d-utilization", "0.995")]));
         assert_eq!(r.status, "exhausted");
     }
 
     #[test]
     fn status_200_exhausted_at_threshold() {
-        let r = probe_with(resp(200, &[("anthropic-ratelimit-tokens-7d-utilization", "0.95")]));
+        let r = probe_with(resp(200, &[("anthropic-ratelimit-tokens-7d-utilization", "0.99")]));
         assert_eq!(r.status, "exhausted");
     }
 
@@ -1036,7 +1036,7 @@ mod tests {
 
     #[test]
     fn status_429_promoted_to_exhausted_above_threshold() {
-        let r = probe_with(resp(429, &[("anthropic-ratelimit-tokens-7d-utilization", "0.97")]));
+        let r = probe_with(resp(429, &[("anthropic-ratelimit-tokens-7d-utilization", "0.995")]));
         assert_eq!(r.status, "exhausted");
     }
 


### PR DESCRIPTION
## Summary
- Raises `EXHAUSTED_THRESHOLD` in `loom-daemon/src/tokens_pool/check.rs` from `0.95` to `0.99` — 95% was retiring accounts from the pool too eagerly, often weeks before their actual weekly (7d) reset.
- Updates the two boundary tests (`status_200_exhausted_at_threshold`, `status_200_exhausted_above_threshold`, `status_429_promoted_to_exhausted_above_threshold`) to the new threshold.
- Updates the two doc mentions in `token-pool.md` (`.loom/docs/` + `defaults/docs/`).

## Context
Ported from a local uncommitted WIP diff sitting on a downstream fork that predates this project's move of the token-probe/select logic from Python (`loom-tools/`) to Rust (`loom-daemon/src/tokens_pool/`). The 429-promoted-to-exhausted behavior (issue #3988) this repo already has; only the threshold value itself was the delta.

## Test plan
- [x] `cargo test --lib tokens_pool::check::` — 42 passed, 0 failed