### PR TITLE
fix(tests): probe both installed and source-repo layouts for champion-doc paths in 7 more suites

### DIFF
--- a/defaults/scripts/tests/test-champion-ci-checks-no-checks-signal.sh
+++ b/defaults/scripts/tests/test-champion-ci-checks-no-checks-signal.sh
@@ -53,9 +53,19 @@ set -uo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)"
-DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
-CHAMPION_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-pr-merge.md"
-CHAMPION_REF_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-reference.md"
+
+# Two `..` reaches repo-root/.claude/commands/loom for an INSTALLED copy
+# (SCRIPTS_DIR is .loom/scripts there); one `..` reaches defaults/.claude/
+# commands/loom when running inside this source repo (SCRIPTS_DIR is
+# defaults/scripts) -- the two layouts differ in depth, so probe both rather
+# than hard-coding one (#6725).
+if [[ -d "$SCRIPTS_DIR/../../.claude/commands/loom" ]]; then
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../../.claude/commands/loom" && pwd)"
+else
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../.claude/commands/loom" && pwd)"
+fi
+CHAMPION_MD="$PROMPT_DIR/champion-pr-merge.md"
+CHAMPION_REF_MD="$PROMPT_DIR/champion-reference.md"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/defaults/scripts/tests/test-champion-critical-file-check.sh
+++ b/defaults/scripts/tests/test-champion-critical-file-check.sh
@@ -43,8 +43,18 @@ set -uo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)"
-DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
-CHAMPION_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-pr-merge.md"
+
+# Two `..` reaches repo-root/.claude/commands/loom for an INSTALLED copy
+# (SCRIPTS_DIR is .loom/scripts there); one `..` reaches defaults/.claude/
+# commands/loom when running inside this source repo (SCRIPTS_DIR is
+# defaults/scripts) -- the two layouts differ in depth, so probe both rather
+# than hard-coding one (#6725).
+if [[ -d "$SCRIPTS_DIR/../../.claude/commands/loom" ]]; then
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../../.claude/commands/loom" && pwd)"
+else
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../.claude/commands/loom" && pwd)"
+fi
+CHAMPION_MD="$PROMPT_DIR/champion-pr-merge.md"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/defaults/scripts/tests/test-classify-dependency-block.sh
+++ b/defaults/scripts/tests/test-classify-dependency-block.sh
@@ -29,11 +29,21 @@ set -uo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)"
-DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
 CDB="$SCRIPTS_DIR/classify-dependency-block.sh"
-CHAMPION_PROMO_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-issue-promo.md"
-CHAMPION_MD="$DEFAULTS_DIR/.claude/commands/loom/champion.md"
-CHAMPION_REF_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-reference.md"
+
+# Two `..` reaches repo-root/.claude/commands/loom for an INSTALLED copy
+# (SCRIPTS_DIR is .loom/scripts there); one `..` reaches defaults/.claude/
+# commands/loom when running inside this source repo (SCRIPTS_DIR is
+# defaults/scripts) -- the two layouts differ in depth, so probe both rather
+# than hard-coding one (#6725).
+if [[ -d "$SCRIPTS_DIR/../../.claude/commands/loom" ]]; then
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../../.claude/commands/loom" && pwd)"
+else
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../.claude/commands/loom" && pwd)"
+fi
+CHAMPION_PROMO_MD="$PROMPT_DIR/champion-issue-promo.md"
+CHAMPION_MD="$PROMPT_DIR/champion.md"
+CHAMPION_REF_MD="$PROMPT_DIR/champion-reference.md"
 
 # Source for the pure helpers BEFORE defining our own colors (the sourced chain
 # defines RED/YELLOW/BLUE/NC itself).

--- a/defaults/scripts/tests/test-dependency-parse.sh
+++ b/defaults/scripts/tests/test-dependency-parse.sh
@@ -40,11 +40,21 @@ set -uo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)"
-DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
-GUIDE_MD="$DEFAULTS_DIR/.claude/commands/loom/guide.md"
-SWEEP_MD="$DEFAULTS_DIR/.claude/commands/loom/sweep.md"
-CHAMPION_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-pr-merge.md"
-CHAMPION_COMMON_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-common.md"
+
+# Two `..` reaches repo-root/.claude/commands/loom for an INSTALLED copy
+# (SCRIPTS_DIR is .loom/scripts there); one `..` reaches defaults/.claude/
+# commands/loom when running inside this source repo (SCRIPTS_DIR is
+# defaults/scripts) -- the two layouts differ in depth, so probe both rather
+# than hard-coding one (#6725).
+if [[ -d "$SCRIPTS_DIR/../../.claude/commands/loom" ]]; then
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../../.claude/commands/loom" && pwd)"
+else
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../.claude/commands/loom" && pwd)"
+fi
+GUIDE_MD="$PROMPT_DIR/guide.md"
+SWEEP_MD="$PROMPT_DIR/sweep.md"
+CHAMPION_MD="$PROMPT_DIR/champion-pr-merge.md"
+CHAMPION_COMMON_MD="$PROMPT_DIR/champion-common.md"
 
 # Source warn-out-of-set-deps.sh's real parse_out_of_set_deps BEFORE defining
 # our own RED/GREEN/NC below — the script's own `[[ -t 2 ]]` color block

--- a/defaults/scripts/tests/test-detect-dependency-cycle.sh
+++ b/defaults/scripts/tests/test-detect-dependency-cycle.sh
@@ -30,10 +30,20 @@ set -uo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)"
-DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
 DDC="$SCRIPTS_DIR/detect-dependency-cycle.sh"
-CHAMPION_MERGE_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-pr-merge.md"
-CHAMPION_PROMO_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-issue-promo.md"
+
+# Two `..` reaches repo-root/.claude/commands/loom for an INSTALLED copy
+# (SCRIPTS_DIR is .loom/scripts there); one `..` reaches defaults/.claude/
+# commands/loom when running inside this source repo (SCRIPTS_DIR is
+# defaults/scripts) -- the two layouts differ in depth, so probe both rather
+# than hard-coding one (#6725).
+if [[ -d "$SCRIPTS_DIR/../../.claude/commands/loom" ]]; then
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../../.claude/commands/loom" && pwd)"
+else
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../.claude/commands/loom" && pwd)"
+fi
+CHAMPION_MERGE_MD="$PROMPT_DIR/champion-pr-merge.md"
+CHAMPION_PROMO_MD="$PROMPT_DIR/champion-issue-promo.md"
 
 # Source the script for its pure helpers BEFORE defining our own colors - the
 # script's own `[[ -t 2 ]]` block defines RED/YELLOW/BLUE/NC, so sourcing first

--- a/defaults/scripts/tests/test-detect-startable-subset.sh
+++ b/defaults/scripts/tests/test-detect-startable-subset.sh
@@ -19,9 +19,19 @@ set -uo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)"
-DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
 DSS="$SCRIPTS_DIR/detect-startable-subset.sh"
-CHAMPION_PROMO_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-issue-promo.md"
+
+# Two `..` reaches repo-root/.claude/commands/loom for an INSTALLED copy
+# (SCRIPTS_DIR is .loom/scripts there); one `..` reaches defaults/.claude/
+# commands/loom when running inside this source repo (SCRIPTS_DIR is
+# defaults/scripts) -- the two layouts differ in depth, so probe both rather
+# than hard-coding one (#6725).
+if [[ -d "$SCRIPTS_DIR/../../.claude/commands/loom" ]]; then
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../../.claude/commands/loom" && pwd)"
+else
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../.claude/commands/loom" && pwd)"
+fi
+CHAMPION_PROMO_MD="$PROMPT_DIR/champion-issue-promo.md"
 
 # shellcheck source=/dev/null
 source "$DSS"

--- a/defaults/scripts/tests/test-docs-only-fast-path.sh
+++ b/defaults/scripts/tests/test-docs-only-fast-path.sh
@@ -34,10 +34,20 @@ set -uo pipefail
 
 TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS_DIR="$(cd "$TEST_DIR/.." && pwd)"
-DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
-JUDGE_MD="$DEFAULTS_DIR/.claude/commands/loom/judge.md"
-CHAMPION_MD="$DEFAULTS_DIR/.claude/commands/loom/champion-pr-merge.md"
-GUIDE_MD="$DEFAULTS_DIR/.claude/commands/loom/guide.md"
+
+# Two `..` reaches repo-root/.claude/commands/loom for an INSTALLED copy
+# (SCRIPTS_DIR is .loom/scripts there); one `..` reaches defaults/.claude/
+# commands/loom when running inside this source repo (SCRIPTS_DIR is
+# defaults/scripts) -- the two layouts differ in depth, so probe both rather
+# than hard-coding one (#6725).
+if [[ -d "$SCRIPTS_DIR/../../.claude/commands/loom" ]]; then
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../../.claude/commands/loom" && pwd)"
+else
+    PROMPT_DIR="$(cd "$SCRIPTS_DIR/../.claude/commands/loom" && pwd)"
+fi
+JUDGE_MD="$PROMPT_DIR/judge.md"
+CHAMPION_MD="$PROMPT_DIR/champion-pr-merge.md"
+GUIDE_MD="$PROMPT_DIR/guide.md"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary

7 more `defaults/scripts/tests/*.sh` suites shared the same `DEFAULTS_DIR`
off-by-one path-depth bug already fixed for `test-classify-capacity-defer.sh`
and others in #6725 / #6737:

- `test-classify-dependency-block.sh`
- `test-detect-dependency-cycle.sh`
- `test-detect-startable-subset.sh`
- `test-champion-critical-file-check.sh`
- `test-champion-ci-checks-no-checks-signal.sh`
- `test-docs-only-fast-path.sh`
- `test-dependency-parse.sh`

Each built its `.claude/commands/loom/*.md` path via
`DEFAULTS_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"` followed by
`$DEFAULTS_DIR/.claude/commands/loom/<doc>.md`. That resolves correctly only
in the source-repo layout, where `SCRIPTS_DIR` is `defaults/scripts` (so one
`..` reaches `defaults/.claude/commands/loom`). In an **installed** consumer
repo, `SCRIPTS_DIR` is `.loom/scripts`, and `.claude/commands/loom` lives at
the repo root — two `..` are needed, not one. Every `assert_doc_contains`
check against those docs failed there with "No such file or directory",
even though the suites pass cleanly inside this source repo.

## Fix

Same dual-candidate probe pattern as #6725 / #6737: try the installed-layout
path (`$SCRIPTS_DIR/../../.claude/commands/loom`) first, fall back to the
source-repo-layout path (`$SCRIPTS_DIR/../.claude/commands/loom`) if that
doesn't exist. Applied identically to all 7 files, replacing the
`DEFAULTS_DIR`+`.claude/commands/loom` construction with a `PROMPT_DIR`
variable resolved once per file.

## Verification

- All 7 suites run clean from within this checkout (source-repo layout):
  `test-classify-dependency-block.sh` 171/171,
  `test-detect-dependency-cycle.sh` 62/62,
  `test-detect-startable-subset.sh` 25/25,
  `test-champion-critical-file-check.sh` 44/44,
  `test-champion-ci-checks-no-checks-signal.sh` 26/26,
  `test-docs-only-fast-path.sh` 27/27,
  `test-dependency-parse.sh` 26/26 — all 0 failed.
- Also verified against a simulated **installed** layout (a scratch dir with
  `.loom/scripts/tests/` + repo-root `.claude/commands/loom/`, mirroring how
  a consumer repo like `2AMLogic/2am` lays these files out after
  `resync-installed.sh`): same 7/7 suites, 0 failures each — confirming the
  probe's installed-layout branch resolves correctly and a naive
  fixed-depth fix (the regression class #6725 itself warns about) was
  avoided.
- `shellcheck -x` on all 7 files shows no new findings (pre-existing SC2016
  info-level hits on unrelated heredoc lines only).

Test-only change under `defaults/`, no installed behavior change — carries
`<!-- loom:no-surface-change -->`, matching how #6725 and #6737 handled the
same class of edit.

<!-- loom:no-surface-change -->

Related: 2AMLogic/2am#454 (files the sibling-suite report and tracks the
downstream resync + local verification once this merges).