### PR TITLE
ci: run the five heavy jobs on the dedicated CI runner (2am#29)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,11 @@ jobs:
     name: Rust Unit Tests
     needs: changes
     if: always() && (github.event_name == 'push' || needs.changes.outputs.backend == 'true')
-    runs-on: ubuntu-latest
+    # Heavy jobs run on the dedicated CI runner (2AMLogic/2am#29). The
+    # expression routes same-repo runs to it and sends fork PRs back to
+    # GitHub-hosted instead of skipping them, so required checks never go
+    # missing and no outside fork ever executes on our host.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","heavy"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -108,7 +112,11 @@ jobs:
     name: Rust OTLP Feature Build & Test
     needs: changes
     if: always() && (github.event_name == 'push' || needs.changes.outputs.backend == 'true')
-    runs-on: ubuntu-latest
+    # Heavy jobs run on the dedicated CI runner (2AMLogic/2am#29). The
+    # expression routes same-repo runs to it and sends fork PRs back to
+    # GitHub-hosted instead of skipping them, so required checks never go
+    # missing and no outside fork ever executes on our host.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","heavy"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -358,7 +366,11 @@ jobs:
     needs: changes
     if: always() && (github.event_name == 'push' || needs.changes.outputs.scripts == 'true')
     # Portable across GNU/BSD sed (temp-file + mv idiom) — runs on ubuntu (#3515)
-    runs-on: ubuntu-latest
+    # Heavy jobs run on the dedicated CI runner (2AMLogic/2am#29). The
+    # expression routes same-repo runs to it and sends fork PRs back to
+    # GitHub-hosted instead of skipping them, so required checks never go
+    # missing and no outside fork ever executes on our host.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","heavy"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - name: Check role prompts reference only real labels (#3786)
@@ -484,7 +496,11 @@ jobs:
     # previously not referenced by CI at all). All 8 suites are hermetic
     # (fake/stub binaries or local python3 AST fixtures, no live network or
     # forge calls) and run in well under a second each.
-    runs-on: ubuntu-latest
+    # Heavy jobs run on the dedicated CI runner (2AMLogic/2am#29). The
+    # expression routes same-repo runs to it and sends fork PRs back to
+    # GitHub-hosted instead of skipping them, so required checks never go
+    # missing and no outside fork ever executes on our host.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","heavy"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - name: Configure git identity for suite fixtures
@@ -502,7 +518,11 @@ jobs:
     name: loom-worker Image Smoke Test
     needs: changes
     if: always() && (github.event_name == 'push' || needs.changes.outputs.docker == 'true')
-    runs-on: ubuntu-latest
+    # Heavy jobs run on the dedicated CI runner (2AMLogic/2am#29). The
+    # expression routes same-repo runs to it and sends fork PRs back to
+    # GitHub-hosted instead of skipping them, so required checks never go
+    # missing and no outside fork ever executes on our host.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","heavy"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Routes loom's five heavy CI jobs — `backend-tests`, `backend-otlp-feature`, `shell-suite-tests`, `installer-tests`, `worker-image-smoke` — to the fleet's dedicated runner (2AMLogic/2am#29: c7i.8xlarge, eight ephemeral 4-vCPU container slots, persistent tool caches). Proven first on 2AMLogic/klayout-tools#1246 (`native-techmap` 16 s on the runner vs 46 s p50 on `ubuntu-latest`).

The 14 sub-minute fan-out jobs stay on `ubuntu-latest`. The `runs-on` expression routes by origin: same-repo runs get `[self-hosted, heavy]`; fork PRs go back to `ubuntu-latest` rather than being skipped, so required checks never go missing and no outside fork executes on our host. Fork-PR approval on this repo was moved to `all_external_contributors` beforehand.

Expect `shell-suite-tests` to stay ~10 min: it is sequential by design (#6622 is the fix) — hardware does not touch it. The Rust jobs and the image smoke test are where this should show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)