### PR TITLE
defaults: neutral names in the Gitea Basic-auth example and two vendored role docs

### DIFF
--- a/defaults/.claude/commands/loom/auditor.md
+++ b/defaults/.claude/commands/loom/auditor.md
@@ -167,7 +167,7 @@ repo) then:
 
 Some repos' only "build" is an **expensive** run — most notably SPICE/`ngspice`
 circuit simulations, which have caused sim storms on this fleet (#4903:
-`loom-worker-1` at loadavg 95 on 8 cores from 16 concurrent `ngspice` processes).
+an 8-core fleet worker at loadavg 95 from 16 concurrent `ngspice` processes).
 **A routine interval tick MUST NOT launch simulation or other heavy compute** just
 because it discovered a `Makefile` target that runs one. Only run expensive
 validation when the repo has **explicitly opted in**, signalled by *either*:

--- a/defaults/.claude/commands/loom/comment-body-literal-path.md
+++ b/defaults/.claude/commands/loom/comment-body-literal-path.md
@@ -59,7 +59,7 @@ agents each writing to the same fixed path race on it: one's `create-pr.sh
 agent's body between its write and your read, silently publishing a PR or
 comment with the wrong title, wrong `Closes #N`, or wrong content — with
 nothing failing and no error anywhere (#6381, near-miss in a consumer repo,
-`2AMLogic/pickwell` PR 188). The same collision applies outside wave dispatch
+a private-repo PR). The same collision applies outside wave dispatch
 too: two independent `/loom:sweep` runs (different terminals, same host) can
 just as easily race on an unnamespaced `/tmp` path.
 

--- a/defaults/docs/forge-authentication.md
+++ b/defaults/docs/forge-authentication.md
@@ -105,7 +105,7 @@ Some self-hosted Gitea deployments (cleanroom mirrors, air-gapped environments, 
 Set `GITEA_USERNAME` to switch into Basic Auth mode. The password is taken from the existing `GITEA_TOKEN` (or `FORGE_TOKEN`) variable -- the field is reused so existing config schemas keep working.
 
 ```bash
-export GITEA_USERNAME=sphere
+export GITEA_USERNAME=example-user
 export GITEA_TOKEN='<your-gitea-password>'    # password goes here in Basic mode
 ```
 
@@ -117,7 +117,7 @@ Or in `.loom/config.json`:
     "type": "gitea",
     "gitea": {
       "url": "https://cleanroom-gitea.example.com",
-      "username": "sphere",
+      "username": "example-user",
       "token": "<password>"
     }
   }


### PR DESCRIPTION
Surfaced by a downstream disclosure read-audit: `defaults/docs/forge-authentication.md`'s Basic-auth example used a real cleanroom repository's name as the sample `GITEA_USERNAME` (lines 108/120 → `example-user`), `comment-body-literal-path.md` named a private side-project PR, and `auditor.md` named a fleet worker host. All three are vendored into every consumer repo's installed surfaces, so they were public in ~22 downstream repos; fixing them here reaches all of them on the next resync. The dated incident history in `daemon-reference.md` that names hosts is deliberately untouched — evidence, not an example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- loom:no-surface-change -->
