### PR TITLE
docs: note that Dependabot PRs are inert to Loom automation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,10 @@ If you want to submit a PR directly, you're welcome to, but know that it will be
 
 Run `pnpm check:ci` before pushing. This runs the full CI suite locally (linting, formatting, type checking, tests). PRs that fail CI won't be merged.
 
+### Dependabot PRs
+
+Dependabot's version-update and security-fix PRs are intentionally inert to the agent system: they carry no `loom:*` labels, so no role picks them up, reviews them, or merges them. They are triaged by the maintainer (via Repo Skills' `/repo:deps`), not by Loom — automated dependency bumps merge on human judgment, not agent consensus.
+
 ## Development Setup
 
 If you want to explore the codebase or run Loom locally:


### PR DESCRIPTION
Closes #6656 — final AC.

The other three ACs were executed as repo-settings changes on 2026-08-24 and verified by re-read:
- `PUT repos/rjwalters/loom/vulnerability-alerts` → enabled (re-read 204)
- `PUT repos/rjwalters/loom/automated-security-fixes` → `dependabot_security_updates: enabled`

This PR adds the requested CONTRIBUTING note that Dependabot PRs stay inert to Loom automation (no `loom:*` labels) and are triaged via `/repo:deps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)